### PR TITLE
Support Right Control as push-to-talk key (to use with Karabiner that can emit this keycode when Spotlight or Dictation key is pressed)

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -56,6 +56,7 @@ class HotkeyManager: ObservableObject {
         case rightOption = "rightOption"
         case leftOption = "leftOption"
         case leftControl = "leftControl"
+        case rightControl = "rightControl"
         case fn = "fn"
         case rightCommand = "rightCommand"
         case rightShift = "rightShift"
@@ -65,6 +66,7 @@ class HotkeyManager: ObservableObject {
             case .rightOption: return "Right Option (⌥)"
             case .leftOption: return "Left Option (⌥)"
             case .leftControl: return "Left Control (⌃)"
+            case .rightControl: return "Right Control (⌃)"
             case .fn: return "Fn"
             case .rightCommand: return "Right Command (⌘)"
             case .rightShift: return "Right Shift (⇧)"
@@ -76,6 +78,7 @@ class HotkeyManager: ObservableObject {
             case .rightOption: return 0x3D
             case .leftOption: return 0x3A
             case .leftControl: return 0x3B
+            case .rightControl: return 0x3E
             case .fn: return 0x3F
             case .rightCommand: return 0x36
             case .rightShift: return 0x3C
@@ -87,6 +90,7 @@ class HotkeyManager: ObservableObject {
             case .rightOption: return .maskAlternate
             case .leftOption: return .maskAlternate
             case .leftControl: return .maskControl
+            case .rightControl: return .maskControl
             case .fn: return .maskSecondaryFn
             case .rightCommand: return .maskCommand
             case .rightShift: return .maskShift

--- a/VoiceInk/Views/RecordView.swift
+++ b/VoiceInk/Views/RecordView.swift
@@ -179,6 +179,7 @@ struct RecordView: View {
         case .rightOption: return "⌥"
         case .leftOption: return "⌥"
         case .leftControl: return "⌃"
+        case .rightControl: return "⌃"
         case .fn: return "Fn"
         case .rightCommand: return "⌘"
         case .rightShift: return "⇧"
@@ -190,6 +191,7 @@ struct RecordView: View {
         case .rightOption: return "Right Option"
         case .leftOption: return "Left Option"
         case .leftControl: return "Left Control"
+        case .rightControl: return "Right Control"
         case .fn: return "Function"
         case .rightCommand: return "Right Command"
         case .rightShift: return "Right Shift"
@@ -241,6 +243,8 @@ struct RecordView: View {
             keyName = "left Option (⌥)"
         case .leftControl:
             keyName = "left Control (⌃)"
+        case .rightControl:
+            keyName = "right Control (⌃)"
         case .fn:
             keyName = "Fn"
         case .rightCommand:

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -262,6 +262,8 @@ struct SettingsView: View {
             return "Using Left Option (⌥) key to quickly start recording. Release to stop."
         case .leftControl:
             return "Using Left Control (⌃) key to quickly start recording. Release to stop."
+        case .rightControl:
+            return "Using Right Control (⌃) key to quickly start recording. Release to stop."
         case .fn:
             return "Using Function (Fn) key to quickly start recording. Release to stop."
         case .rightCommand:
@@ -370,6 +372,7 @@ struct PushToTalkKeySelector: View {
         case .rightOption: return "⌥"
         case .leftOption: return "⌥"
         case .leftControl: return "⌃"
+        case .rightControl: return "⌃"
         case .fn: return "Fn"
         case .rightCommand: return "⌘"
         case .rightShift: return "⇧"
@@ -381,6 +384,7 @@ struct PushToTalkKeySelector: View {
         case .rightOption: return "Right Option"
         case .leftOption: return "Left Option"
         case .leftControl: return "Left Control"
+        case .rightControl: return "Right Control"
         case .fn: return "Function"
         case .rightCommand: return "Right Command"
         case .rightShift: return "Right Shift"


### PR DESCRIPTION
<img width="1264" alt="Screenshot 2025-04-14 at 12 59 02" src="https://github.com/user-attachments/assets/fe7ae66d-814e-42ba-89c8-2ad3bb39d93a" />

I struggled to find a good push-to-talk key that:

1) Could be easily activated with the left hand when the right hand is on the mouse
2) Would not be frequently used in combinations like Left Cmd, Left Control etc.

Figured that the function keys row suits well. I was not using the Spotlight key at all. With Karabiner (a free utility), I can make the Spotlight key emit the keycode of the Right Control key (which otherwise does not exist on my magic keyboard; the full size version with the keypad has it, though).

This merge request allows VoiceInk to use Right Control as the push-to-talk key, letting me to achieve the intended goal. It would be even better to support Spotlight, Dictation and similar keys directly in VoiceInk, but this Karabiner method at least gets the job done (and prevents the default MacOS action of the chosen key too, which is necessary).