### PR TITLE
Fix: Correct logging in WhisperState+ModelManager to resolve compile error

### DIFF
--- a/VoiceInk/Whisper/WhisperState+ModelManager.swift
+++ b/VoiceInk/Whisper/WhisperState+ModelManager.swift
@@ -303,7 +303,7 @@ extension WhisperState {
     // MARK: - Helper Methods
     
     private func logError(_ message: String, _ error: Error) {
-        messageLog += "\(message): \(error.localizedDescription)\n"
+        self.logger.error("\(message): \(error.localizedDescription)")
     }
 }
 


### PR DESCRIPTION
This PR fixes a compile error in the `logError` helper function within the `WhisperState+ModelManager.swift` extension.

**Problem:**

The code was attempting to append to a `messageLog` property using `self.messageLog += ...`. This resulted in sequential compile errors:
1. Initially, `Cannot find 'messageLog' in scope` (when `self.` was missing).
2. After adding `self.`, `Value of type 'WhisperState' has no member 'messageLog'`.

Investigation revealed that `WhisperState` does not define a `messageLog` property. Instead, it uses a standard `Logger` instance named `logger` for logging purposes, defined in the main `WhisperState.swift` file.

**Solution:**

The `logError` function has been updated to use the correct logging mechanism provided by `WhisperState`:
```swift
self.logger.error("\(message): \(error.localizedDescription)")
```
This resolves the compile error and ensures that errors within the model manager extension are logged correctly using the designated logger instance.