### PR TITLE
Add custom trigger words for Enhancement Modes

### DIFF
--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -82,6 +82,7 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
     let icon: PromptIcon
     let description: String?
     let isPredefined: Bool
+    let triggerWord: String?
     
     init(
         id: UUID = UUID(),
@@ -90,7 +91,8 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
         isActive: Bool = false,
         icon: PromptIcon = .documentFill,
         description: String? = nil,
-        isPredefined: Bool = false
+        isPredefined: Bool = false,
+        triggerWord: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -99,5 +101,6 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
         self.icon = icon
         self.description = description
         self.isPredefined = isPredefined
+        self.triggerWord = triggerWord
     }
 } 

--- a/VoiceInk/Views/EnhancementSettingsView.swift
+++ b/VoiceInk/Views/EnhancementSettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension CustomPrompt {
-    func promptIcon(isSelected: Bool, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil) -> some View {
+    func promptIcon(isSelected: Bool, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil, assistantTriggerWord: String? = nil) -> some View {
         VStack(spacing: 8) {
             ZStack {
                 // Dynamic background with blur effect
@@ -89,12 +89,46 @@ extension CustomPrompt {
             .frame(width: 48, height: 48)
             
             // Enhanced title styling
-            Text(title)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(isSelected ?
-                    .primary : .secondary)
-                .lineLimit(1)
-                .frame(maxWidth: 70)
+            VStack(spacing: 2) {
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(isSelected ?
+                        .primary : .secondary)
+                    .lineLimit(1)
+                    .frame(maxWidth: 70)
+                
+                // Trigger word section with consistent height
+                ZStack(alignment: .center) {
+                    if id == PredefinedPrompts.assistantPromptId, let assistantTriggerWord = assistantTriggerWord, !assistantTriggerWord.isEmpty {
+                        // Show the global assistant trigger word for the Assistant Mode
+                        HStack(spacing: 2) {
+                            Image(systemName: "mic.fill")
+                                .font(.system(size: 7))
+                                .foregroundColor(isSelected ? .accentColor.opacity(0.9) : .secondary.opacity(0.7))
+                            
+                            Text("\"\(assistantTriggerWord)...\"")
+                                .font(.system(size: 8, weight: .regular))
+                                .foregroundColor(isSelected ? .primary.opacity(0.8) : .secondary.opacity(0.7))
+                                .lineLimit(1)
+                        }
+                        .frame(maxWidth: 70)
+                    } else if let triggerWord = triggerWord, !triggerWord.isEmpty {
+                        // Show custom trigger words for Enhancement Modes
+                        HStack(spacing: 2) {
+                            Image(systemName: "mic.fill")
+                                .font(.system(size: 7))
+                                .foregroundColor(isSelected ? .accentColor.opacity(0.9) : .secondary.opacity(0.7))
+                            
+                            Text("\"\(triggerWord)...\"")
+                                .font(.system(size: 8, weight: .regular))
+                                .foregroundColor(isSelected ? .primary.opacity(0.8) : .secondary.opacity(0.7))
+                                .lineLimit(1)
+                        }
+                        .frame(maxWidth: 70)
+                    }
+                }
+                .frame(height: 16) // Fixed height for all modes, with or without trigger words
+            }
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 6)
@@ -247,7 +281,8 @@ struct EnhancementSettingsView: View {
                                                 enhancementService.setActivePrompt(prompt)
                                             }},
                                             onEdit: { selectedPromptForEdit = $0 },
-                                            onDelete: { enhancementService.deletePrompt($0) }
+                                            onDelete: { enhancementService.deletePrompt($0) },
+                                            assistantTriggerWord: enhancementService.assistantTriggerWord
                                         )
                                     }
                                 }

--- a/VoiceInk/Views/PromptEditorView.swift
+++ b/VoiceInk/Views/PromptEditorView.swift
@@ -24,6 +24,7 @@ struct PromptEditorView: View {
     @State private var promptText: String
     @State private var selectedIcon: PromptIcon
     @State private var description: String
+    @State private var triggerWord: String
     @State private var showingPredefinedPrompts = false
     
     init(mode: Mode) {
@@ -34,11 +35,13 @@ struct PromptEditorView: View {
             _promptText = State(initialValue: "")
             _selectedIcon = State(initialValue: .documentFill)
             _description = State(initialValue: "")
+            _triggerWord = State(initialValue: "")
         case .edit(let prompt):
             _title = State(initialValue: prompt.title)
             _promptText = State(initialValue: prompt.promptText)
             _selectedIcon = State(initialValue: prompt.icon)
             _description = State(initialValue: prompt.description ?? "")
+            _triggerWord = State(initialValue: prompt.triggerWord ?? "")
         }
     }
     
@@ -140,6 +143,22 @@ struct PromptEditorView: View {
                     }
                     .padding(.horizontal)
                     
+                    // Trigger Word Field
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Trigger Word")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+                        
+                        Text("Add a custom word to activate this mode by voice (optional)")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        
+                        TextField("Enter a trigger word", text: $triggerWord)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.body)
+                    }
+                    .padding(.horizontal)
+                    
                     // Prompt Text Section with improved styling
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Mode Instructions")
@@ -211,7 +230,8 @@ struct PromptEditorView: View {
                 title: title,
                 promptText: promptText,
                 icon: selectedIcon,
-                description: description.isEmpty ? nil : description
+                description: description.isEmpty ? nil : description,
+                triggerWord: triggerWord.isEmpty ? nil : triggerWord
             )
         case .edit(let prompt):
             let updatedPrompt = CustomPrompt(
@@ -220,7 +240,8 @@ struct PromptEditorView: View {
                 promptText: promptText,
                 isActive: prompt.isActive,
                 icon: selectedIcon,
-                description: description.isEmpty ? nil : description
+                description: description.isEmpty ? nil : description,
+                triggerWord: triggerWord.isEmpty ? nil : triggerWord
             )
             enhancementService.updatePrompt(updatedPrompt)
         }


### PR DESCRIPTION
Custom Trigger Words for Enhancement Modes – PR Summary

Overview

This PR introduces support for custom trigger words tied to individual Enhancement Modes in the VoiceInk application that can be added by the user. When transcription input includes a defined trigger word, the app automatically:
	•	Activates the corresponding Enhancement Mode
	•	Processes the transcription
	•	Returns to the previously selected mode

⸻

🔧 Changes Made

1. Model Updates

File: /Models/CustomPrompt.swift
	•	Added triggerWord property to store custom trigger words for each Enhancement Mode
	•	Updated initializer to handle and store the new property

2. Enhancement Service Updates

File: /Services/AIEnhancementService.swift
	•	Added originalSelectedPromptId to track the previously selected Enhancement Mode
	•	Updated determineMode method:
	•	Detects custom trigger words
	•	Stores the original prompt ID
	•	Updated enhance method:
	•	Handles trigger word detection and removal from the transcribed input
	•	Added restoreOriginalPrompt method to revert to the original mode after processing
	•	Modified makeRequest to accept a mode parameter to resolve assistant mode issues
	•	Updated addPrompt method to include the new triggerWord parameter

3. UI Updates

PromptEditorView (/Views/PromptEditorView.swift)
	•	Added field for entering trigger words
	•	Updated init and save logic to support trigger words
	•	Enhanced UI with descriptive labels and help text

EnhancementSettingsView (/Views/EnhancementSettingsView.swift)
	•	Display trigger words under mode icons using a microphone icon 🎤
	•	Added ellipses (...) after trigger words for visual continuity
	•	Used ZStack with fixed height to ensure consistent icon height
	•	Displayed the global assistant trigger word under the Assistant Mode icon

⸻

⚙️ Functional Improvements
	•	Users can define custom trigger words per Enhancement Mode
	Upon trigger word detection:
	•	The system activates the corresponding mode
	•	Removes the trigger word from the transcript
	•	Reverts to the previously active mode after enhancement
	•	If multiple modes share the same trigger word, the first match is selected
	•	The global assistant trigger word behavior remains unchanged

⸻

🎨 UI/UX Enhancements
	•	Trigger words shown under each mode with 🎤 microphone icon
	•	Ellipses (...) after trigger words prompt users to continue speaking
	•	Uniform height for all mode icons
	•	Visual distinction between custom and global assistant trigger words

⸻

🚀 Summary

This feature significantly improves the flexibility and usability of the VoiceInk app by enabling voice-triggered dynamic mode switching, allowing users to drive workflows hands-free through natural language—boosting accessibility and enhancing the overall user experience.

<img width="862" alt="Screenshot 2025-05-26 at 5 49 44 PM" src="https://github.com/user-attachments/assets/023ea543-063d-4153-81fa-717ec68f8630" />
