### PR TITLE
Add meeting transcription feature

### DIFF
--- a/VoiceInk/Models/Transcription.swift
+++ b/VoiceInk/Models/Transcription.swift
@@ -9,13 +9,15 @@ final class Transcription {
     var timestamp: Date
     var duration: TimeInterval
     var audioFileURL: String?
+    var isMeeting: Bool
     
-    init(text: String, duration: TimeInterval, enhancedText: String? = nil, audioFileURL: String? = nil) {
+    init(text: String, duration: TimeInterval, enhancedText: String? = nil, audioFileURL: String? = nil, isMeeting: Bool = false) {
         self.id = UUID()
         self.text = text
         self.enhancedText = enhancedText
         self.timestamp = Date()
         self.duration = duration
         self.audioFileURL = audioFileURL
+        self.isMeeting = isMeeting
     }
 }

--- a/VoiceInk/Services/AudioTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioTranscriptionManager.swift
@@ -47,7 +47,7 @@ class AudioTranscriptionManager: ObservableObject {
     
     private init() {}
     
-    func startProcessing(url: URL, modelContext: ModelContext, whisperState: WhisperState) {
+    func startProcessing(url: URL, modelContext: ModelContext, whisperState: WhisperState, isMeeting: Bool = false) {
         // Cancel any existing processing
         cancelProcessing()
         
@@ -108,7 +108,8 @@ class AudioTranscriptionManager: ObservableObject {
                             text: text,
                             duration: duration,
                             enhancedText: enhancedText,
-                            audioFileURL: permanentURL.absoluteString
+                            audioFileURL: permanentURL.absoluteString,
+                            isMeeting: isMeeting
                         )
                         modelContext.insert(transcription)
                         try modelContext.save()
@@ -119,7 +120,8 @@ class AudioTranscriptionManager: ObservableObject {
                         let transcription = Transcription(
                             text: text,
                             duration: duration,
-                            audioFileURL: permanentURL.absoluteString
+                            audioFileURL: permanentURL.absoluteString,
+                            isMeeting: isMeeting
                         )
                         modelContext.insert(transcription)
                         try modelContext.save()
@@ -129,7 +131,8 @@ class AudioTranscriptionManager: ObservableObject {
                     let transcription = Transcription(
                         text: text,
                         duration: duration,
-                        audioFileURL: permanentURL.absoluteString
+                        audioFileURL: permanentURL.absoluteString,
+                        isMeeting: isMeeting
                     )
                     modelContext.insert(transcription)
                     try modelContext.save()

--- a/VoiceInk/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Views/AudioTranscribeView.swift
@@ -12,6 +12,7 @@ struct AudioTranscribeView: View {
     @State private var isAudioFileSelected = false
     @State private var isEnhancementEnabled = false
     @State private var selectedPromptId: UUID?
+    @State private var isMeetingFile: Bool = false // Added for meeting toggle
     
     var body: some View {
         VStack(spacing: 0) {
@@ -108,6 +109,16 @@ struct AudioTranscribeView: View {
                 VStack(spacing: 16) {
                     Text("Audio file selected: \(selectedAudioURL?.lastPathComponent ?? "")")
                         .font(.headline)
+
+                    // Meeting Recording Toggle
+                    Toggle("This is a meeting recording", isOn: $isMeetingFile)
+                        .toggleStyle(.switch)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color(.windowBackgroundColor).opacity(0.4))
+                        )
                     
                     // AI Enhancement Settings
                     if let enhancementService = whisperState.getEnhancementService() {
@@ -187,7 +198,8 @@ struct AudioTranscribeView: View {
                                 transcriptionManager.startProcessing(
                                     url: url,
                                     modelContext: modelContext,
-                                    whisperState: whisperState
+                                    whisperState: whisperState,
+                                    isMeeting: isMeetingFile // Pass the toggle state
                                 )
                             }
                         }

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -14,6 +14,32 @@ struct MenuBarView: View {
     
     var body: some View {
         VStack {
+            // Standard Recording Button
+            Button {
+                Task { await whisperState.toggleRecord() }
+            } label: {
+                HStack {
+                    Image(systemName: whisperState.isRecording && !whisperState.isMeetingRecording ? "stop.circle.fill" : "mic.circle.fill")
+                        .foregroundColor(whisperState.isRecording && !whisperState.isMeetingRecording ? .red : .accentColor)
+                    Text(whisperState.isRecording && !whisperState.isMeetingRecording ? "Stop Recording" : "Start Recording")
+                }
+            }
+            .disabled(whisperState.isMeetingRecording) // Disabled if a meeting is active
+
+            // Meeting Recording Button
+            Button {
+                Task { await whisperState.toggleRecord(forMeeting: true) }
+            } label: {
+                HStack {
+                    Image(systemName: whisperState.isRecording && whisperState.isMeetingRecording ? "stop.circle.fill" : "person.3.fill")
+                        .foregroundColor(whisperState.isRecording && whisperState.isMeetingRecording ? .red : .accentColor)
+                    Text(whisperState.isRecording && whisperState.isMeetingRecording ? "Stop Meeting" : "Start Meeting")
+                }
+            }
+            .disabled(whisperState.isRecording && !whisperState.isMeetingRecording) // Disabled if a standard recording is active
+
+            Divider() // Separate from other menu items
+
             Button("Toggle Mini Recorder") {
                 Task {
                     await whisperState.toggleMiniRecorder()

--- a/VoiceInk/Views/TranscriptionCard.swift
+++ b/VoiceInk/Views/TranscriptionCard.swift
@@ -24,6 +24,11 @@ struct TranscriptionCard: View {
                     Text(transcription.timestamp, style: .date)
                         .font(.system(size: 14, weight: .medium, design: .default))
                         .foregroundColor(.secondary)
+                    if transcription.isMeeting {
+                        Image(systemName: "person.3.fill")
+                            .foregroundColor(.secondary)
+                            .padding(.leading, 4) // Add some spacing
+                    }
                     Spacer()
                     
                     Text(formatDuration(transcription.duration))


### PR DESCRIPTION
This commit introduces a feature to specifically handle meeting transcriptions.

Key changes:
- Added an `isMeeting` boolean flag to the `Transcription` model to distinguish meeting recordings.
- Updated `WhisperState` to manage a new `isMeetingRecording` state. The `toggleRecord` function now accepts a `forMeeting` parameter to initiate a meeting recording.
- The `transcribeAudio` method in `WhisperState` now sets the `isMeeting` flag on the `Transcription` object when appropriate and resets the state.
- Added a new 'Start/Stop Meeting' button to `MenuBarView.swift`. This button's state and actions are managed to differentiate from standard recordings, and buttons are disabled appropriately to prevent concurrent conflicting recordings.
- `TranscriptionCard.swift` now displays a 'person.3.fill' icon for items flagged as meetings in the transcription history.
- `AudioTranscriptionManager`'s `startProcessing` method was updated to accept an `isMeeting` parameter.
- `AudioTranscribeView.swift` now includes a toggle switch allowing you to mark an imported audio file as a meeting recording. This state is then passed to the `AudioTranscriptionManager`.

These changes allow you to record new meetings or import existing meeting audio files and have them specifically identified and displayed as meeting transcriptions within the application.