### PR TITLE
Scratch pad

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -448,21 +448,24 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 138;
 				DEVELOPMENT_ASSET_PATHS = "\"VoiceInk/Preview Content\"";
-				DEVELOPMENT_TEAM = V6J6A3VWY2;
+				DEVELOPMENT_TEAM = 44WC3UNX99;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VoiceInk/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = VoiceInk;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSUIElement = NO;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "VoiceInk needs to interact with your browser to detect the current website for applying website-specific configurations.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "VoiceInk needs access to your microphone to record audio for transcription.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.38;
-				PRODUCT_BUNDLE_IDENTIFIER = com.prakashjoshipax.VoiceInk;
+				PRODUCT_BUNDLE_IDENTIFIER = com.slumdev88.VoiceInk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -481,21 +484,24 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 138;
 				DEVELOPMENT_ASSET_PATHS = "\"VoiceInk/Preview Content\"";
-				DEVELOPMENT_TEAM = V6J6A3VWY2;
+				DEVELOPMENT_TEAM = 44WC3UNX99;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VoiceInk/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = VoiceInk;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSUIElement = NO;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "VoiceInk needs to interact with your browser to detect the current website for applying website-specific configurations.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "VoiceInk needs access to your microphone to record audio for transcription.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.38;
-				PRODUCT_BUNDLE_IDENTIFIER = com.prakashjoshipax.VoiceInk;
+				PRODUCT_BUNDLE_IDENTIFIER = com.slumdev88.VoiceInk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/VoiceInk/Info.plist
+++ b/VoiceInk/Info.plist
@@ -2,21 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSScreenCaptureUsageDescription</key>
+	<string>VoiceInk needs screen recording access to understand context from your screen for improved transcription accuracy.</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://beingpax.github.io/VoiceInk/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>rLRdZIjK3gHKfqNlAF9nT7FbjwSvwkJ8BVn0v2mD1Mo=</string>
-	<key>LSUIElement</key>
-	<false/>
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>VoiceInk needs access to your microphone to record audio for transcription.</string>
-	<key>NSAppleEventsUsageDescription</key>
-	<string>VoiceInk needs to interact with your browser to detect the current website for applying website-specific configurations.</string>
-	<key>NSScreenCaptureUsageDescription</key>
-	<string>VoiceInk needs screen recording access to understand context from your screen for improved transcription accuracy.</string>
 </dict>
 </plist>

--- a/VoiceInk/Services/DailyScratchpadManager.swift
+++ b/VoiceInk/Services/DailyScratchpadManager.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Combine
+
+struct DailyScratchpad: Codable, Identifiable, Equatable {
+    let id: UUID
+    let date: String
+    var content: String
+    var lastModified: Date
+    var entryCount: Int
+    
+    init(id: UUID = UUID(), date: String, content: String, lastModified: Date = Date(), entryCount: Int = 0) {
+        self.id = id
+        self.date = date
+        self.content = content
+        self.lastModified = lastModified
+        self.entryCount = entryCount
+    }
+    
+    var previewText: String {
+        let cleanContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleanContent.isEmpty {
+            return "No entries yet"
+        }
+        let preview = String(cleanContent.prefix(100))
+        return preview + (cleanContent.count > 100 ? "..." : "")
+    }
+    
+    var isToday: Bool {
+        date == Self.todayString
+    }
+    
+    static var todayString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+}
+
+extension Notification.Name {
+    static let scratchpadEntryAdded = Notification.Name("scratchpadEntryAdded")
+}
+
+@MainActor
+class DailyScratchpadManager: ObservableObject {
+    @Published var scratchpads: [DailyScratchpad] = []
+    @Published var currentViewDate: String? = nil
+    
+    private let userDefaults = UserDefaults.standard
+    private let storageKey = "dailyScratchpads"
+    
+    init() {
+        loadScratchpads()
+        setupNotifications()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScratchpadEntry),
+            name: .scratchpadEntryAdded,
+            object: nil
+        )
+    }
+    
+    @objc private func handleScratchpadEntry(_ notification: Notification) {
+        guard let entryText = notification.userInfo?["entry"] as? String else { return }
+        addEntryToToday(entryText)
+    }
+    
+    func addEntryToToday(_ text: String) {
+        let today = DailyScratchpad.todayString
+        
+        if let index = scratchpads.firstIndex(where: { $0.date == today }) {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            let timestamp = formatter.string(from: Date())
+            
+            let newEntry = scratchpads[index].content.isEmpty ? 
+                "\(timestamp) - \(text)" : 
+                "\n\n\(timestamp) - \(text)"
+            
+            scratchpads[index].content += newEntry
+            scratchpads[index].lastModified = Date()
+            scratchpads[index].entryCount += 1
+        } else {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            let timestamp = formatter.string(from: Date())
+            
+            let newScratchpad = DailyScratchpad(
+                date: today,
+                content: "\(timestamp) - \(text)",
+                lastModified: Date(),
+                entryCount: 1
+            )
+            scratchpads.insert(newScratchpad, at: 0)
+        }
+        
+        saveScratchpads()
+    }
+    
+    func getScratchpad(for date: String) -> DailyScratchpad? {
+        return scratchpads.first(where: { $0.date == date })
+    }
+    
+    func getOrCreateScratchpad(for date: String) -> DailyScratchpad {
+        if let existing = getScratchpad(for: date) {
+            return existing
+        }
+        
+        let newScratchpad = DailyScratchpad(date: date, content: "", lastModified: Date(), entryCount: 0)
+        scratchpads.append(newScratchpad)
+        scratchpads.sort { $0.date > $1.date }
+        saveScratchpads()
+        return newScratchpad
+    }
+    
+    func updateScratchpad(_ scratchpad: DailyScratchpad, content: String) {
+        guard let index = scratchpads.firstIndex(where: { $0.id == scratchpad.id }) else { return }
+        scratchpads[index].content = content
+        scratchpads[index].lastModified = Date()
+        saveScratchpads()
+    }
+    
+    func deleteScratchpad(_ scratchpad: DailyScratchpad) {
+        scratchpads.removeAll { $0.id == scratchpad.id }
+        saveScratchpads()
+    }
+    
+    func setCurrentViewDate(_ date: String?) {
+        currentViewDate = date
+        userDefaults.set(date, forKey: "currentScratchpadViewDate")
+    }
+    
+    func restoreLastView() {
+        currentViewDate = userDefaults.string(forKey: "currentScratchpadViewDate")
+    }
+    
+    private func loadScratchpads() {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([DailyScratchpad].self, from: data) else {
+            return
+        }
+        scratchpads = decoded.sorted { $0.date > $1.date }
+    }
+    
+    private func saveScratchpads() {
+        guard let encoded = try? JSONEncoder().encode(scratchpads) else { return }
+        userDefaults.set(encoded, forKey: storageKey)
+    }
+}

--- a/VoiceInk/Views/ContentView.swift
+++ b/VoiceInk/Views/ContentView.swift
@@ -7,6 +7,7 @@ enum ViewType: String, CaseIterable {
     case metrics = "Dashboard"
     case transcribeAudio = "Transcribe Audio"
     case history = "History"
+    case scratchpad = "Scratchpad"
     case models = "AI Models"
     case enhancement = "Enhancement"
     case powerMode = "Power Mode"
@@ -21,6 +22,7 @@ enum ViewType: String, CaseIterable {
         case .metrics: return "gauge.medium"
         case .transcribeAudio: return "waveform.circle.fill"
         case .history: return "doc.text.fill"
+        case .scratchpad: return "note.text"
         case .models: return "brain.head.profile"
         case .enhancement: return "wand.and.stars"
         case .powerMode: return "sparkles.square.fill.on.square"
@@ -245,6 +247,8 @@ struct ContentView: View {
             AudioTranscribeView()
         case .history:
             TranscriptionHistoryView()
+        case .scratchpad:
+            ScratchpadView()
         case .audioInput:
             AudioInputSettingsView()
         case .dictionary:

--- a/VoiceInk/Views/Scratchpad/ScratchpadEditorView.swift
+++ b/VoiceInk/Views/Scratchpad/ScratchpadEditorView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+import SwiftData
+
+struct ScratchpadEditorView: View {
+    @ObservedObject var manager: DailyScratchpadManager
+    @EnvironmentObject private var whisperState: WhisperState
+    let date: String
+    
+    @State private var content: String = ""
+    @State private var hasUnsavedChanges = false
+    @State private var autoSaveTask: Task<Void, Never>?
+    
+    private var currentScratchpad: DailyScratchpad? {
+        manager.getScratchpad(for: date)
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView
+            editorView
+        }
+        .background(Color(.controlBackgroundColor))
+        .onAppear {
+            loadCurrentContent()
+        }
+        .onDisappear {
+            saveChanges()
+        }
+        .onChange(of: manager.scratchpads) { _, _ in
+            loadCurrentContent()
+        }
+    }
+    
+    private var headerView: some View {
+        HStack {
+            // Back button styled to match record button
+            Button(action: { manager.setCurrentViewDate(nil) }) {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 16, weight: .medium))
+                    Text("Back")
+                        .font(.system(size: 14, weight: .medium))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.secondary)
+                )
+            }
+            .buttonStyle(.plain)
+            
+            Spacer()
+            
+            // Centered date section
+            VStack(spacing: 2) {
+                Text(formattedDate)
+                    .font(.system(size: 18, weight: .semibold))
+                
+                if isToday {
+                    Text("Today")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.accentColor)
+                }
+            }
+            
+            Spacer()
+            
+            HStack(spacing: 8) {
+                if hasUnsavedChanges {
+                    Text("Unsaved")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+                
+                Button(action: { 
+                    Task {
+                        await whisperState.startScratchpadRecording()
+                    }
+                }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "mic.circle.fill")
+                            .font(.system(size: 16))
+                        Text("Record")
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.accentColor)
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(whisperState.isRecording || whisperState.isTranscribing)
+                .opacity((whisperState.isRecording || whisperState.isTranscribing) ? 0.6 : 1.0)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(Color(.controlBackgroundColor))
+    }
+    
+    private var editorView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if content.isEmpty {
+                    VStack(spacing: 16) {
+                        Image(systemName: "mic.circle")
+                            .font(.system(size: 48))
+                            .foregroundColor(.secondary)
+                        
+                        Text("No entries for this day yet")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(.secondary)
+                        
+                        Text("Use the record button or keyboard shortcut to add voice memos")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 40)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.top, 80)
+                } else {
+                    TextEditor(text: $content)
+                        .font(.system(size: 15))
+                        .scrollContentBackground(.hidden)
+                        .background(Color.clear)
+                        .onChange(of: content) { _, newValue in
+                            hasUnsavedChanges = true
+                            debounceAutoSave()
+                        }
+                        .frame(minHeight: 400)
+                }
+            }
+            .padding(20)
+        }
+        .background(Color(.textBackgroundColor))
+    }
+    
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .full
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        if let date = dateFormatter.date(from: date) {
+            return formatter.string(from: date)
+        }
+        
+        return date
+    }
+    
+    private var isToday: Bool {
+        date == DailyScratchpad.todayString
+    }
+    
+    private func loadCurrentContent() {
+        if let scratchpad = currentScratchpad {
+            content = scratchpad.content
+        } else {
+            content = ""
+        }
+        hasUnsavedChanges = false
+    }
+    
+    private func saveChanges() {
+        guard hasUnsavedChanges else { return }
+        
+        if let scratchpad = currentScratchpad {
+            manager.updateScratchpad(scratchpad, content: content)
+        } else {
+            let newScratchpad = manager.getOrCreateScratchpad(for: date)
+            manager.updateScratchpad(newScratchpad, content: content)
+        }
+        hasUnsavedChanges = false
+    }
+    
+    private func debounceAutoSave() {
+        autoSaveTask?.cancel()
+        autoSaveTask = Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+            if !Task.isCancelled && hasUnsavedChanges {
+                await MainActor.run {
+                    saveChanges()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    let container = try! ModelContainer(for: Transcription.self)
+    return ScratchpadEditorView(manager: DailyScratchpadManager(), date: "2024-01-01")
+        .environmentObject(WhisperState(modelContext: container.mainContext))
+}

--- a/VoiceInk/Views/Scratchpad/ScratchpadView.swift
+++ b/VoiceInk/Views/Scratchpad/ScratchpadView.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+import SwiftData
+
+struct ScratchpadView: View {
+    @EnvironmentObject private var manager: DailyScratchpadManager
+    @EnvironmentObject private var whisperState: WhisperState
+    @State private var searchText = ""
+    @State private var showingSearch = false
+    
+    var body: some View {
+        Group {
+            if let currentDate = manager.currentViewDate {
+                ScratchpadEditorView(manager: manager, date: currentDate)
+            } else {
+                cardView
+            }
+        }
+        .background(Color(.controlBackgroundColor))
+        .onAppear {
+            manager.restoreLastView()
+        }
+    }
+    
+    private var cardView: some View {
+        VStack(spacing: 0) {
+            headerView
+            
+            if showingSearch {
+                searchBar
+            }
+            
+            if filteredScratchpads.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(filteredScratchpads) { scratchpad in
+                            ScratchpadCardView(scratchpad: scratchpad) {
+                                openEditor(for: scratchpad.date)
+                            }
+                        }
+                    }
+                    .padding(24)
+                }
+                .padding(.vertical, 8)
+            }
+        }
+    }
+    
+    private var headerView: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Scratchpad")
+                    .font(.system(size: 24, weight: .bold))
+                Text("Daily voice memos and notes")
+                    .font(.system(size: 14))
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            Button(action: { showingSearch.toggle() }) {
+                Image(systemName: showingSearch ? "xmark" : "magnifyingglass")
+                    .font(.system(size: 16))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            
+            Button(action: { 
+                Task {
+                    await whisperState.startScratchpadRecording()
+                }
+            }) {
+                HStack(spacing: 6) {
+                    Image(systemName: "mic.circle.fill")
+                        .font(.system(size: 16))
+                    Text("Record")
+                        .font(.system(size: 14, weight: .medium))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.accentColor)
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(whisperState.isRecording || whisperState.isTranscribing)
+            .opacity((whisperState.isRecording || whisperState.isTranscribing) ? 0.6 : 1.0)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+    }
+    
+    private var searchBar: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+            
+            TextField("Search across all days...", text: $searchText)
+                .font(.system(size: 16, weight: .regular, design: .default))
+                .textFieldStyle(PlainTextFieldStyle())
+        }
+        .padding(12)
+        .background(CardBackground(isSelected: false))
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+    }
+    
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "mic.circle")
+                .font(.system(size: 50))
+                .foregroundColor(.secondary)
+            
+            Text("No voice memos yet")
+                .font(.system(size: 24, weight: .semibold, design: .default))
+            
+            Text("Use the record button or keyboard shortcut to start capturing voice memos")
+                .font(.system(size: 18, weight: .regular, design: .default))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(CardBackground(isSelected: false))
+        .padding(24)
+    }
+    
+    private var filteredScratchpads: [DailyScratchpad] {
+        if searchText.isEmpty {
+            return manager.scratchpads
+        } else {
+            return manager.scratchpads.filter { 
+                $0.content.localizedCaseInsensitiveContains(searchText) 
+            }
+        }
+    }
+    
+    private func openEditor(for date: String) {
+        manager.setCurrentViewDate(date)
+    }
+}
+
+struct ScratchpadCardView: View {
+    let scratchpad: DailyScratchpad
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(formattedDate)
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(.primary)
+                        
+                        if scratchpad.isToday {
+                            Text("Today")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(.accentColor)
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text("\(scratchpad.entryCount) entries")
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                        
+                        Text(scratchpad.lastModified, style: .time)
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                
+                Text(scratchpad.previewText)
+                    .font(.system(size: 14))
+                    .foregroundColor(.secondary)
+                    .lineLimit(3)
+                    .multilineTextAlignment(.leading)
+            }
+            .padding(16)
+            .background(CardBackground(isSelected: false))
+            .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+    
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .full
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        if let date = dateFormatter.date(from: scratchpad.date) {
+            return formatter.string(from: date)
+        }
+        
+        return scratchpad.date
+    }
+}
+
+#Preview {
+    let container = try! ModelContainer(for: Transcription.self)
+    return ScratchpadView()
+        .environmentObject(DailyScratchpadManager())
+        .environmentObject(WhisperState(modelContext: container.mainContext))
+}

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -70,6 +70,26 @@ struct SettingsView: View {
                     }
                 }
 
+                // Scratchpad Settings Section
+                SettingsSection(
+                    icon: "note.text",
+                    title: "Scratchpad Shortcut",
+                    subtitle: "Quick voice memos saved to daily notes"
+                ) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        hotkeyView(
+                            title: "Scratchpad Hotkey",
+                            binding: $hotkeyManager.selectedScratchpadHotkey,
+                            shortcutName: .toggleScratchpad
+                        )
+                        
+                        Text("Records voice memos directly to your scratchpad without pasting. Quick tap to start hands-free recording (tap again to stop). Press and hold for push-to-talk (release to stop recording).")
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
                 // Recording Feedback Section
                 SettingsSection(
                     icon: "speaker.wave.2.bubble.left.fill",

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -16,6 +16,7 @@ struct VoiceInkApp: App {
     @StateObject private var aiService = AIService()
     @StateObject private var enhancementService: AIEnhancementService
     @StateObject private var activeWindowService = ActiveWindowService.shared
+    @StateObject private var scratchpadManager = DailyScratchpadManager()
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     
     // Audio cleanup manager for automatic deletion of old audio files
@@ -92,6 +93,7 @@ struct VoiceInkApp: App {
                     .environmentObject(menuBarManager)
                     .environmentObject(aiService)
                     .environmentObject(enhancementService)
+                    .environmentObject(scratchpadManager)
                     .modelContainer(container)
                     .onAppear {
                         updaterViewModel.silentlyCheckForUpdates()


### PR DESCRIPTION
This idea came to me when I had a random thought that I wanted to capture. I did not want to leave my current workflow and go to my note-taking app just to capture that thought.

What I really wanted from VoiceInk was the ability to have a separate shortcut and a voice memo feature. I could press a key on my keyboard, capture whatever is on my mind in that exact moment, and have it automatically saved to a notebook, scratchpad, or memo pad in VoiceInk itself.

My vision for this was to be more flexible in terms of editing. I could go to that scratchpad, edit the text if I wanted to, and collect these thoughts throughout the day. When I have a chance, I could review them and decide which ones to keep, organise, or move into my note storage, and maybe delete the rest.

This is a very initial implementation, and I think it has huge potential. I would love to add proper formatting, markdown support, and some tagging features. It would be even better if we could have AI tagging, so if I make a note to my scratchpad, it could be post-processed with AI and tags could be applied based on the content.

I am also thinking about the longer term, with the database, storage, and searching. If we are taking down random thought dumps, it would be great to be able to search them accurately with AI as the collection builds up over time. 


Hope you like the concept!