### PR TITLE
Potential fix to detecting symlinked apps

### DIFF
--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -680,7 +680,7 @@ struct ConfigurationView: View {
             let enumerator = FileManager.default.enumerator(
                 at: baseURL,
                 includingPropertiesForKeys: [.isApplicationKey, .isDirectoryKey],
-                options: [.skipsHiddenFiles]
+                options: [.skipsHiddenFiles, .followsSymbolicLinks]
             )
             
             return enumerator?.compactMap { item -> URL? in


### PR DESCRIPTION
Hey, there is one problem that's preventing me from purchasing the license - some of my apps don't appear in the power mode app selector. Since I use Nix to set up my Mac, how Home Manager installs apps is that it creates a symlink folder in your user applications folder. And that symlink folder actually includes a bunch of apps which are also symlinks to the Nix store.

I don't know if this is going to fix it, just copy-pasting from AI response. Hopefully you'd be able to resolve that issue soon :)

### How to reproduce (I'm going to use VLC.app for this example):
1. Copy/move one of your `.app` files somewhere where VoiceInk doesn't currently search I'm going to put `VLC.app` in my `~/Downloads`
2. `mkdir ~/Downloads/test_dir`
3.  `ln -s ~/Downloads/VLC.app/ ~/Downloads/test_dir/VLC.app`
4.  `ln -s ~/Downloads/test_dir/ ~/Applications/test_dir`

-----------

Another proposal I got from AI:
```
let allAppURLs = userAppURLs + localAppURLs + systemAppURLs
let apps = allAppURLs.flatMap { baseURL -> [URL] in
    guard let enumerator = FileManager.default.enumerator(
        at: baseURL,
        includingPropertiesForKeys: [.isApplicationKey, .isDirectoryKey, .isSymbolicLinkKey],
        options: [.skipsHiddenFiles]
    ) else { return [] }
    return enumerator.compactMap { item -> URL? in
        guard let url = item as? URL else { return nil }
        let resourceValues = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
        let isSymlink = resourceValues?.isSymbolicLink ?? false
        let isDir = resourceValues?.isDirectory ?? false
        // If this is a symlink, resolve it
        var resolvedURL = url
        if isSymlink {
            if let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: url.path) {
                let resolved = (destination.hasPrefix("/") ? URL(fileURLWithPath: destination) : url.deletingLastPathComponent().appendingPathComponent(destination))
                resolvedURL = resolved
            }
        }
        if resolvedURL.pathExtension == "app" && (isDir || isSymlink) {
            enumerator.skipDescendants()
            return resolvedURL
        }
        return nil
    }
}
```