### PR TITLE
Add double-tap to edit functionality for prompt buttons

### DIFF
--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -234,7 +234,16 @@ extension CustomPrompt {
         .padding(.vertical, 6)
         .contentShape(Rectangle())
         .scaleEffect(isSelected ? 1.05 : 1.0)
-        .onTapGesture(perform: onTap)
+        .onTapGesture(count: 2) {
+            // Double tap to edit
+            if let onEdit = onEdit {
+                onEdit(self)
+            }
+        }
+        .onTapGesture(count: 1) {
+            // Single tap to select
+            onTap()
+        }
         .contextMenu {
             if onEdit != nil || onDelete != nil {
                 if let onEdit = onEdit {
@@ -341,4 +350,4 @@ extension CustomPrompt {
         .contentShape(Rectangle())
         .onTapGesture(perform: action)
     }
-} 
+}

--- a/VoiceInk/Views/Components/PromptSelectionGrid.swift
+++ b/VoiceInk/Views/Components/PromptSelectionGrid.swift
@@ -70,7 +70,7 @@ struct PromptSelectionGrid: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                     
-                    Text("Right-click on prompts to edit or delete")
+                    Text("Double-click to edit • Right-click for more options")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -80,4 +80,3 @@ struct PromptSelectionGrid: View {
         }
     }
 }
-


### PR DESCRIPTION
- Replace single tap gesture with separate single/double tap handlers
- Double-tap now opens edit dialog directly (more intuitive)
- Single-tap still selects prompt (preserves existing behavior)
- Update help text to reflect new interaction pattern
- Right-click context menu remains unchanged

Improves UX by making prompt editing more discoverable and following common UI patterns while maintaining backward compatibility.