### PR TITLE
Add a setting to disable auto update checks

### DIFF
--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @ObservedObject private var mediaController = MediaController.shared
     @ObservedObject private var playbackController = PlaybackController.shared
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = true
+    @AppStorage("autoUpdateCheck") private var autoUpdateCheck = true
     @State private var showResetOnboardingAlert = false
     @State private var currentShortcut = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder)
     @State private var isCustomCancelEnabled = false
@@ -228,8 +229,14 @@ struct SettingsView: View {
                     subtitle: "Keep VoiceInk up to date"
                 ) {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("VoiceInk automatically checks for updates on launch and every other day.")
+                        Text("Choose whether VoiceInk should automatically check for updates on launch and every other day.")
                             .settingsDescription()
+                        
+                        Toggle("Enable automatic update checks", isOn: $autoUpdateCheck)
+                            .toggleStyle(.switch)
+                            .onChange(of: autoUpdateCheck) { _, newValue in
+                                updaterViewModel.toggleAutoUpdates(newValue)
+                            }
                         
                         Button("Check for Updates Now") {
                             updaterViewModel.checkForUpdates()

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -172,6 +172,8 @@ struct VoiceInkApp: App {
 }
 
 class UpdaterViewModel: ObservableObject {
+    @AppStorage("autoUpdateCheck") private var autoUpdateCheck = true
+    
     private let updaterController: SPUStandardUpdaterController
     
     @Published var canCheckForUpdates = false
@@ -180,11 +182,15 @@ class UpdaterViewModel: ObservableObject {
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
         
         // Enable automatic update checking
-        updaterController.updater.automaticallyChecksForUpdates = true
+        updaterController.updater.automaticallyChecksForUpdates = autoUpdateCheck
         updaterController.updater.updateCheckInterval = 24 * 60 * 60
         
         updaterController.updater.publisher(for: \.canCheckForUpdates)
             .assign(to: &$canCheckForUpdates)
+    }
+    
+    func toggleAutoUpdates(_ value: Bool) {
+        updaterController.updater.automaticallyChecksForUpdates = value
     }
     
     func checkForUpdates() {


### PR DESCRIPTION
This adds a setting toggle to be able to disable auto update checks, which can be convenient in case the app is updated via brew or manually.

Closes #52.