### PR TITLE
Implement Retry Logic for AI Enhancement Service

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -7,6 +7,7 @@ extension KeyboardShortcuts.Name {
     static let toggleMiniRecorder = Self("toggleMiniRecorder")
     static let toggleMiniRecorder2 = Self("toggleMiniRecorder2")
     static let pasteLastTranscription = Self("pasteLastTranscription")
+    static let retryLastTranscription = Self("retryLastTranscription")
 }
 
 @MainActor
@@ -133,6 +134,18 @@ class HotkeyManager: ObservableObject {
             }
         }
         
+        // Add retry last transcription shortcut
+        if KeyboardShortcuts.getShortcut(for: .retryLastTranscription) == nil {
+            let defaultRetryShortcut = KeyboardShortcuts.Shortcut(.r, modifiers: [.command, .option])
+            KeyboardShortcuts.setShortcut(defaultRetryShortcut, for: .retryLastTranscription)
+        }
+
+        KeyboardShortcuts.onKeyUp(for: .retryLastTranscription) { [weak self] in
+            guard let self = self else { return }
+            Task { @MainActor in
+                LastTranscriptionService.retryLastTranscription(from: self.whisperState.modelContext, whisperState: self.whisperState)
+            }
+        }
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 100_000_000)
             self.setupHotkeyMonitoring()

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -119,6 +119,23 @@ struct SettingsView: View {
                 }
 
                 SettingsSection(
+                    icon: "arrow.clockwise.circle.fill",
+                    title: "Retry Last Transcription",
+                    subtitle: "Configure shortcut to retry transcribing your most recent audio"
+                ) {
+                    HStack(spacing: 12) {
+                        Text("Retry Shortcut")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.secondary)
+
+                        KeyboardShortcuts.Recorder(for: .retryLastTranscription)
+                            .controlSize(.small)
+
+                        Spacer()
+                    }
+                }
+
+                SettingsSection(
                     icon: "speaker.wave.2.bubble.left.fill",
                     title: "Recording Feedback",
                     subtitle: "Customize app & system feedback"


### PR DESCRIPTION
**Summary**

This pull request introduces a retry mechanism with exponential backoff to the AIEnhancementService , making the AI enhancement feature more resilient to transient network errors and improving the overall user experience.

**Problem**

Previously, the AI enhancement feature would immediately fail if it encountered a temporary network issue (e.g., a lost connection or a brief server-side problem). This resulted in a "network connection was lost" error being shown to the user, even if the issue was short-lived. The lack of a retry mechanism meant that users had to manually trigger the enhancement again. Because of this I have introduced a shortcut found in this PR https://github.com/Beingpax/VoiceInk/pull/259 
But manually invoking the shortcut means running both steps again. So if it's only ai enhancement at fault we may retry two more times until we fail completely.

Me as well as other users observe this issue quite frequently.

**Solution**

To address this, I've implemented a `makeRequestWithRetry` function that wraps the network request and automatically retries it upon failure.

The key aspects of the solution are:

- Automatic Retries: The system will now attempt to resend a failed request up to 3 times.
- Exponential Backoff Strategy: The delay between retries increases exponentially (1s, 2s, 4s) to avoid overwhelming the server and to give the network time to recover.
-  Targeted Error Handling: The retry logic is designed to trigger only for specific, transient network errors and server-side issues:
   - NSURLErrorNotConnectedToInternet
   - NSURLErrorTimedOut
   - NSURLErrorNetworkConnectionLost
   - HTTP 5xx server errors (e.g., 500 , 502 , 503 , 504 )
- Enhanced Logging: I've added os_log warnings to the console to provide visibility into the retry process, making it easier to debug and monitor in production.


**How to Test**

Simplest way is to simulate network failure but turning off Wi-Fi

- Start a transcription that uses an AI enhancement.
- Quickly disable your Mac's Wi-Fi.
- Observe the Xcode console, where you should see a warning message indicating a retry attempt.
- Re-enable Wi-Fi. The subsequent retry should succeed, and the enhancement will complete.

See the attached debug log showing the backoff working.

[debug.log](https://github.com/user-attachments/files/22016001/debug.log)

And at the 3rd retry, when Wi-Fi got reenabled I got this enhanced text successfully.

<img width="428" height="243" alt="image" src="https://github.com/user-attachments/assets/aa554920-e07f-4bb6-9aaf-4d7daf0866cc" />


