### PR TITLE
Implement Hover-to-Show Popovers for Recorder Controls

### DIFF
--- a/VoiceInk/Views/Recorder/RecorderComponents.swift
+++ b/VoiceInk/Views/Recorder/RecorderComponents.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 
+// MARK: - Hover Interaction Manager
+class HoverInteraction: ObservableObject {
+    @Published var isHovered: Bool = false
+    private var timer: Timer?
+
+    func setHover(on: Bool, delay: TimeInterval = 0.1) {
+        if on {
+            timer?.invalidate()
+            if !isHovered {
+                isHovered = true
+            }
+        } else {
+            timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+                self?.isHovered = false
+            }
+        }
+    }
+}
+
 // MARK: - Generic Toggle Button Component
 struct RecorderToggleButton: View {
     let isEnabled: Bool
@@ -127,7 +146,8 @@ struct RecorderPromptButton: View {
     @Binding var showPopover: Bool
     let buttonSize: CGFloat
     let padding: EdgeInsets
-    
+    @StateObject private var hoverInteraction = HoverInteraction()
+
     init(showPopover: Binding<Bool>, buttonSize: CGFloat = 28, padding: EdgeInsets = EdgeInsets(top: 0, leading: 7, bottom: 0, trailing: 0)) {
         self._showPopover = showPopover
         self.buttonSize = buttonSize
@@ -149,9 +169,16 @@ struct RecorderPromptButton: View {
         }
         .frame(width: buttonSize)
         .padding(padding)
+        .onHover { hoverInteraction.setHover(on: $0) }
         .popover(isPresented: $showPopover, arrowEdge: .bottom) {
             EnhancementPromptPopover()
                 .environmentObject(enhancementService)
+                .onHover { hoverInteraction.setHover(on: $0) }
+        }
+        .onChange(of: hoverInteraction.isHovered) { isHovered in
+            if isHovered != showPopover {
+                showPopover = isHovered
+            }
         }
     }
 }
@@ -162,6 +189,7 @@ struct RecorderPowerModeButton: View {
     @Binding var showPopover: Bool
     let buttonSize: CGFloat
     let padding: EdgeInsets
+    @StateObject private var hoverInteraction = HoverInteraction()
     
     init(showPopover: Binding<Bool>, buttonSize: CGFloat = 28, padding: EdgeInsets = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 7)) {
         self._showPopover = showPopover
@@ -180,8 +208,15 @@ struct RecorderPowerModeButton: View {
         }
         .frame(width: buttonSize)
         .padding(padding)
+        .onHover { hoverInteraction.setHover(on: $0) }
         .popover(isPresented: $showPopover, arrowEdge: .bottom) {
             PowerModePopover()
+                .onHover { hoverInteraction.setHover(on: $0) }
+        }
+        .onChange(of: hoverInteraction.isHovered) { isHovered in
+            if isHovered != showPopover {
+                showPopover = isHovered
+            }
         }
     }
 }
@@ -233,4 +268,4 @@ struct RecorderStatusDisplay: View {
             }
         }
     }
-} 
+}


### PR DESCRIPTION
This pull request introduces a new hover interaction for the Mini and Notch recorders. Users can now hover over the enhancement and power mode icons to reveal a popover and select a new option on the fly completely with mouse only.

Key Changes:

- HoverInteraction Class: A new ObservableObject was created in `RecorderComponents.swift` to manage hover states with a slight delay. This ensures that the popover remains open when the user moves their mouse from the button to the popover content.
- RecorderPromptButton & RecorderPowerModeButton : Both components in `RecorderComponents.swift` were updated to use the new HoverInteraction class.
  - An @StateObject for HoverInteraction is now part of these views.
  - .onHover is used to update the hover state.
  - The popover's visibility is now tied to the isHovered property of the HoverInteraction object.
  - The popover content itself also uses .onHover to keep the popover open when the mouse is over it.
How it Works:

1. 
   When the user hovers over the button, hoverInteraction.setHover(on: true) is called, which sets isHovered to true immediately.
2.
   An .onChange modifier observes isHovered and shows the popover.
3.
   When the user's mouse leaves the button or the popover, setHover(on: false) is called. This starts a short timer.
4.
   If the user moves the mouse back over the button or into the popover before the timer fires, the timer is invalidated, and the popover stays open.
5.
   If the timer finishes, isHovered is set to false , and the popover closes.
This implementation provides a smoother and more intuitive user experience for changing recorder settings.