### PR TITLE
Add Middle-Click to Toggle Recording

### DIFF
--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -119,6 +119,48 @@ struct SettingsView: View {
                 }
 
                 SettingsSection(
+                    icon: "computermouse.fill",
+                    title: "Middle-Click Toggle",
+                    subtitle: "Optionally use your middle mouse button to toggle recording"
+                ) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Toggle("Enable Middle-Click Toggle", isOn: $hotkeyManager.isMiddleClickToggleEnabled.animation())
+                            .toggleStyle(.switch)
+
+                        if hotkeyManager.isMiddleClickToggleEnabled {
+                            HStack {
+                                Text("Activation Delay")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.secondary)
+                                
+                                TextField("", value: $hotkeyManager.middleClickActivationDelay, formatter: {
+                                    let formatter = NumberFormatter()
+                                    formatter.numberStyle = .none
+                                    formatter.minimum = 0
+                                    return formatter
+                                }())
+                                .textFieldStyle(PlainTextFieldStyle())
+                                .padding(EdgeInsets(top: 3, leading: 6, bottom: 3, trailing: 6))
+                                .background(Color(NSColor.textBackgroundColor))
+                                .cornerRadius(5)
+                                .frame(width: 70)
+                                
+                                Text("ms")
+                                    .foregroundColor(.secondary)
+                                
+                                Spacer()
+                            }
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                            
+                            Text("A short delay to prevent accidental toggles when closing browser tabs.")
+                                .font(.system(size: 12))
+                                .foregroundColor(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+
+                SettingsSection(
                     icon: "speaker.wave.2.bubble.left.fill",
                     title: "Recording Feedback",
                     subtitle: "Customize app & system feedback"


### PR DESCRIPTION
This pull request introduces a new accessibility feature that allows users to toggle recording by clicking the middle mouse button. This provides a convenient alternative to keyboard shortcuts for starting and stopping transcription. Because most of my PRs circle around the idea of managing VoiceInk in mouse centric workflows as well.

To prevent accidental triggers when using the middle mouse button for other system actions (like opening/closing browser tabs, terminal insert at line actions), an adjustable activation delay has been included in the settings.


**Key Changes**:


- SettingsView.swift :
  
  - Added a new SettingsSection titled "Middle-Click Toggle".
  - Included a Toggle to enable or disable the feature.
  - Added a TextField to configure an Activation Delay (ms) , which only appears when the feature is enabled.


- HotkeyManager.swift :
  
  - Introduced two new @Published properties, isMiddleClickToggleEnabled and middleClickActivationDelay , to manage the feature's state, saved to UserDefaults .
  - Created a setupMiddleClickMonitoring() method that sets up a global event monitor for otherMouseDown and otherMouseUp events.
  - The monitor specifically checks for the middle mouse button (button number 2).
  - On mouseDown , a delayed Task is created to call whisperState.handleToggleMiniRecorder() after the user-defined delay.
  - If a corresponding mouseUp event is detected before the delay completes, the task is cancelled, preventing the recording from toggling.
  - The new monitoring function is integrated into the existing setupHotkeyMonitoring() lifecycle and is properly cleaned up by removeAllMonitoring() .