### PR TITLE
Add auto send label display in Power Mode view

### DIFF
--- a/VoiceInk/PowerMode/PowerModeViewComponents.swift
+++ b/VoiceInk/PowerMode/PowerModeViewComponents.swift
@@ -203,7 +203,7 @@ struct ConfigurationRow: View {
             .padding(.vertical, 12)
             .padding(.horizontal, 14)
             
-            if selectedModel != nil || selectedLanguage != nil || config.isAIEnhancementEnabled {
+            if selectedModel != nil || selectedLanguage != nil || config.isAIEnhancementEnabled || config.isAutoSendEnabled {
                 Divider()
                     .padding(.horizontal, 16)
                 
@@ -259,6 +259,22 @@ struct ConfigurationRow: View {
                         )
                     }
                     
+                    if config.isAutoSendEnabled {
+                        HStack(spacing: 4) {
+                            Image(systemName: "keyboard")
+                                .font(.system(size: 10))
+                            Text("Auto Send")
+                                .font(.caption)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule()
+                            .fill(Color(NSColor.controlBackgroundColor)))
+                        .overlay(
+                            Capsule()
+                                .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+                        )
+                    }
                     if config.isAIEnhancementEnabled {
                         if config.useScreenCapture {
                             HStack(spacing: 4) {
@@ -289,7 +305,7 @@ struct ConfigurationRow: View {
                             .fill(Color.accentColor.opacity(0.1)))
                         .foregroundColor(.accentColor)
                     }
-                    
+
                     Spacer()
                 }
                 .padding(.vertical, 10)
@@ -376,4 +392,4 @@ struct AppGridItem: View {
         }
         .buttonStyle(.plain)
     }
-} 
+}


### PR DESCRIPTION
A simple addition of displaying the Auto Send when it's enabled for a specific power mode in the Power Mode settings view. 

<img width="1221" height="1241" alt="image" src="https://github.com/user-attachments/assets/02ce77cd-40c9-41d8-9255-5020c09d9006" />
