### PR TITLE
Implement default power mode quick change

### DIFF
--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -182,18 +182,16 @@ struct ConfigurationView: View {
                         }
                         
                         // Default Power Mode Toggle
-                        if !powerModeManager.hasDefaultConfiguration() || isCurrentConfigDefault {
-                            HStack {
-                                Toggle("Set as default power mode", isOn: $isDefault)
-                                    .font(.system(size: 14))
-                                
-                                InfoTip(
-                                    title: "Default Power Mode",
-                                    message: "Default power mode is used when no specific app or website matches are found"
-                                )
-                                
-                                Spacer()
-                            }
+                        HStack {
+                            Toggle("Set as default power mode", isOn: $isDefault)
+                                .font(.system(size: 14))
+                            
+                            InfoTip(
+                                title: "Default Power Mode",
+                                message: "Default power mode is used when no specific app or website matches are found"
+                            )
+                            
+                            Spacer()
                         }
                     }
                     .padding(.horizontal, 20)


### PR DESCRIPTION
**Description:**
This pull request introduces the ability for users to set a default Power Mode from any power mode configuration view. 
Previously, the user had to disable the default Power Mode and then enable the new one which was a two step effort. Currently, when the user goes into Power Mode configuration view, they can enable it right away, which will trigger the disabling of the previous one. 

This change ensures the "Set as default power mode" toggle is always visible, allowing users to select any Power Mode as their default. The underlying `PowerModeManager` already handles the logic for ensuring only one Power Mode is marked as default at any given time, automatically disabling the previous default when a new one is selected.

**Changes Made:**
- Modified `PowerModeConfigView.swift` to always display the "Set as default power mode" toggle.
- Leveraged existing `PowerModeManager` logic for setting and managing default configurations.

**Problem Solved:**
- Users can now intuitively change their default Power Mode without needing to first disable the existing default.
- Improves the user experience by making the default selection process more straightforward.

Quick demo.

https://github.com/user-attachments/assets/25952457-7fcc-4299-8382-fd68c1d71013

