### PR TITLE
Add Open with VoiceInk handling

### DIFF
--- a/VoiceInk/Info.plist
+++ b/VoiceInk/Info.plist
@@ -18,5 +18,64 @@
 	<string>VoiceInk needs to interact with your browser to detect the current website for applying website-specific configurations.</string>
 	<key>NSScreenCaptureUsageDescription</key>
 	<string>VoiceInk needs screen recording access to understand context from your screen for improved transcription accuracy.</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Audio/Video File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.audio</string>
+				<string>public.movie</string>
+			</array>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>wav</string>
+				<string>mp3</string>
+				<string>m4a</string>
+				<string>aiff</string>
+				<string>mp4</string>
+				<string>mov</string>
+				<string>aac</string>
+				<string>flac</string>
+				<string>caf</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>
+<!-- Somewhere near the existing keys -->
+<key>CFBundleDocumentTypes</key>
+<array>
+    <dict>
+        <key>CFBundleTypeName</key>
+        <string>Audio/Video File</string>
+        <key>CFBundleTypeRole</key>
+        <string>Viewer</string>
+        <key>LSHandlerRank</key>
+        <string>Alternate</string>
+        <key>LSItemContentTypes</key>
+        <array>
+            <string>public.audio</string>
+            <string>public.movie</string>
+        </array>
+        <key>CFBundleTypeExtensions</key>
+        <array>
+            <string>wav</string>
+            <string>mp3</string>
+            <string>m4a</string>
+            <string>aiff</string>
+            <string>mp4</string>
+            <string>mov</string>
+            <string>aac</string>
+            <string>flac</string>
+            <string>caf</string>
+        </array>
+    </dict>
+</array>
 </dict>
 </plist>

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -14,4 +14,5 @@ extension Notification.Name {
     static let powerModeConfigurationApplied = Notification.Name("powerModeConfigurationApplied")
     static let transcriptionCreated = Notification.Name("transcriptionCreated")
     static let enhancementToggleChanged = Notification.Name("enhancementToggleChanged")
+    static let openFileForTranscription = Notification.Name("openFileForTranscription")
 }

--- a/VoiceInk/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Views/AudioTranscribeView.swift
@@ -112,6 +112,12 @@ struct AudioTranscribeView: View {
                 Text(errorMessage)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openFileForTranscription)) { notification in
+            if let url = notification.userInfo?["url"] as? URL {
+                // Do not auto-start; only select file for manual transcription
+                validateAndSetAudioFile(url)
+            }
+        }
     }
     
     private var dropZoneView: some View {
@@ -381,4 +387,4 @@ struct AudioTranscribeView: View {
         let seconds = Int(duration) % 60
         return String(format: "%d:%02d", minutes, seconds)
     }
-} 
+}

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -114,6 +114,15 @@ struct VoiceInkApp: App {
                         if !UserDefaults.standard.bool(forKey: "IsTranscriptionCleanupEnabled") {
                             audioCleanupManager.startAutomaticCleanup(modelContext: container.mainContext)
                         }
+                        
+                        // Process any pending open-file request now that the main ContentView is ready.
+                        if let pendingURL = appDelegate.pendingOpenFileURL {
+                            NotificationCenter.default.post(name: .navigateToDestination, object: nil, userInfo: ["destination": "Transcribe Audio"])
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                NotificationCenter.default.post(name: .openFileForTranscription, object: nil, userInfo: ["url": pendingURL])
+                            }
+                            appDelegate.pendingOpenFileURL = nil
+                        }
                     }
                     .background(WindowAccessor { window in
                         WindowManager.shared.configureWindow(window)


### PR DESCRIPTION
**Summary**

This PR introduces Finder “Open With VoiceInk” support and improves the macOS window/tab experience:

- Opening a supported file from Finder now routes the app directly to the Transcribe Audio view and pre-selects the file, without auto-starting transcription.
- Prevents creating new windows/tabs when handling “Open With”; all actions occur in the existing main window/tab.
- Dynamically updates the tab/window title to reflect the currently active view (e.g., “Transcribe Audio”, “History”, etc.).

**What changed**

- Info.plist: Added CFBundleDocumentTypes for audio/video types to enable “Open With”.
- AppNotifications.swift: Introduced openFileForTranscription notification.
- ContentView.swift:
  - Handles navigateToDestination for in-place routing (including “Transcribe Audio”).
  - Captures hosting NSWindow and updates window/tab title whenever selectedView changes.
- AudioTranscribeView.swift: Subscribes to openFileForTranscription to receive and validate the file URL without auto-starting transcription.
- AppDelegate.swift:
  - application( :open:) / application( :openURLs:) activates the app and routes to Transcribe Audio.
  - Reuses the existing main window; if cold-start, defers delivery until ContentView is ready.
- VoiceInk.swift: On app launch, picks up any pending file URL and posts notifications after ContentView mounts.
- (If applicable) WindowManager.swift: Ensured no extra main windows/tabs are created during “Open With”.
Feature details

- “Open With” behavior:
  - Supported file types: wav, mp3, m4a, aiff, mp4, mov, aac, flac, caf.
  - App always navigates to Transcribe Audio and puts focus there.
  - File selection is prepopulated; user manually initiates transcription.
  - Completed transcriptions are saved to and visible in History.
- Dynamic title updates:
  - Each tab’s title is set to the currently active view name.
  - Works across multiple tabs as each ContentView instance updates its hosting NSWindow.


**Problem solved**

- Prior behavior created a new tab when opening files from Finder and could navigate to unintended views.
- Window/tab titles were static and did not reflect the user’s current context.
- This PR fixes both issues, improving app ergonomics and aligning with the desired UX.


**Quick demo**

https://github.com/user-attachments/assets/365429c2-7bbd-4c4e-9059-58a78da4a477


