### PR TITLE
Update Groq Kimi K2 model name

### DIFF
--- a/VoiceInk/Services/AIService.swift
+++ b/VoiceInk/Services/AIService.swift
@@ -82,7 +82,7 @@ enum AIProvider: String, CaseIterable {
         case .groq:
             return [
                 "llama-3.3-70b-versatile",
-                "moonshotai/kimi-k2-instruct",
+                "moonshotai/kimi-k2-instruct-0905",
                 "qwen/qwen3-32b",
                 "meta-llama/llama-4-maverick-17b-128e-instruct",
                 "openai/gpt-oss-120b"


### PR DESCRIPTION
According to Groq [docs](https://console.groq.com/docs/deprecations), `moonshotai/kimi-k2-instruct` model will be deprecated soon, new model that should be used instead is - `moonshotai/kimi-k2-instruct-0905`.
This PR updates Kimi K2 model's name.