### PR TITLE
Bugfix: Add shortcut handler for paste last transcription

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -150,6 +150,13 @@ class HotkeyManager: ObservableObject {
             }
         }
 
+        KeyboardShortcuts.onKeyUp(for: .pasteLastEnhancement) { [weak self] in
+            guard let self = self else { return }
+            Task { @MainActor in
+                LastTranscriptionService.pasteLastEnhancement(from: self.whisperState.modelContext)
+            }
+        }
+
         KeyboardShortcuts.onKeyUp(for: .retryLastTranscription) { [weak self] in
             guard let self = self else { return }
             Task { @MainActor in


### PR DESCRIPTION
Paste Last Transcript (Enchanced) wasn't triggering because handler went missing.
This PR re-introduces it.