### PR TITLE
Add capability to see AI request in history view

### DIFF
--- a/VoiceInk/Models/Transcription.swift
+++ b/VoiceInk/Models/Transcription.swift
@@ -14,8 +14,10 @@ final class Transcription {
     var promptName: String?
     var transcriptionDuration: TimeInterval?
     var enhancementDuration: TimeInterval?
+    var aiRequestSystemMessage: String?
+    var aiRequestUserMessage: String?
     
-    init(text: String, duration: TimeInterval, enhancedText: String? = nil, audioFileURL: String? = nil, transcriptionModelName: String? = nil, aiEnhancementModelName: String? = nil, promptName: String? = nil, transcriptionDuration: TimeInterval? = nil, enhancementDuration: TimeInterval? = nil) {
+    init(text: String, duration: TimeInterval, enhancedText: String? = nil, audioFileURL: String? = nil, transcriptionModelName: String? = nil, aiEnhancementModelName: String? = nil, promptName: String? = nil, transcriptionDuration: TimeInterval? = nil, enhancementDuration: TimeInterval? = nil, aiRequestSystemMessage: String? = nil, aiRequestUserMessage: String? = nil) {
         self.id = UUID()
         self.text = text
         self.enhancedText = enhancedText
@@ -27,5 +29,7 @@ final class Transcription {
         self.promptName = promptName
         self.transcriptionDuration = transcriptionDuration
         self.enhancementDuration = enhancementDuration
+        self.aiRequestSystemMessage = aiRequestSystemMessage
+        self.aiRequestUserMessage = aiRequestUserMessage
     }
 }

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -124,6 +124,7 @@ class AudioTranscriptionManager: ObservableObject {
                    enhancementService.isConfigured {
                     processingPhase = .enhancing
                     do {
+                        // inside the enhancement success path where transcription is created
                         let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(text)
                         let transcription = Transcription(
                             text: text,
@@ -134,7 +135,9 @@ class AudioTranscriptionManager: ObservableObject {
                             aiEnhancementModelName: enhancementService.getAIService()?.currentModel,
                             promptName: promptName,
                             transcriptionDuration: transcriptionDuration,
-                            enhancementDuration: enhancementDuration
+                            enhancementDuration: enhancementDuration,
+                            aiRequestSystemMessage: enhancementService.lastSystemMessageSent,
+                            aiRequestUserMessage: enhancementService.lastUserMessageSent
                         )
                         modelContext.insert(transcription)
                         try modelContext.save()
@@ -211,4 +214,4 @@ enum TranscriptionError: Error, LocalizedError {
             return "Transcription was cancelled"
         }
     }
-} 
+}

--- a/VoiceInk/Services/AudioFileTranscriptionService.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionService.swift
@@ -95,8 +95,8 @@ class AudioTranscriptionService: ObservableObject {
                enhancementService.isEnhancementEnabled,
                enhancementService.isConfigured {
                 do {
+                    // inside the enhancement success path where newTranscription is created
                     let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(text)
-                    
                     let newTranscription = Transcription(
                         text: text,
                         duration: duration,
@@ -106,7 +106,9 @@ class AudioTranscriptionService: ObservableObject {
                         aiEnhancementModelName: enhancementService.getAIService()?.currentModel,
                         promptName: promptName,
                         transcriptionDuration: transcriptionDuration,
-                        enhancementDuration: enhancementDuration
+                        enhancementDuration: enhancementDuration,
+                        aiRequestSystemMessage: enhancementService.lastSystemMessageSent,
+                        aiRequestUserMessage: enhancementService.lastUserMessageSent
                     )
                     modelContext.insert(newTranscription)
                     do {

--- a/VoiceInk/Views/TranscriptionCard.swift
+++ b/VoiceInk/Views/TranscriptionCard.swift
@@ -7,6 +7,7 @@ struct TranscriptionCard: View {
     let isSelected: Bool
     let onDelete: () -> Void
     let onToggleSelection: () -> Void
+    @State private var isAIRequestExpanded: Bool = false
     
     var body: some View {
         HStack(spacing: 12) {
@@ -73,6 +74,63 @@ struct TranscriptionCard: View {
                             }
                             Spacer()
                             AnimatedCopyButton(textToCopy: enhancedText)
+                        }
+                    }
+                }
+                
+                // NEW: AI Request payload (System + User messages) - folded by default
+                if isExpanded, (transcription.aiRequestSystemMessage != nil || transcription.aiRequestUserMessage != nil) {
+                    Divider()
+                        .padding(.vertical, 8)
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "paperplane.fill")
+                                .foregroundColor(.purple)
+                            Text("AI Request")
+                                .fontWeight(.semibold)
+                                .foregroundColor(.purple)
+                            Spacer()
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(.easeInOut) {
+                                isAIRequestExpanded.toggle()
+                            }
+                        }
+
+                        if isAIRequestExpanded {
+                            VStack(alignment: .leading, spacing: 12) {
+                                if let systemMsg = transcription.aiRequestSystemMessage, !systemMsg.isEmpty {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack {
+                                            Text("System Prompt")
+                                                .font(.system(size: 13, weight: .semibold))
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                            AnimatedCopyButton(textToCopy: systemMsg)
+                                        }
+                                        Text(systemMsg)
+                                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                                            .lineSpacing(2)
+                                    }
+                                }
+                                
+                                if let userMsg = transcription.aiRequestUserMessage, !userMsg.isEmpty {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack {
+                                            Text("User Message")
+                                                .font(.system(size: 13, weight: .semibold))
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                            AnimatedCopyButton(textToCopy: userMsg)
+                                        }
+                                        Text(userMsg)
+                                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                                            .lineSpacing(2)
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -298,17 +298,19 @@ class WhisperState: NSObject, ObservableObject {
                     await MainActor.run { self.recordingState = .enhancing }
                     let textForAI = promptDetectionResult?.processedText ?? text
                     let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(textForAI)
-                    let newTranscription = Transcription(
-                        text: originalText,
-                        duration: actualDuration,
-                        enhancedText: enhancedText,
-                        audioFileURL: url.absoluteString,
-                        transcriptionModelName: model.displayName,
-                        aiEnhancementModelName: enhancementService.getAIService()?.currentModel,
-                        promptName: promptName,
-                        transcriptionDuration: transcriptionDuration,
-                        enhancementDuration: enhancementDuration
-                    )
+        let newTranscription = Transcription(
+            text: originalText,
+            duration: actualDuration,
+            enhancedText: enhancedText,
+            audioFileURL: url.absoluteString,
+            transcriptionModelName: model.displayName,
+            aiEnhancementModelName: enhancementService.getAIService()?.currentModel,
+            promptName: promptName,
+            transcriptionDuration: transcriptionDuration,
+            enhancementDuration: enhancementDuration,
+            aiRequestSystemMessage: enhancementService.lastSystemMessageSent,
+            aiRequestUserMessage: enhancementService.lastUserMessageSent
+        )
                     modelContext.insert(newTranscription)
                     try? modelContext.save()
                     NotificationCenter.default.post(name: .transcriptionCreated, object: newTranscription)


### PR DESCRIPTION
**Summary**

The feature allows users to view the exact system and user messages sent to the AI for transcription enhancement directly within the Transcription History View. This information is now stored with each transcription and displayed in a collapsible section on the transcription card, providing transparency and context for the AI's output.

**Demo**


https://github.com/user-attachments/assets/1f9a933a-43f0-4abc-8922-2995c75e4639

