### PR TITLE
Fix: Enable Clipboard context with custom AI enhancers

### DIFF
--- a/VoiceInk/Services/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancementService.swift
@@ -134,7 +134,7 @@ class AIEnhancementService: ObservableObject {
     private func getSystemMessage(for mode: EnhancementPrompt) -> String {
         let clipboardSnapshot = NSPasteboard.general.string(forType: .string)
         let selectedText = SelectedTextService.fetchSelectedText()
-        
+
         if let activePrompt = activePrompt,
            activePrompt.id == PredefinedPrompts.assistantPromptId,
            let selectedText = selectedText, !selectedText.isEmpty {

--- a/VoiceInk/Services/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancementService.swift
@@ -132,8 +132,9 @@ class AIEnhancementService: ObservableObject {
     }
 
     private func getSystemMessage(for mode: EnhancementPrompt) -> String {
+        let clipboardSnapshot = NSPasteboard.general.string(forType: .string)
         let selectedText = SelectedTextService.fetchSelectedText()
-
+        
         if let activePrompt = activePrompt,
            activePrompt.id == PredefinedPrompts.assistantPromptId,
            let selectedText = selectedText, !selectedText.isEmpty {
@@ -149,7 +150,7 @@ class AIEnhancementService: ObservableObject {
         }
 
         let clipboardContext = if useClipboardContext,
-                              let clipboardText = NSPasteboard.general.string(forType: .string),
+                              let clipboardText = clipboardSnapshot ?? NSPasteboard.general.string(forType: .string),
                               !clipboardText.isEmpty {
             "\n\n<CLIPBOARD_CONTEXT>\n\(clipboardText)\n</CLIPBOARD_CONTEXT>"
         } else {

--- a/VoiceInk/Services/SelectedTextService.swift
+++ b/VoiceInk/Services/SelectedTextService.swift
@@ -1,7 +1,9 @@
 import Foundation
 import AppKit
 class SelectedTextService {
-    
+    // Private pasteboard type to avoid clipboard history pollution
+    private static let privatePasteboardType = NSPasteboard.PasteboardType("com.prakashjoshipax.VoiceInk.transient")
+
     static func fetchSelectedText() -> String? {
         // Don't check for selected text within VoiceInk itself
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication,

--- a/VoiceInk/Services/SelectedTextService.swift
+++ b/VoiceInk/Services/SelectedTextService.swift
@@ -1,11 +1,7 @@
 import Foundation
 import AppKit
-
 class SelectedTextService {
     
-    // Private pasteboard type to avoid clipboard history pollution
-    private static let privatePasteboardType = NSPasteboard.PasteboardType("com.prakashjoshipax.VoiceInk.transient")
-
     static func fetchSelectedText() -> String? {
         // Don't check for selected text within VoiceInk itself
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
@@ -14,10 +10,15 @@ class SelectedTextService {
         }
 
         let pasteboard = NSPasteboard.general
-        
-        // Save original clipboard content
+        let originalClipboardText = pasteboard.string(forType: .string)
+
+        // Save original clipboard content (all UTIs with their data)
         let originalPasteboardItems = pasteboard.pasteboardItems?.map { item in
-            (item.types, item.data(forType: item.types.first ?? .string))
+            item.types.reduce(into: [NSPasteboard.PasteboardType: Data]()) { acc, type in
+                if let data = item.data(forType: type) {
+                    acc[type] = data
+                }
+            }
         }
 
         // Clear clipboard to prepare for selection detection
@@ -43,23 +44,26 @@ class SelectedTextService {
 
         // Read the copied text
         let selectedText = pasteboard.string(forType: .string)
-        
+
         // Restore original clipboard content
         pasteboard.clearContents()
-        if let originalItems = originalPasteboardItems {
-            for (types, data) in originalItems {
-                if let data = data {
-                    let pasteboardItem = NSPasteboardItem()
-                    pasteboardItem.setData(data, forType: types.first ?? .string)
-                    pasteboard.writeObjects([pasteboardItem])
+        if let originalItems = originalPasteboardItems, !originalItems.isEmpty {
+            let restoredItems: [NSPasteboardItem] = originalItems.compactMap { dataMap in
+                guard !dataMap.isEmpty else { return nil }
+                let item = NSPasteboardItem()
+                for (type, data) in dataMap {
+                    item.setData(data, forType: type)
                 }
+                return item
             }
+            if !restoredItems.isEmpty {
+                pasteboard.writeObjects(restoredItems)
+            } else if let originalClipboardText {
+                _ = pasteboard.setString(originalClipboardText, forType: .string)
+            }
+        } else if let originalClipboardText {
+            _ = pasteboard.setString(originalClipboardText, forType: .string)
         }
-        
-        // Clear clipboard history by writing transient data
-        let transientItem = NSPasteboardItem()
-        transientItem.setString("", forType: privatePasteboardType)
-        pasteboard.writeObjects([transientItem])
 
         return selectedText
     }


### PR DESCRIPTION
## Issue Summary

Custom AI enhancers never received <CLIPBOARD_CONTEXT> even though the toggle was enabled; the clipboard looked empty when the prompt ran. Verified by looking at the debug messages

**Note**: I am unsure whether this issue occurs for other people as well, or only for me. 

## Diagnosis

SelectedTextService.fetchSelectedText() cleared the pasteboard, copied the selection, then rewrote it with a transient item. That wiped the original clipboard before AIEnhancementService tried to read it, so any prompt relying on clipboard context saw an empty string.

## Fix

- Preserve the clipboard: snapshot every pasteboard UTI before the simulated copy, restore the items afterward, and return the previous plain-text value.
- Reuse that preserved snapshot inside getSystemMessage when constructing <CLIPBOARD_CONTEXT>, so all prompts—default or custom—receive the same clipboard data.