### PR TITLE
green save bottom button for power mode

### DIFF
--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -613,12 +613,22 @@ struct ConfigurationView: View {
                     .background(CardBackground(isSelected: false))
                     .padding(.horizontal)
                     
-                    VoiceInkButton(
-                        title: mode.isAdding ? "Add New Power Mode" : "Save Changes",
-                        action: saveConfiguration,
-                        isDisabled: !canSave
-                    )
-                    .frame(maxWidth: .infinity)
+                    HStack {
+                        Spacer()
+                        Button(action: saveConfiguration) {
+                            Text(mode.isAdding ? "Add New Power Mode" : "Save Changes")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .fill(canSave ? .green : .green.opacity(0.5))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(!canSave)
+                    }
                     .padding(.horizontal)
                 }
                 .padding(.vertical)


### PR DESCRIPTION
<img width="983" height="972" alt="image" src="https://github.com/user-attachments/assets/bf856f61-bf88-455f-a730-340b43faf4e4" />

So, it's more UX-friendly this way. 