### PR TITLE
Add labels for ai prompts

### DIFF
--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -108,8 +108,8 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
 
 // MARK: - UI Extensions
 extension CustomPrompt {
-    func promptIcon(isSelected: Bool, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil) -> some View {
-        VStack(spacing: 8) {
+    func promptIcon(isSelected: Bool, shortcutIndex: Int? = nil, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil) -> some View {
+        VStack(spacing: 4) {
             ZStack {
                 // Dynamic background with blur effect
                 RoundedRectangle(cornerRadius: 14)
@@ -229,6 +229,8 @@ extension CustomPrompt {
                 }
                 .frame(height: 16)
             }
+            
+            shortcutLabel(for: shortcutIndex)
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 6)
@@ -265,9 +267,28 @@ extension CustomPrompt {
         }
     }
     
+    @ViewBuilder
+    private func shortcutLabel(for index: Int?) -> some View {
+        let labelHeight: CGFloat = 16
+        if let index = index, index < 10 {
+            let numberToShow = (index + 1) % 10
+            HStack(spacing: 2) {
+                Image(systemName: "option")
+                    .font(.system(size: 9, weight: .medium))
+                Text("\(numberToShow)")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundColor(.secondary)
+            .frame(height: labelHeight)
+            .transition(.opacity)
+        } else {
+            Spacer().frame(height: labelHeight)
+        }
+    }
+    
     // Static method to create an "Add New" button with the same styling as the prompt icons
     static func addNewButton(action: @escaping () -> Void) -> some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 4) {
             ZStack {
                 // Dynamic background with blur effect - same styling as promptIcon
                 RoundedRectangle(cornerRadius: 14)
@@ -344,6 +365,9 @@ extension CustomPrompt {
                 Spacer()
                     .frame(height: 16)
             }
+            
+            // Spacer to match shortcut label height
+            Spacer().frame(height: 16)
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 6)

--- a/VoiceInk/Views/Components/PromptSelectionGrid.swift
+++ b/VoiceInk/Views/Components/PromptSelectionGrid.swift
@@ -41,9 +41,10 @@ struct PromptSelectionGrid: View {
                 ]
                 
                 LazyVGrid(columns: columns, spacing: 16) {
-                    ForEach(prompts) { prompt in
+                    ForEach(Array(prompts.enumerated()), id: \.element.id) { index, prompt in
                         prompt.promptIcon(
                             isSelected: selectedPromptId == prompt.id,
+                            shortcutIndex: index,
                             onTap: { 
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                     onPromptSelected(prompt)

--- a/VoiceInk/Views/EnhancementSettingsView.swift
+++ b/VoiceInk/Views/EnhancementSettingsView.swift
@@ -138,9 +138,10 @@ private struct ReorderablePromptGrid: View {
                 ]
                 
                 LazyVGrid(columns: columns, spacing: 16) {
-                    ForEach(enhancementService.customPrompts) { prompt in
+                    ForEach(Array(enhancementService.customPrompts.enumerated()), id: \.element.id) { index, prompt in
                         prompt.promptIcon(
                             isSelected: selectedPromptId == prompt.id,
+                            shortcutIndex: index,
                             onTap: {
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                     onPromptSelected(prompt)


### PR DESCRIPTION
This commit toggles Enhancement via the Option key and adds labels to the interface, as shown in the screenshot. 
<img width="919" height="186" alt="image" src="https://github.com/user-attachments/assets/c5942072-3d4d-4de9-917f-47e73a01a702" />

This PR should be applied after the PR below is applied. 
https://github.com/Beingpax/VoiceInk/pull/310