### PR TITLE
feat: Add Power Mode display to transcription history

### DIFF
--- a/VoiceInk/Models/Transcription.swift
+++ b/VoiceInk/Models/Transcription.swift
@@ -16,8 +16,22 @@ final class Transcription {
     var enhancementDuration: TimeInterval?
     var aiRequestSystemMessage: String?
     var aiRequestUserMessage: String?
-    
-    init(text: String, duration: TimeInterval, enhancedText: String? = nil, audioFileURL: String? = nil, transcriptionModelName: String? = nil, aiEnhancementModelName: String? = nil, promptName: String? = nil, transcriptionDuration: TimeInterval? = nil, enhancementDuration: TimeInterval? = nil, aiRequestSystemMessage: String? = nil, aiRequestUserMessage: String? = nil) {
+    var powerModeName: String?
+    var powerModeEmoji: String?
+
+    init(text: String,
+         duration: TimeInterval,
+         enhancedText: String? = nil,
+         audioFileURL: String? = nil,
+         transcriptionModelName: String? = nil,
+         aiEnhancementModelName: String? = nil,
+         promptName: String? = nil,
+         transcriptionDuration: TimeInterval? = nil,
+         enhancementDuration: TimeInterval? = nil,
+         aiRequestSystemMessage: String? = nil,
+         aiRequestUserMessage: String? = nil,
+         powerModeName: String? = nil,
+         powerModeEmoji: String? = nil) {
         self.id = UUID()
         self.text = text
         self.enhancedText = enhancedText
@@ -31,5 +45,7 @@ final class Transcription {
         self.enhancementDuration = enhancementDuration
         self.aiRequestSystemMessage = aiRequestSystemMessage
         self.aiRequestUserMessage = aiRequestUserMessage
+        self.powerModeName = powerModeName
+        self.powerModeEmoji = powerModeEmoji
     }
 }

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -114,6 +114,11 @@ class AudioTranscriptionManager: ObservableObject {
                 text = WhisperHallucinationFilter.filter(text)
                 text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
+                let powerModeManager = PowerModeManager.shared
+                let activePowerModeConfig = powerModeManager.currentActiveConfiguration
+                let powerModeName = (activePowerModeConfig?.isEnabled == true) ? activePowerModeConfig?.name : nil
+                let powerModeEmoji = (activePowerModeConfig?.isEnabled == true) ? activePowerModeConfig?.emoji : nil
+
                 if UserDefaults.standard.object(forKey: "IsTextFormattingEnabled") as? Bool ?? true {
                     text = WhisperTextFormatter.format(text)
                 }
@@ -142,7 +147,9 @@ class AudioTranscriptionManager: ObservableObject {
                             transcriptionDuration: transcriptionDuration,
                             enhancementDuration: enhancementDuration,
                             aiRequestSystemMessage: enhancementService.lastSystemMessageSent,
-                            aiRequestUserMessage: enhancementService.lastUserMessageSent
+                            aiRequestUserMessage: enhancementService.lastUserMessageSent,
+                            powerModeName: powerModeName,
+                            powerModeEmoji: powerModeEmoji
                         )
                         modelContext.insert(transcription)
                         try modelContext.save()
@@ -156,7 +163,9 @@ class AudioTranscriptionManager: ObservableObject {
                             audioFileURL: permanentURL.absoluteString,
                             transcriptionModelName: currentModel.displayName,
                             promptName: nil,
-                            transcriptionDuration: transcriptionDuration
+                            transcriptionDuration: transcriptionDuration,
+                            powerModeName: powerModeName,
+                            powerModeEmoji: powerModeEmoji
                         )
                         modelContext.insert(transcription)
                         try modelContext.save()
@@ -170,7 +179,9 @@ class AudioTranscriptionManager: ObservableObject {
                         audioFileURL: permanentURL.absoluteString,
                         transcriptionModelName: currentModel.displayName,
                         promptName: nil,
-                        transcriptionDuration: transcriptionDuration
+                        transcriptionDuration: transcriptionDuration,
+                        powerModeName: powerModeName,
+                        powerModeEmoji: powerModeEmoji
                     )
                     modelContext.insert(transcription)
                     try modelContext.save()

--- a/VoiceInk/Services/AudioFileTranscriptionService.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionService.swift
@@ -64,6 +64,11 @@ class AudioTranscriptionService: ObservableObject {
             text = WhisperHallucinationFilter.filter(text)
             text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
+            let powerModeManager = PowerModeManager.shared
+            let activePowerModeConfig = powerModeManager.currentActiveConfiguration
+            let powerModeName = (activePowerModeConfig?.isEnabled == true) ? activePowerModeConfig?.name : nil
+            let powerModeEmoji = (activePowerModeConfig?.isEnabled == true) ? activePowerModeConfig?.emoji : nil
+
             if UserDefaults.standard.object(forKey: "IsTextFormattingEnabled") as? Bool ?? true {
                 text = WhisperTextFormatter.format(text)
             }
@@ -124,7 +129,9 @@ class AudioTranscriptionService: ObservableObject {
                         transcriptionDuration: transcriptionDuration,
                         enhancementDuration: enhancementDuration,
                         aiRequestSystemMessage: enhancementService.lastSystemMessageSent,
-                        aiRequestUserMessage: enhancementService.lastUserMessageSent
+                        aiRequestUserMessage: enhancementService.lastUserMessageSent,
+                        powerModeName: powerModeName,
+                        powerModeEmoji: powerModeEmoji
                     )
                     modelContext.insert(newTranscription)
                     do {
@@ -152,7 +159,9 @@ class AudioTranscriptionService: ObservableObject {
                         audioFileURL: permanentURLString,
                         transcriptionModelName: model.displayName,
                         promptName: nil,
-                        transcriptionDuration: transcriptionDuration
+                        transcriptionDuration: transcriptionDuration,
+                        powerModeName: powerModeName,
+                        powerModeEmoji: powerModeEmoji
                     )
                     modelContext.insert(newTranscription)
                     do {
@@ -175,7 +184,9 @@ class AudioTranscriptionService: ObservableObject {
                     audioFileURL: permanentURLString,
                     transcriptionModelName: model.displayName,
                     promptName: nil,
-                    transcriptionDuration: transcriptionDuration
+                    transcriptionDuration: transcriptionDuration,
+                    powerModeName: powerModeName,
+                    powerModeEmoji: powerModeEmoji
                 )
                 modelContext.insert(newTranscription)
                 do {

--- a/VoiceInk/Services/VoiceInkCSVExportService.swift
+++ b/VoiceInk/Services/VoiceInkCSVExportService.swift
@@ -24,26 +24,27 @@ class VoiceInkCSVExportService {
     }
     
     private func generateCSV(for transcriptions: [Transcription]) -> String {
-        var csvString = "Original Transcript,Enhanced Transcript,Enhancement Model,Prompt Name,Transcription Model,Enhancement Time,Transcription Time,Timestamp,Duration\n"
-        
+        var csvString = "Original Transcript,Enhanced Transcript,Enhancement Model,Prompt Name,Transcription Model,Power Mode,Enhancement Time,Transcription Time,Timestamp,Duration\n"
+
         for transcription in transcriptions {
             let originalText = escapeCSVString(transcription.text)
             let enhancedText = escapeCSVString(transcription.enhancedText ?? "")
             let enhancementModel = escapeCSVString(transcription.aiEnhancementModelName ?? "")
             let promptName = escapeCSVString(transcription.promptName ?? "")
             let transcriptionModel = escapeCSVString(transcription.transcriptionModelName ?? "")
+            let powerMode = escapeCSVString(powerModeDisplay(name: transcription.powerModeName, emoji: transcription.powerModeEmoji))
             let enhancementTime = transcription.enhancementDuration ?? 0
             let transcriptionTime = transcription.transcriptionDuration ?? 0
             let timestamp = transcription.timestamp.ISO8601Format()
             let duration = transcription.duration
-            
-            let row = "\(originalText),\(enhancedText),\(enhancementModel),\(promptName),\(transcriptionModel),\(enhancementTime),\(transcriptionTime),\(timestamp),\(duration)\n"
+
+            let row = "\(originalText),\(enhancedText),\(enhancementModel),\(promptName),\(transcriptionModel),\(powerMode),\(enhancementTime),\(transcriptionTime),\(timestamp),\(duration)\n"
             csvString.append(row)
         }
-        
+
         return csvString
     }
-    
+
     private func escapeCSVString(_ string: String) -> String {
         let escapedString = string.replacingOccurrences(of: "\"", with: "\"\"")
         if escapedString.contains(",") || escapedString.contains("\n") {
@@ -51,4 +52,17 @@ class VoiceInkCSVExportService {
         }
         return escapedString
     }
-} 
+
+    private func powerModeDisplay(name: String?, emoji: String?) -> String {
+        switch (emoji?.trimmingCharacters(in: .whitespacesAndNewlines), name?.trimmingCharacters(in: .whitespacesAndNewlines)) {
+        case let (.some(emojiValue), .some(nameValue)) where !emojiValue.isEmpty && !nameValue.isEmpty:
+            return "\(emojiValue) \(nameValue)"
+        case let (.some(emojiValue), _) where !emojiValue.isEmpty:
+            return emojiValue
+        case let (_, .some(nameValue)) where !nameValue.isEmpty:
+            return nameValue
+        default:
+            return ""
+        }
+    }
+}

--- a/VoiceInk/Views/TranscriptionCard.swift
+++ b/VoiceInk/Views/TranscriptionCard.swift
@@ -148,8 +148,18 @@ struct TranscriptionCard: View {
                 if isExpanded && hasMetadata {
                     Divider()
                         .padding(.vertical, 8)
-                    
+
                     VStack(alignment: .leading, spacing: 10) {
+                        if let powerModeValue = powerModeDisplay(
+                            name: transcription.powerModeName,
+                            emoji: transcription.powerModeEmoji
+                        ) {
+                            metadataRow(
+                                icon: "bolt.fill",
+                                label: "Power Mode",
+                                value: powerModeValue
+                            )
+                        }
                         metadataRow(icon: "hourglass", label: "Audio Duration", value: formatTiming(transcription.duration))
                         if let modelName = transcription.transcriptionModelName {
                             metadataRow(icon: "cpu.fill", label: "Transcription Model", value: modelName)
@@ -196,8 +206,10 @@ struct TranscriptionCard: View {
             }
         }
     }
-    
+
     private var hasMetadata: Bool {
+        transcription.powerModeName != nil ||
+        transcription.powerModeEmoji != nil ||
         transcription.transcriptionModelName != nil ||
         transcription.aiEnhancementModelName != nil ||
         transcription.promptName != nil ||
@@ -231,6 +243,21 @@ struct TranscriptionCard: View {
             Text(value)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(.secondary)
+        }
+    }
+
+    private func powerModeDisplay(name: String?, emoji: String?) -> String? {
+        guard name != nil || emoji != nil else { return nil }
+
+        switch (emoji?.trimmingCharacters(in: .whitespacesAndNewlines), name?.trimmingCharacters(in: .whitespacesAndNewlines)) {
+        case let (.some(emojiValue), .some(nameValue)) where !emojiValue.isEmpty && !nameValue.isEmpty:
+            return "\(emojiValue) \(nameValue)"
+        case let (.some(emojiValue), _) where !emojiValue.isEmpty:
+            return emojiValue
+        case let (_, .some(nameValue)) where !nameValue.isEmpty:
+            return nameValue
+        default:
+            return nil
         }
     }
 }


### PR DESCRIPTION
Closes #257 

## 1. Default Power Mode without AI Enhancement
<img width="1400" height="938" alt="power_mode_default_no_ai" src="https://github.com/user-attachments/assets/1eb8648c-5e1e-49a6-ad5e-0e70fd38f7cb" />

## 2. Custom Power Mode using AI Enhancement
<img width="1386" height="1356" alt="power_mode_message_apps_with_ai" src="https://github.com/user-attachments/assets/8d6c3b5a-5af9-4fda-9668-2560582a85e1" />

## 3. Power Mode has not been configured, not using AI
<img width="1392" height="876" alt="no_power_mode_no_ai" src="https://github.com/user-attachments/assets/19edd2e6-2db9-4473-be59-85b8991ed389" />

## 4. Power Mode has not been configured, using AI
<img width="1386" height="1300" alt="no_power_mode_with_ai" src="https://github.com/user-attachments/assets/8a6bbf35-d8b4-42ef-aa2b-a8d369eabf22" />

## 4. Backward capability, an old item from history
<img width="1396" height="1298" alt="backward_capability_history_item" src="https://github.com/user-attachments/assets/820a3f24-f3f7-4776-8d6f-c7dee03cbe95" />
