### PR TITLE
Add Makefile for automated building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+.PHONY: all clean whisper setup build check healthcheck help dev run
+
+# Default target
+all: check build
+
+# Development workflow
+dev: build run
+
+# Prerequisites
+check:
+	@echo "Checking prerequisites..."
+	@command -v git >/dev/null 2>&1 || { echo "git is not installed"; exit 1; }
+	@command -v xcodebuild >/dev/null 2>&1 || { echo "xcodebuild is not installed (need Xcode)"; exit 1; }
+	@command -v swift >/dev/null 2>&1 || { echo "swift is not installed"; exit 1; }
+	@echo "Prerequisites OK"
+
+healthcheck: check
+
+# Build process
+whisper:
+	@if [ ! -d "whisper.cpp/build-apple/whisper.xcframework" ]; then \
+		echo "Building whisper.xcframework..."; \
+		git clone https://github.com/ggerganov/whisper.cpp.git || (cd whisper.cpp && git pull); \
+		cd whisper.cpp && ./build-xcframework.sh; \
+	else \
+		echo "whisper.xcframework already built, skipping build"; \
+	fi
+
+setup: whisper
+	@if [ ! -d "VoiceInk/whisper.xcframework" ]; then \
+		echo "Copying whisper.xcframework to VoiceInk..."; \
+		cp -r whisper.cpp/build-apple/whisper.xcframework VoiceInk/; \
+	else \
+		echo "whisper.xcframework already in VoiceInk, skipping copy"; \
+	fi
+
+build: setup
+	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug CODE_SIGN_IDENTITY="" build
+
+# Run application
+run:
+	@echo "Looking for VoiceInk.app..."
+	@APP_PATH=$$(find "$$HOME/Library/Developer/Xcode/DerivedData" -name "VoiceInk.app" -type d | head -1) && \
+	if [ -n "$$APP_PATH" ]; then \
+		echo "Found app at: $$APP_PATH"; \
+		open "$$APP_PATH"; \
+	else \
+		echo "VoiceInk.app not found. Please run 'make build' first."; \
+		exit 1; \
+	fi
+
+# Cleanup
+clean:
+	@echo "Cleaning build artifacts..."
+	@rm -rf whisper.cpp VoiceInk/whisper.xcframework
+	@echo "Clean complete"
+
+# Help
+help:
+	@echo "Available targets:"
+	@echo "  check/healthcheck  Check if required CLI tools are installed"
+	@echo "  whisper            Clone and build whisper.cpp XCFramework"
+	@echo "  setup              Copy whisper XCFramework to VoiceInk project"
+	@echo "  build              Build the VoiceInk Xcode project"
+	@echo "  run                Launch the built VoiceInk app"
+	@echo "  dev                Build and run the app (for development)"
+	@echo "  all                Run full build process (default)"
+	@echo "  clean              Remove build artifacts"
+	@echo "  help               Show this help message"


### PR DESCRIPTION
## What
Adds a Makefile to the VoiceInk repository that automates the entire build process described in BUILDING.md.

## Why
Currently, building VoiceInk requires multiple manual steps: cloning and building whisper.cpp, manually adding the XCFramework to the Xcode project, and running the build. This creates friction for new contributors and complicates CI/CD setups. A Makefile standardizes and simplifies the process, making it easier for everyone to get started and ensuring consistent builds.

## How
The Makefile provides the following targets:
- `make check` / `make healthcheck`: Verify required CLI tools (git, xcodebuild, swift) are installed
- `make whisper`: Clone/update whisper.cpp and build the XCFramework (skips if already exists)
- `make setup`: Copy the whisper XCFramework into the VoiceInk project (skips if already exists)
- `make build`: Build the VoiceInk Xcode project
- `make run`: Launch the built VoiceInk app
- `make dev`: Build and run the app in one command (for development)
- `make all`: Run the complete build process (default target)
- `make clean`: Remove build artifacts (whisper.cpp and whisper.xcframework)
- `make help`: Display usage information

## Key Features
- **Smart dependency checking**: Skips unnecessary steps when dependencies already exist
- **Generic paths**: Uses `$HOME` environment variable instead of hardcoded usernames for portability
- **Optimized for repository context**: No unnecessary cloning since we're already in the VoiceInk repository
- **Robust error handling**: Proper error messages and user feedback throughout the build process
- **Incremental builds**: Efficiently handles partial builds and updates

Simply run `make` in the repository root to automatically handle all dependencies and build the app. The Makefile includes error checking and supports incremental builds.