### PR TITLE
Add multi-channel audio recording support

### DIFF
--- a/VoiceInk/Services/UserDefaultsManager.swift
+++ b/VoiceInk/Services/UserDefaultsManager.swift
@@ -10,6 +10,11 @@ extension UserDefaults {
         static let prioritizedDevices = "prioritizedDevices"
         static let affiliatePromotionDismissed = "VoiceInkAffiliatePromotionDismissed"
 
+        // Multi-channel recording settings
+        static let audioChannelMode = "audioChannelMode"
+        static let audioCustomChannelCount = "audioCustomChannelCount"
+        static let autoDownmixForTranscription = "autoDownmixForTranscription"
+
         // Obfuscated keys for license-related data
         enum License {
             static let trialStartDate = "VoiceInkTrialStartDate"
@@ -78,5 +83,30 @@ extension UserDefaults {
     var affiliatePromotionDismissed: Bool {
         get { bool(forKey: Keys.affiliatePromotionDismissed) }
         set { setValue(newValue, forKey: Keys.affiliatePromotionDismissed) }
+    }
+
+    // MARK: - Multi-Channel Recording Settings
+    var audioChannelMode: String? {
+        get { string(forKey: Keys.audioChannelMode) }
+        set { setValue(newValue, forKey: Keys.audioChannelMode) }
+    }
+
+    var audioCustomChannelCount: Int {
+        get {
+            let count = integer(forKey: Keys.audioCustomChannelCount)
+            return count == 0 ? 2 : count  // Default to 2 if not set
+        }
+        set { setValue(newValue, forKey: Keys.audioCustomChannelCount) }
+    }
+
+    var autoDownmixForTranscription: Bool {
+        get {
+            // Default to true if not explicitly set
+            if object(forKey: Keys.autoDownmixForTranscription) == nil {
+                return true
+            }
+            return bool(forKey: Keys.autoDownmixForTranscription)
+        }
+        set { setValue(newValue, forKey: Keys.autoDownmixForTranscription) }
     }
 } 


### PR DESCRIPTION
Implemented configurable multi-channel recording functionality while maintaining backward compatibility with mono recording for Whisper/Parakeet transcription.

Changes:
- UserDefaultsManager: Added settings for channel mode, custom channel count, and auto-downmix preference
- AudioDeviceManager: Added AudioChannelMode enum and device channel capability querying
- Recorder: Made channel count configurable based on user settings, updated audio metering for multi-channel support
- AudioInputSettingsView: Added "Recording Configuration" UI section with channel selection and transcription compatibility options

Key features:
- Channel modes: Mono, Stereo, Device Maximum, Custom
- Auto-downmix to mono for transcription (preserves original multi-channel file)
- Real-time device capability detection
- Backward compatible defaults (mono recording)
- Multi-channel audio metering with per-channel measurements

The implementation supports recording in multi-channel formats while ensuring transcription services (Whisper, Parakeet) receive the required mono audio through automatic downmixing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable multi-channel recording with per-channel metering and automatic mono downmix for Whisper/Parakeet transcription. Defaults remain mono to keep existing behavior.

- **New Features**
  - Channel modes: Mono, Stereo, Device Maximum, Custom (custom count clamped to device max).
  - Detects each device’s max input channels and updates state in AudioDeviceManager.
  - Recorder uses the selected channel count and outputs per‑channel AudioMeter data.
  - Settings UI adds “Recording Configuration” with channel selection and a mono-downmix toggle for transcription (original multi-channel file preserved).

<sup>Written for commit 25053fcbb8d4dbc9706cc457fe60eb1c14288003. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

