### PR TITLE
Add TranscriptionServiceRegistry to eliminate duplicate service 

### DIFF
--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -16,7 +16,6 @@ class AudioTranscriptionManager: ObservableObject {
     private var currentTask: Task<Void, Error>?
     private let audioProcessor = AudioProcessor()
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "AudioTranscriptionManager")
-    private var serviceRegistry: TranscriptionServiceRegistry?
     
     enum ProcessingPhase {
         case idle
@@ -60,7 +59,7 @@ class AudioTranscriptionManager: ObservableObject {
                     throw TranscriptionError.noModelSelected
                 }
 
-                serviceRegistry = TranscriptionServiceRegistry(whisperState: whisperState, modelsDirectory: whisperState.modelsDirectory)
+                let serviceRegistry = TranscriptionServiceRegistry(whisperState: whisperState, modelsDirectory: whisperState.modelsDirectory)
 
                 processingPhase = .processingAudio
                 let samples = try await audioProcessor.processAudioToSamples(url)
@@ -80,7 +79,7 @@ class AudioTranscriptionManager: ObservableObject {
 
                 processingPhase = .transcribing
                 let transcriptionStart = Date()
-                var text = try await serviceRegistry!.transcribe(audioURL: permanentURL, model: currentModel)
+                var text = try await serviceRegistry.transcribe(audioURL: permanentURL, model: currentModel)
                 let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
                 text = TranscriptionOutputFilter.filter(text)
                 text = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -60,6 +60,9 @@ class AudioTranscriptionManager: ObservableObject {
                 }
 
                 let serviceRegistry = TranscriptionServiceRegistry(whisperState: whisperState, modelsDirectory: whisperState.modelsDirectory)
+                defer {
+                    serviceRegistry.cleanup()
+                }
 
                 processingPhase = .processingAudio
                 let samples = try await audioProcessor.processAudioToSamples(url)

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+import os
+
+@MainActor
+class TranscriptionServiceRegistry {
+    private let whisperState: WhisperState
+    private let modelsDirectory: URL
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionServiceRegistry")
+
+    private(set) lazy var localTranscriptionService = LocalTranscriptionService(
+        modelsDirectory: modelsDirectory,
+        whisperState: whisperState
+    )
+    private(set) lazy var cloudTranscriptionService = CloudTranscriptionService()
+    private(set) lazy var nativeAppleTranscriptionService = NativeAppleTranscriptionService()
+    private(set) lazy var parakeetTranscriptionService = ParakeetTranscriptionService()
+
+    init(whisperState: WhisperState, modelsDirectory: URL) {
+        self.whisperState = whisperState
+        self.modelsDirectory = modelsDirectory
+    }
+
+    func service(for provider: ModelProvider) -> TranscriptionService {
+        switch provider {
+        case .local:
+            return localTranscriptionService
+        case .parakeet:
+            return parakeetTranscriptionService
+        case .nativeApple:
+            return nativeAppleTranscriptionService
+        default:
+            return cloudTranscriptionService
+        }
+    }
+
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+        let service = service(for: model.provider)
+        logger.debug("Transcribing with \(model.displayName) using \(String(describing: type(of: service)))")
+        return try await service.transcribe(audioURL: audioURL, model: model)
+    }
+
+    func cleanup() {
+        parakeetTranscriptionService.cleanup()
+    }
+}

--- a/VoiceInk/Whisper/WhisperState+LocalModelManager.swift
+++ b/VoiceInk/Whisper/WhisperState+LocalModelManager.swift
@@ -340,8 +340,7 @@ extension WhisperState {
         await whisperContext?.releaseResources()
         whisperContext = nil
         isModelLoaded = false
-
-        parakeetTranscriptionService.cleanup()
+        serviceRegistry.cleanup()
     }
     
     // MARK: - Helper Methods


### PR DESCRIPTION

- Create centralized registry for managing transcription services
- Replace duplicate switch statements across 4 manager classes
- Consolidate service initialization into single registry pattern
- Add cleanup method to registry for resource management
- Ensure fresh service registry on each transcription request





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized transcription service routing and lifecycle in a new TranscriptionServiceRegistry. This removes duplicate provider switches across managers and adds explicit cleanup.

- **Refactors**
  - Added TranscriptionServiceRegistry that lazily initializes Local, Cloud, Native Apple, and Parakeet services, and exposes transcribe(audioURL:model:).
  - Replaced per-class routing with registry.transcribe() in AudioTranscriptionManager, AudioTranscriptionService, ModelPrewarmService, and WhisperState.
  - Routed resource release through registry.cleanup(), called on model unload.
  - Created a fresh registry per request in AudioTranscriptionManager to avoid stale state.

<sup>Written for commit 583165f21937d00f1c638e453655b08fdc060ad9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





