### PR TITLE
Fix/bluetooth audio delay

### DIFF
--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -18,10 +18,7 @@ class MediaController: ObservableObject {
         }
     }
 
-    @Published var audioResumptionDelay: Double = {
-        let value = UserDefaults.standard.double(forKey: "audioResumptionDelay")
-        return value < 1.0 ? 1.0 : value
-    }() {
+    @Published var audioResumptionDelay: Double = UserDefaults.standard.double(forKey: "audioResumptionDelay") {
         didSet {
             UserDefaults.standard.set(audioResumptionDelay, forKey: "audioResumptionDelay")
         }
@@ -33,9 +30,7 @@ class MediaController: ObservableObject {
         }
 
         if !UserDefaults.standard.contains(key: "audioResumptionDelay") {
-            UserDefaults.standard.set(1.0, forKey: "audioResumptionDelay")
-        } else if audioResumptionDelay < 1.0 {
-            audioResumptionDelay = 1.0
+            UserDefaults.standard.set(0.0, forKey: "audioResumptionDelay")
         }
     }
     

--- a/VoiceInk/PlaybackController.swift
+++ b/VoiceInk/PlaybackController.swift
@@ -108,13 +108,18 @@ class PlaybackController: ObservableObject {
             return
         }
 
-        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        let task = Task {
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
 
-        if Task.isCancelled {
-            return
+            if Task.isCancelled {
+                return
+            }
+
+            mediaController.play()
         }
 
-        mediaController.play()
+        resumeTask = task
+        await task.value
     }
     
     private func isAppStillRunning(bundleId: String) -> Bool {

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -213,6 +213,7 @@ class Recorder: NSObject, ObservableObject {
     deinit {
         audioLevelCheckTask?.cancel()
         audioMeterUpdateTask?.cancel()
+        audioRestorationTask?.cancel()
         if let observer = deviceObserver {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -15,6 +15,7 @@ class Recorder: NSObject, ObservableObject {
     @Published var audioMeter = AudioMeter(averagePower: 0, peakPower: 0)
     private var audioLevelCheckTask: Task<Void, Never>?
     private var audioMeterUpdateTask: Task<Void, Never>?
+    private var audioRestorationTask: Task<Void, Never>?
     private var hasDetectedAudioInCurrentSession = false
     
     enum RecorderError: Error {
@@ -95,6 +96,9 @@ class Recorder: NSObject, ObservableObject {
 
             logger.info("✅ AudioEngineRecorder started successfully")
 
+            audioRestorationTask?.cancel()
+            audioRestorationTask = nil
+
             Task { [weak self] in
                 guard let self = self else { return }
                 await self.playbackController.pauseMedia()
@@ -146,9 +150,8 @@ class Recorder: NSObject, ObservableObject {
         recorder = nil
         audioMeter = AudioMeter(averagePower: 0, peakPower: 0)
 
-        Task {
+        audioRestorationTask = Task {
             await mediaController.unmuteSystemAudio()
-            try? await Task.sleep(nanoseconds: 100_000_000)
             await playbackController.resumeMedia()
         }
         deviceManager.isRecordingActive = false

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -23,6 +23,7 @@ struct GeneralSettings: Codable {
     let isSoundFeedbackEnabled: Bool?
     let isSystemMuteEnabled: Bool?
     let isPauseMediaEnabled: Bool?
+    let audioResumptionDelay: Double?
     let isTextFormattingEnabled: Bool?
     let isExperimentalFeaturesEnabled: Bool?
     let restoreClipboardAfterPaste: Bool?
@@ -116,6 +117,7 @@ class ImportExportService {
             isSoundFeedbackEnabled: soundManager.isEnabled,
             isSystemMuteEnabled: mediaController.isSystemMuteEnabled,
             isPauseMediaEnabled: playbackController.isPauseMediaEnabled,
+            audioResumptionDelay: mediaController.audioResumptionDelay,
             isTextFormattingEnabled: UserDefaults.standard.object(forKey: keyIsTextFormattingEnabled) as? Bool ?? true,
             isExperimentalFeaturesEnabled: UserDefaults.standard.bool(forKey: "isExperimentalFeaturesEnabled"),
             restoreClipboardAfterPaste: UserDefaults.standard.bool(forKey: "restoreClipboardAfterPaste"),
@@ -322,6 +324,9 @@ class ImportExportService {
                         }
                         if let pauseMedia = general.isPauseMediaEnabled {
                             playbackController.isPauseMediaEnabled = pauseMedia
+                        }
+                        if let audioDelay = general.audioResumptionDelay {
+                            mediaController.audioResumptionDelay = audioDelay
                         }
                         if let experimentalEnabled = general.isExperimentalFeaturesEnabled {
                             UserDefaults.standard.set(experimentalEnabled, forKey: "isExperimentalFeaturesEnabled")

--- a/VoiceInk/Views/Settings/ExpandableToggleSection.swift
+++ b/VoiceInk/Views/Settings/ExpandableToggleSection.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct ExpandableToggleSection<Content: View>: View {
+    let title: String
+    let helpText: String
+    @Binding var isEnabled: Bool
+    @Binding var isExpanded: Bool
+    let content: Content
+
+    init(
+        title: String,
+        helpText: String,
+        isEnabled: Binding<Bool>,
+        isExpanded: Binding<Bool>,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.helpText = helpText
+        self._isEnabled = isEnabled
+        self._isExpanded = isExpanded
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Toggle(isOn: $isEnabled) {
+                    Text(title)
+                }
+                .toggleStyle(.switch)
+                .help(helpText)
+
+                if isEnabled {
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(.easeInOut(duration: 0.2), value: isExpanded)
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                if isEnabled {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded.toggle()
+                    }
+                }
+            }
+
+            if isEnabled && isExpanded {
+                content
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .padding(.top, 4)
+            }
+        }
+    }
+}

--- a/VoiceInk/Views/Settings/ExpandableToggleSection.swift
+++ b/VoiceInk/Views/Settings/ExpandableToggleSection.swift
@@ -29,6 +29,15 @@ struct ExpandableToggleSection<Content: View>: View {
                 }
                 .toggleStyle(.switch)
                 .help(helpText)
+                .onChange(of: isEnabled) { _, newValue in
+                    if newValue {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isExpanded = true
+                        }
+                    } else {
+                        isExpanded = false
+                    }
+                }
 
                 if isEnabled {
                     Spacer()

--- a/VoiceInk/Views/Settings/ExpandableToggleSection.swift
+++ b/VoiceInk/Views/Settings/ExpandableToggleSection.swift
@@ -1,24 +1,40 @@
 import SwiftUI
 
+enum ExpandableSection: Hashable {
+    case soundFeedback
+    case systemMute
+    case pauseMedia
+    case clipboardRestore
+    case customCancel
+    case middleClick
+}
+
 struct ExpandableToggleSection<Content: View>: View {
+    let section: ExpandableSection
     let title: String
     let helpText: String
     @Binding var isEnabled: Bool
-    @Binding var isExpanded: Bool
+    @Binding var expandedSections: Set<ExpandableSection>
     let content: Content
 
     init(
+        section: ExpandableSection,
         title: String,
         helpText: String,
         isEnabled: Binding<Bool>,
-        isExpanded: Binding<Bool>,
+        expandedSections: Binding<Set<ExpandableSection>>,
         @ViewBuilder content: () -> Content
     ) {
+        self.section = section
         self.title = title
         self.helpText = helpText
         self._isEnabled = isEnabled
-        self._isExpanded = isExpanded
+        self._expandedSections = expandedSections
         self.content = content()
+    }
+
+    private var isExpanded: Bool {
+        expandedSections.contains(section)
     }
 
     var body: some View {
@@ -30,12 +46,12 @@ struct ExpandableToggleSection<Content: View>: View {
                 .toggleStyle(.switch)
                 .help(helpText)
                 .onChange(of: isEnabled) { _, newValue in
-                    if newValue {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            isExpanded = true
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if newValue {
+                            _ = expandedSections.insert(section)
+                        } else {
+                            expandedSections.remove(section)
                         }
-                    } else {
-                        isExpanded = false
                     }
                 }
 
@@ -53,7 +69,11 @@ struct ExpandableToggleSection<Content: View>: View {
             .onTapGesture {
                 if isEnabled {
                     withAnimation(.easeInOut(duration: 0.2)) {
-                        isExpanded.toggle()
+                        if isExpanded {
+                            expandedSections.remove(section)
+                        } else {
+                            _ = expandedSections.insert(section)
+                        }
                     }
                 }
             }

--- a/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
+++ b/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
@@ -4,7 +4,7 @@ struct ExperimentalFeaturesSection: View {
     @AppStorage("isExperimentalFeaturesEnabled") private var isExperimentalFeaturesEnabled = false
     @ObservedObject private var playbackController = PlaybackController.shared
     @ObservedObject private var mediaController = MediaController.shared
-    @State private var isPauseMediaExpanded = false
+    @State private var expandedSections: Set<ExpandableSection> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -40,10 +40,11 @@ struct ExperimentalFeaturesSection: View {
                     .transition(.opacity.combined(with: .move(edge: .top)))
 
                 ExpandableToggleSection(
+                    section: .pauseMedia,
                     title: "Pause Media during recording",
                     helpText: "Automatically pause active media playback during recordings and resume afterward.",
                     isEnabled: $playbackController.isPauseMediaEnabled,
-                    isExpanded: $isPauseMediaExpanded
+                    expandedSections: $expandedSections
                 ) {
                     HStack(spacing: 8) {
                         Text("Resumption Delay")

--- a/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
+++ b/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ExperimentalFeaturesSection: View {
     @AppStorage("isExperimentalFeaturesEnabled") private var isExperimentalFeaturesEnabled = false
     @ObservedObject private var playbackController = PlaybackController.shared
+    @ObservedObject private var mediaController = MediaController.shared
+    @State private var isPauseMediaExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -36,13 +38,37 @@ struct ExperimentalFeaturesSection: View {
                 Divider()
                     .padding(.vertical, 4)
                     .transition(.opacity.combined(with: .move(edge: .top)))
-                
-                Toggle(isOn: $playbackController.isPauseMediaEnabled) {
-                    Text("Pause Media during recording")
+
+                ExpandableToggleSection(
+                    title: "Pause Media during recording",
+                    helpText: "Automatically pause active media playback during recordings and resume afterward.",
+                    isEnabled: $playbackController.isPauseMediaEnabled,
+                    isExpanded: $isPauseMediaExpanded
+                ) {
+                    HStack(spacing: 8) {
+                        Text("Resumption Delay")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.secondary)
+
+                        Picker("", selection: $mediaController.audioResumptionDelay) {
+                            Text("1s").tag(1.0)
+                            Text("2s").tag(2.0)
+                            Text("3s").tag(3.0)
+                            Text("4s").tag(4.0)
+                            Text("5s").tag(5.0)
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 80)
+
+                        InfoTip(
+                            title: "Audio Resumption Delay",
+                            message: "Delay before resuming media playback after recording stops. Useful for Bluetooth headphones that need time to switch from microphone mode back to high-quality audio mode. Recommended: 2s for AirPods/Bluetooth headphones, 1s for wired headphones."
+                        )
+
+                        Spacer()
+                    }
+                    .padding(.leading, 16)
                 }
-                .toggleStyle(.switch)
-                .help("Automatically pause active media playback during recordings and resume afterward.")
-                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .animation(.easeInOut(duration: 0.3), value: isExperimentalFeaturesEnabled)

--- a/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
+++ b/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
@@ -47,11 +47,12 @@ struct ExperimentalFeaturesSection: View {
                     expandedSections: $expandedSections
                 ) {
                     HStack(spacing: 8) {
-                        Text("Resumption Delay")
+                        Text("Resume Delay")
                             .font(.system(size: 13, weight: .medium))
                             .foregroundColor(.secondary)
 
                         Picker("", selection: $mediaController.audioResumptionDelay) {
+                            Text("0s").tag(0.0)
                             Text("1s").tag(1.0)
                             Text("2s").tag(2.0)
                             Text("3s").tag(3.0)
@@ -62,8 +63,8 @@ struct ExperimentalFeaturesSection: View {
                         .frame(width: 80)
 
                         InfoTip(
-                            title: "Audio Resumption Delay",
-                            message: "Delay before resuming media playback after recording stops. Useful for Bluetooth headphones that need time to switch from microphone mode back to high-quality audio mode. Recommended: 2s for AirPods/Bluetooth headphones, 1s for wired headphones."
+                            title: "Audio Resume Delay",
+                            message: "Delay before resuming media playback after recording stops. Useful for Bluetooth headphones that need time to switch from microphone mode back to high-quality audio mode. Recommended: 2s for AirPods/Bluetooth headphones, 0s for wired headphones."
                         )
 
                         Spacer()

--- a/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
+++ b/VoiceInk/Views/Settings/ExperimentalFeaturesSection.swift
@@ -67,7 +67,6 @@ struct ExperimentalFeaturesSection: View {
 
                         Spacer()
                     }
-                    .padding(.leading, 16)
                 }
             }
         }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -22,11 +22,7 @@ struct SettingsView: View {
     @State private var showResetOnboardingAlert = false
     @State private var currentShortcut = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder)
     @State private var isCustomCancelEnabled = false
-    @State private var isCustomSoundsExpanded = false
-    @State private var isSystemMuteExpanded = false
-    @State private var isClipboardRestoreExpanded = false
-    @State private var isCustomCancelExpanded = false
-    @State private var isMiddleClickExpanded = false
+    @State private var expandedSections: Set<ExpandableSection> = []
 
     
     var body: some View {
@@ -141,10 +137,11 @@ struct SettingsView: View {
 
 
                         ExpandableToggleSection(
+                            section: .customCancel,
                             title: "Custom Cancel Shortcut",
                             helpText: "Shortcut for cancelling the current recording session. Default: double-tap Escape.",
                             isEnabled: $isCustomCancelEnabled,
-                            isExpanded: $isCustomCancelExpanded
+                            expandedSections: $expandedSections
                         ) {
                             HStack(spacing: 12) {
                                 Text("Cancel Shortcut")
@@ -166,10 +163,11 @@ struct SettingsView: View {
                         Divider()
 
                         ExpandableToggleSection(
+                            section: .middleClick,
                             title: "Enable Middle-Click Toggle",
                             helpText: "Use middle mouse button to toggle VoiceInk recording.",
                             isEnabled: $hotkeyManager.isMiddleClickToggleEnabled,
-                            isExpanded: $isMiddleClickExpanded
+                            expandedSections: $expandedSections
                         ) {
                             HStack(spacing: 8) {
                                 Text("Activation Delay")
@@ -204,10 +202,11 @@ struct SettingsView: View {
                 ) {
                     VStack(alignment: .leading, spacing: 12) {
                         ExpandableToggleSection(
+                            section: .soundFeedback,
                             title: "Sound feedback",
                             helpText: "Play sounds when recording starts and stops",
                             isEnabled: $soundManager.isEnabled,
-                            isExpanded: $isCustomSoundsExpanded
+                            expandedSections: $expandedSections
                         ) {
                             CustomSoundSettingsView()
                         }
@@ -215,10 +214,11 @@ struct SettingsView: View {
                         Divider()
 
                         ExpandableToggleSection(
+                            section: .systemMute,
                             title: "Mute system audio during recording",
                             helpText: "Automatically mute system audio when recording starts and restore when recording stops",
                             isEnabled: $mediaController.isSystemMuteEnabled,
-                            isExpanded: $isSystemMuteExpanded
+                            expandedSections: $expandedSections
                         ) {
                             HStack(spacing: 8) {
                                 Text("Resumption Delay")
@@ -247,10 +247,11 @@ struct SettingsView: View {
                         Divider()
 
                         ExpandableToggleSection(
+                            section: .clipboardRestore,
                             title: "Restore clipboard after paste",
                             helpText: "When enabled, VoiceInk will restore your original clipboard content after pasting the transcription.",
                             isEnabled: $restoreClipboardAfterPaste,
-                            isExpanded: $isClipboardRestoreExpanded
+                            expandedSections: $expandedSections
                         ) {
                             HStack(spacing: 8) {
                                 Text("Restore Delay")

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -221,11 +221,12 @@ struct SettingsView: View {
                             expandedSections: $expandedSections
                         ) {
                             HStack(spacing: 8) {
-                                Text("Resumption Delay")
+                                Text("Resume Delay")
                                     .font(.system(size: 13, weight: .medium))
                                     .foregroundColor(.secondary)
 
                                 Picker("", selection: $mediaController.audioResumptionDelay) {
+                                    Text("0s").tag(0.0)
                                     Text("1s").tag(1.0)
                                     Text("2s").tag(2.0)
                                     Text("3s").tag(3.0)
@@ -236,8 +237,8 @@ struct SettingsView: View {
                                 .frame(width: 80)
 
                                 InfoTip(
-                                    title: "Audio Resumption Delay",
-                                    message: "Delay before unmuting system audio after recording stops. Useful for Bluetooth headphones that need time to switch from microphone mode back to high-quality audio mode. Recommended: 2s for AirPods/Bluetooth headphones, 1s for wired headphones."
+                                    title: "Audio Resume Delay",
+                                    message: "Delay before unmuting system audio after recording stops. Useful for Bluetooth headphones that need time to switch from microphone mode back to high-quality audio mode. Recommended: 2s for AirPods/Bluetooth headphones, 0s for wired headphones."
                                 )
 
                                 Spacer()

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -18,11 +18,12 @@ struct SettingsView: View {
     @AppStorage("autoUpdateCheck") private var autoUpdateCheck = true
     @AppStorage("enableAnnouncements") private var enableAnnouncements = true
     @AppStorage("restoreClipboardAfterPaste") private var restoreClipboardAfterPaste = false
-    @AppStorage("clipboardRestoreDelay") private var clipboardRestoreDelay = 1.5
+    @AppStorage("clipboardRestoreDelay") private var clipboardRestoreDelay = 2.0
     @State private var showResetOnboardingAlert = false
     @State private var currentShortcut = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder)
     @State private var isCustomCancelEnabled = false
     @State private var isCustomSoundsExpanded = false
+    @State private var isSystemMuteExpanded = false
 
     
     var body: some View {
@@ -220,44 +221,49 @@ struct SettingsView: View {
                     subtitle: "Customize app & system feedback"
                 ) {
                     VStack(alignment: .leading, spacing: 12) {
-                        HStack {
-                            Toggle(isOn: $soundManager.isEnabled) {
-                                Text("Sound feedback")
-                            }
-                            .toggleStyle(.switch)
-
-                            if soundManager.isEnabled {
-                                Spacer()
-
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundColor(.secondary)
-                                    .rotationEffect(.degrees(isCustomSoundsExpanded ? 90 : 0))
-                                    .animation(.easeInOut(duration: 0.2), value: isCustomSoundsExpanded)
-                            }
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            if soundManager.isEnabled {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    isCustomSoundsExpanded.toggle()
-                                }
-                            }
-                        }
-
-                        if soundManager.isEnabled && isCustomSoundsExpanded {
+                        ExpandableToggleSection(
+                            title: "Sound feedback",
+                            helpText: "Play sounds when recording starts and stops",
+                            isEnabled: $soundManager.isEnabled,
+                            isExpanded: $isCustomSoundsExpanded
+                        ) {
                             CustomSoundSettingsView()
-                                .transition(.opacity.combined(with: .move(edge: .top)))
-                                .padding(.top, 4)
                         }
 
                         Divider()
 
-                        Toggle(isOn: $mediaController.isSystemMuteEnabled) {
-                            Text("Mute system audio during recording")
+                        ExpandableToggleSection(
+                            title: "Mute system audio during recording",
+                            helpText: "Automatically mute system audio when recording starts and restore when recording stops",
+                            isEnabled: $mediaController.isSystemMuteEnabled,
+                            isExpanded: $isSystemMuteExpanded
+                        ) {
+                            HStack(spacing: 8) {
+                                Text("Resumption Delay")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.secondary)
+
+                                Picker("", selection: $mediaController.audioResumptionDelay) {
+                                    Text("1s").tag(1.0)
+                                    Text("2s").tag(2.0)
+                                    Text("3s").tag(3.0)
+                                    Text("4s").tag(4.0)
+                                    Text("5s").tag(5.0)
+                                }
+                                .pickerStyle(.menu)
+                                .frame(width: 80)
+
+                                InfoTip(
+                                    title: "Audio Resumption Delay",
+                                    message: "Delay before unmuting system audio after recording stops. Useful for Bluetooth headphones that need time to switch from microphone mode back to high-quality audio mode. Recommended: 2s for AirPods/Bluetooth headphones, 1s for wired headphones."
+                                )
+
+                                Spacer()
+                            }
+                            .padding(.leading, 16)
                         }
-                        .toggleStyle(.switch)
-                        .help("Automatically mute system audio when recording starts and restore when recording stops")
+
+                        Divider()
 
                         VStack(alignment: .leading, spacing: 12) {
                             HStack(spacing: 8) {
@@ -277,17 +283,14 @@ struct SettingsView: View {
                                         .foregroundColor(.secondary)
 
                                     Picker("", selection: $clipboardRestoreDelay) {
-                                        Text("0.5s").tag(0.5)
-                                        Text("1.0s").tag(1.0)
-                                        Text("1.5s").tag(1.5)
-                                        Text("2.0s").tag(2.0)
-                                        Text("2.5s").tag(2.5)
-                                        Text("3.0s").tag(3.0)
-                                        Text("4.0s").tag(4.0)
-                                        Text("5.0s").tag(5.0)
+                                        Text("1s").tag(1.0)
+                                        Text("2s").tag(2.0)
+                                        Text("3s").tag(3.0)
+                                        Text("4s").tag(4.0)
+                                        Text("5s").tag(5.0)
                                     }
                                     .pickerStyle(.menu)
-                                    .frame(width: 90)
+                                    .frame(width: 80)
 
                                     Spacer()
                                 }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -25,6 +25,8 @@ struct SettingsView: View {
     @State private var isCustomSoundsExpanded = false
     @State private var isSystemMuteExpanded = false
     @State private var isClipboardRestoreExpanded = false
+    @State private var isCustomCancelExpanded = false
+    @State private var isMiddleClickExpanded = false
 
     
     var body: some View {
@@ -136,81 +138,60 @@ struct SettingsView: View {
 
                         Divider()
 
-                        
-                        
-                        // Custom Cancel Shortcut
-                        VStack(alignment: .leading, spacing: 12) {
-                            HStack(spacing: 8) {
-                                Toggle(isOn: $isCustomCancelEnabled.animation()) {
-                                    Text("Custom Cancel Shortcut")
-                                }
-                                .toggleStyle(.switch)
-                                .onChange(of: isCustomCancelEnabled) { _, newValue in
-                                    if !newValue {
-                                        KeyboardShortcuts.setShortcut(nil, for: .cancelRecorder)
-                                    }
-                                }
-                                
-                                InfoTip(
-                                    title: "Dismiss Recording",
-                                    message: "Shortcut for cancelling the current recording session. Default: double-tap Escape."
-                                )
+
+
+                        ExpandableToggleSection(
+                            title: "Custom Cancel Shortcut",
+                            helpText: "Shortcut for cancelling the current recording session. Default: double-tap Escape.",
+                            isEnabled: $isCustomCancelEnabled,
+                            isExpanded: $isCustomCancelExpanded
+                        ) {
+                            HStack(spacing: 12) {
+                                Text("Cancel Shortcut")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.secondary)
+
+                                KeyboardShortcuts.Recorder(for: .cancelRecorder)
+                                    .controlSize(.small)
+
+                                Spacer()
                             }
-                            
-                            if isCustomCancelEnabled {
-                                HStack(spacing: 12) {
-                                    Text("Cancel Shortcut")
-                                        .font(.system(size: 13, weight: .medium))
-                                        .foregroundColor(.secondary)
-                                    
-                                    KeyboardShortcuts.Recorder(for: .cancelRecorder)
-                                        .controlSize(.small)
-                                    
-                                    Spacer()
-                                }
-                                .padding(.leading, 16)
-                                .transition(.opacity.combined(with: .move(edge: .top)))
+                        }
+                        .onChange(of: isCustomCancelEnabled) { _, newValue in
+                            if !newValue {
+                                KeyboardShortcuts.setShortcut(nil, for: .cancelRecorder)
                             }
                         }
 
                         Divider()
 
-                        // Middle-Click Toggle
-                        VStack(alignment: .leading, spacing: 12) {
+                        ExpandableToggleSection(
+                            title: "Enable Middle-Click Toggle",
+                            helpText: "Use middle mouse button to toggle VoiceInk recording.",
+                            isEnabled: $hotkeyManager.isMiddleClickToggleEnabled,
+                            isExpanded: $isMiddleClickExpanded
+                        ) {
                             HStack(spacing: 8) {
-                                Toggle("Enable Middle-Click Toggle", isOn: $hotkeyManager.isMiddleClickToggleEnabled)
-                                    .toggleStyle(.switch)
+                                Text("Activation Delay")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.secondary)
 
-                                InfoTip(
-                                    title: "Middle-Click Toggle",
-                                    message: "Use middle mouse button to toggle VoiceInk recording."
-                                )
-                            }
+                                TextField("", value: $hotkeyManager.middleClickActivationDelay, formatter: {
+                                    let formatter = NumberFormatter()
+                                    formatter.numberStyle = .none
+                                    formatter.minimum = 0
+                                    return formatter
+                                }())
+                                .textFieldStyle(PlainTextFieldStyle())
+                                .padding(EdgeInsets(top: 3, leading: 6, bottom: 3, trailing: 6))
+                                .background(Color(NSColor.textBackgroundColor))
+                                .cornerRadius(5)
+                                .frame(width: 70)
 
-                            if hotkeyManager.isMiddleClickToggleEnabled {
-                                HStack(spacing: 8) {
-                                    Text("Activation Delay")
-                                        .font(.system(size: 13, weight: .medium))
-                                        .foregroundColor(.secondary)
+                                Text("ms")
+                                    .foregroundColor(.secondary)
 
-                                    TextField("", value: $hotkeyManager.middleClickActivationDelay, formatter: {
-                                        let formatter = NumberFormatter()
-                                        formatter.numberStyle = .none
-                                        formatter.minimum = 0
-                                        return formatter
-                                    }())
-                                    .textFieldStyle(PlainTextFieldStyle())
-                                    .padding(EdgeInsets(top: 3, leading: 6, bottom: 3, trailing: 6))
-                                    .background(Color(NSColor.textBackgroundColor))
-                                    .cornerRadius(5)
-                                    .frame(width: 70)
-
-                                    Text("ms")
-                                        .foregroundColor(.secondary)
-
-                                    Spacer()
-                                }
-                                .padding(.leading, 16)
+                                Spacer()
                             }
                         }
                     }
@@ -261,7 +242,6 @@ struct SettingsView: View {
 
                                 Spacer()
                             }
-                            .padding(.leading, 16)
                         }
 
                         Divider()
@@ -289,7 +269,6 @@ struct SettingsView: View {
 
                                 Spacer()
                             }
-                            .padding(.leading, 16)
                         }
 
                     }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     @State private var isCustomCancelEnabled = false
     @State private var isCustomSoundsExpanded = false
     @State private var isSystemMuteExpanded = false
+    @State private var isClipboardRestoreExpanded = false
 
     
     var body: some View {
@@ -265,37 +266,30 @@ struct SettingsView: View {
 
                         Divider()
 
-                        VStack(alignment: .leading, spacing: 12) {
+                        ExpandableToggleSection(
+                            title: "Restore clipboard after paste",
+                            helpText: "When enabled, VoiceInk will restore your original clipboard content after pasting the transcription.",
+                            isEnabled: $restoreClipboardAfterPaste,
+                            isExpanded: $isClipboardRestoreExpanded
+                        ) {
                             HStack(spacing: 8) {
-                                Toggle("Restore clipboard after paste", isOn: $restoreClipboardAfterPaste)
-                                    .toggleStyle(.switch)
+                                Text("Restore Delay")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.secondary)
 
-                                InfoTip(
-                                    title: "Restore Clipboard",
-                                    message: "When enabled, VoiceInk will restore your original clipboard content after pasting the transcription."
-                                )
-                            }
-
-                            if restoreClipboardAfterPaste {
-                                HStack(spacing: 8) {
-                                    Text("Restore Delay")
-                                        .font(.system(size: 13, weight: .medium))
-                                        .foregroundColor(.secondary)
-
-                                    Picker("", selection: $clipboardRestoreDelay) {
-                                        Text("1s").tag(1.0)
-                                        Text("2s").tag(2.0)
-                                        Text("3s").tag(3.0)
-                                        Text("4s").tag(4.0)
-                                        Text("5s").tag(5.0)
-                                    }
-                                    .pickerStyle(.menu)
-                                    .frame(width: 80)
-
-                                    Spacer()
+                                Picker("", selection: $clipboardRestoreDelay) {
+                                    Text("1s").tag(1.0)
+                                    Text("2s").tag(2.0)
+                                    Text("3s").tag(3.0)
+                                    Text("4s").tag(4.0)
+                                    Text("5s").tag(5.0)
                                 }
-                                .padding(.leading, 16)
+                                .pickerStyle(.menu)
+                                .frame(width: 80)
+
+                                Spacer()
                             }
+                            .padding(.leading, 16)
                         }
 
                     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a configurable “Resume Delay” to prevent Bluetooth audio dropouts by waiting before unmuting system audio and resuming media after recording. Also updates Settings with expandable toggles and includes the delay in import/export.

- **New Features**
  - Resume Delay (0–5s) applied to both system unmute and media resume; defaults to 0s, recommended 2s for Bluetooth headphones.
  - Added pickers for Resume Delay under “Mute system audio during recording” and “Pause Media during recording”.
  - Import/Export now includes audioResumptionDelay.

- **Refactors**
  - Introduced a reusable ExpandableToggleSection and applied it to Sound feedback, System mute, Pause media, Clipboard restore, Custom cancel, and Middle-click.
  - Safer task handling: cancel pending unmute/resume tasks when starting/stopping recordings to avoid race conditions.
  - Clipboard restore: default delay set to 2s and picker simplified (1–5s).

<sup>Written for commit a702199b5619a3480b869135524a465e4babf129. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

