### PR TITLE
Migrate API keys from UserDefaults to Keychain for secure storage wit…

### DIFF
--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -99,18 +99,20 @@ struct CustomCloudModel: TranscriptionModel, Codable {
     let description: String
     let provider: ModelProvider = .custom
     let apiEndpoint: String
-    let apiKey: String
     let modelName: String
     let isMultilingualModel: Bool
     let supportedLanguages: [String: String]
 
-    init(id: UUID = UUID(), name: String, displayName: String, description: String, apiEndpoint: String, apiKey: String, modelName: String, isMultilingual: Bool = true, supportedLanguages: [String: String]? = nil) {
+    var apiKey: String? {
+        KeychainManager.shared.retrieve(forKey: "CustomModel_\(id)_APIKey")
+    }
+
+    init(id: UUID = UUID(), name: String, displayName: String, description: String, apiEndpoint: String, modelName: String, isMultilingual: Bool = true, supportedLanguages: [String: String]? = nil) {
         self.id = id
         self.name = name
         self.displayName = displayName
         self.description = description
         self.apiEndpoint = apiEndpoint
-        self.apiKey = apiKey
         self.modelName = modelName
         self.isMultilingualModel = isMultilingual
         self.supportedLanguages = supportedLanguages ?? PredefinedModels.getLanguageDictionary(isMultilingual: isMultilingual)

--- a/VoiceInk/Services/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/DeepgramTranscriptionService.swift
@@ -42,10 +42,10 @@ class DeepgramTranscriptionService {
     }
     
     private func getAPIConfig(for model: any TranscriptionModel) throws -> APIConfig {
-        guard let apiKey = UserDefaults.standard.string(forKey: "DeepgramAPIKey"), !apiKey.isEmpty else {
+        guard let apiKey = KeychainManager.shared.retrieve(forKey: "deepgramAPIKey"), !apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
-        
+
         // Build the URL with query parameters
         var components = URLComponents(string: "https://api.deepgram.com/v1/listen")!
         var queryItems: [URLQueryItem] = []

--- a/VoiceInk/Services/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -6,10 +6,10 @@ class ElevenLabsTranscriptionService {
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ElevenLabsTranscriptionService")
     
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        guard let apiKey = UserDefaults.standard.string(forKey: "ElevenLabsAPIKey"), !apiKey.isEmpty else {
+        guard let apiKey = KeychainManager.shared.retrieve(forKey: "elevenLabsAPIKey"), !apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
-        
+
         let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"

--- a/VoiceInk/Services/CloudTranscription/GeminiTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/GeminiTranscriptionService.swift
@@ -75,15 +75,15 @@ class GeminiTranscriptionService {
     }
     
     private func getAPIConfig(for model: any TranscriptionModel) throws -> APIConfig {
-        guard let apiKey = UserDefaults.standard.string(forKey: "GeminiAPIKey"), !apiKey.isEmpty else {
+        guard let apiKey = KeychainManager.shared.retrieve(forKey: "geminiAPIKey"), !apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
-        
+
         let urlString = "https://generativelanguage.googleapis.com/v1beta/models/\(model.name):generateContent"
         guard let apiURL = URL(string: urlString) else {
             throw CloudTranscriptionError.dataEncodingError
         }
-        
+
         return APIConfig(url: apiURL, apiKey: apiKey, modelName: model.name)
     }
     

--- a/VoiceInk/Services/CloudTranscription/GroqTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/GroqTranscriptionService.swift
@@ -102,10 +102,10 @@ class GroqTranscriptionService {
     }
 
     private func getAPIConfig(for model: any TranscriptionModel) throws -> APIConfig {
-        guard let apiKey = UserDefaults.standard.string(forKey: "GROQAPIKey"), !apiKey.isEmpty else {
+        guard let apiKey = KeychainManager.shared.retrieve(forKey: "groqAPIKey"), !apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
-        
+
         guard let apiURL = URL(string: "https://api.groq.com/openai/v1/audio/transcriptions") else {
             throw NSError(domain: "GroqTranscriptionService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid API URL"])
         }

--- a/VoiceInk/Services/CloudTranscription/MistralTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/MistralTranscriptionService.swift
@@ -6,8 +6,7 @@ class MistralTranscriptionService {
     
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
         logger.notice("Sending transcription request to Mistral for model: \(model.name)")
-        let apiKey = UserDefaults.standard.string(forKey: "MistralAPIKey") ?? ""
-        guard !apiKey.isEmpty else {
+        guard let apiKey = KeychainManager.shared.retrieve(forKey: "mistralAPIKey"), !apiKey.isEmpty else {
             logger.error("Mistral API key is missing.")
             throw CloudTranscriptionError.missingAPIKey
         }

--- a/VoiceInk/Services/CloudTranscription/SonioxTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/SonioxTranscriptionService.swift
@@ -24,7 +24,7 @@ class SonioxTranscriptionService {
     }
     
     private func getAPIConfig(for model: any TranscriptionModel) throws -> APIConfig {
-        guard let apiKey = UserDefaults.standard.string(forKey: "SonioxAPIKey"), !apiKey.isEmpty else {
+        guard let apiKey = KeychainManager.shared.retrieve(forKey: "sonioxAPIKey"), !apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
         return APIConfig(apiKey: apiKey)

--- a/VoiceInk/Services/KeychainManager.swift
+++ b/VoiceInk/Services/KeychainManager.swift
@@ -1,0 +1,283 @@
+//
+//  KeychainManager.swift
+//  VoiceInk
+//
+//  Created by Claude Code
+//
+
+import Foundation
+import Security
+
+/// A clean and simple manager for securely storing API keys and sensitive data in the Keychain
+/// with iCloud sync support for seamless syncing between macOS and iOS devices.
+class KeychainManager {
+
+    // MARK: - Singleton
+
+    static let shared = KeychainManager()
+
+    private init() {}
+
+    // MARK: - Configuration
+
+    /// The service identifier for all keychain items
+    /// This keeps all VoiceInk keys grouped together in the Keychain
+    private let service = "com.prakashjoshipax.VoiceInk"
+
+    /// The access group for sharing keychain items between macOS and iOS apps
+    /// Format: TeamID.BundleIdentifier.shared
+    private let accessGroup = "V6J6A3VWY2.com.prakashjoshipax.VoiceInk.shared"
+
+    // MARK: - Error Types
+
+    enum KeychainError: Error, LocalizedError {
+        case duplicateItem
+        case itemNotFound
+        case invalidData
+        case unexpectedStatus(OSStatus)
+
+        var errorDescription: String? {
+            switch self {
+            case .duplicateItem:
+                return "Item already exists in Keychain"
+            case .itemNotFound:
+                return "Item not found in Keychain"
+            case .invalidData:
+                return "Invalid data format"
+            case .unexpectedStatus(let status):
+                return "Keychain error: \(status)"
+            }
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Save a value to the Keychain with iCloud sync enabled
+    /// - Parameters:
+    ///   - value: The string value to save (e.g., API key)
+    ///   - key: The key to store the value under
+    /// - Throws: KeychainError if the operation fails
+    func save(_ value: String, forKey key: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.invalidData
+        }
+
+        // First, try to delete any existing item
+        try? delete(forKey: key)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+            kSecAttrSynchronizable as String: true,  // Enable iCloud sync
+            kSecAttrAccessGroup as String: accessGroup  // Share between macOS and iOS
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Retrieve a value from the Keychain
+    /// - Parameter key: The key to retrieve the value for
+    /// - Returns: The stored string value, or nil if not found
+    func retrieve(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecAttrSynchronizable as String: true,  // Search in synced items
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return value
+    }
+
+    /// Delete a value from the Keychain
+    /// - Parameter key: The key to delete
+    /// - Throws: KeychainError if the operation fails
+    func delete(forKey key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrSynchronizable as String: true,
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        // It's okay if the item doesn't exist
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Update an existing value in the Keychain
+    /// - Parameters:
+    ///   - value: The new string value
+    ///   - key: The key to update
+    /// - Throws: KeychainError if the operation fails
+    func update(_ value: String, forKey key: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.invalidData
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrSynchronizable as String: true,
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        // If item doesn't exist, save it instead
+        if status == errSecItemNotFound {
+            try save(value, forKey: key)
+        } else if status != errSecSuccess {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Check if a value exists in the Keychain
+    /// - Parameter key: The key to check
+    /// - Returns: true if the key exists, false otherwise
+    func exists(forKey key: String) -> Bool {
+        return retrieve(forKey: key) != nil
+    }
+
+    /// Delete all VoiceInk keychain items
+    /// Use with caution - this will remove all stored API keys
+    func deleteAll() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrSynchronizable as String: true,
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}
+
+// MARK: - Convenience Methods for API Keys
+
+extension KeychainManager {
+
+    /// All API key identifiers used in VoiceInk
+    /// Using iOS format (lowercase camelCase) for cross-platform sync compatibility
+    enum APIKeyIdentifier: String {
+        case openAI = "openAIAPIKey"
+        case anthropic = "anthropicAPIKey"
+        case gemini = "geminiAPIKey"
+        case groq = "groqAPIKey"
+        case mistral = "mistralAPIKey"
+        case elevenLabs = "elevenLabsAPIKey"
+        case deepgram = "deepgramAPIKey"
+        case soniox = "sonioxAPIKey"
+        case openRouter = "openRouterAPIKey"
+        case cerebras = "cerebrasAPIKey"
+        case custom = "customAPIKey"
+    }
+
+    /// Save an API key for a specific provider
+    func saveAPIKey(_ value: String, for identifier: APIKeyIdentifier) throws {
+        try save(value, forKey: identifier.rawValue)
+    }
+
+    /// Retrieve an API key for a specific provider
+    func retrieveAPIKey(for identifier: APIKeyIdentifier) -> String? {
+        return retrieve(forKey: identifier.rawValue)
+    }
+
+    /// Delete an API key for a specific provider
+    func deleteAPIKey(for identifier: APIKeyIdentifier) throws {
+        try delete(forKey: identifier.rawValue)
+    }
+
+    /// Check if an API key exists for a specific provider
+    func hasAPIKey(for identifier: APIKeyIdentifier) -> Bool {
+        return exists(forKey: identifier.rawValue)
+    }
+}
+
+// MARK: - Migration Helper
+
+extension KeychainManager {
+
+    /// Migrate API keys from UserDefaults to Keychain
+    /// Maps old UserDefaults keys (uppercase) to new Keychain keys (iOS lowercase format)
+    /// This should be called once when transitioning from UserDefaults to Keychain
+    /// - Returns: The number of keys successfully migrated
+    @discardableResult
+    func migrateFromUserDefaults() -> Int {
+        let defaults = UserDefaults.standard
+        var migratedCount = 0
+
+        // Map old UserDefaults keys to new Keychain identifiers
+        let migrationMap: [(oldKey: String, identifier: APIKeyIdentifier)] = [
+            ("OpenAIAPIKey", .openAI),
+            ("AnthropicAPIKey", .anthropic),
+            ("GeminiAPIKey", .gemini),
+            ("GROQAPIKey", .groq),
+            ("MistralAPIKey", .mistral),
+            ("ElevenLabsAPIKey", .elevenLabs),
+            ("DeepgramAPIKey", .deepgram),
+            ("SonioxAPIKey", .soniox),
+            ("OpenRouterAPIKey", .openRouter),
+            ("CerebrasAPIKey", .cerebras),
+            ("CustomAPIKey", .custom)
+        ]
+
+        for (oldKey, identifier) in migrationMap {
+            // Check if key exists in UserDefaults (old format)
+            if let value = defaults.string(forKey: oldKey),
+               !value.isEmpty {
+                do {
+                    // Save to Keychain with new iOS format key
+                    try saveAPIKey(value, for: identifier)
+
+                    // Remove from UserDefaults after successful migration
+                    defaults.removeObject(forKey: oldKey)
+
+                    migratedCount += 1
+                    print("✓ Migrated \(oldKey) → \(identifier.rawValue)")
+                } catch {
+                    print("✗ Failed to migrate \(oldKey): \(error.localizedDescription)")
+                }
+            }
+        }
+
+        if migratedCount > 0 {
+            defaults.synchronize()
+            print("Successfully migrated \(migratedCount) API key(s) to Keychain with iOS format")
+        }
+
+        return migratedCount
+    }
+}

--- a/VoiceInk/Views/AI Models/AddCustomModelView.swift
+++ b/VoiceInk/Views/AI Models/AddCustomModelView.swift
@@ -234,10 +234,17 @@ struct AddCustomModelCardView: View {
                     displayName: trimmedDisplayName,
                     description: "Custom transcription model",
                     apiEndpoint: trimmedApiEndpoint,
-                    apiKey: trimmedApiKey,
                     modelName: trimmedModelName,
                     isMultilingual: isMultilingual
                 )
+
+                // Save API key to Keychain
+                do {
+                    try KeychainManager.shared.save(trimmedApiKey, forKey: "CustomModel_\(updatedModel.id)_APIKey")
+                } catch {
+                    print("Failed to save custom model API key: \(error)")
+                }
+
                 customModelManager.updateCustomModel(updatedModel)
             } else {
                 // Add new model
@@ -246,10 +253,17 @@ struct AddCustomModelCardView: View {
                     displayName: trimmedDisplayName,
                     description: "Custom transcription model",
                     apiEndpoint: trimmedApiEndpoint,
-                    apiKey: trimmedApiKey,
                     modelName: trimmedModelName,
                     isMultilingual: isMultilingual
                 )
+
+                // Save API key to Keychain
+                do {
+                    try KeychainManager.shared.save(trimmedApiKey, forKey: "CustomModel_\(customModel.id)_APIKey")
+                } catch {
+                    print("Failed to save custom model API key: \(error)")
+                }
+
                 customModelManager.addCustomModel(customModel)
             }
             

--- a/VoiceInk/VoiceInk.entitlements
+++ b/VoiceInk/VoiceInk.entitlements
@@ -23,6 +23,7 @@
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
+		<string>$(AppIdentifierPrefix)com.prakashjoshipax.VoiceInk.shared</string>
 		<string>$(AppIdentifierPrefix)com.prakashjoshipax.VoiceInk</string>
 	</array>
 </dict>

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -36,6 +36,9 @@ struct VoiceInkApp: App {
         // Configure FluidAudio logging subsystem
         AppLogger.defaultSubsystem = "com.prakashjoshipax.voiceink.parakeet"
 
+        // Migrate API keys from UserDefaults to Keychain (one-time operation)
+        KeychainManager.shared.migrateFromUserDefaults()
+
         if UserDefaults.standard.object(forKey: "powerModeUIFlag") == nil {
             let hasEnabledPowerModes = PowerModeManager.shared.configurations.contains { $0.isEnabled }
             UserDefaults.standard.set(hasEnabledPowerModes, forKey: "powerModeUIFlag")

--- a/VoiceInk/Whisper/WhisperState+ModelQueries.swift
+++ b/VoiceInk/Whisper/WhisperState+ModelQueries.swift
@@ -15,23 +15,17 @@ extension WhisperState {
                     return false
                 }
             case .groq:
-                let key = UserDefaults.standard.string(forKey: "GROQAPIKey")
-                return key != nil && !key!.isEmpty
+                return KeychainManager.shared.exists(forKey: "groqAPIKey")
             case .elevenLabs:
-                let key = UserDefaults.standard.string(forKey: "ElevenLabsAPIKey")
-                return key != nil && !key!.isEmpty
+                return KeychainManager.shared.exists(forKey: "elevenLabsAPIKey")
             case .deepgram:
-                let key = UserDefaults.standard.string(forKey: "DeepgramAPIKey")
-                return key != nil && !key!.isEmpty
+                return KeychainManager.shared.exists(forKey: "deepgramAPIKey")
             case .mistral:
-                let key = UserDefaults.standard.string(forKey: "MistralAPIKey")
-                return key != nil && !key!.isEmpty
+                return KeychainManager.shared.exists(forKey: "mistralAPIKey")
             case .gemini:
-                let key = UserDefaults.standard.string(forKey: "GeminiAPIKey")
-                return key != nil && !key!.isEmpty
+                return KeychainManager.shared.exists(forKey: "geminiAPIKey")
             case .soniox:
-                let key = UserDefaults.standard.string(forKey: "SonioxAPIKey")
-                return key != nil && !key!.isEmpty
+                return KeychainManager.shared.exists(forKey: "sonioxAPIKey")
             case .custom:
                 // Custom models are always usable since they contain their own API keys
                 return true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated all API keys from UserDefaults to the Keychain with iCloud sync for stronger security and cross-device access. Updated services and UI to use unified provider key names and read/write keys via Keychain, including per-model keys for custom models.

- **New Features**
  - Added KeychainManager with save/retrieve/update/delete, iCloud sync, and shared access group.
  - Unified provider key names via AIProvider.apiKeyName; all cloud transcription services and AIService now use Keychain.
  - Custom models: store API keys per model in Keychain; persist the custom models list in Keychain.

- **Migration**
  - Automatically migrates existing API keys from UserDefaults on app launch.
  - Migrates legacy custom model records and their API keys to Keychain; removes old UserDefaults entries.
  - Updated entitlements to include the shared keychain access group.

<sup>Written for commit 4b8f69ff6c35d2fd8788ed87cd47abad3bc942cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

