### PR TITLE
Add auto-switch language based on current keyboard langauge

### DIFF
--- a/VoiceInk/Services/KeyboardInputSourceMonitor.swift
+++ b/VoiceInk/Services/KeyboardInputSourceMonitor.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Carbon
+import OSLog
+
+final class KeyboardInputSourceMonitor: ObservableObject {
+    static let shared = KeyboardInputSourceMonitor()
+
+    @Published private(set) var currentKeyboardLanguage: String = ""
+    @Published private(set) var currentKeyboardDisplayName: String = ""
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "KeyboardInputSourceMonitor")
+    private var isMonitoring = false
+
+    private init() {
+        updateCurrentKeyboard()
+        startMonitoring()
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    private func startMonitoring() {
+        guard !isMonitoring else { return }
+        isMonitoring = true
+
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(keyboardInputSourceChanged),
+            name: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
+            object: nil
+        )
+
+        logger.debug("Started monitoring keyboard input source changes")
+    }
+
+    private func stopMonitoring() {
+        guard isMonitoring else { return }
+        isMonitoring = false
+
+        DistributedNotificationCenter.default().removeObserver(
+            self,
+            name: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
+            object: nil
+        )
+
+        logger.debug("Stopped monitoring keyboard input source changes")
+    }
+
+    @objc private func keyboardInputSourceChanged(_ notification: Notification) {
+        DispatchQueue.main.async { [weak self] in
+            self?.updateCurrentKeyboard()
+            self?.syncLanguageIfEnabled()
+        }
+    }
+
+    private func updateCurrentKeyboard() {
+        guard let inputSource = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
+            logger.warning("Could not get current keyboard input source")
+            return
+        }
+
+        if let languagePtr = TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceLanguages) {
+            let languages = Unmanaged<CFArray>.fromOpaque(languagePtr).takeUnretainedValue() as? [String]
+            if let primaryLanguage = languages?.first {
+                currentKeyboardLanguage = primaryLanguage
+            }
+        }
+
+        if let namePtr = TISGetInputSourceProperty(inputSource, kTISPropertyLocalizedName) {
+            let name = Unmanaged<CFString>.fromOpaque(namePtr).takeUnretainedValue() as String
+            currentKeyboardDisplayName = name
+        }
+
+        logger.debug("Keyboard changed to: \(self.currentKeyboardDisplayName) (\(self.currentKeyboardLanguage))")
+    }
+
+    func syncLanguageIfEnabled() {
+        let autoSwitch = UserDefaults.standard.bool(forKey: "AutoSwitchLanguageByKeyboard")
+        guard autoSwitch else { return }
+
+        let mappedLanguage = mapKeyboardToAppLanguage(currentKeyboardLanguage)
+
+        guard isLanguageSupported(mappedLanguage) else {
+            logger.info("Keyboard language '\(self.currentKeyboardLanguage)' maps to '\(mappedLanguage)' which is not supported by current model")
+            return
+        }
+
+        let currentLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
+        guard mappedLanguage != currentLanguage else { return }
+
+        UserDefaults.standard.set(mappedLanguage, forKey: "SelectedLanguage")
+        logger.info("Auto-switched language from '\(currentLanguage)' to '\(mappedLanguage)' based on keyboard")
+
+        NotificationCenter.default.post(name: .languageDidChange, object: nil)
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+    }
+
+    private func mapKeyboardToAppLanguage(_ keyboardLanguage: String) -> String {
+        let baseCode = keyboardLanguage.components(separatedBy: "-").first ?? keyboardLanguage
+
+        switch keyboardLanguage.lowercased() {
+        case let lang where lang.hasPrefix("zh-hans"):
+            return "zh"
+        case let lang where lang.hasPrefix("zh-hant"):
+            return "zh"
+        case let lang where lang.hasPrefix("yue-hans"), let lang where lang.hasPrefix("yue-hant"):
+            return "yue"
+        default:
+            break
+        }
+
+        switch baseCode.lowercased() {
+        case "nb":
+            return "no"
+        case "cmn":
+            return "zh"
+        default:
+            return baseCode.lowercased()
+        }
+    }
+
+    private func isLanguageSupported(_ languageCode: String) -> Bool {
+        return PredefinedModels.allLanguages.keys.contains(languageCode)
+    }
+}

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -9,9 +9,11 @@ enum LanguageDisplayMode {
 struct LanguageSelectionView: View {
     @ObservedObject var whisperState: WhisperState
     @AppStorage("SelectedLanguage") private var selectedLanguage: String = "en"
-    // Add display mode parameter with full as the default
+    @AppStorage("AutoSwitchLanguageByKeyboard") private var autoSwitchEnabled: Bool = false
     var displayMode: LanguageDisplayMode = .full
     @ObservedObject var whisperPrompt: WhisperPrompt
+    @StateObject private var keyboardMonitor = KeyboardInputSourceMonitor.shared
+    @State private var expandedSections: Set<ExpandableSection> = []
 
     private func updateLanguage(_ language: String) {
         // Update UI state - the UserDefaults updating is now automatic with @AppStorage
@@ -105,6 +107,7 @@ struct LanguageSelectionView: View {
                             }
                         }
                         .pickerStyle(MenuPickerStyle())
+                        .disabled(autoSwitchEnabled)
                         .onChange(of: selectedLanguage) { oldValue, newValue in
                             updateLanguage(newValue)
                         }
@@ -119,8 +122,11 @@ struct LanguageSelectionView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                     }
+
+                    Divider()
+
+                    autoSwitchKeyboardSection
                 } else {
-                    // For English-only models, force set language to English
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Language: English")
                             .font(.subheadline)
@@ -137,7 +143,6 @@ struct LanguageSelectionView: View {
                         .foregroundColor(.secondary)
                     }
                     .onAppear {
-                        // Ensure English is set when viewing English-only model
                         updateLanguage("en")
                     }
                 }
@@ -151,6 +156,44 @@ struct LanguageSelectionView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(NSColor.controlBackgroundColor))
         .cornerRadius(10)
+    }
+
+    private var autoSwitchKeyboardSection: some View {
+        ExpandableToggleSection(
+            section: .autoSwitchKeyboard,
+            title: "Auto-switch with keyboard",
+            helpText: "Automatically change the transcription language when you switch your system keyboard input source",
+            isEnabled: $autoSwitchEnabled,
+            expandedSections: $expandedSections
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Image(systemName: "keyboard")
+                        .foregroundColor(.secondary)
+                    Text("Current keyboard:")
+                        .foregroundColor(.secondary)
+                    Text(keyboardMonitor.currentKeyboardDisplayName)
+                        .fontWeight(.medium)
+                }
+                .font(.caption)
+
+                HStack(spacing: 8) {
+                    Image(systemName: "globe")
+                        .foregroundColor(.secondary)
+                    Text("Detected language:")
+                        .foregroundColor(.secondary)
+                    Text(keyboardMonitor.currentKeyboardLanguage)
+                        .fontWeight(.medium)
+                }
+                .font(.caption)
+            }
+            .padding(.vertical, 4)
+        }
+        .onChange(of: autoSwitchEnabled) { _, newValue in
+            if newValue {
+                keyboardMonitor.syncLanguageIfEnabled()
+            }
+        }
     }
 
     // New compact view for menu bar

--- a/VoiceInk/Views/Settings/ExpandableToggleSection.swift
+++ b/VoiceInk/Views/Settings/ExpandableToggleSection.swift
@@ -7,6 +7,7 @@ enum ExpandableSection: Hashable {
     case clipboardRestore
     case customCancel
     case middleClick
+    case autoSwitchKeyboard
 }
 
 struct ExpandableToggleSection<Content: View>: View {

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -213,6 +213,8 @@ struct VoiceInkApp: App {
                             return
                         }
 
+                        _ = KeyboardInputSourceMonitor.shared
+
                         // Migrate dictionary data from UserDefaults to SwiftData (one-time operation)
                         DictionaryMigrationService.shared.migrateIfNeeded(context: container.mainContext)
 


### PR DESCRIPTION
# Demo

https://github.com/user-attachments/assets/d156533e-ecc2-40b5-9148-d7b945e42d8f


# ⚠️ This Project Does Not Accept Pull Requests

Thank you for your interest in contributing to VoiceInk!

However, **this project is not currently accepting pull requests.**

## Please close this PR

## Alternative ways to contribute:

- 🐛 **Report bugs**: Open an [issue](../../issues) with detailed information
- 💡 **Suggest features**: Share your ideas via [issues](../../issues) or [discussions](../../discussions)
- 🍴 **Fork the project**: You're welcome to create and maintain your own fork
- 📖 **Improve documentation**: Suggest corrections or clarifications via issues

Thank you for understanding, and I appreciate your interest in VoiceInk!

---

For more information, see [CONTRIBUTING.md](../CONTRIBUTING.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-switches the app’s transcription language based on the current macOS keyboard input source. Adds a simple toggle in language settings and updates the selected language automatically when you change keyboards.

- **New Features**
  - Added KeyboardInputSourceMonitor to watch system keyboard input source changes using Carbon TIS.
  - Maps keyboard language codes to app languages and validates against supported model languages.
  - Automatically updates SelectedLanguage, posts language change notifications, and disables manual picker when enabled.
  - New “Auto-switch with keyboard” toggle in LanguageSelectionView with live display of current keyboard and detected language.
  - Initialized the monitor at app launch to keep language in sync.

<sup>Written for commit 86c25230b31dd4fffc76cb64a75a69af430927c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

