### PR TITLE
Fix onboarding focus ring artifact

### DIFF
--- a/VoiceInk/Views/Onboarding/OnboardingModelDownloadView.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingModelDownloadView.swift
@@ -13,126 +13,127 @@ struct OnboardingModelDownloadView: View {
     
     var body: some View {
         ZStack {
-            GeometryReader { geometry in
-                // Reusable background
-                OnboardingBackgroundView()
-                
-                VStack(spacing: 40) {
-                    // Model icon and title
-                    VStack(spacing: 30) {
-                        // Model icon
-                        ZStack {
-                            Circle()
-                                .fill(Color.accentColor.opacity(0.1))
-                                .frame(width: 100, height: 100)
-                            
-                            if isModelSet {
-                                Image(systemName: "checkmark.seal.fill")
-                                    .font(.system(size: 50))
-                                    .foregroundColor(.accentColor)
-                                    .transition(.scale.combined(with: .opacity))
-                            } else {
-                                Image(systemName: "brain")
-                                    .font(.system(size: 40))
-                                    .foregroundColor(.accentColor)
-                            }
-                        }
-                        .scaleEffect(scale)
-                        .opacity(opacity)
-                        
-                        // Title and description
-                        VStack(spacing: 12) {
-                            Text("Download AI Model")
-                                .font(.title2)
-                                .fontWeight(.bold)
-                                .foregroundColor(.white)
-                            
-                            Text("We'll download the optimized model to get you started.")
-                                .font(.body)
-                                .foregroundColor(.white.opacity(0.7))
-                                .multilineTextAlignment(.center)
-                                .padding(.horizontal)
-                        }
-                        .scaleEffect(scale)
-                        .opacity(opacity)
-                    }
-                    
-                    // Model card - Centered and compact
-                    VStack(alignment: .leading, spacing: 16) {
-                        // Model name and details
-                        VStack(alignment: .center, spacing: 8) {
-                            Text(turboModel.displayName)
-                                .font(.headline)
-                                .foregroundColor(.white)
-                            Text("\(turboModel.size) • \(turboModel.language)")
-                                .font(.caption)
-                                .foregroundColor(.white.opacity(0.7))
-                        }
-                        .frame(maxWidth: .infinity)
-                        
-                        Divider()
-                            .background(Color.white.opacity(0.1))
-                        
-                        // Performance indicators in a more compact layout
-                        HStack(spacing: 20) {
-                            performanceIndicator(label: "Speed", value: turboModel.speed)
-                            performanceIndicator(label: "Accuracy", value: turboModel.accuracy)
-                            ramUsageLabel(gb: turboModel.ramUsage)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        
-                        // Download progress
-                        if isDownloading {
-                            DownloadProgressView(
-                                modelName: turboModel.name,
-                                downloadProgress: whisperState.downloadProgress
-                            )
-                            .transition(.opacity)
-                        }
-                    }
-                    .padding(24)
-                    .frame(width: min(geometry.size.width * 0.6, 400))
-                    .background(Color.black.opacity(0.3))
-                    .cornerRadius(16)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(Color.white.opacity(0.1), lineWidth: 1)
-                    )
-                    .scaleEffect(scale)
-                    .opacity(opacity)
-                    
-                    // Action buttons
-                    VStack(spacing: 16) {
-                        Button(action: handleAction) {
-                            Text(getButtonTitle())
-                                .font(.headline)
-                                .foregroundColor(.white)
-                                .frame(width: 200, height: 50)
-                                .background(Color.accentColor)
-                                .cornerRadius(25)
-                        }
-                        .buttonStyle(ScaleButtonStyle())
-                        .disabled(isDownloading)
-                        
-                        if !isModelSet {
-                            SkipButton(text: "Skip for now") {
-                                withAnimation {
-                                    showTutorial = true
-                                }
-                            }
-                        }
-                    }
-                    .opacity(opacity)
-                }
-                .padding()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .frame(width: min(geometry.size.width * 0.8, 600))
-                .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-            }
-            
             if showTutorial {
                 OnboardingTutorialView(hasCompletedOnboarding: $hasCompletedOnboarding)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
+            } else {
+                GeometryReader { geometry in
+                    // Reusable background
+                    OnboardingBackgroundView()
+                    
+                    VStack(spacing: 40) {
+                        // Model icon and title
+                        VStack(spacing: 30) {
+                            // Model icon
+                            ZStack {
+                                Circle()
+                                    .fill(Color.accentColor.opacity(0.1))
+                                    .frame(width: 100, height: 100)
+                                
+                                if isModelSet {
+                                    Image(systemName: "checkmark.seal.fill")
+                                        .font(.system(size: 50))
+                                        .foregroundColor(.accentColor)
+                                        .transition(.scale.combined(with: .opacity))
+                                } else {
+                                    Image(systemName: "brain")
+                                        .font(.system(size: 40))
+                                        .foregroundColor(.accentColor)
+                                }
+                            }
+                            .scaleEffect(scale)
+                            .opacity(opacity)
+                            
+                            // Title and description
+                            VStack(spacing: 12) {
+                                Text("Download AI Model")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.white)
+                                
+                                Text("We'll download the optimized model to get you started.")
+                                    .font(.body)
+                                    .foregroundColor(.white.opacity(0.7))
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal)
+                            }
+                            .scaleEffect(scale)
+                            .opacity(opacity)
+                        }
+                        
+                        // Model card - Centered and compact
+                        VStack(alignment: .leading, spacing: 16) {
+                            // Model name and details
+                            VStack(alignment: .center, spacing: 8) {
+                                Text(turboModel.displayName)
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                Text("\(turboModel.size) • \(turboModel.language)")
+                                    .font(.caption)
+                                    .foregroundColor(.white.opacity(0.7))
+                            }
+                            .frame(maxWidth: .infinity)
+                            
+                            Divider()
+                                .background(Color.white.opacity(0.1))
+                            
+                            // Performance indicators in a more compact layout
+                            HStack(spacing: 20) {
+                                performanceIndicator(label: "Speed", value: turboModel.speed)
+                                performanceIndicator(label: "Accuracy", value: turboModel.accuracy)
+                                ramUsageLabel(gb: turboModel.ramUsage)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            
+                            // Download progress
+                            if isDownloading {
+                                DownloadProgressView(
+                                    modelName: turboModel.name,
+                                    downloadProgress: whisperState.downloadProgress
+                                )
+                                .transition(.opacity)
+                            }
+                        }
+                        .padding(24)
+                        .frame(width: min(geometry.size.width * 0.6, 400))
+                        .background(Color.black.opacity(0.3))
+                        .cornerRadius(16)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 16)
+                                .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                        )
+                        .scaleEffect(scale)
+                        .opacity(opacity)
+                        
+                        // Action buttons
+                        VStack(spacing: 16) {
+                            Button(action: handleAction) {
+                                Text(getButtonTitle())
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                    .frame(width: 200, height: 50)
+                                    .background(Color.accentColor)
+                                    .cornerRadius(25)
+                            }
+                            .buttonStyle(ScaleButtonStyle())
+                            .disabled(isDownloading)
+                            
+                            if !isModelSet {
+                                SkipButton(text: "Skip for now") {
+                                    withAnimation {
+                                        showTutorial = true
+                                    }
+                                }
+                            }
+                        }
+                        .opacity(opacity)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(width: min(geometry.size.width * 0.8, 600))
+                    .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+                }
+                .transition(.move(edge: .leading).combined(with: .opacity))
             }
         }
         .onAppear {
@@ -225,4 +226,3 @@ struct OnboardingModelDownloadView: View {
         }
     }
 }
-


### PR DESCRIPTION
## Problem

During onboarding, after selecting a model and transitioning to the tutorial screen, a blue focus ring rectangle appears as a UI artifact

<img width="1062" height="924" alt="VoiceInk 2026-01-24 12 25 39 PM" src="https://github.com/user-attachments/assets/7769f0df-47cd-4793-8956-a4479cd0db56" />

## Root Cause

The `OnboardingTutorialView` was being **overlaid** on top of `OnboardingModelDownloadView` using a `ZStack`. This kept the underlying "Continue" button in the responder chain, causing its macOS focus ring to render on top of the tutorial view.

## Solution

Changed from overlay-based to conditional rendering:

```swift
// Before: both views exist simultaneously
ZStack {
    GeometryReader { ... } // model download content
    if showTutorial {
        OnboardingTutorialView(...)
    }
}

// After: only one view exists at a time  
ZStack {
    if showTutorial {
        OnboardingTutorialView(...)
    } else {
        GeometryReader { ... } // model download content
    }
}
```

This removes the underlying view entirely when transitioning, eliminating the focus ring artifact while preserving the slide transition animations.

## Testing

- [ ] Manual testing needed: run onboarding flow and verify no focus ring appears on tutorial screen