### PR TITLE
Fix: Whisper XCFramework path mismatch with Makefile

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		E11473B02CBE0F0A00318EE4 /* VoiceInk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VoiceInk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11473C32CBE0F0B00318EE4 /* VoiceInkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VoiceInkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11473CD2CBE0F0B00318EE4 /* VoiceInkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VoiceInkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		E1A0BD052EB1E7B800266859 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
+		E1A0BD052EB1E7B800266859 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "$(HOME)/VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 		E1B2DCAA2E3DE70A008DFD68 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 		E1CE28772E4336150082B758 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */


### PR DESCRIPTION
## Problem

The project references the whisper.xcframework using a relative path:
```
../VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework
```

This path is relative to `VoiceInk.xcodeproj`, so it resolves to wherever the repo is cloned + `../VoiceInk-Dependencies/...`.

However, the Makefile (and BUILDING.md instructions) builds the framework to:
```
~/VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework
```

This means if you clone the repo anywhere other than `~/` (e.g., `~/dev/VoiceInk`), the paths don't match and Xcode fails with:
> There is no XCFramework found at '.../VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework'

## Fix

Changed the framework path to use `$(HOME)` so it always resolves to the user's home directory, matching where the Makefile builds:
```
$(HOME)/VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework
```

## Result

`make whisper` + Xcode build now works regardless of where the repo is cloned.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Whisper xcframework path in Xcode with the Makefile by using $(HOME)/VoiceInk-Dependencies/... This fixes “No XCFramework found” errors and makes “make whisper” + Xcode builds work regardless of where the repo is cloned.

<sup>Written for commit 0dbd8fa668d8eb6b9fc75ea7f1d14e1d8fd355e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

