### PR TITLE
Fix recording stopped by redundant device change handler

### DIFF
--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -8,7 +8,6 @@ class Recorder: NSObject, ObservableObject {
     private var recorder: CoreAudioRecorder?
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "Recorder")
     private let deviceManager = AudioDeviceManager.shared
-    private var deviceObserver: NSObjectProtocol?
     private var deviceSwitchObserver: NSObjectProtocol?
     private var isReconfiguring = false
     private let mediaController = MediaController.shared
@@ -25,16 +24,7 @@ class Recorder: NSObject, ObservableObject {
     
     override init() {
         super.init()
-        setupDeviceChangeObserver()
         setupDeviceSwitchObserver()
-    }
-
-    private func setupDeviceChangeObserver() {
-        deviceObserver = AudioDeviceConfiguration.createDeviceChangeObserver { [weak self] in
-            Task {
-                await self?.handleDeviceChange()
-            }
-        }
     }
 
     private func setupDeviceSwitchObserver() {
@@ -47,29 +37,6 @@ class Recorder: NSObject, ObservableObject {
                 await self?.handleDeviceSwitchRequired(notification)
             }
         }
-    }
-
-    private func handleDeviceChange() async {
-        logger.notice("handleDeviceChange called")
-        guard !isReconfiguring else {
-            logger.notice("handleDeviceChange: skipped, already reconfiguring")
-            return
-        }
-        guard recorder != nil else {
-            logger.notice("handleDeviceChange: skipped, no active recorder")
-            return
-        }
-
-        isReconfiguring = true
-
-        try? await Task.sleep(nanoseconds: 200_000_000)
-
-        logger.notice("handleDeviceChange: posting .toggleMiniRecorder notification")
-        await MainActor.run {
-            NotificationCenter.default.post(name: .toggleMiniRecorder, object: nil)
-        }
-
-        isReconfiguring = false
     }
 
     private func handleDeviceSwitchRequired(_ notification: Notification) async {
@@ -258,9 +225,6 @@ class Recorder: NSObject, ObservableObject {
         audioLevelCheckTask?.cancel()
         audioMeterUpdateTask?.cancel()
         audioRestorationTask?.cancel()
-        if let observer = deviceObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
         if let observer = deviceSwitchObserver {
             NotificationCenter.default.removeObserver(observer)
         }


### PR DESCRIPTION
## Summary

Fixes #497 - Recording feels slow to start, sometimes fails to record entirely, and long recordings get lost on macOS Tahoe.

This PR removes the redundant `handleDeviceChange()` method from `Recorder.swift` that was silently killing recordings immediately after they started.

Tested on macOS Tahoe 26.2 (25C56).

## The User-Facing Problem

Users reported:
- **"Recorder takes time to start"** - pressing the hotkey felt unresponsive
- **"Sometimes fails to record"** - recordings would silently fail
- **"Lost 2-3 minute recordings"** - recordings disappeared without appearing in history

## What Was Actually Happening

The perceived delay wasn't slow startup - recordings were **starting and then immediately getting stopped**:

```
User presses hotkey
  → Recording starts successfully
  → CoreAudio AUHAL opens the input device
  → macOS adjusts audio routing internally
  → This triggers a device list change notification
  → AudioDeviceManager.handleDeviceListChange() fires
  → Calls notifyDeviceChange()
  → Recorder.handleDeviceChange() receives it
  → Waits 200ms...
  → Posts .toggleMiniRecorder
  → Recording STOPS (the one that just started!)
```

From the user's perspective: "I pressed the hotkey and nothing happened" or "it was slow." In reality, the recording started fine but was immediately killed by `handleDeviceChange()` firing in response to the audio system reconfiguring itself when the AUHAL input device was opened.

On macOS Tahoe, the audio subsystem appears to fire device change notifications more aggressively, making this problem much worse than on previous macOS versions.

## Root Cause

Two separate device change handlers conflicted:

1. **`AudioDeviceManager.handleDeviceListChange()`** - The correct handler (added in `c530367`) that checks `isRecordingActive`, hot-switches via `.audioDeviceSwitchRequired` if device becomes unavailable, and only stops recording if no devices are available
2. **`Recorder.handleDeviceChange()`** - Legacy handler that **unconditionally** posted `.toggleMiniRecorder` after 200ms on ANY device change, stopping recordings even when the device was still available

A partial fix was attempted in `d750441` which added `guard recorder != nil` to prevent triggering when NOT recording, but this didn't address the core issue: when recording IS active, `handleDeviceChange()` still fires and unnecessarily stops the recording.

## Changes

Removed from `Recorder.swift` (pure deletion, 36 lines removed):
- `deviceObserver` property
- `setupDeviceChangeObserver()` method  
- `handleDeviceChange()` method
- Observer cleanup in `deinit`

Kept `handleDeviceSwitchRequired()` which handles legitimate device hot-switching via `.audioDeviceSwitchRequired` notification from `AudioDeviceManager`.

## One Behavioral Change

| Scenario | Before | After |
|----------|--------|-------|
| User changes audio device in Settings while recording | Recording stops after 200ms | Recording continues with current device |

This is advantageous: prevents accidental interruption of recordings, and is a rare scenario (users don't typically change Settings mid-recording). System-level device changes (Bluetooth disconnect, USB unplug) are still handled correctly by `AudioDeviceManager`.

## Test Plan

Tested on macOS Tahoe 26.2 (25C56):

- [x] Hotkey starts recording immediately with no delay
- [x] Basic recording and transcription works
- [x] Long recordings (2-3 min) complete successfully
- [x] Connecting headphones during recording doesn't stop it
- [x] Recordings appear in history
- [x] Transcription completes normally after device change during recording
- [x] Verified `handleDeviceChange: posting .toggleMiniRecorder` no longer appears in Console logs

cc @Beingpax

🤖 Generated with [Claude Code](https://claude.com/claude-code)