### PR TITLE
Add Azure OpenAI provider integration with configurable auth methods

### DIFF
--- a/VoiceInk/Services/APIKeyManager.swift
+++ b/VoiceInk/Services/APIKeyManager.swift
@@ -21,6 +21,7 @@ final class APIKeyManager {
         "elevenlabs": "elevenLabsAPIKey",
         "soniox": "sonioxAPIKey",
         "openai": "openAIAPIKey",
+        "azure openai": "azureOpenAIAPIKey",
         "anthropic": "anthropicAPIKey",
         "openrouter": "openRouterAPIKey"
     ]


### PR DESCRIPTION
- Add Azure OpenAI as new provider option with deployment-based model selection
- Implement two authentication methods: standard (api-key) and API Management (Ocp-Apim-Subscription-Key)
- Support custom endpoint URLs for enterprise Azure gateways
- Add comprehensive debug logging to temp file for troubleshooting
- Include Azure-specific configuration UI with resource name, deployment, and API version fields



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure OpenAI as a provider with deployment-based selection, configurable auth headers, and custom endpoint support. Includes a focused settings UI and key verification for Azure.

- **New Features**
  - New provider: Azure OpenAI with selectable auth headers (api-key or Ocp-Apim-Subscription-Key).
  - Auto-builds endpoint from resource/deployment/api-version, or uses a custom endpoint URL.
  - Deployment-based “model” selection and Azure-specific request handling and error mapping.
  - API key verification updated to use Azure headers; new key storage mapping.

- **Migration**
  - In API Key Management, choose Azure OpenAI, set resource, deployment, API version or a custom endpoint, pick auth method, then verify and save the key.
  - If using a custom endpoint, you can provide a full /deployments/.../chat/completions URL; otherwise the app constructs it from your inputs.

<sup>Written for commit 137af1eb634074891fb4ed68cda929e9fea23282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

