### PR TITLE
Feat/streaming transcription

### DIFF
--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
         "branch" : "main",
-        "revision" : "b598f43ed4056765349f068b13d0bed8cdabde07"
+        "revision" : "4de9aca1d1dbdafa72f6d349b15d0009032a83f8"
       }
     },
     {
@@ -80,6 +80,33 @@
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
+        "version" : "1.1.6"
       }
     },
     {

--- a/VoiceInk.xcodeproj/xcshareddata/xcschemes/VoiceInk.xcscheme
+++ b/VoiceInk.xcodeproj/xcshareddata/xcschemes/VoiceInk.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E11473AF2CBE0F0A00318EE4"
+               BuildableName = "VoiceInk.app"
+               BlueprintName = "VoiceInk"
+               ReferencedContainer = "container:VoiceInk.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E11473C22CBE0F0B00318EE4"
+               BuildableName = "VoiceInkTests.xctest"
+               BlueprintName = "VoiceInkTests"
+               ReferencedContainer = "container:VoiceInk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E11473CC2CBE0F0B00318EE4"
+               BuildableName = "VoiceInkUITests.xctest"
+               BlueprintName = "VoiceInkUITests"
+               ReferencedContainer = "container:VoiceInk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E11473AF2CBE0F0A00318EE4"
+            BuildableName = "VoiceInk.app"
+            BlueprintName = "VoiceInk"
+            ReferencedContainer = "container:VoiceInk.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E11473AF2CBE0F0A00318EE4"
+            BuildableName = "VoiceInk.app"
+            BlueprintName = "VoiceInk"
+            ReferencedContainer = "container:VoiceInk.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/VoiceInk/CoreAudioRecorder.swift
+++ b/VoiceInk/CoreAudioRecorder.swift
@@ -48,6 +48,9 @@ final class CoreAudioRecorder {
     private var renderBuffer: UnsafeMutablePointer<Float32>?
     private var renderBufferSize: UInt32 = 0
 
+    /// Called on the audio thread with raw PCM data (16-bit, 16kHz, mono) for streaming.
+    var onAudioChunk: ((_ data: Data) -> Void)?
+
     // MARK: - Initialization
 
     init() {}
@@ -699,6 +702,13 @@ final class CoreAudioRecorder {
         let writeStatus = ExtAudioFileWrite(file, outputFrameCount, &outputBufferList)
         if writeStatus != noErr {
             logger.error("🎙️ ExtAudioFileWrite failed with status: \(writeStatus)")
+        }
+
+        // Send the same PCM data to the streaming callback if set
+        if let onAudioChunk = onAudioChunk {
+            let byteCount = Int(outputFrameCount) * MemoryLayout<Int16>.size
+            let data = Data(bytes: outputBuffer, count: byteCount)
+            onAudioChunk(data)
         }
     }
 

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -229,8 +229,8 @@ import Foundation
        ),
        CloudModel(
            name: "scribe_v2",
-           displayName: "Scribe v2 (ElevenLabs)",
-           description: "ElevenLabs' Scribe v2 model for the most accurate transcription.",
+           displayName: "Scribe V2 Real-Time (ElevenLabs)",
+           description: "ElevenLabs' Scribe V2 Real-Time model for the most accurate transcription.",
            provider: .elevenLabs,
            speed: 0.75,
            accuracy: 0.99,

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -96,7 +96,7 @@ import Foundation
         NativeAppleModel(
             name: "apple-speech",
             displayName: "Apple Speech",
-            description: "Uses the native Apple Speech framework for transcription. Requires macOS 26.",
+            description: "Uses the native Apple Speech framework for transcription. Requires macOS 26",
             isMultilingualModel: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .nativeApple)
         ),
@@ -105,7 +105,7 @@ import Foundation
         ParakeetModel(
             name: "parakeet-tdt-0.6b-v2",
             displayName: "Parakeet V2",
-            description: "NVIDIA's Parakeet V2 model optimized for lightning-fast English-only transcription.",
+            description: "NVIDIA's Parakeet V2 model optimized for lightning-fast English-only transcription",
             size: "474 MB",
             speed: 0.99,
             accuracy: 0.94,
@@ -115,7 +115,7 @@ import Foundation
         ParakeetModel(
             name: "parakeet-tdt-0.6b-v3",
             displayName: "Parakeet V3",
-            description: "NVIDIA's Parakeet V3 model with multilingual support across English and 25 European languages.",
+            description: "NVIDIA's Parakeet V3 model with multilingual support across English and 25 European languages",
             size: "494 MB",
             speed: 0.99,
             accuracy: 0.94,
@@ -213,14 +213,14 @@ import Foundation
             description: "Whisper Large v3 Turbo model with Groq's lightning-speed inference",
             provider: .groq,
             speed: 0.65,
-            accuracy: 0.96,
+            accuracy: 0.95,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .groq)
         ),
         CloudModel(
            name: "scribe_v1",
            displayName: "Scribe v1 (ElevenLabs)",
-           description: "ElevenLabs' Scribe model for fast & accurate transcription.",
+           description: "ElevenLabs' Scribe model for fast & accurate transcription",
            provider: .elevenLabs,
            speed: 0.7,
            accuracy: 0.98,
@@ -230,29 +230,29 @@ import Foundation
        CloudModel(
            name: "scribe_v2",
            displayName: "Scribe V2 Realtime (ElevenLabs)",
-           description: "ElevenLabs' Scribe V2 Realtime model for the most accurate transcription.",
+           description: "ElevenLabs' Scribe V2 Realtime model for the most accurate transcription",
            provider: .elevenLabs,
-           speed: 0.75,
-           accuracy: 0.99,
+           speed: 0.99,
+           accuracy: 0.98,
            isMultilingual: true,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .elevenLabs)
        ),
        CloudModel(
            name: "nova-3",
            displayName: "Nova 3 Realtime (Deepgram)",
-           description: "Deepgram's latest Nova 3 model with 54% lower WER and support for 40+ languages.",
+           description: "Deepgram's latest Nova 3 model for realtime transcription",
            provider: .deepgram,
-           speed: 0.95,
-           accuracy: 0.97,
+           speed: 0.99,
+           accuracy: 0.96,
            isMultilingual: true,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .deepgram)
        ),
        CloudModel(
            name: "nova-3-medical",
            displayName: "Nova 3 Medical Realtime (Deepgram)",
-           description: "Specialized medical transcription model optimized for clinical environments.",
+           description: "Specialized medical transcription model optimized for clinical environments",
            provider: .deepgram,
-           speed: 0.9,
+           speed: 0.99,
            accuracy: 0.96,
            isMultilingual: false,
            supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .deepgram)
@@ -260,10 +260,10 @@ import Foundation
         CloudModel(
             name: "voxtral-mini-latest",
             displayName: "Voxtral Transcribe 2 (Mistral)",
-            description: "Mistral's latest transcription model for fast and accurate transcription.",
+            description: "Mistral's latest transcription model for fast and accurate transcription",
             provider: .mistral,
             speed: 0.8,
-            accuracy: 0.97,
+            accuracy: 0.98,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
         ),
@@ -272,8 +272,8 @@ import Foundation
             displayName: "Voxtral Realtime (Mistral)",
             description: "Mistral's Voxtral Realtime model for streaming transcription",
             provider: .mistral,
-            speed: 0.95,
-            accuracy: 0.95,
+            speed: 0.99,
+            accuracy: 0.97,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
         ),
@@ -282,27 +282,27 @@ import Foundation
         CloudModel(
             name: "gemini-2.5-pro",
             displayName: "Gemini 2.5 Pro",
-            description: "Google's advanced multimodal model with high-quality transcription capabilities.",
+            description: "Google's advanced model with high-quality transcription capabilities",
             provider: .gemini,
             speed: 0.7,
-            accuracy: 0.96,
+            accuracy: 0.97,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .gemini)
         ),
         CloudModel(
             name: "gemini-2.5-flash",
             displayName: "Gemini 2.5 Flash",
-            description: "Google's optimized model for low-latency transcription with multimodal support.",
+            description: "Google's optimized model for low-latency transcription",
             provider: .gemini,
             speed: 0.9,
-            accuracy: 0.94,
+            accuracy: 0.95,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .gemini)
         ),
         CloudModel(
             name: "gemini-3-pro-preview",
             displayName: "Gemini 3 Pro",
-            description: "Google's latest multimodal model with enhanced transcription capabilities.",
+            description: "Google's latest model with enhanced transcription capabilities",
             provider: .gemini,
             speed: 0.75,
             accuracy: 0.97,
@@ -312,7 +312,7 @@ import Foundation
         CloudModel(
             name: "gemini-3-flash-preview",
             displayName: "Gemini 3 Flash",
-            description: "Google's newest fast model combining intelligence with superior speed.",
+            description: "Google's newest fast model combining intelligence with superior speed",
             provider: .gemini,
             speed: 0.92,
             accuracy: 0.95,
@@ -323,20 +323,20 @@ import Foundation
         CloudModel(
             name: "stt-async-v4",
             displayName: "Soniox V4",
-            description: "Soniox asynchronous transcription model v4 with human-parity accuracy across 60+ languages.",
+            description: "Soniox asynchronous transcription model v4 with human-parity accuracy",
             provider: .soniox,
             speed: 0.8,
-            accuracy: 0.97,
+            accuracy: 0.98,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
         ),
         CloudModel(
             name: "stt-rt-v4",
             displayName: "Soniox Realtime V4",
-            description: "Soniox real-time streaming model v4 for low-latency voice interactions with 60+ language support.",
+            description: "Soniox real-time streaming model v4 for low-latency transcription",
             provider: .soniox,
-            speed: 0.95,
-            accuracy: 0.96,
+            speed: 0.99,
+            accuracy: 0.97,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
         )

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -229,8 +229,8 @@ import Foundation
        ),
        CloudModel(
            name: "scribe_v2",
-           displayName: "Scribe V2 Real-Time (ElevenLabs)",
-           description: "ElevenLabs' Scribe V2 Real-Time model for the most accurate transcription.",
+           displayName: "Scribe V2 Realtime (ElevenLabs)",
+           description: "ElevenLabs' Scribe V2 Realtime model for the most accurate transcription.",
            provider: .elevenLabs,
            speed: 0.75,
            accuracy: 0.99,
@@ -238,18 +238,18 @@ import Foundation
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .elevenLabs)
        ),
        CloudModel(
-           name: "nova-2",
-           displayName: "Nova (Deepgram)",
-           description: "Deepgram's Nova model for fast, accurate, and cost-effective transcription.",
+           name: "nova-3",
+           displayName: "Nova 3 Realtime (Deepgram)",
+           description: "Deepgram's latest Nova 3 model with 54% lower WER and support for 40+ languages.",
            provider: .deepgram,
-           speed: 0.9,
-           accuracy: 0.95,
+           speed: 0.95,
+           accuracy: 0.97,
            isMultilingual: true,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .deepgram)
        ),
        CloudModel(
            name: "nova-3-medical",
-           displayName: "Nova-3 Medical (Deepgram)",
+           displayName: "Nova 3 Medical Realtime (Deepgram)",
            description: "Specialized medical transcription model optimized for clinical environments.",
            provider: .deepgram,
            speed: 0.9,

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -322,11 +322,21 @@ import Foundation
         ,
         CloudModel(
             name: "stt-async-v4",
-            displayName: "Soniox (stt-async-v4)",
+            displayName: "Soniox V4",
             description: "Soniox asynchronous transcription model v4 with human-parity accuracy across 60+ languages.",
             provider: .soniox,
             speed: 0.8,
             accuracy: 0.97,
+            isMultilingual: true,
+            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
+        ),
+        CloudModel(
+            name: "stt-rt-v4",
+            displayName: "Soniox Realtime V4",
+            description: "Soniox real-time streaming model v4 for low-latency voice interactions with 60+ language support.",
+            provider: .soniox,
+            speed: 0.95,
+            accuracy: 0.96,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
         )

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -259,11 +259,21 @@ import Foundation
        ),
         CloudModel(
             name: "voxtral-mini-latest",
-            displayName: "Voxtral Mini (Mistral)",
-            description: "Mistral's latest SOTA transcription model.",
+            displayName: "Voxtral Transcribe 2 (Mistral)",
+            description: "Mistral's latest transcription model for fast and accurate transcription.",
             provider: .mistral,
             speed: 0.8,
             accuracy: 0.97,
+            isMultilingual: true,
+            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
+        ),
+        CloudModel(
+            name: "voxtral-mini-transcribe-realtime-2602",
+            displayName: "Voxtral Realtime (Mistral)",
+            description: "Mistral's Voxtral Realtime model for streaming transcription",
+            provider: .mistral,
+            speed: 0.95,
+            accuracy: 0.95,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
         ),

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -26,13 +26,14 @@ protocol TranscriptionModel: Identifiable, Hashable {
     // Language capabilities
     var isMultilingualModel: Bool { get }
     var supportedLanguages: [String: String] { get }
+
 }
 
 extension TranscriptionModel {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
-    
+
     var language: String {
         isMultilingualModel ? "Multilingual" : "English-only"
     }

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -19,8 +19,11 @@ class Recorder: NSObject, ObservableObject {
     private var audioRestorationTask: Task<Void, Never>?
     private var hasDetectedAudioInCurrentSession = false
 
-    /// Audio chunk callback for streaming. Set before calling startRecording().
-    var onAudioChunk: ((_ data: Data) -> Void)?
+    /// Audio chunk callback for streaming. Can be updated while recording;
+    /// changes are forwarded to the live CoreAudioRecorder.
+    var onAudioChunk: ((_ data: Data) -> Void)? {
+        didSet { recorder?.onAudioChunk = onAudioChunk }
+    }
     
     enum RecorderError: Error {
         case couldNotStartRecording

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -161,7 +161,7 @@ class Recorder: NSObject, ObservableObject {
             audioMeterUpdateTask = Task {
                 while recorder != nil && !Task.isCancelled {
                     updateAudioMeter()
-                    try? await Task.sleep(nanoseconds: 17_000_000)
+                    try? await Task.sleep(nanoseconds: 33_000_000) // ~30Hz
                 }
             }
 

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -18,6 +18,9 @@ class Recorder: NSObject, ObservableObject {
     private var audioMeterUpdateTask: Task<Void, Never>?
     private var audioRestorationTask: Task<Void, Never>?
     private var hasDetectedAudioInCurrentSession = false
+
+    /// Audio chunk callback for streaming. Set before calling startRecording().
+    var onAudioChunk: ((_ data: Data) -> Void)?
     
     enum RecorderError: Error {
         case couldNotStartRecording
@@ -134,6 +137,7 @@ class Recorder: NSObject, ObservableObject {
 
         do {
             let coreAudioRecorder = CoreAudioRecorder()
+            coreAudioRecorder.onAudioChunk = onAudioChunk
             recorder = coreAudioRecorder
 
             try coreAudioRecorder.startRecording(toOutputFile: url, deviceID: deviceID)
@@ -192,6 +196,7 @@ class Recorder: NSObject, ObservableObject {
         audioMeterUpdateTask?.cancel()
         recorder?.stopRecording()
         recorder = nil
+        onAudioChunk = nil
         audioMeter = AudioMeter(averagePower: 0, peakPower: 0)
 
         audioRestorationTask = Task {

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -15,9 +15,11 @@ class Recorder: NSObject, ObservableObject {
     private let playbackController = PlaybackController.shared
     @Published var audioMeter = AudioMeter(averagePower: 0, peakPower: 0)
     private var audioLevelCheckTask: Task<Void, Never>?
-    private var audioMeterUpdateTask: Task<Void, Never>?
+    private var audioMeterUpdateTimer: DispatchSourceTimer?
+    private let audioMeterQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.audiometer", qos: .userInteractive)
     private var audioRestorationTask: Task<Void, Never>?
     private var hasDetectedAudioInCurrentSession = false
+    private let smoothedValuesLock = NSLock()
     private var smoothedAverage: Float = 0
     private var smoothedPeak: Float = 0
 
@@ -158,14 +160,9 @@ class Recorder: NSObject, ObservableObject {
             }
 
             audioLevelCheckTask?.cancel()
-            audioMeterUpdateTask?.cancel()
+            audioMeterUpdateTimer?.cancel()
 
-            audioMeterUpdateTask = Task {
-                while recorder != nil && !Task.isCancelled {
-                    updateAudioMeter()
-                    try? await Task.sleep(nanoseconds: 33_000_000) // ~30Hz
-                }
-            }
+            startAudioMeterTimer()
 
             audioLevelCheckTask = Task {
                 let notificationChecks: [TimeInterval] = [5.0, 12.0]
@@ -198,12 +195,17 @@ class Recorder: NSObject, ObservableObject {
     func stopRecording() {
         logger.notice("stopRecording called")
         audioLevelCheckTask?.cancel()
-        audioMeterUpdateTask?.cancel()
+        audioMeterUpdateTimer?.cancel()
+        audioMeterUpdateTimer = nil
         recorder?.stopRecording()
         recorder = nil
         onAudioChunk = nil
+
+        smoothedValuesLock.lock()
         smoothedAverage = 0
         smoothedPeak = 0
+        smoothedValuesLock.unlock()
+
         audioMeter = AudioMeter(averagePower: 0, peakPower: 0)
 
         audioRestorationTask = Task {
@@ -228,12 +230,24 @@ class Recorder: NSObject, ObservableObject {
         }
     }
 
+    private func startAudioMeterTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: audioMeterQueue)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(33)) // ~30Hz
+        timer.setEventHandler { [weak self] in
+            self?.updateAudioMeter()
+        }
+        timer.resume()
+        audioMeterUpdateTimer = timer
+    }
+
     private func updateAudioMeter() {
         guard let recorder = recorder else { return }
 
+        // Sample audio levels (thread-safe read)
         let averagePower = recorder.averagePower
         let peakPower = recorder.peakPower
 
+        // Normalize values
         let minVisibleDb: Float = -60.0
         let maxVisibleDb: Float = 0.0
 
@@ -255,23 +269,28 @@ class Recorder: NSObject, ObservableObject {
             normalizedPeak = (peakPower - minVisibleDb) / (maxVisibleDb - minVisibleDb)
         }
 
+        // Apply EMA smoothing with thread-safe access
+        smoothedValuesLock.lock()
         smoothedAverage = smoothedAverage * 0.6 + normalizedAverage * 0.4
         smoothedPeak = smoothedPeak * 0.6 + normalizedPeak * 0.4
-
         let newAudioMeter = AudioMeter(averagePower: Double(smoothedAverage), peakPower: Double(smoothedPeak))
+        smoothedValuesLock.unlock()
 
-        if !hasDetectedAudioInCurrentSession && newAudioMeter.averagePower > 0.01 {
-            hasDetectedAudioInCurrentSession = true
+        // Dispatch to main queue for UI updates (more efficient than Task)
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if !self.hasDetectedAudioInCurrentSession && newAudioMeter.averagePower > 0.01 {
+                self.hasDetectedAudioInCurrentSession = true
+            }
+            self.audioMeter = newAudioMeter
         }
-
-        audioMeter = newAudioMeter
     }
     
     // MARK: - Cleanup
 
     deinit {
         audioLevelCheckTask?.cancel()
-        audioMeterUpdateTask?.cancel()
+        audioMeterUpdateTimer?.cancel()
         audioRestorationTask?.cancel()
         if let observer = deviceObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -232,7 +232,7 @@ class Recorder: NSObject, ObservableObject {
 
     private func startAudioMeterTimer() {
         let timer = DispatchSource.makeTimerSource(queue: audioMeterQueue)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(33)) // ~30Hz
+        timer.schedule(deadline: .now(), repeating: .milliseconds(17)) 
         timer.setEventHandler { [weak self] in
             self?.updateAudioMeter()
         }

--- a/VoiceInk/Services/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/DeepgramTranscriptionService.swift
@@ -53,9 +53,8 @@ class DeepgramTranscriptionService {
         // Add language parameter if not auto-detect
         let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
         
-        // Choose model based on language
-        let modelName = selectedLanguage == "en" ? "nova-3" : "nova-2"
-        queryItems.append(URLQueryItem(name: "model", value: modelName))
+        // Use the model name from the TranscriptionModel (nova-3 or nova-3-medical)
+        queryItems.append(URLQueryItem(name: "model", value: model.name))
         
         queryItems.append(contentsOf: [
             URLQueryItem(name: "smart_format", value: "true"),

--- a/VoiceInk/Services/CloudTranscription/SonioxTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/SonioxTranscriptionService.swift
@@ -77,9 +77,14 @@ class SonioxTranscriptionService {
                 "terms": dictionaryTerms
             ]
         }
+
         let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
         if selectedLanguage != "auto" && !selectedLanguage.isEmpty {
             payload["language_hints"] = [selectedLanguage]
+            payload["language_hints_strict"] = true
+            payload["enable_language_identification"] = true
+        } else {
+            payload["enable_language_identification"] = true
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
         let (data, response) = try await URLSession.shared.data(for: request)

--- a/VoiceInk/Services/ParakeetTranscriptionService.swift
+++ b/VoiceInk/Services/ParakeetTranscriptionService.swift
@@ -4,21 +4,12 @@ import AVFoundation
 import FluidAudio
 import os.log
 
-enum ParakeetTranscriptionError: LocalizedError {
-    case modelValidationFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .modelValidationFailed(let message):
-            return message
-        }
-    }
-}
-
 class ParakeetTranscriptionService: TranscriptionService {
     private var asrManager: AsrManager?
     private var vadManager: VadManager?
     private var activeVersion: AsrModelVersion?
+    private var cachedModels: AsrModels?
+    private var loadingTask: Task<AsrModels, Error>?
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink.parakeet", category: "ParakeetTranscriptionService")
 
     private func version(for model: any TranscriptionModel) -> AsrModelVersion {
@@ -26,28 +17,52 @@ class ParakeetTranscriptionService: TranscriptionService {
     }
 
     private func ensureModelsLoaded(for version: AsrModelVersion) async throws {
-        if let manager = asrManager, activeVersion == version {
+        if asrManager != nil, activeVersion == version {
             return
         }
 
-        cleanup()
+        // Clean up existing manager but preserve cachedModels for reuse
+        asrManager?.cleanup()
+        asrManager = nil
+        vadManager = nil
+        activeVersion = nil
 
-        // Validate models before loading
-        let isValid = try await AsrModels.isModelValid(version: version)
-
-        if !isValid {
-            logger.error("Model validation failed for \(version == .v2 ? "v2" : "v3"). Models are corrupted.")
-            throw ParakeetTranscriptionError.modelValidationFailed("Parakeet models are corrupted. Please delete and re-download the model.")
-        }
+        let models = try await getOrLoadModels(for: version)
 
         let manager = AsrManager(config: .default)
-        let models = try await AsrModels.loadFromCache(
-            configuration: nil,
-            version: version
-        )
         try await manager.initialize(models: models)
         self.asrManager = manager
         self.activeVersion = version
+    }
+
+    // Returns cached models or loads from disk; deduplicates concurrent loads
+    func getOrLoadModels(for version: AsrModelVersion) async throws -> AsrModels {
+        if let cached = cachedModels, cached.version == version {
+            return cached
+        }
+
+        // Deduplicate concurrent loads
+        if let existing = loadingTask {
+            return try await existing.value
+        }
+
+        let task = Task {
+            try await AsrModels.loadFromCache(
+                configuration: nil,
+                version: version
+            )
+        }
+        loadingTask = task
+
+        do {
+            let models = try await task.value
+            self.cachedModels = models
+            self.loadingTask = nil
+            return models
+        } catch {
+            self.loadingTask = nil
+            throw error
+        }
     }
 
     func loadModel(for model: ParakeetModel) async throws {
@@ -115,10 +130,12 @@ class ParakeetTranscriptionService: TranscriptionService {
         }
     }
 
+    // Releases ASR/VAD resources but preserves cached models for reuse
     func cleanup() {
         asrManager?.cleanup()
         asrManager = nil
         vadManager = nil
         activeVersion = nil
     }
+
 }

--- a/VoiceInk/Services/ParakeetTranscriptionService.swift
+++ b/VoiceInk/Services/ParakeetTranscriptionService.swift
@@ -57,10 +57,16 @@ class ParakeetTranscriptionService: TranscriptionService {
         do {
             let models = try await task.value
             self.cachedModels = models
-            self.loadingTask = nil
+            // Only clear if we're still the current loading task
+            if loadingTask?.version == version {
+                self.loadingTask = nil
+            }
             return models
         } catch {
-            self.loadingTask = nil
+            // Only clear if we're still the current loading task
+            if loadingTask?.version == version {
+                self.loadingTask = nil
+            }
             throw error
         }
     }

--- a/VoiceInk/Services/StreamingTranscription/DeepgramStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/DeepgramStreamingProvider.swift
@@ -1,0 +1,228 @@
+import Foundation
+import os
+
+/// Deepgram Nova-3 Real-Time streaming provider using WebSocket.
+final class DeepgramStreamingProvider: StreamingTranscriptionProvider {
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "DeepgramStreaming")
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var receiveTask: Task<Void, Never>?
+    private var keepaliveTask: Task<Void, Never>?
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init() {
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    deinit {
+        keepaliveTask?.cancel()
+        receiveTask?.cancel()
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        urlSession?.invalidateAndCancel()
+        eventsContinuation?.finish()
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "Deepgram"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        // Build the WebSocket URL with query parameters
+        var components = URLComponents(string: "wss://api.deepgram.com/v1/listen")!
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "model", value: model.name),
+            URLQueryItem(name: "encoding", value: "linear16"),
+            URLQueryItem(name: "sample_rate", value: "16000"),
+            URLQueryItem(name: "channels", value: "1"),
+            URLQueryItem(name: "smart_format", value: "true"),
+            URLQueryItem(name: "punctuate", value: "true"),
+            URLQueryItem(name: "interim_results", value: "true")
+        ]
+
+        if let language = language, language != "auto", !language.isEmpty {
+            queryItems.append(URLQueryItem(name: "language", value: language))
+        }
+
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw StreamingTranscriptionError.connectionFailed("Invalid WebSocket URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Token \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: request)
+
+        self.urlSession = session
+        self.webSocketTask = task
+
+        task.resume()
+
+        logger.notice("WebSocket connecting to \(url.absoluteString)")
+
+        // Deepgram doesn't send a session_started message, connection is established when resume() succeeds
+        eventsContinuation?.yield(.sessionStarted)
+        logger.notice("Streaming session started")
+
+        // Start the background receive loop
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+
+        // Start keepalive timer (send keepalive every 5 seconds)
+        keepaliveTask = Task { [weak self] in
+            await self?.keepaliveLoop()
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        // Deepgram expects raw binary PCM data (NOT base64 encoded)
+        try await task.send(.data(data))
+    }
+
+    func commit() async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        // Send Finalize message to commit remaining audio
+        let finalizeMessage: [String: Any] = ["type": "Finalize"]
+        let jsonData = try JSONSerialization.data(withJSONObject: finalizeMessage)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        logger.notice("Sending finalize message")
+        try await task.send(.string(jsonString))
+    }
+
+    func disconnect() async {
+        // Stop keepalive first
+        keepaliveTask?.cancel()
+        keepaliveTask = nil
+
+        // Send CloseStream message if still connected
+        if let task = webSocketTask {
+            do {
+                let closeMessage: [String: Any] = ["type": "CloseStream"]
+                let jsonData = try JSONSerialization.data(withJSONObject: closeMessage)
+                let jsonString = String(data: jsonData, encoding: .utf8)!
+                try await task.send(.string(jsonString))
+            } catch {
+                logger.warning("Failed to send CloseStream message: \(error.localizedDescription)")
+            }
+        }
+
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        eventsContinuation?.finish()
+        logger.notice("WebSocket disconnected")
+    }
+
+    // MARK: - Private
+
+    private func keepaliveLoop() async {
+        while !Task.isCancelled {
+            do {
+                // Wait 5 seconds between keepalives
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+
+                guard let task = webSocketTask, !Task.isCancelled else { break }
+
+                let keepaliveMessage: [String: Any] = ["type": "KeepAlive"]
+                let jsonData = try JSONSerialization.data(withJSONObject: keepaliveMessage)
+                let jsonString = String(data: jsonData, encoding: .utf8)!
+
+                try await task.send(.string(jsonString))
+                logger.debug("Sent keepalive")
+            } catch {
+                if !Task.isCancelled {
+                    logger.warning("Keepalive error: \(error.localizedDescription)")
+                }
+                break
+            }
+        }
+    }
+
+    private func receiveLoop() async {
+        guard let task = webSocketTask else { return }
+
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                switch message {
+                case .string(let text):
+                    handleMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        handleMessage(text)
+                    }
+                @unknown default:
+                    break
+                }
+            } catch {
+                if !Task.isCancelled {
+                    logger.error("WebSocket receive error: \(error.localizedDescription)")
+                    eventsContinuation?.yield(.error(error))
+                }
+                break
+            }
+        }
+    }
+
+    private func handleMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            logger.warning("Received unparseable message")
+            return
+        }
+
+        // Check for error messages
+        if let errorMessage = json["error"] as? String {
+            logger.error("Server error: \(errorMessage)")
+            eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(errorMessage)))
+            return
+        }
+
+        // Check for type field (control messages)
+        if let type = json["type"] as? String {
+            logger.debug("Received control message: \(type)")
+            return
+        }
+
+        // Parse transcription results
+        guard let channel = json["channel"] as? [String: Any],
+              let alternatives = channel["alternatives"] as? [[String: Any]],
+              let firstAlternative = alternatives.first,
+              let transcript = firstAlternative["transcript"] as? String,
+              !transcript.isEmpty else {
+            return
+        }
+
+        // Check if this is a final result
+        let isFinal = json["is_final"] as? Bool ?? false
+        let speechFinal = json["speech_final"] as? Bool ?? false
+
+        if isFinal || speechFinal {
+            // Final transcript
+            logger.notice("Final: \(transcript)")
+            eventsContinuation?.yield(.committed(text: transcript))
+        } else {
+            // Partial transcript
+            eventsContinuation?.yield(.partial(text: transcript))
+        }
+    }
+}

--- a/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
@@ -18,6 +18,13 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
         eventsContinuation = continuation
     }
 
+    deinit {
+        receiveTask?.cancel()
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        urlSession?.invalidateAndCancel()
+        eventsContinuation?.finish()
+    }
+
     func connect(model: any TranscriptionModel, language: String?) async throws {
         guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "ElevenLabs"), !apiKey.isEmpty else {
             throw StreamingTranscriptionError.missingAPIKey

--- a/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
@@ -177,7 +177,6 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
         switch messageType {
         case "partial_transcript":
             if let transcript = json["text"] as? String {
-                logger.debug("Partial: \(transcript)")
                 eventsContinuation?.yield(.partial(text: transcript))
             }
 

--- a/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
@@ -11,7 +11,6 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
     private var receiveTask: Task<Void, Never>?
 
     private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
-    private var _eventStream: AsyncStream<StreamingTranscriptionEvent>?
 
     init() {
         var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
@@ -29,7 +28,7 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
         var queryItems: [URLQueryItem] = [
             URLQueryItem(name: "model_id", value: "scribe_v2_realtime"),
             URLQueryItem(name: "audio_format", value: "pcm_16000"),
-            URLQueryItem(name: "commit_strategy", value: "manual"),
+            URLQueryItem(name: "commit_strategy", value: "vad"),
         ]
 
         if let language = language, language != "auto", !language.isEmpty {

--- a/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-/// ElevenLabs Scribe v2 realtime streaming provider using WebSocket.
+/// ElevenLabs Scribe V2 Real-Time streaming provider using WebSocket.
 final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
 
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ElevenLabsStreaming")

--- a/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
@@ -1,0 +1,195 @@
+import Foundation
+import os
+
+/// ElevenLabs Scribe v2 realtime streaming provider using WebSocket.
+final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ElevenLabsStreaming")
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var receiveTask: Task<Void, Never>?
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+    private var _eventStream: AsyncStream<StreamingTranscriptionEvent>?
+
+    init() {
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "ElevenLabs"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        // Build the WebSocket URL with query parameters
+        var components = URLComponents(string: "wss://api.elevenlabs.io/v1/speech-to-text/realtime")!
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "model_id", value: "scribe_v2_realtime"),
+            URLQueryItem(name: "audio_format", value: "pcm_16000"),
+            URLQueryItem(name: "commit_strategy", value: "manual"),
+        ]
+
+        if let language = language, language != "auto", !language.isEmpty {
+            queryItems.append(URLQueryItem(name: "language_code", value: language))
+        }
+
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw StreamingTranscriptionError.connectionFailed("Invalid WebSocket URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: request)
+
+        self.urlSession = session
+        self.webSocketTask = task
+
+        task.resume()
+
+        logger.notice("WebSocket connecting to \(url.absoluteString)")
+
+        // Wait for the session_started message to confirm connection
+        let message = try await task.receive()
+        switch message {
+        case .string(let text):
+            if let data = text.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let messageType = json["message_type"] as? String {
+                if messageType == "session_started" {
+                    logger.notice("Streaming session started")
+                    eventsContinuation?.yield(.sessionStarted)
+                } else if messageType == "error" || messageType == "auth_error" {
+                    let errorMsg = json["message"] as? String ?? "Unknown error"
+                    throw StreamingTranscriptionError.serverError(errorMsg)
+                }
+            }
+        case .data:
+            break
+        @unknown default:
+            break
+        }
+
+        // Start the background receive loop
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        let base64Audio = data.base64EncodedString()
+
+        let message: [String: Any] = [
+            "message_type": "input_audio_chunk",
+            "audio_base_64": base64Audio,
+            "commit": false,
+            "sample_rate": 16000
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: message)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        try await task.send(.string(jsonString))
+    }
+
+    func commit() async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        let message: [String: Any] = [
+            "message_type": "input_audio_chunk",
+            "audio_base_64": "",
+            "commit": true,
+            "sample_rate": 16000
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: message)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        logger.notice("Sending commit message")
+        try await task.send(.string(jsonString))
+    }
+
+    func disconnect() async {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        eventsContinuation?.finish()
+        logger.notice("WebSocket disconnected")
+    }
+
+    // MARK: - Private
+
+    private func receiveLoop() async {
+        guard let task = webSocketTask else { return }
+
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                switch message {
+                case .string(let text):
+                    handleMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        handleMessage(text)
+                    }
+                @unknown default:
+                    break
+                }
+            } catch {
+                if !Task.isCancelled {
+                    logger.error("WebSocket receive error: \(error.localizedDescription)")
+                    eventsContinuation?.yield(.error(error))
+                }
+                break
+            }
+        }
+    }
+
+    private func handleMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let messageType = json["message_type"] as? String else {
+            logger.warning("Received unparseable message")
+            return
+        }
+
+        switch messageType {
+        case "partial_transcript":
+            if let transcript = json["text"] as? String {
+                logger.debug("Partial: \(transcript)")
+                eventsContinuation?.yield(.partial(text: transcript))
+            }
+
+        case "committed_transcript", "committed_transcript_with_timestamps":
+            if let transcript = json["text"] as? String {
+                logger.notice("Committed: \(transcript)")
+                eventsContinuation?.yield(.committed(text: transcript))
+            }
+
+        case "error", "auth_error", "quota_exceeded", "rate_limited",
+             "resource_exhausted", "session_time_limit_exceeded",
+             "input_error", "chunk_size_exceeded", "transcriber_error":
+            let errorMsg = json["message"] as? String ?? messageType
+            logger.error("Server error: \(messageType) - \(errorMsg)")
+            eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(errorMsg)))
+
+        default:
+            logger.debug("Unhandled message type: \(messageType)")
+        }
+    }
+}

--- a/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ElevenLabsStreamingProvider.swift
@@ -182,7 +182,6 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
 
         case "committed_transcript", "committed_transcript_with_timestamps":
             if let transcript = json["text"] as? String {
-                logger.notice("Committed: \(transcript)")
                 eventsContinuation?.yield(.committed(text: transcript))
             }
 

--- a/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
@@ -1,0 +1,238 @@
+import Foundation
+import os
+
+/// Mistral Voxtral Realtime streaming provider using WebSocket.
+final class MistralStreamingProvider: StreamingTranscriptionProvider {
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MistralStreaming")
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var receiveTask: Task<Void, Never>?
+
+    /// Accumulated text from transcription.text.delta events.
+    private var accumulatedText = ""
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init() {
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "Mistral"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        var components = URLComponents(string: "wss://api.mistral.ai/v1/audio/transcriptions/realtime")!
+        components.queryItems = [
+            URLQueryItem(name: "model", value: "voxtral-mini-transcribe-realtime-2602")
+        ]
+
+        guard let url = components.url else {
+            throw StreamingTranscriptionError.connectionFailed("Invalid WebSocket URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: request)
+
+        self.urlSession = session
+        self.webSocketTask = task
+
+        task.resume()
+
+        logger.notice("WebSocket connecting to \(url.absoluteString)")
+
+        // Wait for the session.created message to confirm connection
+        let message = try await task.receive()
+        switch message {
+        case .string(let text):
+            if let data = text.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let type = json["type"] as? String {
+                if type == "session.created" {
+                    logger.notice("Streaming session created")
+                    eventsContinuation?.yield(.sessionStarted)
+                } else if type == "error" {
+                    let errorMsg = extractErrorMessage(from: json)
+                    throw StreamingTranscriptionError.serverError(errorMsg)
+                }
+            }
+        case .data:
+            break
+        @unknown default:
+            break
+        }
+
+        // Send session.update with audio format configuration
+        try await sendSessionUpdate()
+
+        // Start the background receive loop
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        let base64Audio = data.base64EncodedString()
+
+        let message: [String: Any] = [
+            "type": "input_audio.append",
+            "audio": base64Audio
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: message)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        try await task.send(.string(jsonString))
+    }
+
+    func commit() async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        let message: [String: Any] = [
+            "type": "input_audio.end"
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: message)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        logger.notice("Sending input_audio.end (commit)")
+        try await task.send(.string(jsonString))
+    }
+
+    func disconnect() async {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        eventsContinuation?.finish()
+        accumulatedText = ""
+        logger.notice("WebSocket disconnected")
+    }
+
+    // MARK: - Private
+
+    private func sendSessionUpdate() async throws {
+        guard let task = webSocketTask else { return }
+
+        let message: [String: Any] = [
+            "type": "session.update",
+            "session": [
+                "audio_format": [
+                    "encoding": "pcm_s16le",
+                    "sample_rate": 16000
+                ]
+            ]
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: message)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        try await task.send(.string(jsonString))
+        logger.notice("Sent session.update with audio format config")
+    }
+
+    private func receiveLoop() async {
+        guard let task = webSocketTask else { return }
+
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                switch message {
+                case .string(let text):
+                    handleMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        handleMessage(text)
+                    }
+                @unknown default:
+                    break
+                }
+            } catch {
+                if !Task.isCancelled {
+                    logger.error("WebSocket receive error: \(error.localizedDescription)")
+                    eventsContinuation?.yield(.error(error))
+                }
+                break
+            }
+        }
+    }
+
+    private func handleMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else {
+            logger.warning("Received unparseable message")
+            return
+        }
+
+        switch type {
+        case "transcription.text.delta":
+            if let deltaText = json["text"] as? String {
+                accumulatedText += deltaText
+                logger.debug("Delta: \(deltaText)")
+                eventsContinuation?.yield(.partial(text: accumulatedText))
+            }
+
+        case "transcription.done":
+            let finalText = accumulatedText
+            logger.notice("Transcription done, accumulated text: \(finalText.prefix(80))…")
+            eventsContinuation?.yield(.committed(text: finalText))
+            accumulatedText = ""
+
+        case "transcription.segment":
+            // Segment events may contain finalized segment text; log for now
+            if let segmentText = json["text"] as? String {
+                logger.debug("Segment: \(segmentText.prefix(60))")
+            }
+
+        case "transcription.language":
+            if let language = json["language"] as? String {
+                logger.notice("Detected language: \(language)")
+            }
+
+        case "session.updated":
+            logger.notice("Session updated acknowledged")
+
+        case "error":
+            let errorMsg = extractErrorMessage(from: json)
+            logger.error("Server error: \(errorMsg)")
+            eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(errorMsg)))
+
+        default:
+            logger.debug("Unhandled message type: \(type)")
+        }
+    }
+
+    private func extractErrorMessage(from json: [String: Any]) -> String {
+        if let error = json["error"] as? [String: Any] {
+            if let message = error["message"] as? String {
+                return message
+            }
+            if let detail = error["detail"] as? String {
+                return detail
+            }
+        }
+        if let error = json["error"] as? String {
+            return error
+        }
+        if let message = json["message"] as? String {
+            return message
+        }
+        return "Unknown error"
+    }
+}

--- a/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
@@ -191,7 +191,6 @@ final class MistralStreamingProvider: StreamingTranscriptionProvider {
         case "transcription.text.delta":
             if let deltaText = json["text"] as? String {
                 accumulatedText += deltaText
-                logger.debug("Delta: \(deltaText)")
                 eventsContinuation?.yield(.partial(text: accumulatedText))
             }
 

--- a/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
@@ -196,14 +196,12 @@ final class MistralStreamingProvider: StreamingTranscriptionProvider {
 
         case "transcription.done":
             let finalText = accumulatedText
-            logger.notice("Transcription done, accumulated text: \(finalText.prefix(80))…")
             eventsContinuation?.yield(.committed(text: finalText))
             accumulatedText = ""
 
         case "transcription.segment":
-            // Segment events may contain finalized segment text; log for now
+            // Segment events may contain finalized segment text
             if let segmentText = json["text"] as? String {
-                logger.debug("Segment: \(segmentText.prefix(60))")
             }
 
         case "transcription.language":

--- a/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/MistralStreamingProvider.swift
@@ -21,6 +21,13 @@ final class MistralStreamingProvider: StreamingTranscriptionProvider {
         eventsContinuation = continuation
     }
 
+    deinit {
+        receiveTask?.cancel()
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        urlSession?.invalidateAndCancel()
+        eventsContinuation?.finish()
+    }
+
     func connect(model: any TranscriptionModel, language: String?) async throws {
         guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "Mistral"), !apiKey.isEmpty else {
             throw StreamingTranscriptionError.missingAPIKey

--- a/VoiceInk/Services/StreamingTranscription/ParakeetStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ParakeetStreamingProvider.swift
@@ -22,6 +22,11 @@ final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
         eventsContinuation = continuation
     }
 
+    deinit {
+        updateConsumerTask?.cancel()
+        eventsContinuation?.finish()
+    }
+
     func connect(model: any TranscriptionModel, language: String?) async throws {
         let version: AsrModelVersion = model.name.lowercased().contains("v2") ? .v2 : .v3
         let models = try await parakeetService.getOrLoadModels(for: version)

--- a/VoiceInk/Services/StreamingTranscription/ParakeetStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ParakeetStreamingProvider.swift
@@ -52,7 +52,6 @@ final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
         }
 
         let finalText = try await manager.finish()
-        logger.notice("Parakeet streaming finished: \(finalText.count) characters")
         eventsContinuation?.yield(.committed(text: finalText))
     }
 

--- a/VoiceInk/Services/StreamingTranscription/ParakeetStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/ParakeetStreamingProvider.swift
@@ -1,0 +1,109 @@
+import AVFoundation
+import FluidAudio
+import Foundation
+import os
+
+/// On-device streaming transcription provider using FluidAudio's StreamingAsrManager
+/// with Parakeet TDT models (v2/v3).
+final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ParakeetStreaming")
+    private let parakeetService: ParakeetTranscriptionService
+    private var streamingManager: StreamingAsrManager?
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var updateConsumerTask: Task<Void, Never>?
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init(parakeetService: ParakeetTranscriptionService) {
+        self.parakeetService = parakeetService
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        let version: AsrModelVersion = model.name.lowercased().contains("v2") ? .v2 : .v3
+        let models = try await parakeetService.getOrLoadModels(for: version)
+
+        let manager = StreamingAsrManager(config: .streaming)
+        try await manager.start(models: models)
+        self.streamingManager = manager
+
+        startUpdateConsumer()
+
+        eventsContinuation?.yield(.sessionStarted)
+        logger.notice("Parakeet streaming started for \(model.displayName)")
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        guard let manager = streamingManager else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        let buffer = Self.convertToAudioBuffer(data)
+        await manager.streamAudio(buffer)
+    }
+
+    func commit() async throws {
+        guard let manager = streamingManager else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        let finalText = try await manager.finish()
+        logger.notice("Parakeet streaming finished: \(finalText.count) characters")
+        eventsContinuation?.yield(.committed(text: finalText))
+    }
+
+    func disconnect() async {
+        updateConsumerTask?.cancel()
+        updateConsumerTask = nil
+
+        if let manager = streamingManager {
+            await manager.cancel()
+        }
+        streamingManager = nil
+
+        eventsContinuation?.finish()
+        logger.notice("Parakeet streaming disconnected")
+    }
+
+    // MARK: - Private
+
+    private func startUpdateConsumer() {
+        guard let manager = streamingManager else { return }
+
+        updateConsumerTask = Task { [weak self] in
+            for await update in await manager.transcriptionUpdates {
+                guard let self = self else { break }
+                if !update.text.isEmpty {
+                    self.eventsContinuation?.yield(.partial(text: update.text))
+                }
+            }
+        }
+    }
+
+    /// Converts raw PCM Int16 16kHz mono Data to a Float32 AVAudioPCMBuffer
+    /// that FluidAudio's AudioConverter can process.
+    private static func convertToAudioBuffer(_ data: Data) -> AVAudioPCMBuffer {
+        let sampleCount = data.count / MemoryLayout<Int16>.size
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: true
+        )!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(sampleCount))!
+        buffer.frameLength = AVAudioFrameCount(sampleCount)
+
+        data.withUnsafeBytes { rawPtr in
+            let int16Ptr = rawPtr.bindMemory(to: Int16.self)
+            let floatPtr = buffer.floatChannelData![0]
+            for i in 0..<sampleCount {
+                floatPtr[i] = Float(int16Ptr[i]) / 32767.0
+            }
+        }
+
+        return buffer
+    }
+}

--- a/VoiceInk/Services/StreamingTranscription/SonioxStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/SonioxStreamingProvider.swift
@@ -116,10 +116,13 @@ final class SonioxStreamingProvider: StreamingTranscriptionProvider {
             "num_channels": 1
         ]
 
-        // Add language hints if specified
         let selectedLanguage = language ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
         if selectedLanguage != "auto" && !selectedLanguage.isEmpty {
             config["language_hints"] = [selectedLanguage]
+            config["language_hints_strict"] = true
+            config["enable_language_identification"] = true
+        } else {
+            config["enable_language_identification"] = true
         }
 
         // Add custom vocabulary context

--- a/VoiceInk/Services/StreamingTranscription/SonioxStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/SonioxStreamingProvider.swift
@@ -208,7 +208,6 @@ final class SonioxStreamingProvider: StreamingTranscriptionProvider {
             logger.notice("Received finished signal - session complete")
             // Yield any remaining accumulated final text
             if !finalText.isEmpty {
-                logger.notice("Session finished, yielding final text: \(self.finalText.count) chars")
                 eventsContinuation?.yield(.committed(text: finalText))
                 finalText = ""
             } else {
@@ -262,7 +261,6 @@ final class SonioxStreamingProvider: StreamingTranscriptionProvider {
 
         // If we saw <fin> marker, yield ALL accumulated final text (including tokens from this batch)
         if sawFinMarker {
-            logger.notice("Finalization complete, total final text: \(self.finalText.count) chars")
             eventsContinuation?.yield(.committed(text: finalText))
             finalText = ""
         } else if !newPartialText.isEmpty {

--- a/VoiceInk/Services/StreamingTranscription/SonioxStreamingProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/SonioxStreamingProvider.swift
@@ -1,0 +1,279 @@
+import Foundation
+import SwiftData
+import os
+
+/// Soniox stt-rt-v4 realtime streaming provider using WebSocket.
+final class SonioxStreamingProvider: StreamingTranscriptionProvider {
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "SonioxStreaming")
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var receiveTask: Task<Void, Never>?
+    private let modelContext: ModelContext
+
+    /// Accumulated non-final tokens for partial transcription.
+    private var partialText = ""
+    /// Accumulated final tokens for committed transcription.
+    private var finalText = ""
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    deinit {
+        receiveTask?.cancel()
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        urlSession?.invalidateAndCancel()
+        eventsContinuation?.finish()
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "Soniox"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        let urlString = "wss://stt-rt.soniox.com/transcribe-websocket"
+        guard let url = URL(string: urlString) else {
+            throw StreamingTranscriptionError.connectionFailed("Invalid WebSocket URL")
+        }
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: url)
+
+        self.urlSession = session
+        self.webSocketTask = task
+
+        task.resume()
+
+        logger.notice("WebSocket connecting to \(url.absoluteString)")
+
+        // Send initial configuration message
+        try await sendConfiguration(apiKey: apiKey, model: model, language: language)
+
+        logger.notice("Sent configuration, starting receive loop")
+        eventsContinuation?.yield(.sessionStarted)
+
+        // Start the background receive loop
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        // Soniox expects raw binary audio frames, not base64-encoded JSON
+        try await task.send(.data(data))
+    }
+
+    func commit() async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        // Send manual finalization message to finalize all pending audio
+        let finalizeMessage: [String: Any] = ["type": "finalize"]
+        let jsonData = try JSONSerialization.data(withJSONObject: finalizeMessage)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        logger.notice("Sending finalize message (commit)")
+        try await task.send(.string(jsonString))
+    }
+
+    func disconnect() async {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        eventsContinuation?.finish()
+        partialText = ""
+        finalText = ""
+        logger.notice("WebSocket disconnected")
+    }
+
+    // MARK: - Private
+
+    private func sendConfiguration(apiKey: String, model: any TranscriptionModel, language: String?) async throws {
+        guard let task = webSocketTask else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        var config: [String: Any] = [
+            "api_key": apiKey,
+            "model": model.name,
+            "audio_format": "pcm_s16le",
+            "sample_rate": 16000,
+            "num_channels": 1
+        ]
+
+        // Add language hints if specified
+        let selectedLanguage = language ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
+        if selectedLanguage != "auto" && !selectedLanguage.isEmpty {
+            config["language_hints"] = [selectedLanguage]
+        }
+
+        // Add custom vocabulary context
+        let dictionaryTerms = getCustomDictionaryTerms()
+        if !dictionaryTerms.isEmpty {
+            config["context"] = [
+                "terms": dictionaryTerms
+            ]
+            logger.debug("Added \(dictionaryTerms.count) vocabulary terms to context")
+        }
+
+        let jsonData = try JSONSerialization.data(withJSONObject: config)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        try await task.send(.string(jsonString))
+        logger.notice("Sent configuration with model \(model.name)")
+    }
+
+    private func getCustomDictionaryTerms() -> [String] {
+        // Fetch vocabulary words from SwiftData
+        let descriptor = FetchDescriptor<VocabularyWord>(sortBy: [SortDescriptor(\.word)])
+        guard let vocabularyWords = try? modelContext.fetch(descriptor) else {
+            return []
+        }
+
+        let words = vocabularyWords
+            .map { $0.word.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        // De-duplicate while preserving order
+        var seen = Set<String>()
+        var unique: [String] = []
+        for w in words {
+            let key = w.lowercased()
+            if !seen.contains(key) {
+                seen.insert(key)
+                unique.append(w)
+            }
+        }
+        return unique
+    }
+
+    private func receiveLoop() async {
+        guard let task = webSocketTask else { return }
+
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                switch message {
+                case .string(let text):
+                    handleMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        handleMessage(text)
+                    }
+                @unknown default:
+                    break
+                }
+            } catch {
+                if !Task.isCancelled {
+                    logger.error("WebSocket receive error: \(error.localizedDescription)")
+                    eventsContinuation?.yield(.error(error))
+                }
+                break
+            }
+        }
+    }
+
+    private func handleMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            logger.warning("Received unparseable message")
+            return
+        }
+
+        // Check for error
+        if let errorCode = json["error_code"] as? Int {
+            let errorMsg = json["error_message"] as? String ?? "Unknown error (code \(errorCode))"
+            logger.error("Server error: \(errorMsg)")
+            eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(errorMsg)))
+            return
+        }
+
+        // Check for finished signal
+        if let finished = json["finished"] as? Bool, finished {
+            logger.notice("Received finished signal - session complete")
+            // Yield any remaining accumulated final text
+            if !finalText.isEmpty {
+                logger.notice("Session finished, yielding final text: \(self.finalText.count) chars")
+                eventsContinuation?.yield(.committed(text: finalText))
+                finalText = ""
+            } else {
+                // Yield empty committed event to signal completion
+                eventsContinuation?.yield(.committed(text: ""))
+            }
+            return
+        }
+
+        // Parse tokens
+        guard let tokens = json["tokens"] as? [[String: Any]] else {
+            logger.debug("Received message without tokens array")
+            return
+        }
+
+        // Process tokens if array is not empty
+        if !tokens.isEmpty {
+            processTokens(tokens)
+        }
+    }
+
+    private func processTokens(_ tokens: [[String: Any]]) {
+        var newFinalText = ""
+        var newPartialText = ""
+        var sawFinMarker = false
+
+        // First pass: process ALL tokens in this batch
+        for token in tokens {
+            guard let text = token["text"] as? String else { continue }
+
+            // Check for the special <fin> marker token
+            if text == "<fin>" {
+                logger.debug("Received <fin> marker in token batch")
+                sawFinMarker = true
+                continue
+            }
+
+            let isFinal = token["is_final"] as? Bool ?? false
+
+            if isFinal {
+                newFinalText += text
+            } else {
+                newPartialText += text
+            }
+        }
+
+        // Accumulate final text from this batch
+        if !newFinalText.isEmpty {
+            finalText += newFinalText
+            logger.debug("Accumulated final text: +\(newFinalText.count) chars, total: \(self.finalText.count) chars")
+        }
+
+        // If we saw <fin> marker, yield ALL accumulated final text (including tokens from this batch)
+        if sawFinMarker {
+            logger.notice("Finalization complete, total final text: \(self.finalText.count) chars")
+            eventsContinuation?.yield(.committed(text: finalText))
+            finalText = ""
+        }
+
+        // Update partial text (replace, not accumulate, since it's provisional)
+        if !newPartialText.isEmpty {
+            partialText = newPartialText
+            let fullPartial = finalText + partialText
+            logger.debug("Partial: \(fullPartial.suffix(60))")
+            eventsContinuation?.yield(.partial(text: fullPartial))
+        }
+    }
+}

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionProvider.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionProvider.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Events emitted by a streaming transcription provider
+enum StreamingTranscriptionEvent {
+    case sessionStarted
+    case partial(text: String)
+    case committed(text: String)
+    case error(Error)
+}
+
+/// Errors specific to streaming transcription
+enum StreamingTranscriptionError: LocalizedError {
+    case missingAPIKey
+    case connectionFailed(String)
+    case timeout
+    case serverError(String)
+    case notConnected
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "API key not configured for streaming transcription"
+        case .connectionFailed(let message):
+            return "Streaming connection failed: \(message)"
+        case .timeout:
+            return "Streaming transcription timed out waiting for final result"
+        case .serverError(let message):
+            return "Streaming server error: \(message)"
+        case .notConnected:
+            return "Not connected to streaming transcription service"
+        }
+    }
+}
+
+/// Protocol for streaming transcription providers.
+protocol StreamingTranscriptionProvider: AnyObject {
+    /// Connect to the streaming transcription endpoint
+    func connect(model: any TranscriptionModel, language: String?) async throws
+
+    /// Send a chunk of raw PCM audio data (16-bit, 16kHz, mono, little-endian)
+    func sendAudioChunk(_ data: Data) async throws
+
+    /// Commit the current audio buffer to finalize transcription
+    func commit() async throws
+
+    /// Disconnect from the streaming endpoint
+    func disconnect() async
+
+    /// Stream of transcription events from the provider
+    var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent> { get }
+}

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 import os
 
 /// Sendable source that bridges audio chunks from any thread into an AsyncStream.
@@ -48,9 +49,11 @@ class StreamingTranscriptionService {
     private var state: StreamingState = .idle
     private var committedSegments: [String] = []
     private let parakeetService: ParakeetTranscriptionService
+    private let modelContext: ModelContext
 
-    init(parakeetService: ParakeetTranscriptionService) {
+    init(parakeetService: ParakeetTranscriptionService, modelContext: ModelContext) {
         self.parakeetService = parakeetService
+        self.modelContext = modelContext
     }
 
     deinit {
@@ -167,6 +170,8 @@ class StreamingTranscriptionService {
             return ParakeetStreamingProvider(parakeetService: parakeetService)
         case .mistral:
             return MistralStreamingProvider()
+        case .soniox:
+            return SonioxStreamingProvider(modelContext: modelContext)
         default:
             fatalError("Unsupported streaming provider: \(model.provider). Check supportsStreaming() before calling startStreaming().")
         }

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
@@ -244,7 +244,7 @@ class StreamingTranscriptionService {
                         self.logger.error("Streaming event error: \(error.localizedDescription)")
                     }
                 }
-            }
+            }  
         }
     }
 

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
@@ -154,6 +154,8 @@ class StreamingTranscriptionService {
             return ElevenLabsStreamingProvider()
         case .parakeet:
             return ParakeetStreamingProvider(parakeetService: parakeetService)
+        case .mistral:
+            return MistralStreamingProvider()
         default:
             fatalError("Unsupported streaming provider: \(model.provider). Check supportsStreaming() before calling startStreaming().")
         }

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
@@ -1,0 +1,238 @@
+import Foundation
+import os
+
+/// Thread-safe lock-based buffer for audio chunks, accessible from any thread.
+private final class ChunkBuffer: @unchecked Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: [Data]())
+
+    func append(_ data: Data) {
+        storage.withLock { $0.append(data) }
+    }
+
+    func drainAll() -> [Data] {
+        storage.withLock { chunks in
+            let result = chunks
+            chunks.removeAll()
+            return result
+        }
+    }
+
+    func clear() {
+        storage.withLock { $0.removeAll() }
+    }
+}
+
+/// Lifecycle states for a streaming transcription session.
+enum StreamingState {
+    case idle
+    case connecting
+    case streaming
+    case committing
+    case done
+    case failed
+    case cancelled
+}
+
+/// Manages a streaming transcription lifecycle: buffers audio chunks, sends them to the provider, and collects the final text on commit.
+@MainActor
+class StreamingTranscriptionService {
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "StreamingTranscriptionService")
+    private var provider: StreamingTranscriptionProvider?
+    private var sendTask: Task<Void, Never>?
+    private let chunkBuffer = ChunkBuffer()
+    private var state: StreamingState = .idle
+
+    /// Whether the streaming connection is fully established and actively sending.
+    var isActive: Bool { state == .streaming || state == .committing }
+
+    /// Start a streaming transcription session for the given model.
+    func startStreaming(model: any TranscriptionModel) async throws {
+        state = .connecting
+
+        let provider = createProvider(for: model)
+        self.provider = provider
+
+        let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
+
+        try await provider.connect(model: model, language: selectedLanguage)
+
+        // If cancel() was called while we were awaiting the connection, tear down immediately.
+        if state == .cancelled {
+            await provider.disconnect()
+            self.provider = nil
+            return
+        }
+
+        state = .streaming
+        startSendLoop()
+
+        logger.notice("Streaming started for model: \(model.displayName)")
+    }
+
+    /// Buffers an audio chunk for sending. Safe to call from the audio callback thread.
+    nonisolated func sendAudioChunk(_ data: Data) {
+        chunkBuffer.append(data)
+    }
+
+    /// Stops streaming, commits remaining audio, and returns the final transcribed text.
+    func stopAndGetFinalText() async throws -> String {
+        guard let provider = provider, state == .streaming else {
+            throw StreamingTranscriptionError.notConnected
+        }
+
+        state = .committing
+
+        // Drain any remaining buffered chunks
+        await drainRemainingChunks()
+
+        // Send commit to finalize transcription
+        do {
+            try await provider.commit()
+        } catch {
+            logger.error("Failed to send commit: \(error.localizedDescription)")
+            state = .failed
+            await cleanupStreaming()
+            throw error
+        }
+
+        // Wait for the committed_transcript event with a timeout
+        let finalText = await waitForCommittedTranscript(provider: provider)
+
+        state = .done
+        await cleanupStreaming()
+
+        return finalText
+    }
+
+    /// Cancels the streaming session without waiting for results.
+    func cancel() {
+        state = .cancelled
+        sendTask?.cancel()
+        sendTask = nil
+
+        let providerToDisconnect = provider
+        provider = nil
+
+        Task {
+            chunkBuffer.clear()
+            await providerToDisconnect?.disconnect()
+        }
+
+        logger.notice("Streaming cancelled")
+    }
+
+    // MARK: - Private
+
+    private func createProvider(for model: any TranscriptionModel) -> StreamingTranscriptionProvider {
+        switch model.provider {
+        case .elevenLabs:
+            return ElevenLabsStreamingProvider()
+        default:
+            fatalError("Unsupported streaming provider: \(model.provider). Check supportsStreaming() before calling startStreaming().")
+        }
+    }
+
+    private func startSendLoop() {
+        let buffer = chunkBuffer
+        let provider = provider
+
+        sendTask = Task.detached { [weak self] in
+            while !Task.isCancelled {
+                let chunks = buffer.drainAll()
+
+                if !chunks.isEmpty {
+                    // Finish sending the entire batch before checking cancellation
+                    for chunk in chunks {
+                        do {
+                            try await provider?.sendAudioChunk(chunk)
+                        } catch {
+                            let desc = error.localizedDescription
+                            await MainActor.run {
+                                self?.logger.error("Failed to send audio chunk: \(desc)")
+                            }
+                        }
+                    }
+                }
+
+                // Small sleep to batch chunks and avoid excessive sends
+                try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            }
+        }
+    }
+
+    private func drainRemainingChunks() async {
+        sendTask?.cancel()
+        sendTask = nil
+
+        // Send any chunks that arrived after the send loop's last drain
+        let remaining = chunkBuffer.drainAll()
+
+        for chunk in remaining {
+            do {
+                try await provider?.sendAudioChunk(chunk)
+            } catch {
+                logger.error("Failed to send remaining chunk: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func waitForCommittedTranscript(provider: StreamingTranscriptionProvider) async -> String {
+        let events = provider.transcriptionEvents
+
+        return await withTaskGroup(of: String.self) { group in
+            // Task 1: Listen for the committed transcript
+            group.addTask { [logger] in
+                var lastPartial = ""
+                for await event in events {
+                    switch event {
+                    case .committed(let text):
+                        logger.notice("Received final committed transcript")
+                        return text
+                    case .partial(let text):
+                        lastPartial = text
+                    case .error(let error):
+                        logger.error("Streaming error while waiting for commit: \(error.localizedDescription)")
+                        return lastPartial
+                    case .sessionStarted:
+                        break
+                    }
+                }
+                return lastPartial
+            }
+
+            // Task 2: Timeout after 10 seconds
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return ""
+            }
+
+            // Whichever finishes first wins
+            var result = ""
+            if let first = await group.next() {
+                result = first
+            }
+            group.cancelAll()
+
+            // If the timeout won (empty string), give the event task a moment
+            // to return any accumulated partial text after cancellation.
+            if result.isEmpty, let second = await group.next() {
+                result = second
+            }
+
+            if result.isEmpty {
+                logger.warning("No transcript received from streaming")
+            }
+            return result
+        }
+    }
+
+    private func cleanupStreaming() async {
+        sendTask?.cancel()
+        sendTask = nil
+        await provider?.disconnect()
+        provider = nil
+        state = .idle
+        chunkBuffer.clear()
+    }
+}

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
@@ -50,7 +50,7 @@ class StreamingTranscriptionService {
     private var committedSegments: [String] = []
     private let parakeetService: ParakeetTranscriptionService
     private let modelContext: ModelContext
-    private let onPartialTranscript: ((String) -> Void)?
+    private var onPartialTranscript: ((String) -> Void)?
 
     init(parakeetService: ParakeetTranscriptionService, modelContext: ModelContext, onPartialTranscript: ((String) -> Void)? = nil) {
         self.parakeetService = parakeetService
@@ -59,6 +59,7 @@ class StreamingTranscriptionService {
     }
 
     deinit {
+        onPartialTranscript = nil
         sendTask?.cancel()
         eventConsumerTask?.cancel()
         chunkSource.finish()
@@ -141,6 +142,7 @@ class StreamingTranscriptionService {
     /// Cancels the streaming session without waiting for results.
     func cancel() {
         state = .cancelled
+        onPartialTranscript = nil
         eventConsumerTask?.cancel()
         eventConsumerTask = nil
         sendTask?.cancel()
@@ -283,6 +285,7 @@ class StreamingTranscriptionService {
     }
 
     private func cleanupStreaming() async {
+        onPartialTranscript = nil
         eventConsumerTask?.cancel()
         eventConsumerTask = nil
         sendTask?.cancel()

--- a/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
+++ b/VoiceInk/Services/StreamingTranscription/StreamingTranscriptionService.swift
@@ -43,6 +43,11 @@ class StreamingTranscriptionService {
     private let chunkSource = AudioChunkSource()
     private var state: StreamingState = .idle
     private var committedSegments: [String] = []
+    private let parakeetService: ParakeetTranscriptionService
+
+    init(parakeetService: ParakeetTranscriptionService) {
+        self.parakeetService = parakeetService
+    }
 
     /// Signal used to notify `waitForFinalCommit` when a new committed segment arrives.
     private var commitSignal: AsyncStream<Void>.Continuation?
@@ -147,6 +152,8 @@ class StreamingTranscriptionService {
         switch model.provider {
         case .elevenLabs:
             return ElevenLabsStreamingProvider()
+        case .parakeet:
+            return ParakeetStreamingProvider(parakeetService: parakeetService)
         default:
             fatalError("Unsupported streaming provider: \(model.provider). Check supportsStreaming() before calling startStreaming().")
         }

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -57,6 +57,8 @@ class TranscriptionServiceRegistry {
             return model.name == "scribe_v2"
         case .parakeet:
             return true
+        case .mistral:
+            return model.name == "voxtral-mini-transcribe-realtime-2602"
         default:
             return false
         }

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -42,7 +42,10 @@ class TranscriptionServiceRegistry {
     /// Creates a streaming or file-based session depending on the model's capabilities.
     func createSession(for model: any TranscriptionModel) -> TranscriptionSession {
         if supportsStreaming(model: model) {
-            let streamingService = StreamingTranscriptionService(parakeetService: parakeetTranscriptionService)
+            let streamingService = StreamingTranscriptionService(
+                parakeetService: parakeetTranscriptionService,
+                modelContext: whisperState.modelContext
+            )
             let fallback = service(for: model.provider)
             return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback)
         } else {
@@ -59,6 +62,8 @@ class TranscriptionServiceRegistry {
             return true
         case .mistral:
             return model.name == "voxtral-mini-transcribe-realtime-2602"
+        case .soniox:
+            return model.name == "stt-rt-v4"
         default:
             return false
         }

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -15,7 +15,6 @@ class TranscriptionServiceRegistry {
     private(set) lazy var cloudTranscriptionService = CloudTranscriptionService(modelContext: whisperState.modelContext)
     private(set) lazy var nativeAppleTranscriptionService = NativeAppleTranscriptionService()
     private(set) lazy var parakeetTranscriptionService = ParakeetTranscriptionService()
-
     init(whisperState: WhisperState, modelsDirectory: URL) {
         self.whisperState = whisperState
         self.modelsDirectory = modelsDirectory
@@ -38,6 +37,27 @@ class TranscriptionServiceRegistry {
         let service = service(for: model.provider)
         logger.debug("Transcribing with \(model.displayName) using \(String(describing: type(of: service)))")
         return try await service.transcribe(audioURL: audioURL, model: model)
+    }
+
+    /// Creates a streaming or file-based session depending on the model's capabilities.
+    func createSession(for model: any TranscriptionModel) -> TranscriptionSession {
+        if supportsStreaming(model: model) {
+            let streamingService = StreamingTranscriptionService()
+            let fallback = service(for: model.provider)
+            return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback)
+        } else {
+            return FileTranscriptionSession(service: service(for: model.provider))
+        }
+    }
+
+    /// Whether the given model supports streaming transcription
+    private func supportsStreaming(model: any TranscriptionModel) -> Bool {
+        switch model.provider {
+        case .elevenLabs:
+            return model.name == "scribe_v2"
+        default:
+            return false
+        }
     }
 
     func cleanup() {

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -42,7 +42,7 @@ class TranscriptionServiceRegistry {
     /// Creates a streaming or file-based session depending on the model's capabilities.
     func createSession(for model: any TranscriptionModel) -> TranscriptionSession {
         if supportsStreaming(model: model) {
-            let streamingService = StreamingTranscriptionService()
+            let streamingService = StreamingTranscriptionService(parakeetService: parakeetTranscriptionService)
             let fallback = service(for: model.provider)
             return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback)
         } else {
@@ -55,6 +55,8 @@ class TranscriptionServiceRegistry {
         switch model.provider {
         case .elevenLabs:
             return model.name == "scribe_v2"
+        case .parakeet:
+            return true
         default:
             return false
         }

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -44,7 +44,10 @@ class TranscriptionServiceRegistry {
         if supportsStreaming(model: model) {
             let streamingService = StreamingTranscriptionService(
                 parakeetService: parakeetTranscriptionService,
-                modelContext: whisperState.modelContext
+                modelContext: whisperState.modelContext,
+                onPartialTranscript: { [weak whisperState] text in
+                    whisperState?.partialTranscript = text
+                }
             )
             let fallback = service(for: model.provider)
             return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback)

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -59,6 +59,8 @@ class TranscriptionServiceRegistry {
         switch model.provider {
         case .elevenLabs:
             return model.name == "scribe_v2"
+        case .deepgram:
+            return model.name == "nova-3" || model.name == "nova-3-medical"
         case .parakeet:
             return true
         case .mistral:

--- a/VoiceInk/Services/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Services/TranscriptionServiceRegistry.swift
@@ -40,14 +40,12 @@ class TranscriptionServiceRegistry {
     }
 
     /// Creates a streaming or file-based session depending on the model's capabilities.
-    func createSession(for model: any TranscriptionModel) -> TranscriptionSession {
+    func createSession(for model: any TranscriptionModel, onPartialTranscript: ((String) -> Void)? = nil) -> TranscriptionSession {
         if supportsStreaming(model: model) {
             let streamingService = StreamingTranscriptionService(
                 parakeetService: parakeetTranscriptionService,
                 modelContext: whisperState.modelContext,
-                onPartialTranscript: { [weak whisperState] text in
-                    whisperState?.partialTranscript = text
-                }
+                onPartialTranscript: onPartialTranscript
             )
             let fallback = service(for: model.provider)
             return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback)

--- a/VoiceInk/Services/TranscriptionSession.swift
+++ b/VoiceInk/Services/TranscriptionSession.swift
@@ -1,0 +1,111 @@
+import Foundation
+import os
+
+/// Encapsulates a single recording-to-transcription lifecycle (streaming or file-based).
+@MainActor
+protocol TranscriptionSession: AnyObject {
+    /// Prepares the session. Returns an audio chunk callback for streaming, or nil for file-based.
+    func prepare(model: any TranscriptionModel) async throws -> ((Data) -> Void)?
+
+    /// Called after recording stops. Returns the final transcribed text.
+    func transcribe(audioURL: URL) async throws -> String
+
+    /// Cancel the session and clean up resources.
+    func cancel()
+}
+
+// MARK: - File-Based Session
+
+/// File-based session: records to file, uploads after stop.
+@MainActor
+final class FileTranscriptionSession: TranscriptionSession {
+    private let service: TranscriptionService
+    private var model: (any TranscriptionModel)?
+
+    init(service: TranscriptionService) {
+        self.service = service
+    }
+
+    func prepare(model: any TranscriptionModel) async throws -> ((Data) -> Void)? {
+        self.model = model
+        return nil
+    }
+
+    func transcribe(audioURL: URL) async throws -> String {
+        guard let model = model else {
+            throw WhisperStateError.transcriptionFailed
+        }
+        return try await service.transcribe(audioURL: audioURL, model: model)
+    }
+
+    func cancel() {
+        // No-op for file-based transcription
+    }
+}
+
+// MARK: - Streaming Session
+
+/// Streaming session with automatic fallback to file-based upload on failure.
+@MainActor
+final class StreamingTranscriptionSession: TranscriptionSession {
+    private let streamingService: StreamingTranscriptionService
+    private let fallbackService: TranscriptionService
+    private var model: (any TranscriptionModel)?
+    private var streamingFailed = false
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "StreamingTranscriptionSession")
+
+    init(streamingService: StreamingTranscriptionService, fallbackService: TranscriptionService) {
+        self.streamingService = streamingService
+        self.fallbackService = fallbackService
+    }
+
+    func prepare(model: any TranscriptionModel) async throws -> ((Data) -> Void)? {
+        self.model = model
+
+        // Return callback immediately; WebSocket connects in background
+        let service = streamingService
+        let callback: (Data) -> Void = { [weak service] data in
+            service?.sendAudioChunk(data)
+        }
+
+        Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                try await self.streamingService.startStreaming(model: model)
+                self.logger.notice("Streaming connected for \(model.displayName)")
+            } catch {
+                self.logger.error("Failed to start streaming, will fall back to batch: \(error.localizedDescription)")
+                self.streamingFailed = true
+            }
+        }
+
+        return callback
+    }
+
+    func transcribe(audioURL: URL) async throws -> String {
+        guard let model = model else {
+            throw WhisperStateError.transcriptionFailed
+        }
+
+        if !streamingFailed {
+            do {
+                let text = try await streamingService.stopAndGetFinalText()
+                logger.notice("Streaming transcript received")
+                return text
+            } catch {
+                logger.error("Streaming failed, falling back to batch: \(error.localizedDescription)")
+                streamingService.cancel()
+            }
+        } else {
+            streamingService.cancel()
+        }
+
+        // Fallback to file-based transcription
+        logger.notice("Using batch fallback for \(model.displayName)")
+        return try await fallbackService.transcribe(audioURL: audioURL, model: model)
+    }
+
+    func cancel() {
+        streamingService.cancel()
+    }
+}

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -126,12 +126,17 @@ struct CloudModelCardView: View {
                 .font(.system(size: 11))
                 .foregroundColor(Color(.secondaryLabelColor))
                 .lineLimit(1)
-            
-            Label("Cloud Model", systemImage: "icloud")
-                .font(.system(size: 11))
-                .foregroundColor(Color(.secondaryLabelColor))
-                .lineLimit(1)
-            
+
+            // Speed
+            HStack(spacing: 3) {
+                Text("Speed")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(Color(.secondaryLabelColor))
+                progressDotsWithNumber(value: model.speed * 10)
+            }
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+
             // Accuracy
             HStack(spacing: 3) {
                 Text("Accuracy")

--- a/VoiceInk/Views/Recorder/AudioVisualizerView.swift
+++ b/VoiceInk/Views/Recorder/AudioVisualizerView.swift
@@ -37,7 +37,9 @@ struct AudioVisualizer: View {
             updateWave(level: isActive ? newValue.averagePower : 0)
         }
         .onChange(of: isActive) { _, active in
-            if !active { resetWave() }
+            if !active {
+                resetWave()
+            }
         }
     }
 

--- a/VoiceInk/Views/Recorder/AudioVisualizerView.swift
+++ b/VoiceInk/Views/Recorder/AudioVisualizerView.swift
@@ -13,8 +13,6 @@ struct AudioVisualizer: View {
 
     private let phases: [Double]
 
-    @State private var heights: [CGFloat]
-
     init(audioMeter: AudioMeter, color: Color, isActive: Bool) {
         self.audioMeter = audioMeter
         self.color = color
@@ -22,50 +20,38 @@ struct AudioVisualizer: View {
 
         // Create smooth wave phases
         self.phases = (0..<barCount).map { Double($0) * 0.4 }
-        _heights = State(initialValue: Array(repeating: minHeight, count: barCount))
     }
 
     var body: some View {
-        HStack(spacing: barSpacing) {
-            ForEach(0..<barCount, id: \.self) { index in
-                RoundedRectangle(cornerRadius: barWidth / 2)
-                    .fill(color.opacity(0.85))
-                    .frame(width: barWidth, height: heights[index])
-            }
-        }
-        .onChange(of: audioMeter) { _, newValue in
-            updateWave(level: isActive ? newValue.averagePower : 0)
-        }
-        .onChange(of: isActive) { _, active in
-            if !active {
-                resetWave()
+        // TimelineView with 60Hz updates (native approach recommended by Apple WWDC 2021+)
+        TimelineView(.animation(minimumInterval: 0.016)) { context in
+            HStack(spacing: barSpacing) {
+                ForEach(0..<barCount, id: \.self) { index in
+                    RoundedRectangle(cornerRadius: barWidth / 2)
+                        .fill(color.opacity(0.85))
+                        .frame(width: barWidth, height: calculateHeight(for: index, at: context.date))
+                }
             }
         }
     }
 
-    private func updateWave(level: Double) {
-        let time = Date().timeIntervalSince1970
+    private func calculateHeight(for index: Int, at date: Date) -> CGFloat {
+        guard isActive else { return minHeight }
+
+        let time = date.timeIntervalSince1970
+        let level = audioMeter.averagePower
         let amplitude = max(0, min(1, level))
 
         // Boost lower levels for better visibility
         let boosted = pow(amplitude, 0.7)
 
-        withAnimation(.easeOut(duration: 0.08)) {
-            for i in 0..<barCount {
-                let wave = sin(time * 8 + phases[i]) * 0.5 + 0.5
-                let centerDistance = abs(Double(i) - Double(barCount) / 2) / Double(barCount / 2)
-                let centerBoost = 1.0 - (centerDistance * 0.4)
+        // Wave calculation
+        let wave = sin(time * 8 + phases[index]) * 0.5 + 0.5
+        let centerDistance = abs(Double(index) - Double(barCount) / 2) / Double(barCount / 2)
+        let centerBoost = 1.0 - (centerDistance * 0.4)
 
-                let height = minHeight + CGFloat(boosted * wave * centerBoost) * (maxHeight - minHeight)
-                heights[i] = max(minHeight, height)
-            }
-        }
-    }
-
-    private func resetWave() {
-        withAnimation(.easeOut(duration: 0.2)) {
-            heights = Array(repeating: minHeight, count: barCount)
-        }
+        let height = minHeight + CGFloat(boosted * wave * centerBoost) * (maxHeight - minHeight)
+        return max(minHeight, height)
     }
 }
 

--- a/VoiceInk/Views/Recorder/MiniRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderPanel.swift
@@ -32,11 +32,12 @@ class MiniRecorderPanel: NSPanel {
     
     static func calculateWindowMetrics() -> NSRect {
         guard let screen = NSScreen.main else {
-            return NSRect(x: 0, y: 0, width: 184, height: 40)
+            return NSRect(x: 0, y: 0, width: 300, height: 80)
         }
 
-        let width: CGFloat = 184
-        let height: CGFloat = 40
+        // Fixed window size - content animates within
+        let width: CGFloat = 300
+        let height: CGFloat = 80
         let padding: CGFloat = 24
 
         let visibleFrame = screen.visibleFrame
@@ -51,7 +52,7 @@ class MiniRecorderPanel: NSPanel {
             height: height
         )
     }
-    
+
     func show() {
         let metrics = MiniRecorderPanel.calculateWindowMetrics()
         setFrame(metrics, display: true)

--- a/VoiceInk/Views/Recorder/MiniRecorderView.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderView.swift
@@ -8,69 +8,89 @@ struct MiniRecorderView: View {
 
     @State private var activePopover: ActivePopoverState = .none
 
-    private var backgroundView: some View {
-        ZStack {
-            Color.black.opacity(0.9)
-            LinearGradient(
-                colors: [
-                    Color.black.opacity(0.95),
-                    Color(red: 0.15, green: 0.15, blue: 0.15).opacity(0.9)
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            VisualEffectView(material: .hudWindow, blendingMode: .withinWindow)
-                .opacity(0.05)
-        }
-        .clipShape(Capsule())
+    // MARK: - Design Constants
+    private let mainContentHeight: CGFloat = 40
+    private let compactWidth: CGFloat = 184
+    private let expandedWidth: CGFloat = 300
+    private let compactCornerRadius: CGFloat = 20
+    private let expandedCornerRadius: CGFloat = 12
+
+    private var hasPartialText: Bool {
+        whisperState.recordingState == .recording && !whisperState.partialTranscript.isEmpty
     }
 
-    private var statusView: some View {
-        RecorderStatusDisplay(
-            currentState: whisperState.recordingState,
-            audioMeter: recorder.audioMeter
-        )
+    private var currentWidth: CGFloat {
+        hasPartialText ? expandedWidth : compactWidth
+    }
+
+    private var currentCornerRadius: CGFloat {
+        hasPartialText ? expandedCornerRadius : compactCornerRadius
     }
 
     private var contentLayout: some View {
         HStack(spacing: 0) {
-            // Left button zone - always visible
-            RecorderPromptButton(activePopover: $activePopover)
-                .padding(.leading, 7)
+            RecorderPromptButton(
+                activePopover: $activePopover,
+                buttonSize: 22,
+                padding: EdgeInsets()
+            )
+            .padding(.leading, 12)
 
-            Spacer()
+            Spacer(minLength: 0)
 
-            // Fixed visualizer zone
-            statusView
-                .frame(maxWidth: .infinity)
+            RecorderStatusDisplay(
+                currentState: whisperState.recordingState,
+                audioMeter: recorder.audioMeter
+            )
 
-            Spacer()
+            Spacer(minLength: 0)
 
-            // Right button zone - always visible
-            RecorderPowerModeButton(activePopover: $activePopover)
-                .padding(.trailing, 7)
+            RecorderPowerModeButton(
+                activePopover: $activePopover,
+                buttonSize: 22,
+                padding: EdgeInsets()
+            )
+            .padding(.trailing, 12)
         }
-        .padding(.vertical, 9)
+        .frame(height: mainContentHeight)
     }
 
-    private var recorderCapsule: some View {
-        Capsule()
-            .fill(.clear)
-            .background(backgroundView)
-            .overlay {
-                Capsule()
-                    .strokeBorder(Color.white.opacity(0.3), lineWidth: 0.5)
+    private var partialTextSection: some View {
+        // Polls at 10Hz to detect transcript updates
+        TimelineView(.animation(minimumInterval: 0.1)) { _ in
+            VStack(spacing: 0) {
+                Divider()
+                    .background(Color.white.opacity(0.15))
+
+                Text(whisperState.partialTranscript)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.8))
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 5)
             }
-            .overlay {
-                contentLayout
-            }
+            .opacity(hasPartialText ? 1 : 0)
+            .frame(height: hasPartialText ? nil : 0)
+            .clipped()
+        }
     }
 
     var body: some View {
-        Group {
-            if windowManager.isVisible {
-                recorderCapsule
+        if windowManager.isVisible {
+            VStack(spacing: 0) {
+                contentLayout
+
+                partialTextSection
             }
+            .frame(width: currentWidth)
+            .background(Color.black)
+            .clipShape(RoundedRectangle(cornerRadius: currentCornerRadius, style: .continuous))
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .animation(.snappy(duration: 0.35), value: currentWidth)
+            .animation(.snappy(duration: 0.35), value: currentCornerRadius)
         }
     }
 }
+

--- a/VoiceInk/Views/Recorder/MiniRecorderView.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderView.swift
@@ -5,9 +5,9 @@ struct MiniRecorderView: View {
     @ObservedObject var recorder: Recorder
     @EnvironmentObject var windowManager: MiniWindowManager
     @EnvironmentObject private var enhancementService: AIEnhancementService
-    
+
     @State private var activePopover: ActivePopoverState = .none
-    
+
     private var backgroundView: some View {
         ZStack {
             Color.black.opacity(0.9)
@@ -24,14 +24,14 @@ struct MiniRecorderView: View {
         }
         .clipShape(Capsule())
     }
-    
+
     private var statusView: some View {
         RecorderStatusDisplay(
             currentState: whisperState.recordingState,
             audioMeter: recorder.audioMeter
         )
     }
-    
+
     private var contentLayout: some View {
         HStack(spacing: 0) {
             // Left button zone - always visible
@@ -52,7 +52,7 @@ struct MiniRecorderView: View {
         }
         .padding(.vertical, 9)
     }
-    
+
     private var recorderCapsule: some View {
         Capsule()
             .fill(.clear)
@@ -65,7 +65,7 @@ struct MiniRecorderView: View {
                 contentLayout
             }
     }
-    
+
     var body: some View {
         Group {
             if windowManager.isVisible {

--- a/VoiceInk/Views/Recorder/MiniWindowManager.swift
+++ b/VoiceInk/Views/Recorder/MiniWindowManager.swift
@@ -36,7 +36,7 @@ class MiniWindowManager: ObservableObject {
         let activeScreen = NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens[0]
 
         initializeWindow(screen: activeScreen)
-        self.isVisible = true
+        self.isVisible = true 
         miniPanel?.show()
     }
 

--- a/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
@@ -98,22 +98,21 @@ class NotchRecorderPanel: KeyablePanel {
         // Calculate exact notch width
         let baseNotchWidth: CGFloat = safeAreaInsets.left > 0 ? safeAreaInsets.left * 2 : 200
         
-        // Calculate total width including controls and padding
-        let controlsWidth: CGFloat = 64 // Space for buttons on each side (increased width)
-        let paddingWidth: CGFloat = 32 // 16pt on each side
+        let controlsWidth: CGFloat = 64
+        let paddingWidth: CGFloat = 32
         let totalWidth = baseNotchWidth + controlsWidth * 2 + paddingWidth
-        
-        // Position exactly at the center
+
+        let maxContentHeight: CGFloat = 200
         let xPosition = screen.frame.midX - (totalWidth / 2)
-        let yPosition = screen.frame.maxY - notchHeight
-        
+        let yPosition = screen.frame.maxY - maxContentHeight
+
         let frame = NSRect(
             x: xPosition,
             y: yPosition,
             width: totalWidth,
-            height: notchHeight
+            height: maxContentHeight
         )
-        
+
         return (frame, baseNotchWidth, notchHeight)
     }
     

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -78,8 +78,29 @@ struct NotchRecorderView: View {
         .padding(.trailing, 8)
     }
 
-    private var hasTranscript: Bool {
-        whisperState.recordingState == .recording && !whisperState.partialTranscript.isEmpty
+    private var bottomSection: some View {
+        // TimelineView polls transcript at 10Hz and controls visibility
+        // Same pattern as AudioVisualizer - no forced re-renders
+        TimelineView(.animation(minimumInterval: 0.1)) { context in
+            let hasText = whisperState.recordingState == .recording && !whisperState.partialTranscript.isEmpty
+
+            VStack(spacing: 0) {
+                Divider()
+                    .background(Color.white.opacity(0.15))
+
+                Text(whisperState.partialTranscript)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.8))
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 5)
+            }
+            .opacity(hasText ? 1 : 0)
+            .frame(height: hasText ? nil : 0)
+            .clipped()
+        }
     }
 
     private var topCornerRadius: CGFloat {
@@ -88,22 +109,6 @@ struct NotchRecorderView: View {
 
     private var bottomCornerRadius: CGFloat {
         10
-    }
-
-    private var bottomSection: some View {
-        VStack(spacing: 0) {
-            Divider()
-                .background(Color.white.opacity(0.15))
-
-            Text(whisperState.recordingState == .recording ? whisperState.partialTranscript : "")
-                .font(.system(size: 11))
-                .foregroundColor(.white.opacity(0.8))
-                .lineLimit(1)
-                .truncationMode(.head)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 5)
-        }
     }
 
     var body: some View {
@@ -117,10 +122,7 @@ struct NotchRecorderView: View {
                     }
                     .frame(height: menuBarHeight)
 
-                    if hasTranscript {
-                        bottomSection
-                            .transition(.opacity)
-                    }
+                    bottomSection
                 }
                 .background(Color.black)
                 .mask {
@@ -135,7 +137,6 @@ struct NotchRecorderView: View {
                     isHovering = hovering
                 }
                 .opacity(windowManager.isVisible ? 1 : 0)
-                .animation(.easeInOut(duration: 0.2), value: hasTranscript)
             }
         }
     }

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -31,7 +31,7 @@ struct NotchRecorderView: View {
     }
     
     private var leftSection: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 16) {
             RecorderPromptButton(
                 activePopover: $activePopover,
                 buttonSize: 22,
@@ -48,6 +48,7 @@ struct NotchRecorderView: View {
         }
         .frame(width: 64)
         .padding(.leading, 16)
+        .padding(.leading, 4)
     }
     
     private var centerSection: some View {
@@ -64,6 +65,7 @@ struct NotchRecorderView: View {
         }
         .frame(width: 64)
         .padding(.trailing, 16)
+        .padding(.trailing, 4)
     }
     
     private var statusDisplay: some View {
@@ -75,25 +77,65 @@ struct NotchRecorderView: View {
         .frame(width: 70)
         .padding(.trailing, 8)
     }
-    
+
+    private var hasTranscript: Bool {
+        !whisperState.partialTranscript.isEmpty
+    }
+
+    private var topCornerRadius: CGFloat {
+        6
+    }
+
+    private var bottomCornerRadius: CGFloat {
+        10
+    }
+
+    private var bottomSection: some View {
+        VStack(spacing: 0) {
+            Divider()
+                .background(Color.white.opacity(0.15))
+
+            Text(whisperState.recordingState == .recording ? whisperState.partialTranscript : "")
+                .font(.system(size: 11))
+                .foregroundColor(.white.opacity(0.8))
+                .lineLimit(1)
+                .truncationMode(.head)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 5)
+        }
+    }
+
     var body: some View {
         Group {
             if windowManager.isVisible {
-                HStack(spacing: 0) {
-                    leftSection
-                    centerSection
-                    rightSection
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        leftSection
+                        centerSection
+                        rightSection
+                    }
+                    .frame(height: menuBarHeight)
+
+                    if hasTranscript {
+                        bottomSection
+                            .transition(.opacity)
+                    }
                 }
-                .frame(height: menuBarHeight)
                 .background(Color.black)
                 .mask {
-                    NotchShape(cornerRadius: 10)
+                    NotchShape(
+                        topCornerRadius: topCornerRadius,
+                        bottomCornerRadius: bottomCornerRadius
+                    )
                 }
                 .clipped()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .onHover { hovering in
                     isHovering = hovering
                 }
                 .opacity(windowManager.isVisible ? 1 : 0)
+                .animation(.easeInOut(duration: 0.2), value: hasTranscript)
             }
         }
     }

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -79,7 +79,7 @@ struct NotchRecorderView: View {
     }
 
     private var hasTranscript: Bool {
-        !whisperState.partialTranscript.isEmpty
+        whisperState.recordingState == .recording && !whisperState.partialTranscript.isEmpty
     }
 
     private var topCornerRadius: CGFloat {

--- a/VoiceInk/Views/Recorder/NotchShape.swift
+++ b/VoiceInk/Views/Recorder/NotchShape.swift
@@ -1,54 +1,47 @@
 import SwiftUI
 
 struct NotchShape: Shape {
-    var topCornerRadius: CGFloat {
-        if bottomCornerRadius > 15 {
-            bottomCornerRadius - 5
-        } else {
-            5
-        }
-    }
-    
+    var topCornerRadius: CGFloat
     var bottomCornerRadius: CGFloat
-    
-    init(cornerRadius: CGFloat? = nil) {
-        if cornerRadius == nil {
-            self.bottomCornerRadius = 10
-        } else {
-            self.bottomCornerRadius = cornerRadius!
-        }
+
+    init(topCornerRadius: CGFloat = 5, bottomCornerRadius: CGFloat = 10) {
+        self.topCornerRadius = topCornerRadius
+        self.bottomCornerRadius = bottomCornerRadius
     }
-    
-    var animatableData: CGFloat {
-        get { bottomCornerRadius }
-        set { bottomCornerRadius = newValue }
+
+    // Backwards compatibility
+    init(cornerRadius: CGFloat? = nil) {
+        let radius = cornerRadius ?? 10
+        self.topCornerRadius = max(radius - 5, 5)
+        self.bottomCornerRadius = radius
+    }
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { AnimatablePair(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
     }
     
     func path(in rect: CGRect) -> Path {
         var path = Path()
-        // Start from the top left corner
         path.move(to: CGPoint(x: rect.minX, y: rect.minY))
-        // Top left inner curve
         path.addQuadCurve(
             to: CGPoint(x: rect.minX + topCornerRadius, y: topCornerRadius),
             control: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY)
         )
-        // Left vertical line
         path.addLine(to: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY - bottomCornerRadius))
-        // Bottom left corner
         path.addQuadCurve(
             to: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY),
             control: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY)
         )
         path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius, y: rect.maxY))
-        // Bottom right corner
         path.addQuadCurve(
             to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY - bottomCornerRadius),
             control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY)
         )
         path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY + bottomCornerRadius))
-        
-        // Closing the path to top right inner curve
         path.addQuadCurve(
             to: CGPoint(x: rect.maxX, y: rect.minY),
             control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)

--- a/VoiceInk/Views/Recorder/NotchWindowManager.swift
+++ b/VoiceInk/Views/Recorder/NotchWindowManager.swift
@@ -1,17 +1,18 @@
 import SwiftUI
 import AppKit
 
+@MainActor
 class NotchWindowManager: ObservableObject {
     @Published var isVisible = false
     private var windowController: NSWindowController?
      var notchPanel: NotchRecorderPanel?
     private let whisperState: WhisperState
     private let recorder: Recorder
-    
+
     init(whisperState: WhisperState, recorder: Recorder) {
         self.whisperState = whisperState
         self.recorder = recorder
-        
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleHideNotification),
@@ -30,10 +31,9 @@ class NotchWindowManager: ObservableObject {
     
     func show() {
         if isVisible { return }
-        
-        // Get the active screen from the key window or fallback to main screen
+
         let activeScreen = NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens[0]
-        
+
         initializeWindow(screen: activeScreen)
         self.isVisible = true
         notchPanel?.show()

--- a/VoiceInk/Whisper/WhisperState+UI.swift
+++ b/VoiceInk/Whisper/WhisperState+UI.swift
@@ -61,11 +61,15 @@ extension WhisperState {
         }
 
         let wasRecording = recordingState == .recording
- 
+
         await MainActor.run {
             self.recordingState = .busy
         }
-        
+
+        // Cancel and release any active streaming session to prevent resource leaks.
+        currentSession?.cancel()
+        currentSession = nil
+
         if wasRecording {
             await recorder.stopRecording()
         }

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -28,7 +28,7 @@ class WhisperState: NSObject, ObservableObject {
     @Published var clipboardMessage = ""
     @Published var miniRecorderError: String?
     @Published var shouldCancelRecording = false
-    @Published var partialTranscript: String = ""
+    var partialTranscript: String = ""
     var currentSession: TranscriptionSession?
 
 
@@ -224,7 +224,11 @@ class WhisperState: NSObject, ObservableObject {
 
                             // Create session with the resolved model (skip if user already stopped)
                             if self.recordingState == .recording, let model = self.currentTranscriptionModel {
-                                let session = self.serviceRegistry.createSession(for: model)
+                                let session = self.serviceRegistry.createSession(for: model, onPartialTranscript: { [weak self] partial in
+                                    Task { @MainActor in
+                                        self?.partialTranscript = partial
+                                    }
+                                })
                                 self.currentSession = session
                                 let realCallback = try await session.prepare(model: model)
 

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -148,6 +148,7 @@ class WhisperState: NSObject, ObservableObject {
         logger.notice("toggleRecord called – state=\(String(describing: self.recordingState))")
         if recordingState == .recording {
             partialTranscript = ""
+            recordingState = .transcribing
             await recorder.stopRecording()
             if let recordedFile {
                 if !shouldCancelRecording {
@@ -194,6 +195,7 @@ class WhisperState: NSObject, ObservableObject {
                 return
             }
             shouldCancelRecording = false
+            partialTranscript = ""
             requestRecordPermission { [self] granted in
                 if granted {
                     Task {

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -9,6 +9,7 @@ import os
 // MARK: - Recording State Machine
 enum RecordingState: Equatable {
     case idle
+    case starting
     case recording
     case transcribing
     case enhancing
@@ -27,7 +28,7 @@ class WhisperState: NSObject, ObservableObject {
     @Published var clipboardMessage = ""
     @Published var miniRecorderError: String?
     @Published var shouldCancelRecording = false
-    private var currentSession: TranscriptionSession?
+    var currentSession: TranscriptionSession?
 
 
     @Published var recorderType: String = UserDefaults.standard.string(forKey: "RecorderType") ?? "mini" {

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -28,6 +28,7 @@ class WhisperState: NSObject, ObservableObject {
     @Published var clipboardMessage = ""
     @Published var miniRecorderError: String?
     @Published var shouldCancelRecording = false
+    @Published var partialTranscript: String = ""
     var currentSession: TranscriptionSession?
 
 
@@ -146,6 +147,7 @@ class WhisperState: NSObject, ObservableObject {
     func toggleRecord(powerModeId: UUID? = nil) async {
         logger.notice("toggleRecord called – state=\(String(describing: self.recordingState))")
         if recordingState == .recording {
+            partialTranscript = ""
             await recorder.stopRecording()
             if let recordedFile {
                 if !shouldCancelRecording {


### PR DESCRIPTION
\

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds realtime streaming transcription across multiple providers with a unified session architecture. Improves the recorder UI with smoother visualization, live partial transcripts, and clearer cloud model speed/accuracy display.

- **New Features**
  - WebSocket streaming providers: Deepgram Nova 3, ElevenLabs Scribe V2 Realtime, Soniox stt-rt-v4, Mistral Voxtral, and on-device Parakeet v2/v3.
  - StreamingTranscriptionService with AsyncStream events, VAD commit, and fallback to file upload.
  - Recorder/CoreAudio onAudioChunk streams 16-bit 16kHz mono PCM; no audio lost during handshake.
  - Live partial transcript in mini/notch recorder; updated model names; stricter Soniox language hints with language identification.
  - Cloud model card shows speed dots and updated accuracy values; Deepgram uses explicit model.name (incl. medical variants).

- **Refactors**
  - TranscriptionSession protocol unifies streaming and file flows; WhisperState manages sessions and partial text.
  - Smoother visualization: EMA-smoothed audio meter, background timer, and 60Hz TimelineView.
  - Fixed leaked sessions, end-of-recording audio loss, Parakeet v2/v3 mismatch; cached models; cleared stale partial callbacks.
  - Fixed concurrent model loading version bug in Parakeet; removed transcript logging from all streaming providers.

<sup>Written for commit 780fce93c2b65c0f4941fca38731bbc5e1ea4511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

