### PR TITLE
Fix metrics background loading, deletion notifications, and task life…

### DIFF
--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -14,6 +14,7 @@ extension Notification.Name {
     static let powerModeConfigurationApplied = Notification.Name("powerModeConfigurationApplied")
     static let transcriptionCreated = Notification.Name("transcriptionCreated")
     static let transcriptionCompleted = Notification.Name("transcriptionCompleted")
+    static let transcriptionDeleted = Notification.Name("transcriptionDeleted")
     static let enhancementToggleChanged = Notification.Name("enhancementToggleChanged")
     static let openFileForTranscription = Notification.Name("openFileForTranscription")
     static let audioDeviceSwitchRequired = Notification.Name("audioDeviceSwitchRequired")

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -82,6 +82,7 @@ class TranscriptionAutoCleanupService {
 
         do {
             try modelContext.save()
+            NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
         } catch {
             logger.error("Failed to save after transcription deletion: \(error.localizedDescription)")
         }
@@ -97,25 +98,33 @@ class TranscriptionAutoCleanupService {
 
         let cutoffDate = Date().addingTimeInterval(TimeInterval(-effectiveMinutes * 60))
 
+        let modelContainer = await MainActor.run { modelContext.container }
+
         do {
-            try await MainActor.run {
-                let descriptor = FetchDescriptor<Transcription>(
-                    predicate: #Predicate<Transcription> { transcription in
-                        transcription.timestamp < cutoffDate
-                    }
-                )
-                let items = try modelContext.fetch(descriptor)
-                var deletedCount = 0
-                for transcription in items {
-                    if let urlString = transcription.audioFileURL,
-                       let url = URL(string: urlString),
-                       FileManager.default.fileExists(atPath: url.path) {
-                        try? FileManager.default.removeItem(at: url)
-                    }
-                    modelContext.delete(transcription)
-                    deletedCount += 1
+            let backgroundContext = ModelContext(modelContainer)
+
+            let descriptor = FetchDescriptor<Transcription>(
+                predicate: #Predicate<Transcription> { transcription in
+                    transcription.timestamp < cutoffDate
                 }
-                if deletedCount > 0 { try modelContext.save() }
+            )
+            let items = try backgroundContext.fetch(descriptor)
+            var deletedCount = 0
+            for transcription in items {
+                if let urlString = transcription.audioFileURL,
+                   let url = URL(string: urlString),
+                   FileManager.default.fileExists(atPath: url.path) {
+                    try? FileManager.default.removeItem(at: url)
+                }
+                backgroundContext.delete(transcription)
+                deletedCount += 1
+            }
+            if deletedCount > 0 {
+                try backgroundContext.save()
+                logger.notice("Cleaned up \(deletedCount) old transcription(s)")
+                await MainActor.run {
+                    NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
+                }
             }
         } catch {
             logger.error("Failed during transcription cleanup: \(error.localizedDescription)")
@@ -128,34 +137,38 @@ class TranscriptionAutoCleanupService {
             return
         }
 
+        let modelContainer = await MainActor.run { modelContext.container }
+
         do {
-            try await MainActor.run {
-                let descriptor = FetchDescriptor<Transcription>()
-                let transcriptions = try modelContext.fetch(descriptor)
-                let referencedFiles = Set(transcriptions.compactMap { transcription -> String? in
-                    guard let urlString = transcription.audioFileURL,
-                          let url = URL(string: urlString) else { return nil }
-                    return url.lastPathComponent
-                })
+            let backgroundContext = ModelContext(modelContainer)
 
-                guard FileManager.default.fileExists(atPath: recordingsDirectory.path) else { return }
-                let filesInDirectory = try FileManager.default.contentsOfDirectory(
-                    at: recordingsDirectory,
-                    includingPropertiesForKeys: nil
-                )
+            var descriptor = FetchDescriptor<Transcription>()
+            descriptor.propertiesToFetch = [\.audioFileURL]
 
-                var deletedCount = 0
-                for fileURL in filesInDirectory {
-                    let fileName = fileURL.lastPathComponent
-                    if !referencedFiles.contains(fileName) {
-                        try? FileManager.default.removeItem(at: fileURL)
-                        deletedCount += 1
-                    }
+            let transcriptions = try backgroundContext.fetch(descriptor)
+            let referencedFiles = Set(transcriptions.compactMap { transcription -> String? in
+                guard let urlString = transcription.audioFileURL,
+                      let url = URL(string: urlString) else { return nil }
+                return url.lastPathComponent
+            })
+
+            guard FileManager.default.fileExists(atPath: recordingsDirectory.path) else { return }
+            let filesInDirectory = try FileManager.default.contentsOfDirectory(
+                at: recordingsDirectory,
+                includingPropertiesForKeys: nil
+            )
+
+            var deletedCount = 0
+            for fileURL in filesInDirectory {
+                let fileName = fileURL.lastPathComponent
+                if !referencedFiles.contains(fileName) {
+                    try? FileManager.default.removeItem(at: fileURL)
+                    deletedCount += 1
                 }
+            }
 
-                if deletedCount > 0 {
-                    logger.notice("Cleaned up \(deletedCount) orphan audio file(s)")
-                }
+            if deletedCount > 0 {
+                logger.notice("Cleaned up \(deletedCount) orphan audio file(s)")
             }
         } catch {
             logger.error("Failed during orphan audio cleanup: \(error.localizedDescription)")

--- a/VoiceInk/Views/History/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/History/TranscriptionHistoryView.swift
@@ -401,6 +401,7 @@ struct TranscriptionHistoryView: View {
     private func saveAndReload() async {
         do {
             try modelContext.save()
+            NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
             await loadInitialContent()
         } catch {
             print("Error saving deletion: \(error.localizedDescription)")

--- a/VoiceInk/Views/Metrics/MetricsContent.swift
+++ b/VoiceInk/Views/Metrics/MetricsContent.swift
@@ -1,13 +1,25 @@
 import SwiftUI
+import SwiftData
+import os
 
 struct MetricsContent: View {
-    let transcriptions: [Transcription]
+    private let logger = Logger(subsystem: "com.prakashjoshipax.VoiceInk", category: "MetricsContent")
+    let modelContext: ModelContext
     let licenseState: LicenseViewModel.LicenseState
+
+    @State private var totalCount: Int = 0
+    @State private var totalWords: Int = 0
+    @State private var totalDuration: TimeInterval = 0
+    @State private var isLoadingMetrics: Bool = true
+    @State private var metricsTask: Task<Void, Never>?
 
     var body: some View {
         Group {
-            if transcriptions.isEmpty {
+            if totalCount == 0 && !isLoadingMetrics {
                 emptyStateView
+            } else if isLoadingMetrics {
+                ProgressView("Loading metrics...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 GeometryReader { geometry in
                     ScrollView {
@@ -34,8 +46,90 @@ struct MetricsContent: View {
                 }
             }
         }
+        .task {
+            await loadMetricsEfficiently()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionCreated)) { _ in
+            metricsTask?.cancel()
+            metricsTask = Task {
+                await loadMetricsEfficiently()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionCompleted)) { _ in
+            metricsTask?.cancel()
+            metricsTask = Task {
+                await loadMetricsEfficiently()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { _ in
+            metricsTask?.cancel()
+            metricsTask = Task {
+                await loadMetricsEfficiently()
+            }
+        }
+        .onDisappear {
+            metricsTask?.cancel()
+        }
     }
     
+    private func loadMetricsEfficiently() async {
+        await MainActor.run {
+            self.isLoadingMetrics = true
+        }
+
+        let modelContainer = modelContext.container
+
+        let backgroundContext = ModelContext(modelContainer)
+
+        do {
+            guard !Task.isCancelled else {
+                await MainActor.run {
+                    self.isLoadingMetrics = false
+                }
+                return
+            }
+
+            let count = try backgroundContext.fetchCount(FetchDescriptor<Transcription>())
+
+            guard !Task.isCancelled else {
+                await MainActor.run {
+                    self.isLoadingMetrics = false
+                }
+                return
+            }
+
+            var descriptor = FetchDescriptor<Transcription>()
+            descriptor.propertiesToFetch = [\.text, \.duration]
+
+            var words = 0
+            var duration: TimeInterval = 0
+
+            try backgroundContext.enumerate(descriptor) { transcription in
+                words += transcription.text.split(whereSeparator: \.isWhitespace).count
+                duration += transcription.duration
+            }
+
+            guard !Task.isCancelled else {
+                await MainActor.run {
+                    self.isLoadingMetrics = false
+                }
+                return
+            }
+
+            await MainActor.run {
+                self.totalCount = count
+                self.totalWords = words
+                self.totalDuration = duration
+                self.isLoadingMetrics = false
+            }
+        } catch {
+            logger.error("Error loading metrics: \(error.localizedDescription)")
+            await MainActor.run {
+                self.isLoadingMetrics = false
+            }
+        }
+    }
+
     private var emptyStateView: some View {
         VStack(spacing: 20) {
             Image(systemName: "waveform")
@@ -103,15 +197,15 @@ struct MetricsContent: View {
             MetricCard(
                 icon: "mic.fill",
                 title: "Sessions Recorded",
-                value: "\(transcriptions.count)",
+                value: "\(totalCount)",
                 detail: "VoiceInk sessions completed",
                 color: .purple
             )
-            
+
             MetricCard(
                 icon: "text.alignleft",
                 title: "Words Dictated",
-                value: Formatters.formattedNumber(totalWordsTranscribed),
+                value: Formatters.formattedNumber(totalWords),
                 detail: "words generated",
                 color: Color(nsColor: .controlAccentColor)
             )
@@ -146,15 +240,14 @@ struct MetricsContent: View {
     }
     
     private var heroSubtitle: String {
-        guard !transcriptions.isEmpty else {
+        guard totalCount > 0 else {
             return "Your VoiceInk journey starts with your first recording."
         }
-        
-        let wordsText = Formatters.formattedNumber(totalWordsTranscribed)
-        let sessionCount = transcriptions.count
-        let sessionText = sessionCount == 1 ? "session" : "sessions"
-        
-        return "Dictated \(wordsText) words across \(sessionCount) \(sessionText)."
+
+        let wordsText = Formatters.formattedNumber(totalWords)
+        let sessionText = totalCount == 1 ? "session" : "sessions"
+
+        return "Dictated \(wordsText) words across \(totalCount) \(sessionText)."
     }
     
     private var heroGradient: LinearGradient {
@@ -170,38 +263,24 @@ struct MetricsContent: View {
     }
     
     // MARK: - Computed Metrics
-    
-    private var totalWordsTranscribed: Int {
-        transcriptions.reduce(0) { $0 + $1.text.split(separator: " ").count }
-    }
-    
-    private var totalRecordedTime: TimeInterval {
-        transcriptions.reduce(0) { $0 + $1.duration }
-    }
-    
+
     private var estimatedTypingTime: TimeInterval {
         let averageTypingSpeed: Double = 35 // words per minute
-        let totalWords = Double(totalWordsTranscribed)
-        let estimatedTypingTimeInMinutes = totalWords / averageTypingSpeed
+        let estimatedTypingTimeInMinutes = Double(totalWords) / averageTypingSpeed
         return estimatedTypingTimeInMinutes * 60
     }
-    
+
     private var timeSaved: TimeInterval {
-        max(estimatedTypingTime - totalRecordedTime, 0)
+        max(estimatedTypingTime - totalDuration, 0)
     }
-    
+
     private var averageWordsPerMinute: Double {
-        guard totalRecordedTime > 0 else { return 0 }
-        return Double(totalWordsTranscribed) / (totalRecordedTime / 60.0)
+        guard totalDuration > 0 else { return 0 }
+        return Double(totalWords) / (totalDuration / 60.0)
     }
-    
+
     private var totalKeystrokesSaved: Int {
-        Int(Double(totalWordsTranscribed) * 5.0)
-    }
-    
-    private var firstTranscriptionDateText: String? {
-        guard let firstDate = transcriptions.map(\.timestamp).min() else { return nil }
-        return dateFormatter.string(from: firstDate)
+        Int(Double(totalWords) * 5.0)
     }
     
     private var dateFormatter: DateFormatter {

--- a/VoiceInk/Views/MetricsView.swift
+++ b/VoiceInk/Views/MetricsView.swift
@@ -5,7 +5,6 @@ import KeyboardShortcuts
 
 struct MetricsView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \Transcription.timestamp) private var transcriptions: [Transcription]
     @EnvironmentObject private var whisperState: WhisperState
     @EnvironmentObject private var hotkeyManager: HotkeyManager
     @StateObject private var licenseViewModel = LicenseViewModel()
@@ -44,7 +43,7 @@ struct MetricsView: View {
             }
 
             MetricsContent(
-                transcriptions: Array(transcriptions),
+                modelContext: modelContext,
                 licenseState: licenseViewModel.licenseState
             )
         }

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -430,9 +430,8 @@ class WhisperState: NSObject, ObservableObject {
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
         }
 
-        // --- Finalize and save ---
         try? modelContext.save()
-        
+
         if transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue {
             NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load metrics in the background with a proper loading state, and refresh metrics when transcriptions are deleted. This fixes stale UI updates and reduces UI blocking during metrics calculation.

- **Performance**
  - Compute metrics (count, words, duration) in a background SwiftData context using fetchCount/enumerate with propertiesToFetch, and show a loading indicator until ready.
  - Run cleanup of old transcriptions and orphan audio files in a background context with batched save and logging.

- **Bug Fixes**
  - Add and post a new transcriptionDeleted notification after deletions (auto cleanup and manual), and listen for it so metrics refresh immediately.
  - Manage task lifecycle in MetricsContent: cancel running tasks before starting new ones on create/complete/delete events and on view disappear to prevent overlapping work.

<sup>Written for commit ede9b86645c8f926766ed2eeb8fecf6e29b7bbc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

