### PR TITLE
Replace deprecated CGWindowList with ScreenCaptureKit

### DIFF
--- a/VoiceInk/Services/ScreenCaptureService.swift
+++ b/VoiceInk/Services/ScreenCaptureService.swift
@@ -7,160 +7,104 @@ import ScreenCaptureKit
 class ScreenCaptureService: ObservableObject {
     @Published var isCapturing = false
     @Published var lastCapturedText: String?
-    
-    private struct WindowCandidate {
-        let title: String
-        let ownerName: String
-        let windowID: CGWindowID
-        let ownerPID: pid_t
-        let layer: Int32
-    }
 
-    private func getActiveWindowInfo() -> (title: String, ownerName: String, windowID: CGWindowID)? {
+    private func findActiveWindow(in content: SCShareableContent) -> SCWindow? {
         let currentPID = ProcessInfo.processInfo.processIdentifier
         let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
-        let windowListInfo = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] ?? []
-        
-        let candidates = windowListInfo.compactMap { info -> WindowCandidate? in
-            guard let windowID = info[kCGWindowNumber as String] as? CGWindowID,
-                  let ownerName = info[kCGWindowOwnerName as String] as? String,
-                  let ownerPIDNumber = info[kCGWindowOwnerPID as String] as? NSNumber,
-                  let layer = info[kCGWindowLayer as String] as? Int32 else {
-                return nil
-            }
 
-            let rawTitle = (info[kCGWindowName as String] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let resolvedTitle = rawTitle?.isEmpty == false ? rawTitle! : ownerName
-
-            return WindowCandidate(
-                title: resolvedTitle,
-                ownerName: ownerName,
-                windowID: windowID,
-                ownerPID: ownerPIDNumber.int32Value,
-                layer: layer
-            )
+        if let frontmostPID,
+           let window = content.windows.first(where: {
+               $0.owningApplication?.processID == frontmostPID &&
+               $0.owningApplication?.processID != currentPID &&
+               $0.windowLayer == 0 &&
+               $0.isOnScreen
+           }) {
+            return window
         }
 
-        func isEligible(_ candidate: WindowCandidate) -> Bool {
-            guard candidate.layer == 0 else { return false }
-            guard candidate.ownerPID != currentPID else { return false }
-            return true
+        return content.windows.first {
+            $0.owningApplication?.processID != currentPID &&
+            $0.windowLayer == 0 &&
+            $0.isOnScreen
         }
-
-        if let frontmostPID = frontmostPID,
-           let focusedWindow = candidates.first(where: { isEligible($0) && $0.ownerPID == frontmostPID }) {
-            return (title: focusedWindow.title, ownerName: focusedWindow.ownerName, windowID: focusedWindow.windowID)
-        }
-
-        if let fallbackWindow = candidates.first(where: isEligible) {
-            return (title: fallbackWindow.title, ownerName: fallbackWindow.ownerName, windowID: fallbackWindow.windowID)
-        }
-
-        return nil
     }
-    
-    func captureActiveWindow() async -> NSImage? {
-        guard let windowInfo = getActiveWindowInfo() else {
-            return nil
+
+    func captureAndExtractText() async -> String? {
+        guard !isCapturing else { return nil }
+
+        isCapturing = true
+        defer {
+            DispatchQueue.main.async { self.isCapturing = false }
         }
-        
+
         do {
             let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
-            
-            guard let targetWindow = content.windows.first(where: { $0.windowID == windowInfo.windowID }) else {
-                return nil
-            }
-            
-            let filter = SCContentFilter(desktopIndependentWindow: targetWindow)
-            
+
+            guard let window = findActiveWindow(in: content) else { return nil }
+
+            let title = window.title ?? window.owningApplication?.applicationName ?? "Unknown"
+            let appName = window.owningApplication?.applicationName ?? "Unknown"
+
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+
             let configuration = SCStreamConfiguration()
-            configuration.width = Int(targetWindow.frame.width) * 2
-            configuration.height = Int(targetWindow.frame.height) * 2
-            
+            configuration.width = Int(window.frame.width) * 2
+            configuration.height = Int(window.frame.height) * 2
+
             let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
-            
-            return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-            
+            let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+
+            var contextText = """
+            Active Window: \(title)
+            Application: \(appName)
+
+            """
+
+            let extractedText = await extractText(from: nsImage)
+            if let extractedText, !extractedText.isEmpty {
+                contextText += "Window Content:\n\(extractedText)"
+            } else {
+                contextText += "Window Content:\nNo text detected via OCR"
+            }
+
+            lastCapturedText = contextText
+            return contextText
+
         } catch {
             return nil
         }
     }
-    
+
     private func extractText(from image: NSImage) async -> String? {
         guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             return nil
         }
-        
+
         let result: Result<String?, Error> = await Task.detached(priority: .userInitiated) {
             let request = VNRecognizeTextRequest()
             request.recognitionLevel = .accurate
             request.usesLanguageCorrection = true
             request.automaticallyDetectsLanguage = true
-            
+
             let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-            
+
             do {
                 try requestHandler.perform([request])
-                guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                guard let observations = request.results else {
                     return .success(nil)
                 }
-                
                 let text = observations
                     .compactMap { $0.topCandidates(1).first?.string }
                     .joined(separator: "\n")
-                
                 return .success(text.isEmpty ? nil : text)
             } catch {
                 return .failure(error)
             }
         }.value
-        
+
         switch result {
-        case .success(let text):
-            return text
-        case .failure:
-            return nil
+        case .success(let text): return text
+        case .failure: return nil
         }
     }
-    
-    func captureAndExtractText() async -> String? {
-        guard !isCapturing else { 
-            return nil 
-        }
-        
-        isCapturing = true
-        defer { 
-            DispatchQueue.main.async {
-                self.isCapturing = false
-            }
-        }
-
-        guard let windowInfo = getActiveWindowInfo() else {
-            return nil
-        }
-
-        var contextText = """
-        Active Window: \(windowInfo.title)
-        Application: \(windowInfo.ownerName)
-        
-        """
-
-        if let capturedImage = await captureActiveWindow() {
-            let extractedText = await extractText(from: capturedImage)
-            
-            if let extractedText = extractedText, !extractedText.isEmpty {
-                contextText += "Window Content:\n\(extractedText)"
-            } else {
-                contextText += "Window Content:\nNo text detected via OCR"
-            }
-            
-            await MainActor.run {
-                self.lastCapturedText = contextText
-            }
-            
-            return contextText
-        }
-
-        return nil
-    }
-} 
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced deprecated CGWindowList-based capture with ScreenCaptureKit to reliably capture the active window and build a clear OCR context. Modernizes the screen capture path and improves window detection.

- **Refactors**
  - Use SCShareableContent and SCWindow instead of CGWindowListCopyWindowInfo.
  - Added findActiveWindow to choose the frontmost on-screen window (layer 0, not our app), with a safe fallback.
  - Capture via SCContentFilter + SCScreenshotManager and scale resolution by 2.
  - Consolidated flow into captureAndExtractText, returning a context string (window title, app name, OCR content) and updating lastCapturedText.
  - Simplified OCR with VNRecognizeTextRequest and cleaner result handling.
  - Removed WindowCandidate, getActiveWindowInfo, and captureActiveWindow.

<sup>Written for commit 851fa295b99048e8f2ba57b8bc6f402b4e250b0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

