### PR TITLE
Fix transcript cleanup ignoring failed recordings and window close state

### DIFF
--- a/VoiceInk/Views/Metrics/MetricsContent.swift
+++ b/VoiceInk/Views/Metrics/MetricsContent.swift
@@ -89,7 +89,8 @@ struct MetricsContent: View {
                 return
             }
 
-            let count = try backgroundContext.fetchCount(FetchDescriptor<Transcription>())
+            let completedFilter = #Predicate<Transcription> { $0.transcriptionStatus == "completed" }
+            let count = try backgroundContext.fetchCount(FetchDescriptor<Transcription>(predicate: completedFilter))
 
             guard !Task.isCancelled else {
                 await MainActor.run {
@@ -98,7 +99,7 @@ struct MetricsContent: View {
                 return
             }
 
-            var descriptor = FetchDescriptor<Transcription>()
+            var descriptor = FetchDescriptor<Transcription>(predicate: completedFilter)
             descriptor.propertiesToFetch = [\.text, \.duration]
 
             var words = 0

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -119,6 +119,9 @@ struct VoiceInkApp: App {
         }
 
         AppShortcuts.updateAppShortcutParameters()
+
+        // Start cleanup service for the app's lifetime, not tied to window lifecycle
+        TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: container.mainContext)
     }
     
     // MARK: - Container Creation Helpers
@@ -228,9 +231,6 @@ struct VoiceInkApp: App {
                             AnnouncementsService.shared.start()
                         }
                         
-                        // Start the transcription auto-cleanup service (handles immediate and scheduled transcript deletion)
-                        transcriptionAutoCleanupService.startMonitoring(modelContext: container.mainContext)
-                        
                         // Start the automatic audio cleanup process only if transcript cleanup is not enabled
                         if !UserDefaults.standard.bool(forKey: "IsTranscriptionCleanupEnabled") {
                             audioCleanupManager.startAutomaticCleanup(modelContext: container.mainContext)
@@ -251,9 +251,6 @@ struct VoiceInkApp: App {
                     .onDisappear {
                         AnnouncementsService.shared.stop()
                         whisperState.unloadModel()
-                        
-                        // Stop the transcription auto-cleanup service
-                        transcriptionAutoCleanupService.stopMonitoring()
                         
                         // Stop the automatic audio cleanup process
                         audioCleanupManager.stopAutomaticCleanup()

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -432,9 +432,7 @@ class WhisperState: NSObject, ObservableObject {
 
         try? modelContext.save()
 
-        if transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue {
-            NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
-        }
+        NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
 
         if await checkCancellationAndCleanup() { return }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix transcript auto-cleanup to include failed recordings and keep running after the window closes. Metrics now only count completed transcriptions for accurate stats.

- **Bug Fixes**
  - Start the transcription auto-cleanup service at app launch so it persists beyond window lifecycle.
  - Always post the transcriptionCompleted notification, regardless of status, so failed recordings are cleaned up.
  - Filter metrics queries to completed transcriptions for counts and word/duration calculations.

<sup>Written for commit 158efc5d9b585cf2e89396389710290371669c65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

