### PR TITLE
Fix Groq transcription 404 caused by doubled /v1 in URL

### DIFF
--- a/VoiceInk/Services/CloudTranscription/CloudTranscriptionService.swift
+++ b/VoiceInk/Services/CloudTranscription/CloudTranscriptionService.swift
@@ -53,7 +53,7 @@ class CloudTranscriptionService: TranscriptionService {
                 let apiKey = try requireAPIKey(forProvider: "Groq")
                 let prompt = transcriptionPrompt()
                 return try await OpenAITranscriptionClient.transcribe(
-                    baseURL: URL(string: "https://api.groq.com/openai/v1")!,
+                    baseURL: URL(string: "https://api.groq.com/openai")!,
                     audioData: audioData,
                     fileName: fileName,
                     apiKey: apiKey,


### PR DESCRIPTION
## Summary
- The Groq base URL was set to `https://api.groq.com/openai/v1`, but `OpenAITranscriptionClient.transcribe()` in LLMkit appends `/v1/audio/transcriptions` to the base URL, resulting in `POST /openai/v1/v1/audio/transcriptions` → 404
- Removes the trailing `/v1` from the base URL so the final request path matches Groq's documented endpoint: `POST /openai/v1/audio/transcriptions`

Reference: https://console.groq.com/docs/speech-to-text

## Test plan
- [x] Select Groq `whisper-large-v3-turbo` as transcription model
- [x] Configure Groq API key
- [x] Record and transcribe audio — previously returned 404, now transcribes successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Groq transcription 404 by removing the trailing /v1 from the base URL (https://api.groq.com/openai/v1 → https://api.groq.com/openai). Requests now target /openai/v1/audio/transcriptions as documented, so transcriptions complete successfully.

<sup>Written for commit 052fa2aeb5cb977037b7ce42a22cecb7f654e3ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

