### PR TITLE
feat: Add multiple AI provider configurations per enhancement prompt

### DIFF
--- a/VoiceInk/Models/AIProviderConfiguration.swift
+++ b/VoiceInk/Models/AIProviderConfiguration.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+struct AIProviderConfiguration: Identifiable, Codable, Equatable {
+    let id: UUID
+    var name: String
+    var provider: AIProvider
+    var model: String
+    var customBaseURL: String?
+    var customModel: String?
+    var isDefault: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, provider, model, customBaseURL, customModel, isDefault
+    }
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        provider: AIProvider,
+        model: String = "",
+        customBaseURL: String? = nil,
+        customModel: String? = nil,
+        isDefault: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.provider = provider
+        self.model = model.isEmpty ? provider.defaultModel : model
+        self.customBaseURL = customBaseURL
+        self.customModel = customModel
+        self.isDefault = isDefault
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        provider = try container.decode(AIProvider.self, forKey: .provider)
+        model = try container.decode(String.self, forKey: .model)
+        customBaseURL = try container.decodeIfPresent(String.self, forKey: .customBaseURL)
+        customModel = try container.decodeIfPresent(String.self, forKey: .customModel)
+        isDefault = try container.decodeIfPresent(Bool.self, forKey: .isDefault) ?? false
+    }
+
+    var effectiveModel: String {
+        if provider == .custom, let custom = customModel, !custom.isEmpty {
+            return custom
+        }
+        return model
+    }
+
+    var effectiveBaseURL: String {
+        if let custom = customBaseURL, !custom.isEmpty {
+            return custom
+        }
+        return provider.baseURL
+    }
+
+    var hasAPIKey: Bool {
+        if !provider.requiresAPIKey {
+            return true
+        }
+        return APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue)
+    }
+}
+
+struct ResolvedProviderConfig {
+    let provider: AIProvider
+    let apiKey: String
+    let model: String
+    let baseURL: String
+}

--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -85,6 +85,7 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
     let isPredefined: Bool
     let triggerWords: [String]
     let useSystemInstructions: Bool
+    let providerConfigurationId: UUID?
     
     init(
         id: UUID = UUID(),
@@ -95,7 +96,8 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
         description: String? = nil,
         isPredefined: Bool = false,
         triggerWords: [String] = [],
-        useSystemInstructions: Bool = true
+        useSystemInstructions: Bool = true,
+        providerConfigurationId: UUID? = nil
     ) {
         self.id = id
         self.title = title
@@ -106,10 +108,11 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
         self.isPredefined = isPredefined
         self.triggerWords = triggerWords
         self.useSystemInstructions = useSystemInstructions
+        self.providerConfigurationId = providerConfigurationId
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, title, promptText, isActive, icon, description, isPredefined, triggerWords, useSystemInstructions
+        case id, title, promptText, isActive, icon, description, isPredefined, triggerWords, useSystemInstructions, providerConfigurationId
     }
 
     init(from decoder: Decoder) throws {
@@ -123,6 +126,7 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
         isPredefined = try container.decode(Bool.self, forKey: .isPredefined)
         triggerWords = try container.decode([String].self, forKey: .triggerWords)
         useSystemInstructions = try container.decodeIfPresent(Bool.self, forKey: .useSystemInstructions) ?? true
+        providerConfigurationId = try container.decodeIfPresent(UUID.self, forKey: .providerConfigurationId)
     }
     
     var finalPromptText: String {
@@ -136,7 +140,7 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
 
 // MARK: - UI Extensions
 extension CustomPrompt {
-    func promptIcon(isSelected: Bool, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil) -> some View {
+    func promptIcon(isSelected: Bool, modelName: String? = nil, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil) -> some View {
         VStack(spacing: 8) {
             ZStack {
                 // Dynamic background with blur effect
@@ -239,7 +243,7 @@ extension CustomPrompt {
                             Image(systemName: "mic.fill")
                                 .font(.system(size: 7))
                                 .foregroundColor(isSelected ? .accentColor.opacity(0.9) : .secondary.opacity(0.7))
-                            
+
                             if triggerWords.count == 1 {
                                 Text("\"\(triggerWords[0])...\"")
                                     .font(.system(size: 8, weight: .regular))
@@ -256,6 +260,20 @@ extension CustomPrompt {
                     }
                 }
                 .frame(height: 16)
+
+                // Model name
+                if let modelName = modelName {
+                    HStack(spacing: 2) {
+                        Image(systemName: "cpu")
+                            .font(.system(size: 7))
+                            .foregroundColor(isSelected ? .accentColor.opacity(0.9) : .secondary.opacity(0.6))
+                        Text(modelName)
+                            .font(.system(size: 8, weight: .regular))
+                            .foregroundColor(isSelected ? .primary.opacity(0.8) : .secondary.opacity(0.6))
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: 70)
+                }
             }
         }
         .padding(.horizontal, 4)

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -12,15 +12,15 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var selectedTranscriptionModelName: String?
     var selectedLanguage: String?
     var useScreenCapture: Bool
-    var selectedAIProvider: String?
-    var selectedAIModel: String?
     var isAutoSendEnabled: Bool = false
     var isEnabled: Bool = true
     var isDefault: Bool = false
     var hotkeyShortcut: String? = nil
         
     enum CodingKeys: String, CodingKey {
-        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, isEnabled, isDefault, hotkeyShortcut
+        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, useScreenCapture, isAutoSendEnabled, isEnabled, isDefault, hotkeyShortcut
+        // Legacy keys kept for backward-compatible decoding
+        case selectedAIProvider, selectedAIModel
         case selectedWhisperModel
         case selectedTranscriptionModelName
     }
@@ -28,7 +28,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     init(id: UUID = UUID(), name: String, emoji: String, appConfigs: [AppConfig]? = nil,
          urlConfigs: [URLConfig]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, selectedLanguage: String? = nil, useScreenCapture: Bool = false,
-         selectedAIProvider: String? = nil, selectedAIModel: String? = nil, isAutoSendEnabled: Bool = false, isEnabled: Bool = true, isDefault: Bool = false, hotkeyShortcut: String? = nil) {
+         isAutoSendEnabled: Bool = false, isEnabled: Bool = true, isDefault: Bool = false, hotkeyShortcut: String? = nil) {
         self.id = id
         self.name = name
         self.emoji = emoji
@@ -38,8 +38,6 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         self.selectedPrompt = selectedPrompt
         self.useScreenCapture = useScreenCapture
         self.isAutoSendEnabled = isAutoSendEnabled
-        self.selectedAIProvider = selectedAIProvider ?? UserDefaults.standard.string(forKey: "selectedAIProvider")
-        self.selectedAIModel = selectedAIModel
         self.selectedTranscriptionModelName = selectedTranscriptionModelName ?? UserDefaults.standard.string(forKey: "CurrentTranscriptionModel")
         self.selectedLanguage = selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
         self.isEnabled = isEnabled
@@ -58,8 +56,6 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         selectedPrompt = try container.decodeIfPresent(String.self, forKey: .selectedPrompt)
         selectedLanguage = try container.decodeIfPresent(String.self, forKey: .selectedLanguage)
         useScreenCapture = try container.decode(Bool.self, forKey: .useScreenCapture)
-        selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
-        selectedAIModel = try container.decodeIfPresent(String.self, forKey: .selectedAIModel)
         isAutoSendEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoSendEnabled) ?? false
         isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
         isDefault = try container.decodeIfPresent(Bool.self, forKey: .isDefault) ?? false
@@ -85,8 +81,6 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         try container.encodeIfPresent(selectedPrompt, forKey: .selectedPrompt)
         try container.encodeIfPresent(selectedLanguage, forKey: .selectedLanguage)
         try container.encode(useScreenCapture, forKey: .useScreenCapture)
-        try container.encodeIfPresent(selectedAIProvider, forKey: .selectedAIProvider)
-        try container.encodeIfPresent(selectedAIModel, forKey: .selectedAIModel)
         try container.encode(isAutoSendEnabled, forKey: .isAutoSendEnabled)
         try container.encodeIfPresent(selectedTranscriptionModelName, forKey: .selectedTranscriptionModelName)
         try container.encode(isEnabled, forKey: .isEnabled)

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -68,6 +68,13 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         } else {
             selectedTranscriptionModelName = nil
         }
+
+        // Log legacy AI provider settings for migration awareness
+        // These fields are no longer used - provider config is now per-prompt via AIProviderConfiguration
+        if let legacyProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider),
+           let legacyModel = try container.decodeIfPresent(String.self, forKey: .selectedAIModel) {
+            print("[Migration] PowerMode '\(name)' had legacy AI settings: provider=\(legacyProvider), model=\(legacyModel). These have been migrated to the new provider configuration system.")
+        }
     }
 
     func encode(to encoder: Encoder) throws {

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -5,8 +5,6 @@ struct ApplicationState: Codable {
     var isEnhancementEnabled: Bool
     var useScreenCaptureContext: Bool
     var selectedPromptId: String?
-    var selectedAIProvider: String?
-    var selectedAIModel: String?
     var selectedLanguage: String?
     var transcriptionModelName: String?
 }
@@ -47,8 +45,6 @@ class PowerModeSessionManager {
                 isEnhancementEnabled: enhancementService.isEnhancementEnabled,
                 useScreenCaptureContext: enhancementService.useScreenCaptureContext,
                 selectedPromptId: enhancementService.selectedPromptId?.uuidString,
-                selectedAIProvider: enhancementService.getAIService()?.selectedProvider.rawValue,
-                selectedAIModel: enhancementService.getAIService()?.currentModel,
                 selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
                 transcriptionModelName: whisperState.currentTranscriptionModel?.name
             )
@@ -94,8 +90,6 @@ class PowerModeSessionManager {
             isEnhancementEnabled: enhancementService.isEnhancementEnabled,
             useScreenCaptureContext: enhancementService.useScreenCaptureContext,
             selectedPromptId: enhancementService.selectedPromptId?.uuidString,
-            selectedAIProvider: enhancementService.getAIService()?.selectedProvider.rawValue,
-            selectedAIModel: enhancementService.getAIService()?.currentModel,
             selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
             transcriptionModelName: whisperState.currentTranscriptionModel?.name
         )
@@ -114,15 +108,6 @@ class PowerModeSessionManager {
             if config.isAIEnhancementEnabled {
                 if let promptId = config.selectedPrompt, let uuid = UUID(uuidString: promptId) {
                     enhancementService.selectedPromptId = uuid
-                }
-
-                if let aiService = enhancementService.getAIService() {
-                    if let providerName = config.selectedAIProvider, let provider = AIProvider(rawValue: providerName) {
-                        aiService.selectedProvider = provider
-                    }
-                    if let model = config.selectedAIModel {
-                        aiService.selectModel(model)
-                    }
                 }
             }
 
@@ -151,15 +136,6 @@ class PowerModeSessionManager {
             enhancementService.isEnhancementEnabled = state.isEnhancementEnabled
             enhancementService.useScreenCaptureContext = state.useScreenCaptureContext
             enhancementService.selectedPromptId = state.selectedPromptId.flatMap(UUID.init)
-
-            if let aiService = enhancementService.getAIService() {
-                if let providerName = state.selectedAIProvider, let provider = AIProvider(rawValue: providerName) {
-                    aiService.selectedProvider = provider
-                }
-                if let model = state.selectedAIModel {
-                    aiService.selectModel(model)
-                }
-            }
 
             if let language = state.selectedLanguage {
                 UserDefaults.standard.set(language, forKey: "SelectedLanguage")

--- a/VoiceInk/PowerMode/PowerModeViewComponents.swift
+++ b/VoiceInk/PowerMode/PowerModeViewComponents.swift
@@ -94,6 +94,7 @@ struct ConfigurationRow: View {
     let powerModeManager: PowerModeManager
     let onEditConfig: (PowerModeConfig) -> Void
     @EnvironmentObject var enhancementService: AIEnhancementService
+    @EnvironmentObject var aiService: AIService
     @EnvironmentObject var whisperState: WhisperState
     @State private var isHovering = false
     
@@ -249,7 +250,9 @@ struct ConfigurationRow: View {
                         )
                     }
                     
-                    if config.isAIEnhancementEnabled, let modelName = config.selectedAIModel, !modelName.isEmpty {
+                    if config.isAIEnhancementEnabled, let prompt = selectedPrompt {
+                        let resolved = aiService.resolveProviderConfig(forId: prompt.providerConfigurationId)
+                        let modelName = resolved.model
                         HStack(spacing: 4) {
                             Image(systemName: "cpu")
                                 .font(.system(size: 10))

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -193,7 +193,7 @@ class AIService: ObservableObject {
     private let userDefaults = UserDefaults.standard
     private lazy var ollamaService = OllamaService()
     
-    @Published private var openRouterModels: [String] = []
+    @Published private(set) var openRouterModels: [String] = []
     
     @Published var providerConfigurations: [AIProviderConfiguration] = []
     private let providerConfigurationsKey = "aiProviderConfigurations"

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import LLMkit
 
-enum AIProvider: String, CaseIterable {
+enum AIProvider: String, CaseIterable, Codable {
     case cerebras = "Cerebras"
     case groq = "Groq"
     case gemini = "Gemini"
@@ -195,6 +195,9 @@ class AIService: ObservableObject {
     
     @Published private var openRouterModels: [String] = []
     
+    @Published var providerConfigurations: [AIProviderConfiguration] = []
+    private let providerConfigurationsKey = "aiProviderConfigurations"
+    
     var connectedProviders: [AIProvider] {
         AIProvider.allCases.filter { provider in
             if provider == .ollama {
@@ -247,6 +250,24 @@ class AIService: ObservableObject {
 
         loadSavedModelSelections()
         loadSavedOpenRouterModels()
+        loadProviderConfigurations()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAPIKeyChanged),
+            name: .aiProviderKeyChanged,
+            object: nil
+        )
+    }
+
+    /// Incremented when API keys change, used to force SwiftUI re-renders
+    /// of views that depend on `hasAPIKey` (a computed Keychain lookup).
+    @Published private(set) var apiKeyRevision: Int = 0
+
+    @objc private func handleAPIKeyChanged() {
+        DispatchQueue.main.async {
+            self.apiKeyRevision += 1
+        }
     }
     
     private func loadSavedModelSelections() {
@@ -371,11 +392,25 @@ class AIService: ObservableObject {
         return ollamaService.availableModels
     }
     
-    func enhanceWithOllama(text: String, systemPrompt: String) async throws -> String {
+    func enhanceWithOllama(text: String, systemPrompt: String, baseURL: String? = nil, model: String? = nil) async throws -> String {
+        let savedBaseURL = ollamaService.baseURL
+        let savedModel = ollamaService.selectedModel
+        
+        if let baseURL = baseURL {
+            ollamaService.baseURL = baseURL
+        }
+        if let model = model {
+            ollamaService.selectedModel = model
+        }
+        
         do {
             let result = try await ollamaService.enhance(text, withSystemPrompt: systemPrompt)
+            ollamaService.baseURL = savedBaseURL
+            ollamaService.selectedModel = savedModel
             return result
         } catch {
+            ollamaService.baseURL = savedBaseURL
+            ollamaService.selectedModel = savedModel
             throw error
         }
     }
@@ -406,6 +441,236 @@ class AIService: ObservableObject {
                 self.openRouterModels = []
                 self.saveOpenRouterModels()
                 self.objectWillChange.send()
+            }
+        }
+    }
+
+    
+    // MARK: - Provider Configurations
+
+    /// Callback to clear `providerConfigurationId` on prompts that reference a deleted config.
+    /// Set by `AIEnhancementService` after initialization.
+    var onProviderConfigDeleted: ((_ deletedConfigId: UUID) -> Void)?
+
+    var defaultProviderConfiguration: AIProviderConfiguration? {
+        providerConfigurations.first(where: { $0.isDefault })
+    }
+
+    private func loadProviderConfigurations() {
+        if let data = userDefaults.data(forKey: providerConfigurationsKey) {
+            do {
+                providerConfigurations = try JSONDecoder().decode([AIProviderConfiguration].self, from: data)
+            } catch {
+                providerConfigurations = []
+            }
+        }
+
+        migrateExistingProviderIfNeeded()
+        ensureDefaultExists()
+    }
+
+    /// Ensures exactly one configuration is marked as default.
+    /// Repairs corrupted state (zero or multiple defaults).
+    private func ensureDefaultExists() {
+        guard !providerConfigurations.isEmpty else { return }
+
+        let defaults = providerConfigurations.filter { $0.isDefault }
+        if defaults.count == 1 { return }
+
+        // Clear all defaults, then set the first one
+        for i in providerConfigurations.indices {
+            providerConfigurations[i].isDefault = false
+        }
+        providerConfigurations[0].isDefault = true
+        saveProviderConfigurations()
+    }
+
+    private func migrateExistingProviderIfNeeded() {
+        // Only migrate when user has no configurations yet.
+        // This runs on every launch until the user has at least one config
+        // (either from migration or manually added), avoiding the problem
+        // where a one-shot migration flag gets burned on a failed attempt.
+        guard providerConfigurations.isEmpty else { return }
+
+        let enhancementProviders: [AIProvider] = AIProvider.allCases.filter {
+            $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox
+        }
+
+        for provider in enhancementProviders {
+            if provider == .ollama {
+                // Create an Ollama config only if it was the selected provider
+                guard provider == selectedProvider else { continue }
+            } else {
+                guard provider.requiresAPIKey else { continue }
+                guard APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue) else { continue }
+            }
+
+            let modelKey = "\(provider.rawValue)SelectedModel"
+            let model = userDefaults.string(forKey: modelKey) ?? provider.defaultModel
+
+            var baseURL: String? = nil
+            var customModelValue: String? = nil
+            if provider == .ollama {
+                let savedURL = userDefaults.string(forKey: "ollamaBaseURL") ?? ""
+                if !savedURL.isEmpty { baseURL = savedURL }
+            } else if provider == .custom {
+                let savedBaseURL = userDefaults.string(forKey: "customProviderBaseURL") ?? ""
+                if !savedBaseURL.isEmpty { baseURL = savedBaseURL }
+                let savedModel = userDefaults.string(forKey: "customProviderModel") ?? ""
+                if !savedModel.isEmpty { customModelValue = savedModel }
+            }
+
+            // Mark the previously selected global provider as default
+            let isCurrentGlobal = (provider == selectedProvider)
+
+            let config = AIProviderConfiguration(
+                name: provider.rawValue,
+                provider: provider,
+                model: model,
+                customBaseURL: baseURL,
+                customModel: customModelValue,
+                isDefault: isCurrentGlobal
+            )
+            providerConfigurations.append(config)
+        }
+
+        if !providerConfigurations.isEmpty {
+            saveProviderConfigurations()
+        }
+    }
+
+    private func saveProviderConfigurations() {
+        do {
+            let data = try JSONEncoder().encode(providerConfigurations)
+            userDefaults.set(data, forKey: providerConfigurationsKey)
+        } catch {
+            // Encoding failed silently
+        }
+    }
+
+    func addProviderConfiguration(_ config: AIProviderConfiguration) {
+        var newConfig = config
+        // First config added automatically becomes the default
+        if providerConfigurations.isEmpty {
+            newConfig.isDefault = true
+        }
+        providerConfigurations.append(newConfig)
+        saveProviderConfigurations()
+    }
+
+    func updateProviderConfiguration(_ config: AIProviderConfiguration) {
+        guard let index = providerConfigurations.firstIndex(where: { $0.id == config.id }) else { return }
+        var updated = config
+        // Preserve isDefault — callers must use setDefaultProviderConfiguration() to change it
+        updated.isDefault = providerConfigurations[index].isDefault
+        providerConfigurations[index] = updated
+        saveProviderConfigurations()
+    }
+
+    /// Deletes a provider configuration. The default configuration cannot be deleted.
+    /// Any prompts referencing the deleted config have their assignment cleared (falling back to default).
+    /// - Returns: `true` if the config was deleted, `false` if it was the default (protected).
+    @discardableResult
+    func deleteProviderConfiguration(_ config: AIProviderConfiguration) -> Bool {
+        guard !config.isDefault else { return false }
+        providerConfigurations.removeAll { $0.id == config.id }
+        saveProviderConfigurations()
+        onProviderConfigDeleted?(config.id)
+        return true
+    }
+
+    func setDefaultProviderConfiguration(_ config: AIProviderConfiguration) {
+        for i in providerConfigurations.indices {
+            providerConfigurations[i].isDefault = (providerConfigurations[i].id == config.id)
+        }
+        saveProviderConfigurations()
+    }
+
+    func resolveProviderConfig(forId configId: UUID?) -> ResolvedProviderConfig {
+        // Look up by explicit ID
+        if let configId = configId,
+           let config = providerConfigurations.first(where: { $0.id == configId }) {
+            return resolvedConfig(from: config)
+        }
+
+        // Fall back to the default configuration
+        if let defaultConfig = defaultProviderConfiguration {
+            return resolvedConfig(from: defaultConfig)
+        }
+
+        // Last resort: global provider settings (no configs exist yet)
+        return ResolvedProviderConfig(
+            provider: selectedProvider,
+            apiKey: apiKey,
+            model: currentModel,
+            baseURL: selectedProvider == .custom ? customBaseURL : selectedProvider.baseURL
+        )
+    }
+
+    private func resolvedConfig(from config: AIProviderConfiguration) -> ResolvedProviderConfig {
+        let key: String
+        if config.provider.requiresAPIKey {
+            key = APIKeyManager.shared.getAPIKey(forProvider: config.provider.rawValue) ?? ""
+        } else {
+            key = ""
+        }
+        return ResolvedProviderConfig(
+            provider: config.provider,
+            apiKey: key,
+            model: config.effectiveModel,
+            baseURL: config.effectiveBaseURL
+        )
+    }
+    
+    func saveAPIKeyForProvider(_ key: String, provider: AIProvider, model: String = "", completion: @escaping (Bool, String?) -> Void) {
+        guard provider.requiresAPIKey else {
+            completion(true, nil)
+            return
+        }
+
+        let effectiveModel = model.isEmpty ? provider.defaultModel : model
+
+        Task {
+            let result: (isValid: Bool, errorMessage: String?)
+            switch provider {
+            case .anthropic:
+                result = await AnthropicLLMClient.verifyAPIKey(key)
+            case .elevenLabs:
+                result = await ElevenLabsClient.verifyAPIKey(key)
+            case .deepgram:
+                result = await DeepgramClient.verifyAPIKey(key)
+            case .mistral:
+                result = await MistralTranscriptionClient.verifyAPIKey(key)
+            case .soniox:
+                result = await SonioxClient.verifyAPIKey(key)
+            case .openRouter:
+                result = await OpenRouterClient.verifyAPIKey(key, model: effectiveModel)
+            case .gemini:
+                result = await GeminiTranscriptionClient.verifyAPIKey(key)
+            default:
+                guard let baseURL = URL(string: provider.baseURL) else {
+                    DispatchQueue.main.async {
+                        completion(false, "Invalid or missing base URL configuration")
+                    }
+                    return
+                }
+                result = await OpenAILLMClient.verifyAPIKey(
+                    baseURL: baseURL,
+                    apiKey: key,
+                    model: effectiveModel
+                )
+            }
+            DispatchQueue.main.async {
+                if result.isValid {
+                    APIKeyManager.shared.saveAPIKey(key, forProvider: provider.rawValue)
+                    NotificationCenter.default.post(name: .aiProviderKeyChanged, object: nil)
+                    // If this is also the current global provider, update its state
+                    if provider == self.selectedProvider {
+                        self.apiKey = key
+                        self.isAPIKeyValid = true
+                    }
+                }
+                completion(result.isValid, result.errorMessage)
             }
         }
     }

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -105,14 +105,14 @@ class AudioTranscriptionManager: ObservableObject {
                     processingPhase = .enhancing
                     do {
                         // inside the enhancement success path where transcription is created
-                        let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(text)
+                        let (enhancedText, enhancementDuration, promptName, modelName) = try await enhancementService.enhance(text)
                         let transcription = Transcription(
                             text: text,
                             duration: duration,
                             enhancedText: enhancedText,
                             audioFileURL: permanentURL.absoluteString,
                             transcriptionModelName: currentModel.displayName,
-                            aiEnhancementModelName: enhancementService.getAIService()?.currentModel,
+                            aiEnhancementModelName: modelName,
                             promptName: promptName,
                             transcriptionDuration: transcriptionDuration,
                             enhancementDuration: enhancementDuration,

--- a/VoiceInk/Services/AudioFileTranscriptionService.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionService.swift
@@ -93,14 +93,14 @@ class AudioTranscriptionService: ObservableObject {
                enhancementService.isConfigured {
                 do {
                     let textForAI = promptDetectionResult?.processedText ?? text
-                    let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(textForAI)
+                    let (enhancedText, enhancementDuration, promptName, modelName) = try await enhancementService.enhance(textForAI)
                     let newTranscription = Transcription(
                         text: originalText,
                         duration: duration,
                         enhancedText: enhancedText,
                         audioFileURL: permanentURLString,
                         transcriptionModelName: model.displayName,
-                        aiEnhancementModelName: enhancementService.getAIService()?.currentModel,
+                        aiEnhancementModelName: modelName,
                         promptName: promptName,
                         transcriptionDuration: transcriptionDuration,
                         enhancementDuration: enhancementDuration,

--- a/VoiceInk/Services/OllamaService.swift
+++ b/VoiceInk/Services/OllamaService.swift
@@ -88,6 +88,26 @@ class OllamaService: ObservableObject {
         }
     }
 
+    /// Thread-safe enhancement using explicit URL and model parameters.
+    /// Use this overload for concurrent calls to avoid race conditions.
+    func enhance(_ text: String, withSystemPrompt systemPrompt: String, baseURL: String, model: String) async throws -> String {
+        guard let url = URL(string: baseURL) else {
+            throw LocalAIError.invalidURL
+        }
+
+        do {
+            return try await OllamaClient.generate(
+                baseURL: url,
+                model: model,
+                prompt: text,
+                systemPrompt: systemPrompt,
+                temperature: defaultTemperature
+            )
+        } catch let error as LLMKitError {
+            throw mapLLMKitError(error)
+        }
+    }
+
     private func mapLLMKitError(_ error: LLMKitError) -> LocalAIError {
         switch error {
         case .invalidURL:

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -1,297 +1,146 @@
 import SwiftUI
-import LLMkit
 
 struct APIKeyManagementView: View {
     @EnvironmentObject private var aiService: AIService
-    @State private var apiKey: String = ""
-    @State private var showAlert = false
-    @State private var alertMessage = ""
-    @State private var isVerifying = false
-    @State private var ollamaBaseURL: String = UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
-    @State private var ollamaModels: [OllamaModel] = []
-    @State private var selectedOllamaModel: String = UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
-    @State private var isCheckingOllama = false
-    @State private var isEditingURL = false
-    
+
+    var onAddConfig: (() -> Void)?
+    var onEditConfig: ((AIProviderConfiguration) -> Void)?
+
     var body: some View {
-        Section("AI Provider Integration") {
-            HStack {
-                Picker("Provider", selection: $aiService.selectedProvider) {
-                    ForEach(AIProvider.allCases.filter { $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox }, id: \.self) { provider in
-                        Text(provider.rawValue).tag(provider)
-                    }
-                }
-                .pickerStyle(.automatic)
-                .tint(.blue)
-                
-                if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama {
-                    Spacer()
-                    Circle()
-                        .fill(Color.green)
-                        .frame(width: 8, height: 8)
-                    Text("Connected")
+        Section {
+            if aiService.providerConfigurations.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "cpu")
+                        .font(.system(size: 28))
+                        .foregroundColor(.secondary.opacity(0.5))
+
+                    Text("No AI providers configured")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
-                } else if aiService.selectedProvider == .ollama {
-                    Spacer()
-                    if isCheckingOllama {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else if !ollamaModels.isEmpty {
-                        Circle()
-                            .fill(Color.green)
-                            .frame(width: 8, height: 8)
-                        Text("Connected")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                    } else {
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: 8, height: 8)
-                        Text("Disconnected")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+
+                    Text("Add a provider configuration to enable AI enhancement with different models and services.")
+                        .font(.caption)
+                        .foregroundColor(.secondary.opacity(0.8))
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 300)
+
+                    Button {
+                        onAddConfig?()
+                    } label: {
+                        Label("Add Provider", systemImage: "plus.circle.fill")
                     }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
                 }
-            }
-            .onChange(of: aiService.selectedProvider) { oldValue, newValue in
-                if aiService.selectedProvider == .ollama {
-                    checkOllamaConnection()
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 12) {
-                // Model Selection
-                if aiService.selectedProvider == .openRouter {
-                    if aiService.availableModels.isEmpty {
-                        HStack {
-                            Text("No models loaded")
-                                .foregroundColor(.secondary)
-                            Spacer()
-                            Button(action: {
-                                Task {
-                                    await aiService.fetchOpenRouterModels()
-                                }
-                            }) {
-                                Label("Refresh", systemImage: "arrow.clockwise")
-                            }
-                        }
-                    } else {
-                        HStack {
-                            Picker("Model", selection: Binding(
-                                get: { aiService.currentModel },
-                                set: { aiService.selectModel($0) }
-                            )) {
-                                ForEach(aiService.availableModels, id: \.self) { model in
-                                    Text(model).tag(model)
-                                }
-                            }
-
-                            Spacer()
-
-                            Button(action: {
-                                Task {
-                                    await aiService.fetchOpenRouterModels()
-                                }
-                            }) {
-                                Label("Refresh", systemImage: "arrow.clockwise")
-                            }
-                        }
-                    }
-                    
-                } else if !aiService.availableModels.isEmpty &&
-                            aiService.selectedProvider != .ollama &&
-                            aiService.selectedProvider != .custom {
-                    Picker("Model", selection: Binding(
-                        get: { aiService.currentModel },
-                        set: { aiService.selectModel($0) }
-                    )) {
-                        ForEach(aiService.availableModels, id: \.self) { model in
-                            Text(model).tag(model)
-                        }
-                    }
-                }
-
-                Divider()
-
-                if aiService.selectedProvider == .ollama {
-                    if isEditingURL {
-                        HStack {
-                            TextField("Base URL", text: $ollamaBaseURL)
-                                .textFieldStyle(.roundedBorder)
-                            
-                            Button("Save") {
-                                aiService.updateOllamaBaseURL(ollamaBaseURL)
-                                checkOllamaConnection()
-                                isEditingURL = false
-                            }
-                        }
-                    } else {
-                        HStack {
-                            Text("Server: \(ollamaBaseURL)")
-                            Spacer()
-                            Button("Edit") { isEditingURL = true }
-                            Button(action: {
-                                ollamaBaseURL = "http://localhost:11434"
-                                aiService.updateOllamaBaseURL(ollamaBaseURL)
-                                checkOllamaConnection()
-                            }) {
-                                Image(systemName: "arrow.counterclockwise")
-                            }
-                            .help("Reset to default")
-                        }
-                    }
-
-                    if !ollamaModels.isEmpty {
-                        Divider()
-
-                        Picker("Model", selection: $selectedOllamaModel) {
-                            ForEach(ollamaModels) { model in
-                                Text(model.name).tag(model.name)
-                            }
-                        }
-                        .onChange(of: selectedOllamaModel) { oldValue, newValue in
-                            aiService.updateSelectedOllamaModel(newValue)
-                        }
-                    }
-
-                } else if aiService.selectedProvider == .custom {
-                    TextField("API Endpoint URL", text: $aiService.customBaseURL)
-                        .textFieldStyle(.roundedBorder)
-
-                    Divider()
-
-                    TextField("Model Name", text: $aiService.customModel)
-                        .textFieldStyle(.roundedBorder)
-
-                    Divider()
-
-                    if aiService.isAPIKeyValid {
-                        HStack {
-                            Text("API Key Set")
-                            Spacer()
-                            Button("Remove Key", role: .destructive) {
-                                aiService.clearAPIKey()
-                            }
-                        }
-                    } else {
-                        SecureField("API Key", text: $apiKey)
-                            .textFieldStyle(.roundedBorder)
-
-                        Button("Verify and Save") {
-                            isVerifying = true
-                            aiService.saveAPIKey(apiKey) { success, errorMessage in
-                                isVerifying = false
-                                if !success {
-                                    alertMessage = errorMessage ?? "Verification failed"
-                                    showAlert = true
-                                }
-                                apiKey = ""
-                            }
-                        }
-                        .disabled(aiService.customBaseURL.isEmpty || aiService.customModel.isEmpty || apiKey.isEmpty)
-                    }
-                    
-                } else {
-                    if aiService.isAPIKeyValid {
-                        HStack {
-                            Text("API Key")
-                            Spacer()
-                            Text("••••••••")
-                                .foregroundColor(.secondary)
-                            Button("Remove", role: .destructive) {
-                                aiService.clearAPIKey()
-                            }
-                        }
-                    } else {
-                        SecureField("API Key", text: $apiKey)
-                            .textFieldStyle(.roundedBorder)
-
-                        HStack {
-                            if let url = getAPIKeyURL() {
-                                Link(destination: url) {
-                                    HStack {
-                                        Image(systemName: "key.fill")
-                                        Text("Get API Key")
-                                    }
-                                    .font(.caption)
-                                    .foregroundColor(.blue)
-                                    .padding(.vertical, 4)
-                                    .padding(.horizontal, 8)
-                                    .background(Color.blue.opacity(0.1))
-                                    .cornerRadius(6)
-                                }
-                                .buttonStyle(.plain)
-                            }
-
-                            Spacer()
-
-                            Button(action: {
-                                isVerifying = true
-                                aiService.saveAPIKey(apiKey) { success, errorMessage in
-                                    isVerifying = false
-                                    if !success {
-                                        alertMessage = errorMessage ?? "Verification failed"
-                                        showAlert = true
-                                    }
-                                    apiKey = ""
-                                }
-                            }) {
-                                HStack {
-                                    if isVerifying {
-                                        ProgressView().controlSize(.small)
-                                    }
-                                    Text("Verify and Save")
-                                }
-                            }
-                            .disabled(apiKey.isEmpty)
-                        }
-                    }
-                }
-            }
-        }
-        .alert("Error", isPresented: $showAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text(alertMessage)
-        }
-        .onAppear {
-            if aiService.selectedProvider == .ollama {
-                checkOllamaConnection()
-            }
-        }
-    }
-    
-    private func checkOllamaConnection() {
-        isCheckingOllama = true
-        aiService.checkOllamaConnection { connected in
-            if connected {
-                Task {
-                    ollamaModels = await aiService.fetchOllamaModels()
-                    isCheckingOllama = false
-                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
             } else {
-                ollamaModels = []
-                isCheckingOllama = false
-                alertMessage = "Could not connect to Ollama. Please check if Ollama is running and the base URL is correct."
-                showAlert = true
+                ForEach(aiService.providerConfigurations) { config in
+                    ProviderConfigRow(config: config, apiKeyRevision: aiService.apiKeyRevision)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            onEditConfig?(config)
+                        }
+                        .contextMenu {
+                            Button {
+                                onEditConfig?(config)
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+
+                            if !config.isDefault {
+                                Button {
+                                    aiService.setDefaultProviderConfiguration(config)
+                                } label: {
+                                    Label("Set as Default", systemImage: "star")
+                                }
+
+                                Divider()
+
+                                Button(role: .destructive) {
+                                    aiService.deleteProviderConfiguration(config)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                        }
+                }
+            }
+        } header: {
+            HStack {
+                Text("AI Provider Integration")
+                Spacer()
+                Button {
+                    onAddConfig?()
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 18))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Add new provider configuration")
             }
         }
     }
-    
-    private func getAPIKeyURL() -> URL? {
-        switch aiService.selectedProvider {
-        case .groq: return URL(string: "https://console.groq.com/keys")
-        case .openAI: return URL(string: "https://platform.openai.com/api-keys")
-        case .gemini: return URL(string: "https://makersuite.google.com/app/apikey")
-        case .anthropic: return URL(string: "https://console.anthropic.com/settings/keys")
-        case .mistral: return URL(string: "https://console.mistral.ai/api-keys")
-        case .elevenLabs: return URL(string: "https://elevenlabs.io/speech-synthesis")
-        case .deepgram: return URL(string: "https://console.deepgram.com/api-keys")
-        case .soniox: return URL(string: "https://console.soniox.com/")
-        case .openRouter: return URL(string: "https://openrouter.ai/keys")
-        case .cerebras: return URL(string: "https://cloud.cerebras.ai/")
-        default: return nil
+}
+
+private struct ProviderConfigRow: View {
+    let config: AIProviderConfiguration
+    let apiKeyRevision: Int  // Forces re-render when API keys change
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(config.hasAPIKey ? Color.green : Color.red)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(config.name)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+
+                    if config.isDefault {
+                        Text("Default")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(.blue)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(Color.blue.opacity(0.1))
+                            .cornerRadius(4)
+                    }
+                }
+
+                Text("\(config.provider.rawValue) - \(config.effectiveModel)")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.secondary.opacity(0.5))
         }
+        .padding(.vertical, 4)
+    }
+}
+
+func getAPIKeyURL(for provider: AIProvider) -> URL? {
+    switch provider {
+    case .groq: return URL(string: "https://console.groq.com/keys")
+    case .openAI: return URL(string: "https://platform.openai.com/api-keys")
+    case .gemini: return URL(string: "https://makersuite.google.com/app/apikey")
+    case .anthropic: return URL(string: "https://console.anthropic.com/settings/keys")
+    case .mistral: return URL(string: "https://console.mistral.ai/api-keys")
+    case .elevenLabs: return URL(string: "https://elevenlabs.io/speech-synthesis")
+    case .deepgram: return URL(string: "https://console.deepgram.com/api-keys")
+    case .soniox: return URL(string: "https://console.soniox.com/")
+    case .openRouter: return URL(string: "https://openrouter.ai/keys")
+    case .cerebras: return URL(string: "https://cloud.cerebras.ai/")
+    default: return nil
     }
 }

--- a/VoiceInk/Views/ProviderConfigEditorView.swift
+++ b/VoiceInk/Views/ProviderConfigEditorView.swift
@@ -1,0 +1,481 @@
+import SwiftUI
+import LLMkit
+
+struct ProviderConfigEditorView: View {
+    enum Mode {
+        case add
+        case edit(AIProviderConfiguration)
+    }
+
+    let mode: Mode
+    @EnvironmentObject private var aiService: AIService
+    var onDismiss: (() -> Void)?
+
+    @State private var name: String
+    @State private var selectedProvider: AIProvider
+    @State private var selectedModel: String
+    @State private var customBaseURL: String
+    @State private var customModel: String
+    @State private var apiKey: String = ""
+    @State private var isVerifying = false
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+    @State private var ollamaModels: [OllamaModel] = []
+    @State private var isCheckingOllama = false
+
+    private static let enhancementProviders: [AIProvider] = AIProvider.allCases.filter {
+        $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox
+    }
+
+    init(mode: Mode, onDismiss: (() -> Void)? = nil) {
+        self.mode = mode
+        self.onDismiss = onDismiss
+        switch mode {
+        case .add:
+            _name = State(initialValue: "")
+            _selectedProvider = State(initialValue: .gemini)
+            _selectedModel = State(initialValue: AIProvider.gemini.defaultModel)
+            _customBaseURL = State(initialValue: "")
+            _customModel = State(initialValue: "")
+        case .edit(let config):
+            _name = State(initialValue: config.name)
+            _selectedProvider = State(initialValue: config.provider)
+            _selectedModel = State(initialValue: config.model)
+            _customBaseURL = State(initialValue: config.customBaseURL ?? "")
+            _customModel = State(initialValue: config.customModel ?? "")
+        }
+    }
+
+    private var hasAPIKeySet: Bool {
+        if !selectedProvider.requiresAPIKey { return true }
+        return APIKeyManager.shared.hasAPIKey(forProvider: selectedProvider.rawValue)
+    }
+
+    private var availableModels: [String] {
+        if selectedProvider == .ollama {
+            return ollamaModels.map { $0.name }
+        }
+        if selectedProvider == .openRouter {
+            return aiService.availableModels
+        }
+        return selectedProvider.availableModels
+    }
+
+    private var canSave: Bool {
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        if selectedProvider == .custom {
+            return !customBaseURL.isEmpty && !customModel.isEmpty
+        }
+        return true
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack(spacing: 12) {
+                Text(mode.isAdd ? "New Provider" : "Edit Provider")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                Button(action: { onDismiss?() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .padding(6)
+                        .background(Color.secondary.opacity(0.1))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Close")
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .background(Color(NSColor.windowBackgroundColor))
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
+
+            // Content
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Name
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Name")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+
+                        TextField("e.g. Claude for Emails", text: $name)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 14))
+                            .padding(8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                                    .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
+                            )
+                    }
+
+                    // Provider
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Provider")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+
+                        Picker("Provider", selection: $selectedProvider) {
+                            ForEach(Self.enhancementProviders, id: \.self) { provider in
+                                Text(provider.rawValue).tag(provider)
+                            }
+                        }
+                        .pickerStyle(.automatic)
+                        .onChange(of: selectedProvider) { _, newValue in
+                            selectedModel = newValue.defaultModel
+                            if newValue == .ollama {
+                                checkOllamaConnection()
+                            }
+                        }
+                    }
+
+                    // Model
+                    if selectedProvider == .ollama {
+                        ollamaSection
+                    } else if selectedProvider == .custom {
+                        customProviderSection
+                    } else {
+                        modelPickerSection
+                    }
+
+                    Divider().padding(.vertical, 4)
+
+                    // API Key
+                    if selectedProvider.requiresAPIKey {
+                        apiKeySection
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 20)
+            }
+
+            // Footer
+            VStack(spacing: 0) {
+                Divider()
+                HStack {
+                    Button("Cancel") { onDismiss?() }
+                        .keyboardShortcut(.escape, modifiers: [])
+                        .buttonStyle(.plain)
+                        .foregroundColor(.secondary)
+
+                    Spacer()
+
+                    Button {
+                        save()
+                        onDismiss?()
+                    } label: {
+                        Text("Save")
+                            .frame(minWidth: 80)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSave)
+                    .keyboardShortcut(.return, modifiers: .command)
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                .background(Color(NSColor.windowBackgroundColor))
+            }
+        }
+        .frame(minWidth: 400, minHeight: 500)
+        .background(Color(NSColor.windowBackgroundColor))
+        .alert("Error", isPresented: $showAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(alertMessage)
+        }
+        .onAppear {
+            if selectedProvider == .ollama {
+                checkOllamaConnection()
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var modelPickerSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Model")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            if selectedProvider == .openRouter {
+                if availableModels.isEmpty {
+                    HStack {
+                        Text("No models loaded")
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Button {
+                            Task { await aiService.fetchOpenRouterModels() }
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
+                    }
+                } else {
+                    HStack {
+                        Picker("Model", selection: $selectedModel) {
+                            ForEach(availableModels, id: \.self) { model in
+                                Text(model).tag(model)
+                            }
+                        }
+                        Spacer()
+                        Button {
+                            Task { await aiService.fetchOpenRouterModels() }
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
+                    }
+                }
+            } else if !availableModels.isEmpty {
+                Picker("Model", selection: $selectedModel) {
+                    ForEach(availableModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var ollamaSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Base URL")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                TextField("http://localhost:11434", text: $customBaseURL)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14))
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                            .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
+                    )
+            }
+
+            if isCheckingOllama {
+                HStack {
+                    ProgressView().controlSize(.small)
+                    Text("Checking connection...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            } else if !ollamaModels.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Model")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Picker("Model", selection: $selectedModel) {
+                        ForEach(ollamaModels) { model in
+                            Text(model.name).tag(model.name)
+                        }
+                    }
+                }
+
+                HStack(spacing: 4) {
+                    Circle().fill(Color.green).frame(width: 8, height: 8)
+                    Text("Connected")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                HStack(spacing: 4) {
+                    Circle().fill(Color.red).frame(width: 8, height: 8)
+                    Text("Not connected")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Button("Retry") {
+                        checkOllamaConnection()
+                    }
+                    .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var customProviderSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("API Endpoint URL")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                TextField("https://api.example.com/v1/chat/completions", text: $customBaseURL)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14))
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                            .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
+                    )
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Model Name")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                TextField("model-name", text: $customModel)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14))
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                            .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
+                    )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var apiKeySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("API Key")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            if hasAPIKeySet {
+                HStack {
+                    HStack(spacing: 6) {
+                        Circle().fill(Color.green).frame(width: 8, height: 8)
+                        Text("API key is set for \(selectedProvider.rawValue)")
+                            .font(.system(size: 13))
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Button("Remove", role: .destructive) {
+                        APIKeyManager.shared.deleteAPIKey(forProvider: selectedProvider.rawValue)
+                        NotificationCenter.default.post(name: .aiProviderKeyChanged, object: nil)
+                        // Force view update
+                        apiKey = ""
+                    }
+                    .controlSize(.small)
+                }
+            } else {
+                SecureField("Enter API Key", text: $apiKey)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14))
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                            .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
+                    )
+
+                HStack {
+                    if let url = getAPIKeyURL(for: selectedProvider) {
+                        Link(destination: url) {
+                            HStack {
+                                Image(systemName: "key.fill")
+                                Text("Get API Key")
+                            }
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 8)
+                            .background(Color.blue.opacity(0.1))
+                            .cornerRadius(6)
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Spacer()
+
+                    Button {
+                        isVerifying = true
+                        aiService.saveAPIKeyForProvider(apiKey, provider: selectedProvider, model: selectedModel) { success, errorMessage in
+                            isVerifying = false
+                            if success {
+                                apiKey = ""
+                            } else {
+                                alertMessage = errorMessage ?? "Verification failed"
+                                showAlert = true
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            if isVerifying {
+                                ProgressView().controlSize(.small)
+                            }
+                            Text("Verify and Save")
+                        }
+                    }
+                    .disabled(apiKey.isEmpty)
+                }
+            }
+
+            Text("API keys are shared across all configurations using the same provider.")
+                .font(.caption)
+                .foregroundColor(.secondary.opacity(0.7))
+        }
+    }
+
+    // MARK: - Actions
+
+    private func save() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveBaseURL: String? = (selectedProvider == .ollama || selectedProvider == .custom) ? customBaseURL : nil
+        let effectiveCustomModel: String? = selectedProvider == .custom ? customModel : nil
+
+        switch mode {
+        case .add:
+            let config = AIProviderConfiguration(
+                name: trimmedName,
+                provider: selectedProvider,
+                model: selectedModel,
+                customBaseURL: effectiveBaseURL,
+                customModel: effectiveCustomModel
+            )
+            aiService.addProviderConfiguration(config)
+        case .edit(let existing):
+            let config = AIProviderConfiguration(
+                id: existing.id,
+                name: trimmedName,
+                provider: selectedProvider,
+                model: selectedModel,
+                customBaseURL: effectiveBaseURL,
+                customModel: effectiveCustomModel
+            )
+            aiService.updateProviderConfiguration(config)
+        }
+    }
+
+    private func checkOllamaConnection() {
+        isCheckingOllama = true
+        aiService.checkOllamaConnection { connected in
+            if connected {
+                Task {
+                    ollamaModels = await aiService.fetchOllamaModels()
+                    isCheckingOllama = false
+                    if !ollamaModels.isEmpty && selectedModel.isEmpty {
+                        selectedModel = ollamaModels.first?.name ?? ""
+                    }
+                }
+            } else {
+                ollamaModels = []
+                isCheckingOllama = false
+            }
+        }
+    }
+}
+
+extension ProviderConfigEditorView.Mode {
+    var isAdd: Bool {
+        if case .add = self { return true }
+        return false
+    }
+}

--- a/VoiceInk/Views/ProviderConfigEditorView.swift
+++ b/VoiceInk/Views/ProviderConfigEditorView.swift
@@ -56,7 +56,7 @@ struct ProviderConfigEditorView: View {
             return ollamaModels.map { $0.name }
         }
         if selectedProvider == .openRouter {
-            return aiService.availableModels
+            return aiService.openRouterModels
         }
         return selectedProvider.availableModels
     }

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -403,10 +403,10 @@ class WhisperState: NSObject, ObservableObject {
                 let textForAI = promptDetectionResult?.processedText ?? text
                 
                 do {
-                    let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(textForAI)
+                    let (enhancedText, enhancementDuration, promptName, modelName) = try await enhancementService.enhance(textForAI)
                     logger.notice("📝 AI enhancement: \(enhancedText, privacy: .public)")
                     transcription.enhancedText = enhancedText
-                    transcription.aiEnhancementModelName = enhancementService.getAIService()?.currentModel
+                    transcription.aiEnhancementModelName = modelName
                     transcription.promptName = promptName
                     transcription.enhancementDuration = enhancementDuration
                     transcription.aiRequestSystemMessage = enhancementService.lastSystemMessageSent


### PR DESCRIPTION
## Multiple AI Provider Configurations Per Enhancement Prompt

### Summary

- Allow users to create multiple named AI provider configurations (e.g., "Claude for Emails", "GPT for Code") each with their own provider, model, and API key status
- Each Enhancement Prompt can be assigned to a specific provider configuration, or fall back to a designated default
- Remove redundant AI provider/model selection from Power Mode — the prompt's assigned provider configuration is used automatically
- Show the resolved model name below each prompt icon in the Enhancement Prompts grid

### Motivation

Previously, VoiceInk had a single global AI provider setting shared by all Enhancement Prompts. Users who wanted to use different models for different tasks (e.g., Claude for formal writing, GPT for quick notes) had to manually switch providers each time. This change makes provider selection part of the prompt itself, enabling seamless multi-provider workflows.

### Changes

**New files:**
- `AIProviderConfiguration.swift` — Data model for named provider configurations (`name`, `provider`, `model`, `customBaseURL`, `customModel`, `isDefault`)
- `ProviderConfigEditorView.swift` — Slide-out editor panel for creating/editing provider configurations (provider picker, model picker, API key management, base URL fields for Ollama/custom)

**Core logic (`AIService.swift`):**
- CRUD operations for `providerConfigurations` array (persisted to UserDefaults as JSON)
- Default provider invariant: exactly one config is always marked `isDefault`; it cannot be deleted
- `resolveProviderConfig(forId:)` resolves a prompt's `providerConfigurationId` → provider + API key + model + base URL, falling back to the default config
- Automatic migration on first launch: creates provider configurations from existing API keys and global provider selection
- `apiKeyRevision` counter to force SwiftUI re-renders when API keys change in Keychain

**Enhancement pipeline (`AIEnhancementService.swift`):**
- `makeRequest()` now resolves the active prompt's provider configuration instead of reading global state
- `onProviderConfigDeleted` callback clears `providerConfigurationId` from prompts that referenced a deleted config

**Prompt model (`CustomPrompt.swift`):**
- Added `providerConfigurationId: UUID?` field (backward-compatible, defaults to `nil`)
- Added `modelName` parameter to `promptIcon()` to display the resolved model below the trigger word

**Settings UI:**
- `APIKeyManagementView.swift` — Replaced single-provider UI with a multi-configuration list showing name, provider/model subtitle, API key status dot, and "Default" badge
- `PromptEditorView.swift` — Added "AI Provider" picker to assign a provider configuration per prompt
- `EnhancementSettingsView.swift` — Wired up config editor panel; prompt grid now shows resolved model name

**Power Mode cleanup:**
- Removed `selectedAIProvider` and `selectedAIModel` from `PowerModeConfig`, `PowerModeConfigView`, `PowerModeSessionManager`, and `ApplicationState`
- Power Mode's "AI Enhancement" section now shows the prompt picker and a read-only display of the resolved provider/model
- `PowerModeViewComponents` resolves the AI model capsule from the prompt's provider configuration

### Backward Compatibility

- Existing users with API keys get automatic provider configurations created on first launch
- `CustomPrompt` decodes `providerConfigurationId` with `decodeIfPresent` (existing prompts get `nil` → uses default config)
- `PowerModeConfig` keeps legacy `selectedAIProvider`/`selectedAIModel` in `CodingKeys` so old persisted data decodes without error
- `ApplicationState` auto-ignores unknown keys from previously serialized sessions

### Test Plan

- [ ] Fresh install: "AI Provider Integration" section is empty, prompts use no provider until one is added
- [ ] Existing user: existing API keys are migrated into named configurations; the previously active provider is marked as default
- [ ] Add a provider config → verify it appears in the list with correct API key status dot
- [ ] Edit a provider config → change model, verify it persists
- [ ] Delete a non-default config → verify prompts that referenced it fall back to default
- [ ] Attempt to delete the default config → verify it is not allowed
- [ ] Set a different config as default → verify the badge moves
- [ ] Assign different provider configs to different prompts → transcribe with each → verify correct provider/model is used
- [ ] Power Mode: enable AI Enhancement, select a prompt → verify provider/model shown as read-only info
- [ ] Add/remove API key in the config editor → verify the green/red dot updates immediately in the list
- [ ] Restart app → verify all configurations and prompt assignments persist



<img width="937" height="797" alt="image" src="https://github.com/user-attachments/assets/7da4e214-2d2d-4201-aca2-18ffeff0b45d" />

<img width="931" height="801" alt="image" src="https://github.com/user-attachments/assets/8f52b950-3531-4371-af2e-34ffde6a2882" />

<img width="940" height="796" alt="image" src="https://github.com/user-attachments/assets/3cbacfe6-8a0c-4175-a837-bbfb30798b2d" />

<img width="944" height="804" alt="image" src="https://github.com/user-attachments/assets/5be329ce-7308-4ab7-8d00-cb40f225e249" />
