### PR TITLE
Offload Core Audio hardware setup to serial background queue to fix h…

### DIFF
--- a/VoiceInk/CoreAudioRecorder.swift
+++ b/VoiceInk/CoreAudioRecorder.swift
@@ -5,7 +5,7 @@ import AVFoundation
 import os
 
 // MARK: - Core Audio Recorder (AUHAL-based, does not change system default device)
-final class CoreAudioRecorder {
+final class CoreAudioRecorder: @unchecked Sendable {
 
     // MARK: - Properties
 

--- a/VoiceInk/Whisper/WhisperState.swift
+++ b/VoiceInk/Whisper/WhisperState.swift
@@ -214,6 +214,14 @@ class WhisperState: NSObject, ObservableObject {
                             // Start recording immediately — no waiting for network
                             try await self.recorder.startRecording(toOutputFile: permanentURL)
 
+                            // Guard against cancellation that occurred while CoreAudio
+                            // was initialising on the background thread.
+                            guard self.isMiniRecorderVisible, !self.shouldCancelRecording else {
+                                self.recorder.stopRecording()
+                                self.recordedFile = nil
+                                return
+                            }
+
                             await MainActor.run {
                                 self.recordingState = .recording
                             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Offloaded Core Audio hardware setup and device switching to a serial background queue to remove hotkey lag and prevent UI stalls. Also added a cancellation guard to avoid stray recordings if the UI is closed mid-initialization.

- **Bug Fixes**
  - Added a dedicated serial background queue for device switching, startRecording, and stopRecording, awaited via withCheckedThrowingContinuation to avoid blocking.
  - Marked CoreAudioRecorder as @unchecked Sendable since all hardware operations are serialized on the queue.
  - Added a cancellation check in WhisperState to stop and clean up if recording is canceled while Core Audio initializes.

<sup>Written for commit 9e88ad8d5dcdef5bb2091f559977ffb6d8603847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

