### PR TITLE
feat: detect clamshell mode and skip built-in mic when lid is closed

### DIFF
--- a/VoiceInk/Services/AudioDeviceManager.swift
+++ b/VoiceInk/Services/AudioDeviceManager.swift
@@ -1,6 +1,8 @@
 import Foundation
 import CoreAudio
 import AVFoundation
+import CoreGraphics
+import AppKit
 import os
 
 struct PrioritizedDevice: Codable, Identifiable {
@@ -23,6 +25,7 @@ class AudioDeviceManager: ObservableObject {
     @Published var prioritizedDevices: [PrioritizedDevice] = []
 
     var isRecordingActive: Bool = false
+    private(set) var isClamshellMode: Bool = false
 
     static let shared = AudioDeviceManager()
 
@@ -41,6 +44,7 @@ class AudioDeviceManager: ObservableObject {
         }
 
         setupDeviceChangeNotifications()
+        setupClamshellMonitoring()
     }
 
     /// Returns the current system default input device from macOS
@@ -115,11 +119,18 @@ class AudioDeviceManager: ObservableObject {
     }
 
     func findBestAvailableDevice() -> AudioDeviceID? {
-        if let device = availableDevices.first(where: { isBuiltInDevice($0.id) }) {
+        // Prefer built-in only when the lid is open and the mic is physically accessible
+        if !isClamshellMode, let device = availableDevices.first(where: { isBuiltInDevice($0.id) }) {
             return device.id
         }
+        // Return first non-built-in device
+        if let device = availableDevices.first(where: { !isBuiltInDevice($0.id) }) {
+            logger.warning("🎙️ No built-in device available, using: \(device.name, privacy: .public)")
+            return device.id
+        }
+        // Last resort: accept the built-in even in clamshell (no other option)
         if let device = availableDevices.first {
-            logger.warning("🎙️ No built-in device found, using: \(device.name, privacy: .public)")
+            logger.warning("🎙️ No alternative device found, using built-in as last resort: \(device.name, privacy: .public)")
             return device.id
         }
         return nil
@@ -298,6 +309,10 @@ class AudioDeviceManager: ObservableObject {
             return getSystemDefaultDevice() ?? findBestAvailableDevice() ?? 0
         case .custom:
             if let id = selectedDeviceID, isDeviceAvailable(id) {
+                // In clamshell mode the built-in mic is physically inaccessible; fall back
+                if isClamshellMode && isBuiltInDevice(id) {
+                    return findBestAvailableDevice() ?? 0
+                }
                 return id
             }
             return findBestAvailableDevice() ?? 0
@@ -305,6 +320,8 @@ class AudioDeviceManager: ObservableObject {
             let sortedDevices = prioritizedDevices.sorted { $0.priority < $1.priority }
             for device in sortedDevices {
                 if let available = availableDevices.first(where: { $0.uid == device.id }) {
+                    // Skip built-in mic when lid is closed
+                    if isClamshellMode && isBuiltInDevice(available.id) { continue }
                     return available.id
                 }
             }
@@ -365,6 +382,11 @@ class AudioDeviceManager: ObservableObject {
 
         for device in sortedDevices {
             if let availableDevice = availableDevices.first(where: { $0.uid == device.id }) {
+                // Skip built-in mic when lid is closed; it is listed but physically inaccessible
+                if isClamshellMode && isBuiltInDevice(availableDevice.id) {
+                    logger.notice("🎙️ Skipping built-in mic in clamshell mode: \(device.name, privacy: .public)")
+                    continue
+                }
                 selectedDeviceID = availableDevice.id
                 logger.notice("🎙️ Selected prioritized device: \(device.name, privacy: .public)")
                 notifyDeviceChange()
@@ -375,6 +397,51 @@ class AudioDeviceManager: ObservableObject {
         fallbackToDefaultDevice()
     }
     
+    // MARK: - Clamshell Detection
+
+    private func setupClamshellMonitoring() {
+        // Seed initial state before any display-change notification arrives
+        updateClamshellState()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScreenParametersChanged),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleScreenParametersChanged() {
+        updateClamshellState()
+    }
+
+    private func updateClamshellState() {
+        let builtInDisplayActive = NSScreen.screens.contains { screen in
+            let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
+            return CGDisplayIsBuiltin(screenNumber)
+        }
+        let newClamshellMode = !builtInDisplayActive
+
+        guard newClamshellMode != isClamshellMode else { return }
+        isClamshellMode = newClamshellMode
+        logger.notice("🎙️ Clamshell mode \(newClamshellMode ? "active (lid closed)" : "inactive (lid open)", privacy: .public) — re-evaluating audio input")
+
+        guard !isRecordingActive else { return }
+        switch inputMode {
+        case .systemDefault:
+            notifyDeviceChange()
+        case .prioritized:
+            selectHighestPriorityAvailableDevice()
+        case .custom:
+            // If the currently selected device is the built-in mic and the lid just closed, fall back
+            if newClamshellMode, let currentID = selectedDeviceID, isBuiltInDevice(currentID) {
+                fallbackToDefaultDevice()
+            } else {
+                notifyDeviceChange()
+            }
+        }
+    }
+
     private func setupDeviceChangeNotifications() {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDevices,


### PR DESCRIPTION
## Summary

Fixes #566

When a MacBook lid is closed in clamshell mode the built-in microphone stays visible in CoreAudio's device list but is physically inaccessible. The existing `kAudioHardwarePropertyDevices` listener never fires (nothing actually disconnects), so VoiceInk had no way to know the mic was unusable and kept trying to use it.

- Subscribe to `NSApplication.didChangeScreenParametersNotification` in `AudioDeviceManager` to detect display configuration changes
- Call `CGDisplayIsBuiltin()` on each active screen's display ID — when no built-in display is found, the lid is closed (`isClamshellMode = true`)
- All three device-selection paths now skip the built-in mic in clamshell mode: `findBestAvailableDevice`, `selectHighestPriorityAvailableDevice`, and `getCurrentDevice` (custom mode)
- If there is truly no alternative mic available the built-in is used as a last resort rather than returning nothing
- State is seeded at launch so the app behaves correctly when started while already docked in clamshell mode
- Active recordings are never interrupted by a lid-close event

## Test plan

- [ ] Start VoiceInk with laptop open (no external display) — internal mic selected as expected
- [ ] Connect external display and close lid — app should automatically switch to next available mic (e.g. AirPods, USB mic) without user interaction
- [ ] Open lid again — built-in mic becomes eligible for selection again
- [ ] Launch VoiceInk while already in clamshell mode — built-in mic is skipped from the start
- [ ] Test all three input modes (System Default, Custom, Prioritized) with lid close/open cycle
- [ ] Verify an active recording is not interrupted when the lid is closed mid-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects clamshell mode and skips the built-in MacBook mic when the lid is closed, so we auto-select a usable external mic. Fixes #566 and keeps ongoing recordings uninterrupted.

- **New Features**
  - Detect clamshell mode via display change notifications (NSApplication.didChangeScreenParametersNotification) and CGDisplayIsBuiltin; seed state at launch.
  - Skip the built-in mic in System Default, Prioritized, and Custom modes when the lid is closed.
  - Fall back to the built-in mic only if no other input is available.
  - Never switch devices mid-recording when the lid closes.

<sup>Written for commit 549b890a1a41205ec9fe32f430f4b932bc02e218. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

