### PR TITLE
Fix make local picking up stale builds without LOCAL_BUILD flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ playground.xcworkspace
 
 .build/
 build/
+.local-build/
 
 # CocoaPods
 #

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 DEPS_DIR := $(HOME)/VoiceInk-Dependencies
 WHISPER_CPP_DIR := $(DEPS_DIR)/whisper.cpp
 FRAMEWORK_PATH := $(WHISPER_CPP_DIR)/build-apple/whisper.xcframework
+LOCAL_DERIVED_DATA := $(CURDIR)/.local-build
 
 .PHONY: all clean whisper setup build local check healthcheck help dev run
 
@@ -46,7 +47,9 @@ build: setup
 # Build for local use without Apple Developer certificate
 local: check setup
 	@echo "Building VoiceInk for local use (no Apple Developer certificate required)..."
+	@rm -rf $(LOCAL_DERIVED_DATA)
 	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug \
+		-derivedDataPath $(LOCAL_DERIVED_DATA) \
 		-xcconfig LocalBuild.xcconfig \
 		CODE_SIGN_IDENTITY="-" \
 		CODE_SIGNING_REQUIRED=NO \
@@ -55,8 +58,8 @@ local: check setup
 		CODE_SIGN_ENTITLEMENTS=$(CURDIR)/VoiceInk/VoiceInk.local.entitlements \
 		SWIFT_ACTIVE_COMPILATION_CONDITIONS='$$(inherited) LOCAL_BUILD' \
 		build
-	@APP_PATH=$$(find "$$HOME/Library/Developer/Xcode/DerivedData" -name "VoiceInk.app" -path "*/Debug/*" -type d | head -1) && \
-	if [ -n "$$APP_PATH" ]; then \
+	@APP_PATH="$(LOCAL_DERIVED_DATA)/Build/Products/Debug/VoiceInk.app" && \
+	if [ -d "$$APP_PATH" ]; then \
 		echo "Copying VoiceInk.app to ~/Downloads..."; \
 		rm -rf "$$HOME/Downloads/VoiceInk.app"; \
 		ditto "$$APP_PATH" "$$HOME/Downloads/VoiceInk.app"; \
@@ -69,7 +72,7 @@ local: check setup
 		echo "  - No iCloud dictionary sync"; \
 		echo "  - No automatic updates (pull new code and rebuild to update)"; \
 	else \
-		echo "Error: Could not find built VoiceInk.app in DerivedData."; \
+		echo "Error: Could not find built VoiceInk.app at $$APP_PATH"; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
The `make local` target searched all of DerivedData with `find ... | head -1` to locate VoiceInk.app, which could pick up a stale build from a prior `make build` or Xcode GUI build that was compiled without the LOCAL_BUILD flag. This caused the licensing bypass to silently not work.

Fix by:
- Building to an isolated .local-build/ derived data directory
- Copying from the known output path instead of searching DerivedData
- Keeping the command-line SWIFT_ACTIVE_COMPILATION_CONDITIONS override (the xcconfig alone doesn't work because target-level build settings take priority over -xcconfig files)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes make local picking up stale builds from global DerivedData so the `LOCAL_BUILD` flag is always applied and the licensing bypass works. Builds now use an isolated `.local-build` and copy from a known output path.

- **Bug Fixes**
  - Build to an isolated `.local-build` via `-derivedDataPath` and add it to `.gitignore`.
  - Copy `VoiceInk.app` from `$(LOCAL_DERIVED_DATA)/Build/Products/Debug/VoiceInk.app` instead of searching `DerivedData`; clearer error on missing app.
  - Keep CLI override `SWIFT_ACTIVE_COMPILATION_CONDITIONS='$$(inherited) LOCAL_BUILD'` to ensure the flag wins over target-level settings.

<sup>Written for commit c6fa97eb428bb145d72a107a4db8736e792fcfe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

