### PR TITLE
Fix CancellationError in Parakeet transcription and Ollama enhancement

### DIFF
--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -220,6 +220,13 @@ class AIEnhancementService: ObservableObject {
             do {
                 let result = try await aiService.enhanceWithOllama(text: formattedText, systemPrompt: systemMessage)
                 return AIEnhancementOutputFilter.filter(result)
+            } catch is CancellationError {
+                // If the task itself was cancelled (user action), propagate cancellation.
+                try Task.checkCancellation()
+                // Otherwise the CancellationError originated inside URLSession/LLMKit
+                // (e.g. connection reset, internal timeout). Treat as transient network error
+                // so makeRequestWithRetry can retry.
+                throw EnhancementError.networkError
             } catch {
                 if let localError = error as? LocalAIError {
                     throw EnhancementError.customError(localError.errorDescription ?? "An unknown Ollama error occurred.")
@@ -334,14 +341,14 @@ class AIEnhancementService: ObservableObject {
         let enhancementPrompt: EnhancementPrompt = .transcriptionEnhancement
         let promptName = activePrompt?.title
 
-        do {
-            let result = try await makeRequestWithRetry(text: text, mode: enhancementPrompt)
-            let endTime = Date()
-            let duration = endTime.timeIntervalSince(startTime)
-            return (result, duration, promptName)
-        } catch {
-            throw error
-        }
+        // Run in a detached task so the AI request is NOT cancelled when
+        // the caller's Task context is torn down (e.g. SwiftUI view lifecycle).
+        let result = try await Task.detached {
+            try await self.makeRequestWithRetry(text: text, mode: enhancementPrompt)
+        }.value
+
+        let duration = Date().timeIntervalSince(startTime)
+        return (result, duration, promptName)
     }
 
     func captureScreenContext() async {

--- a/VoiceInk/Services/OllamaService.swift
+++ b/VoiceInk/Services/OllamaService.swift
@@ -85,6 +85,10 @@ class OllamaService: ObservableObject {
             )
         } catch let error as LLMKitError {
             throw mapLLMKitError(error)
+        } catch is CancellationError {
+            // Propagate real task cancellation; otherwise treat as service unavailable
+            try Task.checkCancellation()
+            throw LocalAIError.serviceUnavailable
         }
     }
 

--- a/VoiceInk/Services/ParakeetTranscriptionService.swift
+++ b/VoiceInk/Services/ParakeetTranscriptionService.swift
@@ -9,7 +9,8 @@ class ParakeetTranscriptionService: TranscriptionService {
     private var vadManager: VadManager?
     private var activeVersion: AsrModelVersion?
     private var cachedModels: AsrModels?
-    private var loadingTask: (version: AsrModelVersion, task: Task<AsrModels, Error>)?
+    /// Deduplicates concurrent calls to ensureModelsLoaded (model loading + AsrManager init).
+    private var initTask: (version: AsrModelVersion, task: Task<Void, Error>)?
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink.parakeet", category: "ParakeetTranscriptionService")
 
     private func version(for model: any TranscriptionModel) -> AsrModelVersion {
@@ -17,6 +18,21 @@ class ParakeetTranscriptionService: TranscriptionService {
     }
 
     private func ensureModelsLoaded(for version: AsrModelVersion) async throws {
+        // Fast path: already initialized for this version
+        if asrManager != nil, activeVersion == version {
+            return
+        }
+
+        // If initialization is already in progress for this version, wait for it
+        if let (v, task) = initTask, v == version {
+            try await task.value
+            // Re-check after waiting — the other caller may have succeeded
+            if asrManager != nil, activeVersion == version {
+                return
+            }
+        }
+
+        // Double-check after possible suspension
         if asrManager != nil, activeVersion == version {
             return
         }
@@ -27,48 +43,50 @@ class ParakeetTranscriptionService: TranscriptionService {
         vadManager = nil
         activeVersion = nil
 
-        let models = try await getOrLoadModels(for: version)
+        // Single task covers model loading AND AsrManager initialization.
+        // Use Task.detached so the init is NOT cancelled when the caller's
+        // Task context is cancelled (e.g. SwiftUI view teardown).
+        let task = Task.detached { [weak self] () -> Void in
+            guard let self else { throw ASRError.notInitialized }
 
-        let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
-        self.asrManager = manager
-        self.activeVersion = version
+            let models: AsrModels
+            if let cached = self.cachedModels, cached.version == version {
+                models = cached
+            } else {
+                models = try await AsrModels.loadFromCache(
+                    configuration: nil,
+                    version: version
+                )
+                self.cachedModels = models
+            }
+
+            let manager = AsrManager(config: .default)
+            try await manager.initialize(models: models)
+            self.asrManager = manager
+            self.activeVersion = version
+        }
+        initTask = (version, task)
+
+        do {
+            try await task.value
+            if initTask?.version == version { initTask = nil }
+        } catch {
+            if initTask?.version == version { initTask = nil }
+            throw error
+        }
     }
 
-    // Returns cached models or loads from disk; deduplicates concurrent loads
+    /// Returns cached models or loads from disk. Used by streaming provider.
     func getOrLoadModels(for version: AsrModelVersion) async throws -> AsrModels {
         if let cached = cachedModels, cached.version == version {
             return cached
         }
-
-        // Deduplicate concurrent loads for the same version
-        if let (existingVersion, existingTask) = loadingTask, existingVersion == version {
-            return try await existingTask.value
-        }
-
-        let task = Task {
-            try await AsrModels.loadFromCache(
-                configuration: nil,
-                version: version
-            )
-        }
-        loadingTask = (version, task)
-
-        do {
-            let models = try await task.value
-            self.cachedModels = models
-            // Only clear if we're still the current loading task
-            if loadingTask?.version == version {
-                self.loadingTask = nil
-            }
-            return models
-        } catch {
-            // Only clear if we're still the current loading task
-            if loadingTask?.version == version {
-                self.loadingTask = nil
-            }
-            throw error
-        }
+        let models = try await AsrModels.loadFromCache(
+            configuration: nil,
+            version: version
+        )
+        cachedModels = models
+        return models
     }
 
     func loadModel(for model: ParakeetModel) async throws {
@@ -76,51 +94,71 @@ class ParakeetTranscriptionService: TranscriptionService {
     }
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        let targetVersion = version(for: model)
-        try await ensureModelsLoaded(for: targetVersion)
-
-        guard let asrManager = asrManager else {
-            throw ASRError.notInitialized
-        }
-
+        // Read audio samples synchronously before entering the detached task
         let audioSamples = try readAudioSamples(from: audioURL)
-
-        let durationSeconds = Double(audioSamples.count) / 16000.0
+        let targetVersion = version(for: model)
         let isVADEnabled = UserDefaults.standard.bool(forKey: "IsVADEnabled")
 
-        var speechAudio = audioSamples
-        if durationSeconds >= 20.0, isVADEnabled {
-            let vadConfig = VadConfig(defaultThreshold: 0.7)
-            if vadManager == nil {
-                do {
-                    vadManager = try await VadManager(config: vadConfig)
-                } catch {
-                    logger.notice("VAD init failed; falling back to full audio: \(error.localizedDescription, privacy: .public)")
-                    vadManager = nil
+        // Run all FluidAudio work in a detached task so it is NOT cancelled
+        // when the caller's Task context is torn down (e.g. SwiftUI view lifecycle).
+        let detachedResult = Task.detached { [weak self] () -> String in
+            guard let self else { throw ASRError.notInitialized }
+
+            // Retry once on CancellationError — FluidAudio can throw this during
+            // concurrent model init or when internal resources are momentarily busy.
+            do {
+                try await self.ensureModelsLoaded(for: targetVersion)
+            } catch is CancellationError {
+                self.logger.notice("Model initialization threw CancellationError, resetting and retrying...")
+                self.asrManager?.cleanup()
+                self.asrManager = nil
+                self.activeVersion = nil
+                self.cachedModels = nil
+                self.initTask = nil
+                try await self.ensureModelsLoaded(for: targetVersion)
+            }
+
+            guard let asrManager = self.asrManager else {
+                throw ASRError.notInitialized
+            }
+
+            let durationSeconds = Double(audioSamples.count) / 16000.0
+
+            var speechAudio = audioSamples
+            if durationSeconds >= 20.0, isVADEnabled {
+                let vadConfig = VadConfig(defaultThreshold: 0.7)
+                if self.vadManager == nil {
+                    do {
+                        self.vadManager = try await VadManager(config: vadConfig)
+                    } catch {
+                        self.logger.notice("VAD init failed; falling back to full audio: \(error.localizedDescription, privacy: .public)")
+                        self.vadManager = nil
+                    }
+                }
+
+                if let vadManager = self.vadManager {
+                    do {
+                        let segments = try await vadManager.segmentSpeechAudio(audioSamples)
+                        speechAudio = segments.isEmpty ? audioSamples : segments.flatMap { $0 }
+                    } catch {
+                        self.logger.notice("VAD segmentation failed; using full audio: \(error.localizedDescription, privacy: .public)")
+                        speechAudio = audioSamples
+                    }
                 }
             }
 
-            if let vadManager {
-                do {
-                    let segments = try await vadManager.segmentSpeechAudio(audioSamples)
-                    speechAudio = segments.isEmpty ? audioSamples : segments.flatMap { $0 }
-                } catch {
-                    logger.notice("VAD segmentation failed; using full audio: \(error.localizedDescription, privacy: .public)")
-                    speechAudio = audioSamples
-                }
+            // Pad with 1s of silence to capture final punctuation at sequence boundary
+            let trailingSilenceSamples = 16_000
+            let maxSingleChunkSamples = 240_000
+            if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
+                speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
             }
+
+            let result = try await asrManager.transcribe(speechAudio)
+            return result.text
         }
 
-        // Pad with 1s of silence to capture final punctuation at sequence boundary
-        let trailingSilenceSamples = 16_000
-        let maxSingleChunkSamples = 240_000
-        if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
-            speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
-        }
-
-        let result = try await asrManager.transcribe(speechAudio)
-
-        return result.text
+        return try await detachedResult.value
     }
 
     private func readAudioSamples(from url: URL) throws -> [Float] {


### PR DESCRIPTION
## Summary

- **Parakeet transcription** and **Ollama AI enhancement** both fail with `Swift.CancellationError error 1` because the recording lifecycle `Task` in `VoiceInkEngine` gets implicitly cancelled when SwiftUI tears down the recorder view, and that cancellation propagates into FluidAudio's ASR engine and Ollama's URLSession.
- Fix: wrap async work in `Task.detached` so it completes independently of the caller's cancellation scope.
- Additionally deduplicate Parakeet model initialization to prevent race conditions between the preload `Task.detached` and the transcription pipeline.

## Changes

### `ParakeetTranscriptionService.swift`
- Replace `loadingTask` (model loading only) with `initTask` that deduplicates the full initialization (model loading + `AsrManager` creation)
- Wrap `transcribe()` body in `Task.detached` so FluidAudio operations are immune to upstream cancellation
- Add `CancellationError` retry with full state reset for transient FluidAudio failures

### `AIEnhancementService.swift`
- Catch `CancellationError` in the Ollama code path; distinguish real user cancellation from internal URLSession cancellation
- Wrap `enhance()` in `Task.detached` so AI requests complete regardless of caller task state

### `OllamaService.swift`
- Catch `CancellationError` in `enhance()` and convert internal cancellations to `LocalAIError.serviceUnavailable` (retryable)

## Test plan
- [ ] Record with Parakeet model selected — transcription should succeed and paste to target app
- [ ] Record with Parakeet + Ollama AI enhancement enabled — both transcription and enhancement should succeed
- [ ] Record with a cloud AI provider (e.g. Gemini, Groq) — verify no regression
- [ ] Cancel recording mid-transcription — verify clean cancellation still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `CancellationError` crashes in Parakeet transcription and Ollama enhancement by isolating async work from SwiftUI teardown and deduplicating Parakeet model initialization. Transcriptions and enhancements now complete reliably even when the recorder view closes.

- **Bug Fixes**
  - Parakeet: run `transcribe()` inside `Task.detached`; retry once on `CancellationError` with a full ASR reset.
  - Ollama: catch `CancellationError`, propagate real user cancels, and map internal `URLSession` cancels to a retryable error.
  - Enhancement: wrap `enhance()` in `Task.detached` so requests aren’t cancelled by the caller’s task scope.

- **Refactors**
  - Replace model-only `loadingTask` with `initTask` that deduplicates the full init (model load + `AsrManager`), removing race conditions and avoiding upstream cancellation.

<sup>Written for commit bb47c225713ea6b1b02b9db42c67e11b9fae667f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

