### PR TITLE
Add per-hotkey activation mode (Toggle, Push to Talk, Hybrid)

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -30,6 +30,16 @@ class HotkeyManager: ObservableObject {
             setupHotkeyMonitoring()
         }
     }
+    @Published var hotkeyMode1: HotkeyMode {
+        didSet {
+            UserDefaults.standard.set(hotkeyMode1.rawValue, forKey: "hotkeyMode1")
+        }
+    }
+    @Published var hotkeyMode2: HotkeyMode {
+        didSet {
+            UserDefaults.standard.set(hotkeyMode2.rawValue, forKey: "hotkeyMode2")
+        }
+    }
     @Published var isMiddleClickToggleEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isMiddleClickToggleEnabled, forKey: "isMiddleClickToggleEnabled")
@@ -64,7 +74,6 @@ class HotkeyManager: ObservableObject {
     // Key state tracking
     private var currentKeyState = false
     private var keyPressEventTime: TimeInterval?
-    private let briefPressThreshold = 0.5
     private var isHandsFreeMode = false
 
     // Debounce for Fn key
@@ -78,6 +87,22 @@ class HotkeyManager: ObservableObject {
     private var shortcutCurrentKeyState = false
     private var lastShortcutTriggerTime: Date?
     private let shortcutCooldownInterval: TimeInterval = 0.5
+
+    private static let hybridPressThreshold: TimeInterval = 0.5
+
+    enum HotkeyMode: String, CaseIterable {
+        case toggle = "toggle"
+        case pushToTalk = "pushToTalk"
+        case hybrid = "hybrid"
+
+        var displayName: String {
+            switch self {
+            case .toggle: return "Toggle"
+            case .pushToTalk: return "Push to Talk"
+            case .hybrid: return "Hybrid"
+            }
+        }
+    }
 
     enum HotkeyOption: String, CaseIterable {
         case none = "none"
@@ -125,6 +150,9 @@ class HotkeyManager: ObservableObject {
     init(engine: VoiceInkEngine, recorderUIManager: RecorderUIManager) {
         self.selectedHotkey1 = HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey1") ?? "") ?? .rightCommand
         self.selectedHotkey2 = HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey2") ?? "") ?? .none
+
+        self.hotkeyMode1 = HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode1") ?? "") ?? .hybrid
+        self.hotkeyMode2 = HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode2") ?? "") ?? .hybrid
 
         self.isMiddleClickToggleEnabled = UserDefaults.standard.bool(forKey: "isMiddleClickToggleEnabled")
         self.middleClickActivationDelay = UserDefaults.standard.integer(forKey: "middleClickActivationDelay")
@@ -242,21 +270,21 @@ class HotkeyManager: ObservableObject {
         if selectedHotkey1 == .custom {
             KeyboardShortcuts.onKeyDown(for: .toggleMiniRecorder) { [weak self] in
                 let eventTime = ProcessInfo.processInfo.systemUptime
-                Task { @MainActor in await self?.handleCustomShortcutKeyDown(eventTime: eventTime) }
+                Task { @MainActor in await self?.handleCustomShortcutKeyDown(eventTime: eventTime, mode: self?.hotkeyMode1 ?? .toggle) }
             }
             KeyboardShortcuts.onKeyUp(for: .toggleMiniRecorder) { [weak self] in
                 let eventTime = ProcessInfo.processInfo.systemUptime
-                Task { @MainActor in await self?.handleCustomShortcutKeyUp(eventTime: eventTime) }
+                Task { @MainActor in await self?.handleCustomShortcutKeyUp(eventTime: eventTime, mode: self?.hotkeyMode1 ?? .toggle) }
             }
         }
         if selectedHotkey2 == .custom {
             KeyboardShortcuts.onKeyDown(for: .toggleMiniRecorder2) { [weak self] in
                 let eventTime = ProcessInfo.processInfo.systemUptime
-                Task { @MainActor in await self?.handleCustomShortcutKeyDown(eventTime: eventTime) }
+                Task { @MainActor in await self?.handleCustomShortcutKeyDown(eventTime: eventTime, mode: self?.hotkeyMode2 ?? .toggle) }
             }
             KeyboardShortcuts.onKeyUp(for: .toggleMiniRecorder2) { [weak self] in
                 let eventTime = ProcessInfo.processInfo.systemUptime
-                Task { @MainActor in await self?.handleCustomShortcutKeyUp(eventTime: eventTime) }
+                Task { @MainActor in await self?.handleCustomShortcutKeyUp(eventTime: eventTime, mode: self?.hotkeyMode2 ?? .toggle) }
             }
         }
     }
@@ -297,13 +325,17 @@ class HotkeyManager: ObservableObject {
         let flags = event.modifierFlags
         let eventTime = event.timestamp
 
+        let activeMode: HotkeyMode
         let activeHotkey: HotkeyOption?
         if selectedHotkey1.isModifierKey && selectedHotkey1.keyCode == keycode {
             activeHotkey = selectedHotkey1
+            activeMode = hotkeyMode1
         } else if selectedHotkey2.isModifierKey && selectedHotkey2.keyCode == keycode {
             activeHotkey = selectedHotkey2
+            activeMode = hotkeyMode2
         } else {
             activeHotkey = nil
+            activeMode = .toggle
         }
 
         guard let hotkey = activeHotkey else { return }
@@ -323,7 +355,7 @@ class HotkeyManager: ObservableObject {
             fnDebounceTask = Task { [pendingState = isKeyPressed, pendingTime = eventTime] in
                 try? await Task.sleep(nanoseconds: 75_000_000) // 75ms
                 if pendingFnKeyState == pendingState {
-                    await self.processKeyPress(isKeyPressed: pendingState, eventTime: pendingTime)
+                    await self.processKeyPress(isKeyPressed: pendingState, eventTime: pendingTime, mode: activeMode)
                 }
             }
             return
@@ -335,39 +367,59 @@ class HotkeyManager: ObservableObject {
             return // Should not reach here
         }
 
-        await processKeyPress(isKeyPressed: isKeyPressed, eventTime: eventTime)
+        await processKeyPress(isKeyPressed: isKeyPressed, eventTime: eventTime, mode: activeMode)
     }
-    
-    private func processKeyPress(isKeyPressed: Bool, eventTime: TimeInterval) async {
+
+    private func processKeyPress(isKeyPressed: Bool, eventTime: TimeInterval, mode: HotkeyMode) async {
         guard isKeyPressed != currentKeyState else { return }
         currentKeyState = isKeyPressed
 
         if isKeyPressed {
             keyPressEventTime = eventTime
 
-            if isHandsFreeMode {
-                isHandsFreeMode = false
-                guard canProcessHotkeyAction else { return }
-                logger.notice("processKeyPress: toggling mini recorder (hands-free toggle)")
-                await recorderUIManager.toggleMiniRecorder()
-                return
-            }
+            switch mode {
+            case .toggle, .hybrid:
+                if isHandsFreeMode {
+                    isHandsFreeMode = false
+                    guard canProcessHotkeyAction else { return }
+                    logger.notice("processKeyPress: toggling mini recorder (hands-free toggle)")
+                    await recorderUIManager.toggleMiniRecorder()
+                    return
+                }
 
-            if !recorderUIManager.isMiniRecorderVisible {
-                guard canProcessHotkeyAction else { return }
-                logger.notice("processKeyPress: toggling mini recorder (key down while not visible)")
-                await recorderUIManager.toggleMiniRecorder()
+                if !recorderUIManager.isMiniRecorderVisible {
+                    guard canProcessHotkeyAction else { return }
+                    logger.notice("processKeyPress: toggling mini recorder (key down while not visible)")
+                    await recorderUIManager.toggleMiniRecorder()
+                }
+
+            case .pushToTalk:
+                if !recorderUIManager.isMiniRecorderVisible {
+                    guard canProcessHotkeyAction else { return }
+                    logger.notice("processKeyPress: starting recording (push-to-talk key down)")
+                    await recorderUIManager.toggleMiniRecorder()
+                }
             }
         } else {
-            if let startTime = keyPressEventTime {
-                let pressDuration = eventTime - startTime
+            switch mode {
+            case .toggle:
+                isHandsFreeMode = true
 
-                if pressDuration < briefPressThreshold {
-                    isHandsFreeMode = true
-                } else {
+            case .pushToTalk:
+                if recorderUIManager.isMiniRecorderVisible {
                     guard canProcessHotkeyAction else { return }
-                    logger.notice("processKeyPress: toggling mini recorder (key up long press)")
+                    logger.notice("processKeyPress: stopping recording (push-to-talk key up)")
                     await recorderUIManager.toggleMiniRecorder()
+                }
+
+            case .hybrid:
+                let pressDuration = keyPressEventTime.map { eventTime - $0 } ?? 0
+                if pressDuration >= Self.hybridPressThreshold && engine.recordingState == .recording {
+                    guard canProcessHotkeyAction else { return }
+                    logger.notice("processKeyPress: stopping recording (hybrid push-to-talk, duration=\(pressDuration, privacy: .public)s)")
+                    await recorderUIManager.toggleMiniRecorder()
+                } else {
+                    isHandsFreeMode = true
                 }
             }
 
@@ -375,7 +427,7 @@ class HotkeyManager: ObservableObject {
         }
     }
     
-    private func handleCustomShortcutKeyDown(eventTime: TimeInterval) async {
+    private func handleCustomShortcutKeyDown(eventTime: TimeInterval, mode: HotkeyMode) async {
         if let lastTrigger = lastShortcutTriggerTime,
            Date().timeIntervalSince(lastTrigger) < shortcutCooldownInterval {
             return
@@ -386,34 +438,54 @@ class HotkeyManager: ObservableObject {
         lastShortcutTriggerTime = Date()
         shortcutKeyPressEventTime = eventTime
 
-        if isShortcutHandsFreeMode {
-            isShortcutHandsFreeMode = false
-            guard canProcessHotkeyAction else { return }
-            logger.notice("handleCustomShortcutKeyDown: toggling mini recorder (hands-free toggle)")
-            await recorderUIManager.toggleMiniRecorder()
-            return
-        }
+        switch mode {
+        case .toggle, .hybrid:
+            if isShortcutHandsFreeMode {
+                isShortcutHandsFreeMode = false
+                guard canProcessHotkeyAction else { return }
+                logger.notice("handleCustomShortcutKeyDown: toggling mini recorder (hands-free toggle)")
+                await recorderUIManager.toggleMiniRecorder()
+                return
+            }
 
-        if !recorderUIManager.isMiniRecorderVisible {
-            guard canProcessHotkeyAction else { return }
-            logger.notice("handleCustomShortcutKeyDown: toggling mini recorder (key down while not visible)")
-            await recorderUIManager.toggleMiniRecorder()
+            if !recorderUIManager.isMiniRecorderVisible {
+                guard canProcessHotkeyAction else { return }
+                logger.notice("handleCustomShortcutKeyDown: toggling mini recorder (key down while not visible)")
+                await recorderUIManager.toggleMiniRecorder()
+            }
+
+        case .pushToTalk:
+            if !recorderUIManager.isMiniRecorderVisible {
+                guard canProcessHotkeyAction else { return }
+                logger.notice("handleCustomShortcutKeyDown: starting recording (push-to-talk key down)")
+                await recorderUIManager.toggleMiniRecorder()
+            }
         }
     }
 
-    private func handleCustomShortcutKeyUp(eventTime: TimeInterval) async {
+    private func handleCustomShortcutKeyUp(eventTime: TimeInterval, mode: HotkeyMode) async {
         guard shortcutCurrentKeyState else { return }
         shortcutCurrentKeyState = false
 
-        if let startTime = shortcutKeyPressEventTime {
-            let pressDuration = eventTime - startTime
+        switch mode {
+        case .toggle:
+            isShortcutHandsFreeMode = true
 
-            if pressDuration < briefPressThreshold {
-                isShortcutHandsFreeMode = true
-            } else {
+        case .pushToTalk:
+            if recorderUIManager.isMiniRecorderVisible {
                 guard canProcessHotkeyAction else { return }
-                logger.notice("handleCustomShortcutKeyUp: toggling mini recorder (key up long press)")
+                logger.notice("handleCustomShortcutKeyUp: stopping recording (push-to-talk key up)")
                 await recorderUIManager.toggleMiniRecorder()
+            }
+
+        case .hybrid:
+            let pressDuration = shortcutKeyPressEventTime.map { eventTime - $0 } ?? 0
+            if pressDuration >= Self.hybridPressThreshold && engine.recordingState == .recording {
+                guard canProcessHotkeyAction else { return }
+                logger.notice("handleCustomShortcutKeyUp: stopping recording (hybrid push-to-talk, duration=\(pressDuration, privacy: .public)s)")
+                await recorderUIManager.toggleMiniRecorder()
+            } else {
+                isShortcutHandsFreeMode = true
             }
         }
 

--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -354,7 +354,8 @@ class HotkeyManager: ObservableObject {
             fnDebounceTask?.cancel()
             fnDebounceTask = Task { [pendingState = isKeyPressed, pendingTime = eventTime] in
                 try? await Task.sleep(nanoseconds: 75_000_000) // 75ms
-                if pendingFnKeyState == pendingState {
+                guard !Task.isCancelled, pendingFnKeyState == pendingState else { return }
+                Task { @MainActor in
                     await self.processKeyPress(isKeyPressed: pendingState, eventTime: pendingTime, mode: activeMode)
                 }
             }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -39,6 +39,7 @@ struct SettingsView: View {
             Section {
                 LabeledContent("Shortcut 1") {
                     HStack(spacing: 8) {
+                        Spacer()
                         if hotkeyManager.selectedHotkey1 != .none {
                             hotkeyModePicker(binding: $hotkeyManager.hotkeyMode1)
                         }
@@ -53,6 +54,7 @@ struct SettingsView: View {
                 if hotkeyManager.selectedHotkey2 != .none {
                     LabeledContent("Shortcut 2") {
                         HStack(spacing: 8) {
+                            Spacer()
                             hotkeyModePicker(binding: $hotkeyManager.hotkeyMode2)
                             hotkeyPicker(binding: $hotkeyManager.selectedHotkey2)
                             if hotkeyManager.selectedHotkey2 == .custom {
@@ -314,7 +316,7 @@ struct SettingsView: View {
             }
         }
         .labelsHidden()
-        .frame(width: 140)
+        .fixedSize()
     }
 
     @ViewBuilder
@@ -325,7 +327,7 @@ struct SettingsView: View {
             }
         }
         .labelsHidden()
-        .frame(width: 110)
+        .fixedSize()
     }
 }
 

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -37,8 +37,11 @@ struct SettingsView: View {
         Form {
             // MARK: - Shortcuts
             Section {
-                LabeledContent("Hotkey 1") {
+                LabeledContent("Shortcut 1") {
                     HStack(spacing: 8) {
+                        if hotkeyManager.selectedHotkey1 != .none {
+                            hotkeyModePicker(binding: $hotkeyManager.hotkeyMode1)
+                        }
                         hotkeyPicker(binding: $hotkeyManager.selectedHotkey1)
                         if hotkeyManager.selectedHotkey1 == .custom {
                             KeyboardShortcuts.Recorder(for: .toggleMiniRecorder)
@@ -48,8 +51,9 @@ struct SettingsView: View {
                 }
 
                 if hotkeyManager.selectedHotkey2 != .none {
-                    LabeledContent("Hotkey 2") {
+                    LabeledContent("Shortcut 2") {
                         HStack(spacing: 8) {
+                            hotkeyModePicker(binding: $hotkeyManager.hotkeyMode2)
                             hotkeyPicker(binding: $hotkeyManager.selectedHotkey2)
                             if hotkeyManager.selectedHotkey2 == .custom {
                                 KeyboardShortcuts.Recorder(for: .toggleMiniRecorder2)
@@ -67,14 +71,12 @@ struct SettingsView: View {
                 }
 
                 if hotkeyManager.selectedHotkey1 != .none && hotkeyManager.selectedHotkey2 == .none {
-                    Button("Add Second Hotkey") {
+                    Button("Add Second Shortcut") {
                         withAnimation { hotkeyManager.selectedHotkey2 = .rightOption }
                     }
                 }
             } header: {
                 Text("Shortcuts")
-            } footer: {
-                Text("Quick tap for hands-free recording, hold for push-to-talk.")
             }
 
             // MARK: - Additional Shortcuts
@@ -313,6 +315,17 @@ struct SettingsView: View {
         }
         .labelsHidden()
         .frame(width: 140)
+    }
+
+    @ViewBuilder
+    private func hotkeyModePicker(binding: Binding<HotkeyManager.HotkeyMode>) -> some View {
+        Picker("", selection: binding) {
+            ForEach(HotkeyManager.HotkeyMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
+        }
+        .labelsHidden()
+        .frame(width: 110)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a per-hotkey activation mode setting, allowing each shortcut to independently use **Toggle**, **Push to Talk**, or **Hybrid** mode
- Previously, all hotkeys shared a single "quick tap = hands-free, hold = push-to-talk" hybrid behavior with no way to change it
- Each shortcut now shows a mode picker in Settings when enabled
- Renamed "Hotkey" labels to "Shortcut" for consistency

## Modes
- **Toggle**: Tap to start, tap again to stop (always hands-free)
- **Push to Talk**: Hold to record, release to stop
- **Hybrid** (default, preserves existing behavior): Quick tap for hands-free, hold for push-to-talk

## Test plan
- [ ] Verify each mode works correctly for both Shortcut 1 and Shortcut 2
- [ ] Test with modifier keys (e.g., Right Command) and custom keyboard shortcuts
- [ ] Confirm mode preference persists across app restarts
- [ ] Verify Fn key debounce still works correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-shortcut activation modes (Toggle, Push to Talk, Hybrid) so each shortcut can act independently with a mode picker in Settings. Also fixes an Fn-key debounce CancellationError and aligns shortcut pickers with auto-sizing.

- **New Features**
  - Per-shortcut mode selection with persistence across restarts (Hybrid is default).
  - Hybrid uses a 0.5s press threshold (tap = hands-free, hold = push-to-talk).
  - Settings polish: mode/hotkey pickers auto-size and right-align; labels now say "Shortcut".

- **Bug Fixes**
  - Prevented CancellationError in the Fn key debounce path when using Toggle mode.

<sup>Written for commit 6ce66ddd22406c7b671d9b22f98850eadcb7d15c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

