### PR TITLE
Fix transcribed text not being pasted

### DIFF
--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -26,14 +26,15 @@ class CursorPaster {
 
         ClipboardManager.setClipboard(text, transient: shouldRestoreClipboard)
 
-        // Only restore the clipboard after pasting if we can actually paste.
-        // When accessibility isn't granted, paste will fail silently — in that
-        // case, keep the transcribed text on the clipboard so the user can
-        // manually Cmd+V instead of having it wiped by the restore timer.
-        let canPaste = AXIsProcessTrusted()
-        let effectiveRestore = shouldRestoreClipboard && canPaste
-
         let useAppleScript = UserDefaults.standard.bool(forKey: "useAppleScriptPaste")
+
+        // Paste can succeed via CGEvent (needs Accessibility) or AppleScript
+        // (needs Automation). When the user chose AppleScript, trust that it
+        // works. On the default CGEvent path without Accessibility, the
+        // AppleScript fallback may or may not succeed — be conservative and
+        // keep the text on the clipboard so the user can manual Cmd+V.
+        let canPaste = AXIsProcessTrusted() || useAppleScript
+        let effectiveRestore = shouldRestoreClipboard && canPaste
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             if useAppleScript {

--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -26,15 +26,24 @@ class CursorPaster {
 
         ClipboardManager.setClipboard(text, transient: shouldRestoreClipboard)
 
+        // Only restore the clipboard after pasting if we can actually paste.
+        // When accessibility isn't granted, paste will fail silently — in that
+        // case, keep the transcribed text on the clipboard so the user can
+        // manually Cmd+V instead of having it wiped by the restore timer.
+        let canPaste = AXIsProcessTrusted()
+        let effectiveRestore = shouldRestoreClipboard && canPaste
+
+        let useAppleScript = UserDefaults.standard.bool(forKey: "useAppleScriptPaste")
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            if UserDefaults.standard.bool(forKey: "useAppleScriptPaste") {
+            if useAppleScript {
                 pasteUsingAppleScript()
             } else {
                 pasteFromClipboard()
             }
         }
 
-        if shouldRestoreClipboard {
+        if effectiveRestore {
             let restoreDelay = UserDefaults.standard.double(forKey: "clipboardRestoreDelay")
             let delay = max(restoreDelay, 0.25)
 
@@ -76,11 +85,6 @@ class CursorPaster {
 
     // Posts Cmd+V via CGEvent without modifying the active input source.
     private static func pasteFromClipboard() {
-        guard AXIsProcessTrusted() else {
-            logger.error("Accessibility not trusted — cannot paste")
-            return
-        }
-
         let source = CGEventSource(stateID: .privateState)
 
         let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: 0x37, keyDown: true)
@@ -97,7 +101,12 @@ class CursorPaster {
         vUp?.post(tap: .cghidEventTap)
         cmdUp?.post(tap: .cghidEventTap)
 
-        logger.notice("CGEvents posted for Cmd+V")
+        // If accessibility isn't granted, CGEvent paste may fail silently.
+        // Try AppleScript as a fallback — it uses a different permission model
+        // (Automation) that may succeed where CGEvent doesn't.
+        if !AXIsProcessTrusted() {
+            pasteUsingAppleScript()
+        }
     }
 
     // MARK: - Enter key

--- a/VoiceInk/Whisper/TranscriptionPipeline.swift
+++ b/VoiceInk/Whisper/TranscriptionPipeline.swift
@@ -149,8 +149,8 @@ class TranscriptionPipeline {
         try? modelContext.save()
         NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
 
-        if shouldCancel() { await onCleanup(); return }
-
+        // Paste if transcription completed — don't check shouldCancel() here because
+        // the user should always get their text pasted once transcription succeeds.
         if var textToPaste = finalPastedText,
            transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue {
             if case .trialExpired = licenseViewModel.licenseState {


### PR DESCRIPTION
## Summary
- After a successful transcription, the text was never actually pasted into the active app
- A `shouldCancel()` check sat between saving to the DB and pasting. If the recorder had already been dismissed by that point, it would bail out even though transcription finished fine
- `CursorPaster` now handles missing accessibility permissions better: it always tries CGEvent paste, falls back to AppleScript, and skips clipboard restore when paste can't work. That way the text at least stays on the clipboard for a manual Cmd+V

## Test plan
- [ ] Record a voice transcription and check that text gets pasted into the active app
- [ ] Confirm clipboard restore still works when accessibility is granted
- [ ] With accessibility NOT granted, confirm transcribed text stays on the clipboard
- [ ] Try with "Use AppleScript paste" both on and off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transcribed text not being pasted into the active app after a successful transcription, and makes paste more reliable when Accessibility is missing by accounting for the AppleScript path.

- **Bug Fixes**
  - Paste now always runs after transcription completes; removed the cancel check between DB save and paste.
  - CGEvent Cmd+V is always attempted and falls back to AppleScript when needed; respects the “Use AppleScript paste” setting.
  - Clipboard restore only runs when paste can work (Accessibility granted or AppleScript selected); otherwise the text stays on the clipboard for manual Cmd+V.

<sup>Written for commit bc5431a6779fea92bfa4b3dacc57b04c55441536. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

