### PR TITLE
Make stopRecording() async to avoid reading incomplete WAV

### DIFF
--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -160,9 +160,14 @@ class Recorder: NSObject, ObservableObject {
         audioMeterUpdateTimer?.cancel()
         audioMeterUpdateTimer = nil
 
-        // Stop the CoreAudioRecorder on the serial hardware queue and wait for
-        // it to finish so the WAV file is fully closed before callers read it.
+        // Capture and clear shared state before awaiting so a concurrent
+        // startRecording() won't have its new state overwritten when we resume.
         let currentRecorder = self.recorder
+        recorder = nil
+        onAudioChunk = nil
+
+        // Wait for the CoreAudioRecorder to finish closing the WAV file on the
+        // serial hardware queue before returning.
         if currentRecorder != nil {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 audioSetupQueue.async {
@@ -171,8 +176,6 @@ class Recorder: NSObject, ObservableObject {
                 }
             }
         }
-        recorder = nil
-        onAudioChunk = nil
 
         smoothedValuesLock.lock()
         smoothedAverage = 0

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -150,20 +150,26 @@ class Recorder: NSObject, ObservableObject {
 
         } catch {
             logger.error("Failed to create audio recorder: \(error.localizedDescription, privacy: .public)")
-            stopRecording()
+            await stopRecording()
             throw RecorderError.couldNotStartRecording
         }
     }
 
-    func stopRecording() {
+    func stopRecording() async {
         logger.notice("stopRecording called")
         audioMeterUpdateTimer?.cancel()
         audioMeterUpdateTimer = nil
-        
-        // Capture current recorder to stop it on the serial hardware queue
+
+        // Stop the CoreAudioRecorder on the serial hardware queue and wait for
+        // it to finish so the WAV file is fully closed before callers read it.
         let currentRecorder = self.recorder
-        audioSetupQueue.async {
-            currentRecorder?.stopRecording()
+        if currentRecorder != nil {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                audioSetupQueue.async {
+                    currentRecorder?.stopRecording()
+                    continuation.resume()
+                }
+            }
         }
         recorder = nil
         onAudioChunk = nil
@@ -186,7 +192,7 @@ class Recorder: NSObject, ObservableObject {
         logger.error("❌ Recording error occurred: \(error.localizedDescription, privacy: .public)")
 
         // Stop the recording
-        stopRecording()
+        await stopRecording()
 
         // Notify the user about the recording failure
         await MainActor.run {

--- a/VoiceInk/Whisper/VoiceInkEngine.swift
+++ b/VoiceInk/Whisper/VoiceInkEngine.swift
@@ -141,7 +141,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             try await self.recorder.startRecording(toOutputFile: permanentURL)
 
                             guard self.recorderUIManager?.isMiniRecorderVisible ?? false, !self.shouldCancelRecording else {
-                                self.recorder.stopRecording()
+                                await self.recorder.stopRecording()
                                 self.recordedFile = nil
                                 return
                             }

--- a/VoiceInk/Whisper/VoiceInkEngine.swift
+++ b/VoiceInk/Whisper/VoiceInkEngine.swift
@@ -141,8 +141,11 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             try await self.recorder.startRecording(toOutputFile: permanentURL)
 
                             guard self.recorderUIManager?.isMiniRecorderVisible ?? false, !self.shouldCancelRecording else {
+                                let fileBeingCancelled = self.recordedFile
                                 await self.recorder.stopRecording()
-                                self.recordedFile = nil
+                                if self.recordedFile == fileBeingCancelled {
+                                    self.recordedFile = nil
+                                }
                                 return
                             }
 


### PR DESCRIPTION
## Summary
- `Recorder.stopRecording()` was fire-and-forget: it dispatched the stop to a serial audio queue and returned right away
- The transcription pipeline could then try to read the WAV file before `CoreAudioRecorder` had finished closing it
- Now async, using `withCheckedContinuation` to actually wait for the stop to finish

## Test plan
- [ ] Record a transcription, check it processes correctly
- [ ] Rapid start/stop cycles — no deadlocks
- [ ] Cancel mid-recording, confirm it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `Recorder.stopRecording()` async and wait for the hardware queue to finish so WAV files are fully closed before reading. Also fixes race conditions during cancel and rapid start/stop.

- **Bug Fixes**
  - Made `stopRecording()` async with `withCheckedContinuation` and wait on `audioSetupQueue`; capture and clear `recorder`/`onAudioChunk` before awaiting to avoid reentrancy and stale cleanup.
  - Updated call sites to `await` the stop in `Recorder` and `VoiceInkEngine`; capture `recordedFile` before awaiting and only nil it if unchanged to keep cancel paths safe.

- **Migration**
  - Callers must `await recorder.stopRecording()`.

<sup>Written for commit 0478469daffa436ff93d55d41e8ae2f2d38d6cf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

