### PR TITLE
Detect self-signed certificate for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,20 @@ build: setup
 
 # Build for local use without Apple Developer certificate
 local: check setup
-	@echo "Building VoiceInk for local use (no Apple Developer certificate required)..."
+	@echo "Building VoiceInk for local use..."
 	@rm -rf "$(LOCAL_DERIVED_DATA)"
+	$(eval LOCAL_SIGN_ID := $(shell security find-identity -v -p codesigning 2>/dev/null | grep "VoiceInk Local Dev" | head -1 | sed 's/.*"\(.*\)"/\1/'))
+	@if [ -n "$(LOCAL_SIGN_ID)" ]; then \
+		echo "Using certificate: $(LOCAL_SIGN_ID)"; \
+	else \
+		echo "No 'VoiceInk Local Dev' certificate found, using ad-hoc signing."; \
+		echo "  Note: Ad-hoc builds cannot auto-paste (no accessibility permission)."; \
+		echo "  Run: make cert  to create a local signing certificate."; \
+	fi
 	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug \
 		-derivedDataPath "$(LOCAL_DERIVED_DATA)" \
 		-xcconfig LocalBuild.xcconfig \
-		CODE_SIGN_IDENTITY="-" \
+		CODE_SIGN_IDENTITY="$(if $(LOCAL_SIGN_ID),$(LOCAL_SIGN_ID),-)" \
 		CODE_SIGNING_REQUIRED=NO \
 		CODE_SIGNING_ALLOWED=YES \
 		DEVELOPMENT_TEAM="" \


### PR DESCRIPTION
## Summary
- `make local` checks the keychain for a "VoiceInk Local Dev" self-signed certificate and uses it if found
- Ad-hoc signing (`CODE_SIGN_IDENTITY="-"`) produces a different CDHash every rebuild, so macOS forgets accessibility and automation permissions each time. That's why auto-paste breaks after rebuilding.
- A stable certificate keeps the same identity across rebuilds, so permissions stick
- If no certificate is found, it falls back to ad-hoc with a warning

## Test plan
- [ ] `make local` without a "VoiceInk Local Dev" cert — should fall back to ad-hoc, print a warning
- [ ] Create the cert, run `make local` — should pick it up and use it
- [ ] Rebuild and confirm macOS doesn't re-prompt for accessibility permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local builds now auto-detect and use a "VoiceInk Local Dev" self-signed certificate to keep a stable code identity, so macOS accessibility/automation permissions (e.g., auto-paste) persist across rebuilds. If the certificate isn’t found, the build falls back to ad-hoc signing and prints a warning.

<sup>Written for commit b2aaeca7e62f0ad8b60f2c383a237c6edeb09c11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

