### PR TITLE
Feature/sliding-panel-refactor-with-new-features

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -42,6 +42,8 @@ enum AppDefaults {
 
             // Enhancement
             "isToggleEnhancementShortcutEnabled": true,
+            "SkipShortEnhancement": true,
+            "ShortEnhancementWordThreshold": 3,
 
             // Model
             "PrewarmModelOnWake": true,

--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -100,14 +100,27 @@ class CursorPaster {
         logger.notice("CGEvents posted for Cmd+V")
     }
 
-    // MARK: - Enter key
+    // MARK: - Auto Send Keys
 
-    // Simulate pressing the Return/Enter key.
-    static func pressEnter() {
+    static func performAutoSend(_ key: AutoSendKey) {
+        guard key.isEnabled else { return }
         guard AXIsProcessTrusted() else { return }
+
         let source = CGEventSource(stateID: .privateState)
         let enterDown = CGEvent(keyboardEventSource: source, virtualKey: 0x24, keyDown: true)
         let enterUp   = CGEvent(keyboardEventSource: source, virtualKey: 0x24, keyDown: false)
+
+        switch key {
+        case .none: return
+        case .enter: break
+        case .shiftEnter:
+            enterDown?.flags = .maskShift
+            enterUp?.flags   = .maskShift
+        case .commandEnter:
+            enterDown?.flags = .maskCommand
+            enterUp?.flags   = .maskCommand
+        }
+
         enterDown?.post(tap: .cghidEventTap)
         enterUp?.post(tap: .cghidEventTap)
     }

--- a/VoiceInk/PowerMode/AppPicker.swift
+++ b/VoiceInk/PowerMode/AppPicker.swift
@@ -1,70 +1,79 @@
 import SwiftUI
 
-// App Picker Sheet
-struct AppPickerSheet: View {
+struct AppPickerPopover: View {
     let installedApps: [(url: URL, name: String, bundleId: String, icon: NSImage)]
     @Binding var selectedAppConfigs: [AppConfig]
     @Binding var searchText: String
-    let onDismiss: () -> Void
-    
+
     var body: some View {
-        VStack(spacing: 16) {
-            // Header
-            HStack {
-                Text("Select Applications")
-                    .font(.headline)
-                
-                Spacer()
-                
-                Button("Done") {
-                    onDismiss()
-                }
-                .keyboardShortcut(.return, modifiers: [])
-            }
-            .padding(.horizontal)
-            .padding(.top)
-            
-            // Search bar
-            HStack {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(.secondary)
-                TextField("Search applications...", text: $searchText)
-                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12))
+                TextField("Search apps...", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
                 if !searchText.isEmpty {
                     Button(action: { searchText = "" }) {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundColor(.secondary)
+                            .font(.system(size: 12))
                     }
                     .buttonStyle(.plain)
                 }
             }
-            .padding(.horizontal)
-                
-            // App Grid
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
             ScrollView {
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 100, maximum: 120), spacing: 16)], spacing: 16) {
-                    ForEach(installedApps.sorted(by: { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }), id: \.bundleId) { app in
-                        AppGridItem(
-                            app: app,
-                            isSelected: selectedAppConfigs.contains(where: { $0.bundleIdentifier == app.bundleId }),
-                            action: { 
-                                toggleAppSelection(app)
+                LazyVStack(spacing: 0) {
+                    ForEach(installedApps, id: \.bundleId) { app in
+                        let isSelected = selectedAppConfigs.contains(where: { $0.bundleIdentifier == app.bundleId })
+
+                        Button {
+                            toggleAppSelection(app)
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(nsImage: app.icon)
+                                    .resizable()
+                                    .frame(width: 28, height: 28)
+                                    .cornerRadius(6)
+
+                                Text(app.name)
+                                    .font(.system(size: 13))
+                                    .foregroundColor(.primary)
+                                    .lineLimit(1)
+
+                                Spacer()
+
+                                if isSelected {
+                                    Image(systemName: "checkmark")
+                                        .font(.system(size: 12, weight: .semibold))
+                                        .foregroundColor(.accentColor)
+                                }
                             }
-                        )
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .contentShape(Rectangle())
+                            .background(isSelected ? Color.accentColor.opacity(0.08) : Color.clear)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
-                .padding()
+                .padding(.vertical, 4)
             }
         }
-        .frame(width: 600, height: 500)
+        .frame(width: 280, height: 380)
     }
-    
+
     private func toggleAppSelection(_ app: (url: URL, name: String, bundleId: String, icon: NSImage)) {
         if let index = selectedAppConfigs.firstIndex(where: { $0.bundleIdentifier == app.bundleId }) {
             selectedAppConfigs.remove(at: index)
         } else {
-            let appConfig = AppConfig(bundleIdentifier: app.bundleId, appName: app.name)
-            selectedAppConfigs.append(appConfig)
+            selectedAppConfigs.append(AppConfig(bundleIdentifier: app.bundleId, appName: app.name))
         }
     }
 }

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -1,6 +1,26 @@
 import Foundation
 import KeyboardShortcuts
 
+enum AutoSendKey: String, Codable, CaseIterable {
+    case none = "none"
+    case enter = "enter"
+    case shiftEnter = "shiftEnter"
+    case commandEnter = "commandEnter"
+
+    var displayName: String {
+        switch self {
+        case .none: return "None"
+        case .enter: return "Return (⏎)"
+        case .shiftEnter: return "Shift + Return (⇧⏎)"
+        case .commandEnter: return "Command + Return (⌘⏎)"
+        }
+    }
+
+    var isEnabled: Bool {
+        self != .none
+    }
+}
+
 struct PowerModeConfig: Codable, Identifiable, Equatable {
     var id: UUID
     var name: String
@@ -14,13 +34,13 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var useScreenCapture: Bool
     var selectedAIProvider: String?
     var selectedAIModel: String?
-    var isAutoSendEnabled: Bool = false
+    var autoSendKey: AutoSendKey = .none
     var isEnabled: Bool = true
     var isDefault: Bool = false
     var hotkeyShortcut: String? = nil
         
     enum CodingKeys: String, CodingKey {
-        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, isEnabled, isDefault, hotkeyShortcut
+        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault, hotkeyShortcut
         case selectedWhisperModel
         case selectedTranscriptionModelName
     }
@@ -28,7 +48,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     init(id: UUID = UUID(), name: String, emoji: String, appConfigs: [AppConfig]? = nil,
          urlConfigs: [URLConfig]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, selectedLanguage: String? = nil, useScreenCapture: Bool = false,
-         selectedAIProvider: String? = nil, selectedAIModel: String? = nil, isAutoSendEnabled: Bool = false, isEnabled: Bool = true, isDefault: Bool = false, hotkeyShortcut: String? = nil) {
+         selectedAIProvider: String? = nil, selectedAIModel: String? = nil, autoSendKey: AutoSendKey = .none, isEnabled: Bool = true, isDefault: Bool = false, hotkeyShortcut: String? = nil) {
         self.id = id
         self.name = name
         self.emoji = emoji
@@ -37,7 +57,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         self.isAIEnhancementEnabled = isAIEnhancementEnabled
         self.selectedPrompt = selectedPrompt
         self.useScreenCapture = useScreenCapture
-        self.isAutoSendEnabled = isAutoSendEnabled
+        self.autoSendKey = autoSendKey
         self.selectedAIProvider = selectedAIProvider ?? UserDefaults.standard.string(forKey: "selectedAIProvider")
         self.selectedAIModel = selectedAIModel
         self.selectedTranscriptionModelName = selectedTranscriptionModelName ?? UserDefaults.standard.string(forKey: "CurrentTranscriptionModel")
@@ -60,7 +80,14 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         useScreenCapture = try container.decode(Bool.self, forKey: .useScreenCapture)
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
         selectedAIModel = try container.decodeIfPresent(String.self, forKey: .selectedAIModel)
-        isAutoSendEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoSendEnabled) ?? false
+        // Migrate from old isAutoSendEnabled bool to new autoSendKey enum
+        if let newKey = try container.decodeIfPresent(AutoSendKey.self, forKey: .autoSendKey) {
+            autoSendKey = newKey
+        } else if let oldBool = try container.decodeIfPresent(Bool.self, forKey: .isAutoSendEnabled), oldBool {
+            autoSendKey = .enter
+        } else {
+            autoSendKey = .none
+        }
         isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
         isDefault = try container.decodeIfPresent(Bool.self, forKey: .isDefault) ?? false
         hotkeyShortcut = try container.decodeIfPresent(String.self, forKey: .hotkeyShortcut)
@@ -87,7 +114,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         try container.encode(useScreenCapture, forKey: .useScreenCapture)
         try container.encodeIfPresent(selectedAIProvider, forKey: .selectedAIProvider)
         try container.encodeIfPresent(selectedAIModel, forKey: .selectedAIModel)
-        try container.encode(isAutoSendEnabled, forKey: .isAutoSendEnabled)
+        try container.encode(autoSendKey, forKey: .autoSendKey)
         try container.encodeIfPresent(selectedTranscriptionModelName, forKey: .selectedTranscriptionModelName)
         try container.encode(isEnabled, forKey: .isEnabled)
         try container.encode(isDefault, forKey: .isDefault)

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -81,7 +81,8 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
         selectedAIModel = try container.decodeIfPresent(String.self, forKey: .selectedAIModel)
         // Migrate from old isAutoSendEnabled bool to new autoSendKey enum
-        if let newKey = try container.decodeIfPresent(AutoSendKey.self, forKey: .autoSendKey) {
+        if let rawValue = try container.decodeIfPresent(String.self, forKey: .autoSendKey),
+           let newKey = AutoSendKey(rawValue: rawValue) {
             autoSendKey = newKey
         } else if let oldBool = try container.decodeIfPresent(Bool.self, forKey: .isAutoSendEnabled), oldBool {
             autoSendKey = .enter

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -4,12 +4,12 @@ import KeyboardShortcuts
 struct ConfigurationView: View {
     let mode: ConfigurationMode
     let powerModeManager: PowerModeManager
+    var onDismiss: () -> Void
     @EnvironmentObject var enhancementService: AIEnhancementService
     @EnvironmentObject var aiService: AIService
-    @Environment(\.presentationMode) private var presentationMode
+    @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
     @FocusState private var isNameFieldFocused: Bool
-    
-    // State for configuration
+
     @State private var configName: String = "New Power Mode"
     @State private var selectedEmoji: String = "💼"
     @State private var isShowingEmojiPicker = false
@@ -20,73 +20,45 @@ struct ConfigurationView: View {
     @State private var selectedLanguage: String?
     @State private var installedApps: [(url: URL, name: String, bundleId: String, icon: NSImage)] = []
     @State private var searchText = ""
-    
-    // Validation state
     @State private var validationErrors: [PowerModeValidationError] = []
     @State private var showValidationAlert = false
-    
-    // New state for AI provider and model
     @State private var selectedAIProvider: String?
     @State private var selectedAIModel: String?
-    
-    // App and Website configurations
     @State private var selectedAppConfigs: [AppConfig] = []
     @State private var websiteConfigs: [URLConfig] = []
     @State private var newWebsiteURL: String = ""
-    
-    // New state for screen capture toggle
     @State private var useScreenCapture = false
     @State private var isAutoSendEnabled = false
     @State private var isDefault = false
-    
     @State private var isShowingDeleteConfirmation = false
-
-    // PowerMode hotkey configuration
     @State private var powerModeConfigId: UUID = UUID()
 
-    private func languageSelectionDisabled() -> Bool {
-        guard let selectedModelName = effectiveModelName,
-              let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName })
-        else {
-            return false
-        }
-        return model.provider == .parakeet || model.provider == .gemini
+    private var effectiveModelName: String? {
+        selectedTranscriptionModelName ?? transcriptionModelManager.currentTranscriptionModel?.name
     }
-    
-    // TranscriptionModelManager for model selection
-    @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
-    
-    // Computed property to check if current config is the default
-    private var isCurrentConfigDefault: Bool {
-        if case .edit(let config) = mode {
-            return config.isDefault
-        }
-        return false
-    }
-    
+
     private var filteredApps: [(url: URL, name: String, bundleId: String, icon: NSImage)] {
-        if searchText.isEmpty {
-            return installedApps
-        }
+        if searchText.isEmpty { return installedApps }
         return installedApps.filter { app in
             app.name.localizedCaseInsensitiveContains(searchText) ||
             app.bundleId.localizedCaseInsensitiveContains(searchText)
         }
     }
-    
-    // Simplified computed property for effective model name
-    private var effectiveModelName: String? {
-        if let model = selectedTranscriptionModelName {
-            return model
-        }
-        return transcriptionModelManager.currentTranscriptionModel?.name
+
+    private var canSave: Bool { !configName.isEmpty }
+
+    private func languageSelectionDisabled() -> Bool {
+        guard let selectedModelName = effectiveModelName,
+              let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName })
+        else { return false }
+        return model.provider == .parakeet || model.provider == .gemini
     }
-    
-    init(mode: ConfigurationMode, powerModeManager: PowerModeManager) {
+
+    init(mode: ConfigurationMode, powerModeManager: PowerModeManager, onDismiss: @escaping () -> Void) {
         self.mode = mode
         self.powerModeManager = powerModeManager
+        self.onDismiss = onDismiss
 
-        // Always fetch the most current configuration data
         switch mode {
         case .add:
             let newId = UUID()
@@ -100,11 +72,11 @@ struct ConfigurationView: View {
             _useScreenCapture = State(initialValue: false)
             _isAutoSendEnabled = State(initialValue: false)
             _isDefault = State(initialValue: false)
-            // Default to current global AI provider/model for new configurations - use UserDefaults only
+            // Use UserDefaults directly since EnvironmentObjects aren't available in init
             _selectedAIProvider = State(initialValue: UserDefaults.standard.string(forKey: "selectedAIProvider"))
-            _selectedAIModel = State(initialValue: nil) // Initialize to nil and set it after view appears
+            _selectedAIModel = State(initialValue: nil)
         case .edit(let config):
-            // Get the latest version of this config from PowerModeManager
+            // Fetch latest version in case config was modified elsewhere
             let latestConfig = powerModeManager.getConfiguration(with: config.id) ?? config
             _powerModeConfigId = State(initialValue: latestConfig.id)
             _isAIEnhancementEnabled = State(initialValue: latestConfig.isAIEnhancementEnabled)
@@ -122,454 +94,470 @@ struct ConfigurationView: View {
             _selectedAIModel = State(initialValue: latestConfig.selectedAIModel)
         }
     }
-    
+
     var body: some View {
-        Form {
-            Section("General") {
-                HStack(spacing: 12) {
-                    Button {
-                        isShowingEmojiPicker.toggle()
-                    } label: {
-                        Text(selectedEmoji)
-                            .font(.system(size: 22))
-                            .frame(width: 32, height: 32)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color(NSColor.controlBackgroundColor))
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .popover(isPresented: $isShowingEmojiPicker, arrowEdge: .bottom) {
-                        EmojiPickerView(
-                            selectedEmoji: $selectedEmoji,
-                            isPresented: $isShowingEmojiPicker
-                        )
-                    }
+        VStack(spacing: 0) {
+            // Header
+            HStack(spacing: 12) {
+                Text(mode.title)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
 
-                    TextField("Name", text: $configName)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isNameFieldFocused)
+                Spacer()
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .padding(6)
+                        .background(Color.secondary.opacity(0.1))
+                        .clipShape(Circle())
                 }
+                .buttonStyle(.plain)
+                .help("Close")
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .background(Color(NSColor.windowBackgroundColor))
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
 
-            Section("Trigger Scenarios") {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack {
-                        Text("Applications")
-                        Spacer()
-                        AddIconButton(helpText: "Add application") {
-                            loadInstalledApps()
-                            isShowingAppPicker = true
-                        }
-                    }
-
-                    if selectedAppConfigs.isEmpty {
-                        Text("No applications added")
-                            .foregroundColor(.secondary)
-                            .font(.subheadline)
-                    } else {
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 44, maximum: 50), spacing: 10)], spacing: 10) {
-                            ForEach(selectedAppConfigs) { appConfig in
-                                ZStack(alignment: .topTrailing) {
-                                    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appConfig.bundleIdentifier) {
-                                        Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fill)
-                                            .frame(width: 44, height: 44)
-                                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                                    } else {
-                                        Image(systemName: "app.fill")
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fit)
-                                            .frame(width: 26, height: 26)
-                                            .frame(width: 44, height: 44)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 10)
-                                                    .fill(Color(NSColor.controlBackgroundColor))
-                                            )
-                                    }
-
-                                    Button {
-                                        selectedAppConfigs.removeAll(where: { $0.id == appConfig.id })
-                                    } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                            .font(.system(size: 14))
-                                            .foregroundColor(.secondary)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .offset(x: 6, y: -6)
-                                }
-                            }
-                        }
-                        .padding(.vertical, 2)
-                    }
-                }
-                .padding(.vertical, 2)
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Websites")
-
-                    HStack {
-                        TextField("Enter website URL (e.g., google.com)", text: $newWebsiteURL)
-                            .textFieldStyle(.roundedBorder)
-                            .onSubmit { addWebsite() }
-
-                        AddIconButton(helpText: "Add website", isDisabled: newWebsiteURL.isEmpty) {
-                            addWebsite()
-                        }
-                    }
-
-                    if websiteConfigs.isEmpty {
-                        Text("No websites added")
-                            .foregroundColor(.secondary)
-                            .font(.subheadline)
-                    } else {
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 140, maximum: 220), spacing: 10)], spacing: 10) {
-                            ForEach(websiteConfigs) { urlConfig in
-                                HStack(spacing: 6) {
-                                    Image(systemName: "globe")
-                                        .foregroundColor(.secondary)
-                                    Text(urlConfig.url)
-                                        .lineLimit(1)
-                                    Spacer(minLength: 0)
-                                    Button {
-                                        websiteConfigs.removeAll(where: { $0.id == urlConfig.id })
-                                    } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                            .foregroundColor(.secondary)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 6)
+            Form {
+                Section("General") {
+                    HStack(spacing: 12) {
+                        Button {
+                            isShowingEmojiPicker.toggle()
+                        } label: {
+                            Text(selectedEmoji)
+                                .font(.system(size: 22))
+                                .frame(width: 32, height: 32)
                                 .background(
                                     RoundedRectangle(cornerRadius: 8)
                                         .fill(Color(NSColor.controlBackgroundColor))
                                 )
-                            }
                         }
-                        .padding(.vertical, 2)
+                        .buttonStyle(.plain)
+                        .popover(isPresented: $isShowingEmojiPicker, arrowEdge: .bottom) {
+                            EmojiPickerView(
+                                selectedEmoji: $selectedEmoji,
+                                isPresented: $isShowingEmojiPicker
+                            )
+                        }
+
+                        TextField("Name", text: $configName)
+                            .textFieldStyle(.roundedBorder)
+                            .focused($isNameFieldFocused)
                     }
                 }
-                .padding(.vertical, 2)
-            }
 
-            Section("Transcription") {
-                if transcriptionModelManager.usableModels.isEmpty {
-                    Text("No transcription models available. Please connect to a cloud service or download a local model in the AI Models tab.")
-                        .foregroundColor(.secondary)
-                } else {
-                    let modelBinding = Binding<String?>(
-                        get: { selectedTranscriptionModelName ?? transcriptionModelManager.currentTranscriptionModel?.name },
-                        set: { selectedTranscriptionModelName = $0 }
-                    )
+                Section("Trigger Scenarios") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("Applications")
+                            Spacer()
+                            AddIconButton(helpText: "Add application") {
+                                loadInstalledApps()
+                                isShowingAppPicker = true
+                            }
+                            .popover(isPresented: $isShowingAppPicker, arrowEdge: .bottom) {
+                                AppPickerPopover(
+                                    installedApps: filteredApps,
+                                    selectedAppConfigs: $selectedAppConfigs,
+                                    searchText: $searchText
+                                )
+                            }
+                        }
 
-                    Picker("Model", selection: modelBinding) {
-                        ForEach(transcriptionModelManager.usableModels, id: \.name) { model in
-                            Text(model.displayName).tag(model.name as String?)
+                        if selectedAppConfigs.isEmpty {
+                            Text("No applications added")
+                                .foregroundColor(.secondary)
+                                .font(.subheadline)
+                        } else {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 44, maximum: 50), spacing: 10)], spacing: 10) {
+                                ForEach(selectedAppConfigs) { appConfig in
+                                    ZStack(alignment: .topTrailing) {
+                                        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appConfig.bundleIdentifier) {
+                                            Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                                .frame(width: 44, height: 44)
+                                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                                        } else {
+                                            Image(systemName: "app.fill")
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fit)
+                                                .frame(width: 26, height: 26)
+                                                .frame(width: 44, height: 44)
+                                                .background(
+                                                    RoundedRectangle(cornerRadius: 10)
+                                                        .fill(Color(NSColor.controlBackgroundColor))
+                                                )
+                                        }
+
+                                        Button {
+                                            selectedAppConfigs.removeAll(where: { $0.id == appConfig.id })
+                                        } label: {
+                                            Image(systemName: "xmark.circle.fill")
+                                                .font(.system(size: 14))
+                                                .foregroundColor(.secondary)
+                                        }
+                                        .buttonStyle(.plain)
+                                        .offset(x: 6, y: -6)
+                                    }
+                                }
+                            }
+                            .padding(.vertical, 2)
                         }
                     }
-                    .onChange(of: selectedTranscriptionModelName) { _, newModelName in
-                        // Auto-set language to "auto" for models that only support auto-detection
-                        if let modelName = newModelName ?? transcriptionModelManager.currentTranscriptionModel?.name,
-                           let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }),
-                           model.provider == .parakeet || model.provider == .gemini {
+                    .padding(.vertical, 2)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Websites")
+
+                        HStack {
+                            TextField("Enter website URL", text: $newWebsiteURL)
+                                .textFieldStyle(.roundedBorder)
+                                .onSubmit { addWebsite() }
+
+                            AddIconButton(helpText: "Add website", isDisabled: newWebsiteURL.isEmpty) {
+                                addWebsite()
+                            }
+                        }
+
+                        if websiteConfigs.isEmpty {
+                            Text("No websites added")
+                                .foregroundColor(.secondary)
+                                .font(.subheadline)
+                        } else {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 140, maximum: 220), spacing: 10)], spacing: 10) {
+                                ForEach(websiteConfigs) { urlConfig in
+                                    HStack(spacing: 6) {
+                                        Image(systemName: "globe")
+                                            .foregroundColor(.secondary)
+                                        Text(urlConfig.url)
+                                            .lineLimit(1)
+                                        Spacer(minLength: 0)
+                                        Button {
+                                            websiteConfigs.removeAll(where: { $0.id == urlConfig.id })
+                                        } label: {
+                                            Image(systemName: "xmark.circle.fill")
+                                                .foregroundColor(.secondary)
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .fill(Color(NSColor.controlBackgroundColor))
+                                    )
+                                }
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+
+                Section("Transcription") {
+                    if transcriptionModelManager.usableModels.isEmpty {
+                        Text("No transcription models available. Please connect to a cloud service or download a local model in the AI Models tab.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        let modelBinding = Binding<String?>(
+                            get: { selectedTranscriptionModelName ?? transcriptionModelManager.currentTranscriptionModel?.name },
+                            set: { selectedTranscriptionModelName = $0 }
+                        )
+
+                        Picker("Model", selection: modelBinding) {
+                            ForEach(transcriptionModelManager.usableModels, id: \.name) { model in
+                                Text(model.displayName).tag(model.name as String?)
+                            }
+                        }
+                        .onChange(of: selectedTranscriptionModelName) { _, newModelName in
+                            // Auto-set language to "auto" for models that only support auto-detection
+                            if let modelName = newModelName ?? transcriptionModelManager.currentTranscriptionModel?.name,
+                               let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }),
+                               model.provider == .parakeet || model.provider == .gemini {
+                                selectedLanguage = "auto"
+                            }
+                        }
+                    }
+
+                    if languageSelectionDisabled() {
+                        LabeledContent("Language") {
+                            Text("Autodetected")
+                                .foregroundColor(.secondary)
+                        }
+                        .onAppear {
                             selectedLanguage = "auto"
                         }
+                    } else if let selectedModel = effectiveModelName,
+                              let modelInfo = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModel }),
+                              modelInfo.isMultilingualModel {
+                        let languageBinding = Binding<String?>(
+                            get: { selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto" },
+                            set: { selectedLanguage = $0 }
+                        )
+
+                        Picker("Language", selection: languageBinding) {
+                            ForEach(modelInfo.supportedLanguages.sorted(by: {
+                                if $0.key == "auto" { return true }
+                                if $1.key == "auto" { return false }
+                                return $0.value < $1.value
+                            }), id: \.key) { key, value in
+                                Text(value).tag(key as String?)
+                            }
+                        }
+                    } else if let selectedModel = effectiveModelName,
+                              let modelInfo = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModel }),
+                              !modelInfo.isMultilingualModel {
+                        EmptyView()
+                            .onAppear {
+                                if selectedLanguage == nil {
+                                    selectedLanguage = "en"
+                                }
+                            }
                     }
                 }
 
-                if languageSelectionDisabled() {
-                    LabeledContent("Language") {
-                        Text("Autodetected")
-                            .foregroundColor(.secondary)
-                    }
-                    .onAppear {
-                        selectedLanguage = "auto"
-                    }
-                } else if let selectedModel = effectiveModelName,
-                          let modelInfo = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModel }),
-                          modelInfo.isMultilingualModel {
-                    let languageBinding = Binding<String?>(
-                        get: { selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto" },
-                        set: { selectedLanguage = $0 }
+                Section("AI Enhancement") {
+                    Toggle("AI Enhancement", isOn: $isAIEnhancementEnabled)
+                        .onChange(of: isAIEnhancementEnabled) { _, newValue in
+                            if newValue {
+                                if selectedAIProvider == nil {
+                                    selectedAIProvider = aiService.selectedProvider.rawValue
+                                }
+                                if selectedAIModel == nil {
+                                    selectedAIModel = aiService.currentModel
+                                }
+                                if selectedPromptId == nil {
+                                    selectedPromptId = enhancementService.allPrompts.first?.id
+                                }
+                            }
+                        }
+
+                    let providerBinding = Binding<AIProvider>(
+                        get: {
+                            if let providerName = selectedAIProvider,
+                               let provider = AIProvider(rawValue: providerName) {
+                                return provider
+                            }
+                            return aiService.selectedProvider
+                        },
+                        set: { newValue in
+                            selectedAIProvider = newValue.rawValue
+                            selectedAIModel = nil
+                        }
                     )
 
-                    Picker("Language", selection: languageBinding) {
-                        ForEach(modelInfo.supportedLanguages.sorted(by: {
-                            if $0.key == "auto" { return true }
-                            if $1.key == "auto" { return false }
-                            return $0.value < $1.value
-                        }), id: \.key) { key, value in
-                            Text(value).tag(key as String?)
-                        }
-                    }
-                } else if let selectedModel = effectiveModelName,
-                          let modelInfo = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModel }),
-                          !modelInfo.isMultilingualModel {
-                    EmptyView()
-                        .onAppear {
-                            if selectedLanguage == nil {
-                                selectedLanguage = "en"
-                            }
-                        }
-                }
-            }
-
-            Section("AI Enhancement") {
-                Toggle("Enable AI Enhancement", isOn: $isAIEnhancementEnabled)
-                    .onChange(of: isAIEnhancementEnabled) { _, newValue in
-                        if newValue {
-                            if selectedAIProvider == nil {
-                                selectedAIProvider = aiService.selectedProvider.rawValue
-                            }
-                            if selectedAIModel == nil {
-                                selectedAIModel = aiService.currentModel
-                            }
-                            if selectedPromptId == nil {
-                                selectedPromptId = enhancementService.allPrompts.first?.id
-                            }
-                        }
-                    }
-
-                let providerBinding = Binding<AIProvider>(
-                    get: {
-                        if let providerName = selectedAIProvider,
-                           let provider = AIProvider(rawValue: providerName) {
-                            return provider
-                        }
-                        return aiService.selectedProvider
-                    },
-                    set: { newValue in
-                        selectedAIProvider = newValue.rawValue
-                        aiService.selectedProvider = newValue
-                        selectedAIModel = nil
-                    }
-                )
-
-                if isAIEnhancementEnabled {
-                    if aiService.connectedProviders.isEmpty {
-                        LabeledContent("AI Provider") {
-                            Text("No providers connected")
-                                .foregroundColor(.secondary)
-                                .italic()
-                        }
-                    } else {
-                        Picker("AI Provider", selection: providerBinding) {
-                            ForEach(aiService.connectedProviders.filter { $0 != .elevenLabs && $0 != .deepgram }, id: \.self) { provider in
-                                Text(provider.rawValue).tag(provider)
-                            }
-                        }
-                        .onChange(of: selectedAIProvider) { _, newValue in
-                            if let provider = newValue.flatMap({ AIProvider(rawValue: $0) }) {
-                                selectedAIModel = provider.defaultModel
-                            }
-                        }
-                    }
-
-                    let providerName = selectedAIProvider ?? aiService.selectedProvider.rawValue
-                    if let provider = AIProvider(rawValue: providerName),
-                       provider != .custom {
-                        if aiService.availableModels.isEmpty {
-                            LabeledContent("AI Model") {
-                                Text(provider == .openRouter ? "No models loaded" : "No models available")
+                    if isAIEnhancementEnabled {
+                        if aiService.connectedProviders.isEmpty {
+                            LabeledContent("AI Provider") {
+                                Text("No providers connected")
                                     .foregroundColor(.secondary)
                                     .italic()
                             }
                         } else {
-                            let modelBinding = Binding<String>(
-                                get: {
-                                    if let model = selectedAIModel, !model.isEmpty { return model }
-                                    return aiService.currentModel
-                                },
-                                set: { newModelValue in
-                                    selectedAIModel = newModelValue
-                                    aiService.selectModel(newModelValue)
-                                }
-                            )
-
-                            let models = provider == .openRouter ? aiService.availableModels : (provider == .ollama ? aiService.availableModels : provider.availableModels)
-
-                            Picker("AI Model", selection: modelBinding) {
-                                ForEach(models, id: \.self) { model in
-                                    Text(model).tag(model)
+                            Picker("AI Provider", selection: providerBinding) {
+                                ForEach(aiService.connectedProviders.filter { $0 != .elevenLabs && $0 != .deepgram }, id: \.self) { provider in
+                                    Text(provider.rawValue).tag(provider)
                                 }
                             }
-
-                            if provider == .openRouter {
-                                Button("Refresh Models") {
-                                    Task { await aiService.fetchOpenRouterModels() }
+                            .onChange(of: selectedAIProvider) { _, newValue in
+                                if let provider = newValue.flatMap({ AIProvider(rawValue: $0) }) {
+                                    selectedAIModel = provider.defaultModel
                                 }
-                                .help("Refresh models")
                             }
+                        }
+
+                        let providerName = selectedAIProvider ?? aiService.selectedProvider.rawValue
+                        if let provider = AIProvider(rawValue: providerName),
+                           provider != .custom {
+                            let models = aiService.availableModels(for: provider)
+                            if models.isEmpty {
+                                LabeledContent("AI Model") {
+                                    Text(provider == .openRouter ? "No models loaded" : "No models available")
+                                        .foregroundColor(.secondary)
+                                        .italic()
+                                }
+                            } else {
+                                let modelBinding = Binding<String>(
+                                    get: {
+                                        if let model = selectedAIModel, !model.isEmpty { return model }
+                                        return aiService.currentModel
+                                    },
+                                    set: { newModelValue in
+                                        selectedAIModel = newModelValue
+                                    }
+                                )
+
+                                Picker("AI Model", selection: modelBinding) {
+                                    ForEach(models, id: \.self) { model in
+                                        Text(model).tag(model)
+                                    }
+                                }
+
+                                if provider == .openRouter {
+                                    Button("Refresh Models") {
+                                        Task { await aiService.fetchOpenRouterModels() }
+                                    }
+                                    .help("Refresh models")
+                                }
+                            }
+                        }
+
+                        if enhancementService.allPrompts.isEmpty {
+                            LabeledContent("Enhancement Prompt") {
+                                Text("No prompts available")
+                                    .foregroundColor(.secondary)
+                            }
+                        } else {
+                            Picker("Enhancement Prompt", selection: $selectedPromptId) {
+                                ForEach(enhancementService.allPrompts) { prompt in
+                                    Text(prompt.title).tag(prompt.id as UUID?)
+                                }
+                            }
+                        }
+
+                        Toggle("Context Awareness", isOn: $useScreenCapture)
+                    }
+                }
+
+                Section("Advanced") {
+                    Toggle(isOn: $isDefault) {
+                        HStack(spacing: 6) {
+                            Text("Set as default")
+                            InfoTip("Default power mode is used when no specific app or website matches are found.")
                         }
                     }
 
-                    if enhancementService.allPrompts.isEmpty {
-                        LabeledContent("Enhancement Prompt") {
-                            Text("No prompts available")
-                                .foregroundColor(.secondary)
-                        }
-                    } else {
-                        Picker("Enhancement Prompt", selection: $selectedPromptId) {
-                            ForEach(enhancementService.allPrompts) { prompt in
-                                Text(prompt.title).tag(prompt.id as UUID?)
-                            }
+                    Toggle(isOn: $isAutoSendEnabled) {
+                        HStack(spacing: 6) {
+                            Text("Auto Send")
+                            InfoTip("Automatically presses the Return/Enter key after pasting text. Useful for chat applications or forms.")
                         }
                     }
 
-                    Toggle("Context Awareness", isOn: $useScreenCapture)
+                    HStack {
+                        Text("Keyboard Shortcut")
+                        InfoTip("Assign a unique keyboard shortcut to instantly activate this Power Mode and start recording.")
+
+                        Spacer()
+
+                        KeyboardShortcuts.Recorder(for: .powerMode(id: powerModeConfigId))
+                            .controlSize(.regular)
+                            .frame(minHeight: 28)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .scrollContentBackground(.hidden)
+            .background(Color(NSColor.controlBackgroundColor))
+            .confirmationDialog(
+                "Delete Power Mode?",
+                isPresented: $isShowingDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                if case .edit(let config) = mode {
+                    Button("Delete", role: .destructive) {
+                        powerModeManager.removeConfiguration(with: config.id)
+                        onDismiss()
+                    }
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                if case .edit(let config) = mode {
+                    Text("Are you sure you want to delete the '\(config.name)' power mode? This action cannot be undone.")
+                }
+            }
+            .powerModeValidationAlert(errors: validationErrors, isPresented: $showValidationAlert)
+            .onAppear {
+                // Set AI provider/model after EnvironmentObjects are available
+                if case .add = mode {
+                    if selectedAIProvider == nil {
+                        selectedAIProvider = aiService.selectedProvider.rawValue
+                    }
+                    if selectedAIModel == nil || selectedAIModel?.isEmpty == true {
+                        selectedAIModel = aiService.currentModel
+                    }
+                }
+
+                if isAIEnhancementEnabled && selectedPromptId == nil {
+                    selectedPromptId = enhancementService.allPrompts.first?.id
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isNameFieldFocused = true
                 }
             }
 
-            Section("Advanced") {
-                Toggle(isOn: $isDefault) {
-                    HStack(spacing: 6) {
-                        Text("Set as default")
-                        InfoTip("Default power mode is used when no specific app or website matches are found.")
-                    }
-                }
-
-                Toggle(isOn: $isAutoSendEnabled) {
-                    HStack(spacing: 6) {
-                        Text("Auto Send")
-                        InfoTip("Automatically presses the Return/Enter key after pasting text. Useful for chat applications or forms.")
-                    }
-                }
-
+            // Footer
+            VStack(spacing: 0) {
                 HStack {
-                    Text("Keyboard Shortcut")
-                    InfoTip("Assign a unique keyboard shortcut to instantly activate this Power Mode and start recording.")
+                    if case .edit = mode {
+                        Button("Delete", role: .destructive) {
+                            isShowingDeleteConfirmation = true
+                        }
+                        .buttonStyle(.bordered)
+                    } else {
+                        Button("Cancel") { onDismiss() }
+                            .keyboardShortcut(.escape, modifiers: [])
+                            .buttonStyle(.plain)
+                            .foregroundColor(.secondary)
+                    }
 
                     Spacer()
 
-                    KeyboardShortcuts.Recorder(for: .powerMode(id: powerModeConfigId))
-                        .controlSize(.regular)
-                        .frame(minHeight: 28)
-                }
-            }
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .background(Color(NSColor.controlBackgroundColor))
-        .navigationTitle(mode.title)
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button("Save") {
-                    saveConfiguration()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!canSave)
-                .buttonStyle(.bordered)
-                .controlSize(.regular)
-                .padding(.horizontal, 4)
-            }
-
-            if case .edit = mode {
-                ToolbarItem {
-                    Button("Delete", role: .destructive) {
-                        isShowingDeleteConfirmation = true
+                    Button {
+                        saveConfiguration()
+                    } label: {
+                        Text("Save Changes")
+                            .frame(minWidth: 100)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.regular)
-                    .padding(.horizontal, 4)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSave)
+                    .keyboardShortcut(.return, modifiers: .command)
                 }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                .background(Color(NSColor.windowBackgroundColor))
             }
         }
-        .confirmationDialog(
-            "Delete Power Mode?",
-            isPresented: $isShowingDeleteConfirmation,
-            titleVisibility: .visible
-        ) {
-            if case .edit(let config) = mode {
-                Button("Delete", role: .destructive) {
-                    powerModeManager.removeConfiguration(with: config.id)
-                    presentationMode.wrappedValue.dismiss()
-                }
-            }
-            Button("Cancel", role: .cancel) { }
-        } message: {
-            if case .edit(let config) = mode {
-                Text("Are you sure you want to delete the '\(config.name)' power mode? This action cannot be undone.")
-            }
-        }
-        .sheet(isPresented: $isShowingAppPicker) {
-            AppPickerSheet(
-                installedApps: filteredApps,
-                selectedAppConfigs: $selectedAppConfigs,
-                searchText: $searchText,
-                onDismiss: { isShowingAppPicker = false }
-            )
-        }
-        .powerModeValidationAlert(errors: validationErrors, isPresented: $showValidationAlert)
-        .onAppear {
-            // Set AI provider and model for new power modes after environment objects are available
-            if case .add = mode {
-                if selectedAIProvider == nil {
-                    selectedAIProvider = aiService.selectedProvider.rawValue
-                }
-                if selectedAIModel == nil || selectedAIModel?.isEmpty == true {
-                    selectedAIModel = aiService.currentModel
-                }
-            }
-            
-            // Select first prompt if AI enhancement is enabled and no prompt is selected
-            if isAIEnhancementEnabled && selectedPromptId == nil {
-                selectedPromptId = enhancementService.allPrompts.first?.id
-            }
+    }
 
-            // Focus the name field for faster keyboard-driven setup
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                isNameFieldFocused = true
-            }
-        }
-    }
-    
-    private var canSave: Bool {
-        return !configName.isEmpty
-    }
-    
+    // MARK: - Actions
+
     private func addWebsite() {
         guard !newWebsiteURL.isEmpty else { return }
-        
         let cleanedURL = powerModeManager.cleanURL(newWebsiteURL)
-        let urlConfig = URLConfig(url: cleanedURL)
-        websiteConfigs.append(urlConfig)
+        websiteConfigs.append(URLConfig(url: cleanedURL))
         newWebsiteURL = ""
     }
-    
-    private func toggleAppSelection(_ app: (url: URL, name: String, bundleId: String, icon: NSImage)) {
-        if let index = selectedAppConfigs.firstIndex(where: { $0.bundleIdentifier == app.bundleId }) {
-            selectedAppConfigs.remove(at: index)
-        } else {
-            let appConfig = AppConfig(bundleIdentifier: app.bundleId, appName: app.name)
-            selectedAppConfigs.append(appConfig)
-        }
-    }
-    
+
     private func getConfigForForm() -> PowerModeConfig {
         let shortcut = KeyboardShortcuts.getShortcut(for: .powerMode(id: powerModeConfigId))
         let hotkeyString = shortcut != nil ? "configured" : nil
 
         switch mode {
         case .add:
-                return PowerModeConfig(
+            return PowerModeConfig(
                 id: powerModeConfigId,
                 name: configName,
                 emoji: selectedEmoji,
                 appConfigs: selectedAppConfigs.isEmpty ? nil : selectedAppConfigs,
                 urlConfigs: websiteConfigs.isEmpty ? nil : websiteConfigs,
-                    isAIEnhancementEnabled: isAIEnhancementEnabled,
-                    selectedPrompt: selectedPromptId?.uuidString,
-                    selectedTranscriptionModelName: selectedTranscriptionModelName,
-                    selectedLanguage: selectedLanguage,
-                    useScreenCapture: useScreenCapture,
-                    selectedAIProvider: selectedAIProvider,
-                    selectedAIModel: selectedAIModel,
-                    isAutoSendEnabled: isAutoSendEnabled,
-                    isDefault: isDefault,
-                    hotkeyShortcut: hotkeyString
-                )
+                isAIEnhancementEnabled: isAIEnhancementEnabled,
+                selectedPrompt: selectedPromptId?.uuidString,
+                selectedTranscriptionModelName: selectedTranscriptionModelName,
+                selectedLanguage: selectedLanguage,
+                useScreenCapture: useScreenCapture,
+                selectedAIProvider: selectedAIProvider,
+                selectedAIModel: selectedAIModel,
+                isAutoSendEnabled: isAutoSendEnabled,
+                isDefault: isDefault,
+                hotkeyShortcut: hotkeyString
+            )
         case .edit(let config):
             var updatedConfig = config
             updatedConfig.name = configName
@@ -589,55 +577,49 @@ struct ConfigurationView: View {
             return updatedConfig
         }
     }
-    
+
     private func loadInstalledApps() {
-        // Get both user-installed and system applications
         let userAppURLs = FileManager.default.urls(for: .applicationDirectory, in: .userDomainMask)
         let localAppURLs = FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask)
         let systemAppURLs = FileManager.default.urls(for: .applicationDirectory, in: .systemDomainMask)
         let allAppURLs = userAppURLs + localAppURLs + systemAppURLs
-        
+
         var allApps: [URL] = []
-        
+
         func scanDirectory(_ baseURL: URL, depth: Int = 0) {
-            // Prevent infinite recursion in case of circular symlinks
+            // Prevent infinite recursion from circular symlinks
             guard depth < 5 else { return }
-            
             guard let enumerator = FileManager.default.enumerator(
                 at: baseURL,
                 includingPropertiesForKeys: [.isApplicationKey, .isDirectoryKey, .isSymbolicLinkKey],
                 options: [.skipsHiddenFiles]
             ) else { return }
-            
+
             for item in enumerator {
                 guard let url = item as? URL else { continue }
-                
                 let resolvedURL = url.resolvingSymlinksInPath()
-                
-                // If it's an app, add it and skip descending into it
+
                 if resolvedURL.pathExtension == "app" {
                     allApps.append(resolvedURL)
                     enumerator.skipDescendants()
                     continue
                 }
-                
-                // Check if this is a symlinked directory we should traverse manually
+
+                // Traverse symlinked directories manually
                 var isDirectory: ObjCBool = false
-                if url != resolvedURL && 
-                   FileManager.default.fileExists(atPath: resolvedURL.path, isDirectory: &isDirectory) && 
+                if url != resolvedURL &&
+                   FileManager.default.fileExists(atPath: resolvedURL.path, isDirectory: &isDirectory) &&
                    isDirectory.boolValue {
-                    // This is a symlinked directory - traverse it manually
                     enumerator.skipDescendants()
                     scanDirectory(resolvedURL, depth: depth + 1)
                 }
             }
         }
-        
-        // Scan all app directories
+
         for baseURL in allAppURLs {
             scanDirectory(baseURL)
         }
-        
+
         installedApps = allApps.compactMap { url in
             guard let bundle = Bundle(url: url),
                   let bundleId = bundle.bundleIdentifier,
@@ -645,27 +627,22 @@ struct ConfigurationView: View {
                             (bundle.infoDictionary?["CFBundleDisplayName"] as? String) else {
                 return nil
             }
-            
             let icon = NSWorkspace.shared.icon(forFile: url.path)
             return (url: url, name: name, bundleId: bundleId, icon: icon)
         }
         .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
-    
+
     private func saveConfiguration() {
-        
-        
         let config = getConfigForForm()
-        
-        // Only validate when the user explicitly tries to save
         let validator = PowerModeValidator(powerModeManager: powerModeManager)
         validationErrors = validator.validateForSave(config: config, mode: mode)
-        
+
         if !validationErrors.isEmpty {
             showValidationAlert = true
             return
         }
-        
+
         if isDefault {
             powerModeManager.setAsDefault(configId: config.id, skipSave: true)
         }
@@ -677,6 +654,6 @@ struct ConfigurationView: View {
             powerModeManager.updateConfiguration(config)
         }
 
-        presentationMode.wrappedValue.dismiss()
+        onDismiss()
     }
 }

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -28,7 +28,7 @@ struct ConfigurationView: View {
     @State private var websiteConfigs: [URLConfig] = []
     @State private var newWebsiteURL: String = ""
     @State private var useScreenCapture = false
-    @State private var isAutoSendEnabled = false
+    @State private var autoSendKey: AutoSendKey = .none
     @State private var isDefault = false
     @State private var isShowingDeleteConfirmation = false
     @State private var powerModeConfigId: UUID = UUID()
@@ -70,7 +70,7 @@ struct ConfigurationView: View {
             _configName = State(initialValue: "")
             _selectedEmoji = State(initialValue: "✏️")
             _useScreenCapture = State(initialValue: false)
-            _isAutoSendEnabled = State(initialValue: false)
+            _autoSendKey = State(initialValue: .none)
             _isDefault = State(initialValue: false)
             // Use UserDefaults directly since EnvironmentObjects aren't available in init
             _selectedAIProvider = State(initialValue: UserDefaults.standard.string(forKey: "selectedAIProvider"))
@@ -88,7 +88,7 @@ struct ConfigurationView: View {
             _selectedAppConfigs = State(initialValue: latestConfig.appConfigs ?? [])
             _websiteConfigs = State(initialValue: latestConfig.urlConfigs ?? [])
             _useScreenCapture = State(initialValue: latestConfig.useScreenCapture)
-            _isAutoSendEnabled = State(initialValue: latestConfig.isAutoSendEnabled)
+            _autoSendKey = State(initialValue: latestConfig.autoSendKey)
             _isDefault = State(initialValue: latestConfig.isDefault)
             _selectedAIProvider = State(initialValue: latestConfig.selectedAIProvider)
             _selectedAIModel = State(initialValue: latestConfig.selectedAIModel)
@@ -432,10 +432,14 @@ struct ConfigurationView: View {
                         }
                     }
 
-                    Toggle(isOn: $isAutoSendEnabled) {
+                    Picker(selection: $autoSendKey) {
+                        ForEach(AutoSendKey.allCases, id: \.self) { key in
+                            Text(key.displayName).tag(key)
+                        }
+                    } label: {
                         HStack(spacing: 6) {
                             Text("Auto Send")
-                            InfoTip("Automatically presses the Return/Enter key after pasting text. Useful for chat applications or forms.")
+                            InfoTip("Automatically presses a key combination after pasting text. Useful for chat applications or forms that use different send shortcuts.")
                         }
                     }
 
@@ -554,7 +558,7 @@ struct ConfigurationView: View {
                 useScreenCapture: useScreenCapture,
                 selectedAIProvider: selectedAIProvider,
                 selectedAIModel: selectedAIModel,
-                isAutoSendEnabled: isAutoSendEnabled,
+                autoSendKey: autoSendKey,
                 isDefault: isDefault,
                 hotkeyShortcut: hotkeyString
             )
@@ -569,7 +573,7 @@ struct ConfigurationView: View {
             updatedConfig.appConfigs = selectedAppConfigs.isEmpty ? nil : selectedAppConfigs
             updatedConfig.urlConfigs = websiteConfigs.isEmpty ? nil : websiteConfigs
             updatedConfig.useScreenCapture = useScreenCapture
-            updatedConfig.isAutoSendEnabled = isAutoSendEnabled
+            updatedConfig.autoSendKey = autoSendKey
             updatedConfig.selectedAIProvider = selectedAIProvider
             updatedConfig.selectedAIModel = selectedAIModel
             updatedConfig.isDefault = isDefault

--- a/VoiceInk/PowerMode/PowerModeView.swift
+++ b/VoiceInk/PowerMode/PowerModeView.swift
@@ -66,7 +66,7 @@ struct PowerModeView: View {
     @State private var configurationMode: ConfigurationMode?
     @State private var isPanelOpen = false
     @State private var panelID = UUID()
-    @State private var isReorderMode = false
+    @State private var isReorderPanelOpen = false
     
     var body: some View {
             VStack(spacing: 0) {
@@ -93,29 +93,28 @@ struct PowerModeView: View {
                         Spacer()
                         
                         HStack(spacing: 8) {
-                            if !isReorderMode {
-                                Button(action: {
-                                    openPanel(mode: .add)
-                                }) {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "plus")
-                                            .font(.system(size: 12, weight: .medium))
-                                        Text("Add Power Mode")
-                                            .font(.system(size: 13, weight: .medium))
-                                    }
-                                    .foregroundColor(.white)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
-                                    .background(Color.accentColor)
-                                    .cornerRadius(6)
-                                }
-                                .buttonStyle(PlainButtonStyle())
-                            }
-                            Button(action: { withAnimation { isReorderMode.toggle() } }) {
+                            Button(action: {
+                                openPanel(mode: .add)
+                            }) {
                                 HStack(spacing: 6) {
-                                    Image(systemName: isReorderMode ? "checkmark" : "arrow.up.arrow.down")
+                                    Image(systemName: "plus")
                                         .font(.system(size: 12, weight: .medium))
-                                    Text(isReorderMode ? "Done" : "Reorder")
+                                    Text("Add Power Mode")
+                                        .font(.system(size: 13, weight: .medium))
+                                }
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Color.accentColor)
+                                .cornerRadius(6)
+                            }
+                            .buttonStyle(PlainButtonStyle())
+
+                            Button(action: { openReorderPanel() }) {
+                                HStack(spacing: 6) {
+                                    Image(systemName: "arrow.up.arrow.down")
+                                        .font(.system(size: 12, weight: .medium))
+                                    Text("Reorder")
                                         .font(.system(size: 13, weight: .medium))
                                 }
                                 .foregroundColor(.primary)
@@ -140,64 +139,6 @@ struct PowerModeView: View {
                 
                 // Content Section
                 Group {
-                    if isReorderMode {
-                        VStack(spacing: 12) {
-                            List {
-                                ForEach(powerModeManager.configurations) { config in
-                                    HStack(spacing: 12) {
-                                        ZStack {
-                                            Circle()
-                                                .fill(Color(NSColor.controlBackgroundColor))
-                                                .frame(width: 40, height: 40)
-                                            Text(config.emoji)
-                                                .font(.system(size: 20))
-                                        }
-
-                                        Text(config.name)
-                                            .font(.system(size: 15, weight: .semibold))
-
-                                        Spacer()
-
-                                        HStack(spacing: 6) {
-                                            if config.isDefault {
-                                                Text("Default")
-                                                    .font(.system(size: 11, weight: .medium))
-                                                    .padding(.horizontal, 6)
-                                                    .padding(.vertical, 2)
-                                                    .background(Capsule().fill(Color.accentColor))
-                                                    .foregroundColor(.white)
-                                            }
-                                            if !config.isEnabled {
-                                                Text("Disabled")
-                                                    .font(.system(size: 11, weight: .medium))
-                                                    .padding(.horizontal, 8)
-                                                    .padding(.vertical, 4)
-                                                    .background(Capsule().fill(Color(NSColor.controlBackgroundColor)))
-                                                    .overlay(
-                                                        Capsule().stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                                                    )
-                                                    .foregroundColor(.secondary)
-                                            }
-                                        }
-                                    }
-                                    .padding(.vertical, 12)
-                                    .padding(.horizontal, 14)
-                                    .background(CardBackground(isSelected: false))
-                                    .listRowInsets(EdgeInsets())
-                                    .listRowBackground(Color.clear)
-                                    .listRowSeparator(.hidden)
-                                    .padding(.vertical, 6)
-                                }
-                                .onMove(perform: powerModeManager.moveConfigurations)
-                            }
-                            .listStyle(.plain)
-                            .listRowSeparator(.hidden)
-                            .scrollContentBackground(.hidden)
-                            .background(Color(NSColor.controlBackgroundColor))
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 20)
-                    } else {
                         GeometryReader { geometry in
                             ScrollView {
                                 VStack(spacing: 0) {
@@ -246,7 +187,6 @@ struct PowerModeView: View {
                                 }
                             }
                         }
-                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color(NSColor.controlBackgroundColor))
@@ -260,6 +200,12 @@ struct PowerModeView: View {
                     ConfigurationView(mode: mode, powerModeManager: powerModeManager, onDismiss: closePanel)
                         .id(panelID)
                 }
+            }
+            .slidingPanel(isPresented: .init(
+                get: { isReorderPanelOpen },
+                set: { if !$0 { closeReorderPanel() } }
+            ), width: 450) {
+                ReorderPanelView(powerModeManager: powerModeManager, onDismiss: closeReorderPanel)
             }
     }
 
@@ -276,6 +222,105 @@ struct PowerModeView: View {
             isPanelOpen = false
             configurationMode = nil
         }
+    }
+
+    private func openReorderPanel() {
+        withAnimation(.smooth(duration: 0.3)) {
+            isReorderPanelOpen = true
+        }
+    }
+
+    private func closeReorderPanel() {
+        withAnimation(.smooth(duration: 0.3)) {
+            isReorderPanelOpen = false
+        }
+    }
+}
+
+struct ReorderPanelView: View {
+    @ObservedObject var powerModeManager: PowerModeManager
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Reorder Power Modes")
+                    .font(.system(size: 16, weight: .semibold))
+                Spacer()
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .padding(.bottom, 16)
+
+            Divider()
+
+            // Reorder list
+            List {
+                ForEach(powerModeManager.configurations) { config in
+                    HStack(spacing: 12) {
+                        Image(systemName: "line.3.horizontal")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+
+                        ZStack {
+                            Circle()
+                                .fill(Color(NSColor.controlBackgroundColor))
+                                .frame(width: 36, height: 36)
+                            Text(config.emoji)
+                                .font(.system(size: 18))
+                        }
+
+                        Text(config.name)
+                            .font(.system(size: 14, weight: .medium))
+
+                        Spacer()
+
+                        HStack(spacing: 6) {
+                            if config.isDefault {
+                                Text("Default")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Capsule().fill(Color.accentColor))
+                                    .foregroundColor(.white)
+                            }
+                            if !config.isEnabled {
+                                Text("Disabled")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(Capsule().fill(Color(NSColor.controlBackgroundColor)))
+                                    .overlay(
+                                        Capsule().stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+                                    )
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color(NSColor.controlBackgroundColor))
+                    )
+                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                }
+                .onMove(perform: powerModeManager.moveConfigurations)
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .padding(.top, 8)
+        }
+        .background(Color(NSColor.windowBackgroundColor))
     }
 }
 

--- a/VoiceInk/PowerMode/PowerModeView.swift
+++ b/VoiceInk/PowerMode/PowerModeView.swift
@@ -64,11 +64,11 @@ struct PowerModeView: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService
     @EnvironmentObject private var aiService: AIService
     @State private var configurationMode: ConfigurationMode?
-    @State private var navigationPath = NavigationPath()
+    @State private var isPanelOpen = false
+    @State private var panelID = UUID()
     @State private var isReorderMode = false
     
     var body: some View {
-        NavigationStack(path: $navigationPath) {
             VStack(spacing: 0) {
                 // Header Section
                 VStack(spacing: 12) {
@@ -95,8 +95,7 @@ struct PowerModeView: View {
                         HStack(spacing: 8) {
                             if !isReorderMode {
                                 Button(action: {
-                                    configurationMode = .add
-                                    navigationPath.append(configurationMode!)
+                                    openPanel(mode: .add)
                                 }) {
                                     HStack(spacing: 6) {
                                         Image(systemName: "plus")
@@ -234,8 +233,7 @@ struct PowerModeView: View {
                                             PowerModeConfigurationsGrid(
                                                 powerModeManager: powerModeManager,
                                                 onEditConfig: { config in
-                                                    configurationMode = .edit(config)
-                                                    navigationPath.append(configurationMode!)
+                                                    openPanel(mode: .edit(config))
                                                 }
                                             )
                                             .padding(.horizontal, 24)
@@ -254,9 +252,29 @@ struct PowerModeView: View {
                 .background(Color(NSColor.controlBackgroundColor))
             }
             .background(Color(NSColor.controlBackgroundColor))
-            .navigationDestination(for: ConfigurationMode.self) { mode in
-                ConfigurationView(mode: mode, powerModeManager: powerModeManager)
+            .slidingPanel(isPresented: .init(
+                get: { isPanelOpen },
+                set: { if !$0 { closePanel() } }
+            ), width: 450) {
+                if let mode = configurationMode {
+                    ConfigurationView(mode: mode, powerModeManager: powerModeManager, onDismiss: closePanel)
+                        .id(panelID)
+                }
             }
+    }
+
+    private func openPanel(mode: ConfigurationMode) {
+        configurationMode = mode
+        panelID = UUID()
+        withAnimation(.smooth(duration: 0.3)) {
+            isPanelOpen = true
+        }
+    }
+
+    private func closePanel() {
+        withAnimation(.smooth(duration: 0.3)) {
+            isPanelOpen = false
+            configurationMode = nil
         }
     }
 }

--- a/VoiceInk/PowerMode/PowerModeView.swift
+++ b/VoiceInk/PowerMode/PowerModeView.swift
@@ -249,11 +249,15 @@ struct ReorderPanelView: View {
                     .font(.system(size: 16, weight: .semibold))
                 Spacer()
                 Button(action: onDismiss) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 18))
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .medium))
                         .foregroundColor(.secondary)
+                        .padding(6)
+                        .background(Color.secondary.opacity(0.1))
+                        .clipShape(Circle())
                 }
-                .buttonStyle(PlainButtonStyle())
+                .buttonStyle(.plain)
+                .help("Close")
             }
             .padding(.horizontal, 20)
             .padding(.top, 16)

--- a/VoiceInk/PowerMode/PowerModeView.swift
+++ b/VoiceInk/PowerMode/PowerModeView.swift
@@ -244,9 +244,11 @@ struct ReorderPanelView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            HStack {
+            HStack(spacing: 12) {
                 Text("Reorder Power Modes")
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
                 Spacer()
                 Button(action: onDismiss) {
                     Image(systemName: "xmark")
@@ -260,10 +262,9 @@ struct ReorderPanelView: View {
                 .help("Close")
             }
             .padding(.horizontal, 20)
-            .padding(.top, 16)
-            .padding(.bottom, 16)
-
-            Divider()
+            .padding(.vertical, 16)
+            .background(Color(NSColor.windowBackgroundColor))
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
 
             // Reorder list
             List {

--- a/VoiceInk/PowerMode/PowerModeViewComponents.swift
+++ b/VoiceInk/PowerMode/PowerModeViewComponents.swift
@@ -211,7 +211,7 @@ struct ConfigurationRow: View {
             .padding(.vertical, 12)
             .padding(.horizontal, 14)
             
-            if selectedModel != nil || selectedLanguage != nil || config.isAIEnhancementEnabled || config.isAutoSendEnabled {
+            if selectedModel != nil || selectedLanguage != nil || config.isAIEnhancementEnabled || config.autoSendKey.isEnabled {
                 Divider()
                 
                 HStack(spacing: 8) {
@@ -266,11 +266,11 @@ struct ConfigurationRow: View {
                         )
                     }
                     
-                    if config.isAutoSendEnabled {
+                    if config.autoSendKey.isEnabled {
                         HStack(spacing: 4) {
                             Image(systemName: "keyboard")
                                 .font(.system(size: 10))
-                            Text("Auto Send")
+                            Text(config.autoSendKey.displayName)
                                 .font(.caption)
                         }
                         .padding(.horizontal, 6)

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -83,7 +83,6 @@ class AIEnhancementService: ObservableObject {
         self.isEnhancementEnabled = UserDefaults.standard.bool(forKey: "isAIEnhancementEnabled")
         self.useClipboardContext = UserDefaults.standard.bool(forKey: "useClipboardContext")
         self.useScreenCaptureContext = UserDefaults.standard.bool(forKey: "useScreenCaptureContext")
-
         if let savedPromptsData = UserDefaults.standard.data(forKey: "customPrompts"),
            let decodedPrompts = try? JSONDecoder().decode([CustomPrompt].self, from: savedPromptsData) {
             self.customPrompts = decodedPrompts

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -217,12 +217,16 @@ class AIService: ObservableObject {
     }
     
     var availableModels: [String] {
-        if selectedProvider == .ollama {
+        availableModels(for: selectedProvider)
+    }
+
+    func availableModels(for provider: AIProvider) -> [String] {
+        if provider == .ollama {
             return ollamaService.availableModels.map { $0.name }
-        } else if selectedProvider == .openRouter {
+        } else if provider == .openRouter {
             return openRouterModels
         }
-        return selectedProvider.availableModels
+        return provider.availableModels
     }
     
     init() {

--- a/VoiceInk/Services/WordCounter.swift
+++ b/VoiceInk/Services/WordCounter.swift
@@ -1,0 +1,9 @@
+import NaturalLanguage
+
+struct WordCounter {
+    static func count(in text: String) -> Int {
+        let tokenizer = NLTokenizer(unit: .word)
+        tokenizer.string = text
+        return tokenizer.tokens(for: text.startIndex..<text.endIndex).count
+    }
+}

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -93,13 +93,12 @@ struct ModelManagementView: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 16)
             .background(Color(NSColor.windowBackgroundColor))
-            .overlay(Divider().opacity(0.5), alignment: .bottom)
+            .overlay(
+                Divider().opacity(0.5), alignment: .bottom
+            )
 
             // Content
-            ScrollView {
-                ModelSettingsView(whisperPrompt: whisperPrompt)
-                    .padding(20)
-            }
+            ModelSettingsView(whisperPrompt: whisperPrompt)
         }
     }
     

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -25,12 +25,20 @@ struct ModelManagementView: View {
 
     @State private var selectedFilter: ModelFilter = .recommended
     @State private var isShowingSettings = false
-    
+
+    private let settingsPanelWidth: CGFloat = 400
+
     // State for the unified alert
     @State private var isShowingDeleteAlert = false
     @State private var alertTitle = ""
     @State private var alertMessage = ""
     @State private var deleteActionClosure: () -> Void = {}
+
+    private func closeSettings() {
+        withAnimation(.smooth(duration: 0.3)) {
+            isShowingSettings = false
+        }
+    }
 
     var body: some View {
         ScrollView {
@@ -47,6 +55,9 @@ struct ModelManagementView: View {
         }
         .frame(minWidth: 600, minHeight: 500)
         .background(Color(NSColor.controlBackgroundColor))
+        .slidingPanel(isPresented: $isShowingSettings, width: settingsPanelWidth) {
+            settingsPanelContent
+        }
         .alert(isPresented: $isShowingDeleteAlert) {
             Alert(
                 title: Text(alertTitle),
@@ -54,6 +65,41 @@ struct ModelManagementView: View {
                 primaryButton: .destructive(Text("Delete"), action: deleteActionClosure),
                 secondaryButton: .cancel()
             )
+        }
+    }
+
+    private var settingsPanelContent: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack(spacing: 12) {
+                Text("Model Settings")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                Button(action: { closeSettings() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .padding(6)
+                        .background(Color.secondary.opacity(0.1))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Close")
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .background(Color(NSColor.windowBackgroundColor))
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
+
+            // Content
+            ScrollView {
+                ModelSettingsView(whisperPrompt: whisperPrompt)
+                    .padding(20)
+            }
         }
     }
     
@@ -104,7 +150,7 @@ struct ModelManagementView: View {
                 Spacer()
                 
                 Button(action: {
-                    withAnimation(.easeInOut(duration: 0.2)) {
+                    withAnimation(.smooth(duration: 0.3)) {
                         isShowingSettings.toggle()
                     }
                 }) {
@@ -120,10 +166,7 @@ struct ModelManagementView: View {
             }
             .padding(.bottom, 12)
             
-            if isShowingSettings {
-                ModelSettingsView(whisperPrompt: whisperPrompt)
-            } else {
-                VStack(spacing: 12) {
+            VStack(spacing: 12) {
                     ForEach(filteredModels, id: \.id) { model in
                         let isWarming = (model as? LocalModel).map { localModel in
                             warmupCoordinator.isWarming(modelNamed: localModel.name)
@@ -211,9 +254,10 @@ struct ModelManagementView: View {
                     }
                 }
             }
-        }
         .padding()
     }
+
+
 
     private var intelMacWarningBanner: some View {
         HStack(spacing: 10) {

--- a/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
+++ b/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct EnhancementSettingsPanel: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService
-    @AppStorage("SkipShortEnhancement") private var isSkipShortEnhancementEnabled = false
-    @AppStorage("ShortEnhancementWordThreshold") private var shortEnhancementWordThreshold = 5
+    @AppStorage("SkipShortEnhancement") private var isSkipShortEnhancementEnabled = true
+    @AppStorage("ShortEnhancementWordThreshold") private var shortEnhancementWordThreshold = 3
     @State private var isShortEnhancementExpanded = false
     @State private var isHandlingToggleChange = false
 

--- a/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
+++ b/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+struct EnhancementSettingsPanel: View {
+    @EnvironmentObject private var enhancementService: AIEnhancementService
+    @AppStorage("SkipShortEnhancement") private var isSkipShortEnhancementEnabled = false
+    @AppStorage("ShortEnhancementWordThreshold") private var shortEnhancementWordThreshold = 5
+    @State private var isShortEnhancementExpanded = false
+    @State private var isHandlingToggleChange = false
+
+    var onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack(spacing: 12) {
+                Text("Enhancement Settings")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .padding(6)
+                        .background(Color.secondary.opacity(0.1))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Close")
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .background(Color(NSColor.windowBackgroundColor))
+            .overlay(
+                Divider().opacity(0.5), alignment: .bottom
+            )
+
+            // Content
+            Form {
+                Section {
+                    Toggle(isOn: $enhancementService.useClipboardContext) {
+                        HStack(spacing: 4) {
+                            Text("Clipboard Context")
+                            InfoTip("Use clipboard text to understand context for better enhancement.")
+                        }
+                    }
+                    .toggleStyle(.switch)
+
+                    Toggle(isOn: $enhancementService.useScreenCaptureContext) {
+                        HStack(spacing: 4) {
+                            Text("Screen Context")
+                            InfoTip("Capture on-screen text to understand context for better enhancement.")
+                        }
+                    }
+                    .toggleStyle(.switch)
+                } header: {
+                    Text("Context")
+                }
+
+                Section {
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack {
+                            Toggle(isOn: Binding(
+                                get: { isSkipShortEnhancementEnabled },
+                                set: { newValue in
+                                    isHandlingToggleChange = true
+                                    isSkipShortEnhancementEnabled = newValue
+                                    if newValue {
+                                        withAnimation(.easeInOut(duration: 0.2)) {
+                                            isShortEnhancementExpanded = true
+                                        }
+                                    } else {
+                                        withAnimation(.easeInOut(duration: 0.2)) {
+                                            isShortEnhancementExpanded = false
+                                        }
+                                    }
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                        isHandlingToggleChange = false
+                                    }
+                                }
+                            )) {
+                                HStack(spacing: 4) {
+                                    Text("Skip short transcriptions")
+                                    InfoTip("Automatically skip AI enhancement when the transcription has very few words. Short phrases like \"yes\", \"thank you\", or quick commands don't benefit from enhancement.")
+                                }
+                            }
+                            .toggleStyle(.switch)
+
+                            Spacer()
+
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundColor(.secondary)
+                                .rotationEffect(.degrees(isSkipShortEnhancementEnabled && isShortEnhancementExpanded ? 90 : 0))
+                                .opacity(isSkipShortEnhancementEnabled ? 1 : 0.4)
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            guard !isHandlingToggleChange else { return }
+                            if isSkipShortEnhancementEnabled {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    isShortEnhancementExpanded.toggle()
+                                }
+                            }
+                        }
+
+                        if isSkipShortEnhancementEnabled && isShortEnhancementExpanded {
+                            Picker("Minimum words", selection: $shortEnhancementWordThreshold) {
+                                ForEach(1...15, id: \.self) { count in
+                                    Text("\(count) \(count == 1 ? "word" : "words")").tag(count)
+                                }
+                            }
+                            .padding(.top, 12)
+                            .padding(.leading, 4)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                        }
+                    }
+                    .animation(.easeInOut(duration: 0.2), value: isShortEnhancementExpanded)
+                }
+
+                Section {
+                    EnhancementShortcutsView()
+                } header: {
+                    Text("Shortcuts")
+                }
+            }
+            .formStyle(.grouped)
+            .scrollContentBackground(.hidden)
+        }
+    }
+}

--- a/VoiceInk/Views/Components/FillerWordsSettingsView.swift
+++ b/VoiceInk/Views/Components/FillerWordsSettingsView.swift
@@ -46,12 +46,12 @@ struct FillerWordsSettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Toggle(isOn: $removeFillerWords) {
-                    Text("Remove filler words")
-                }
-                .toggleStyle(.switch)
-
+                Text("Remove filler words")
                 InfoTip("Automatically remove filler words like 'uh', 'um', 'hmm' from transcriptions.")
+                Spacer()
+                Toggle("", isOn: $removeFillerWords)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
             }
 
             if removeFillerWords {
@@ -59,7 +59,6 @@ struct FillerWordsSettingsView: View {
                     HStack(spacing: 8) {
                         TextField("Add filler word", text: $newWord)
                             .textFieldStyle(.roundedBorder)
-                            .font(.system(size: 12))
                             .onSubmit { addWord() }
 
                         Button(action: addWord) {
@@ -72,6 +71,7 @@ struct FillerWordsSettingsView: View {
                         .help("Add filler word")
                         .disabled(newWord.trimmingCharacters(in: .whitespaces).isEmpty)
                     }
+                    .padding(.vertical, 4)
 
                     if !fillerWordManager.fillerWords.isEmpty {
                         FlowLayout(spacing: 6) {

--- a/VoiceInk/Views/Components/SlidingPanel.swift
+++ b/VoiceInk/Views/Components/SlidingPanel.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct SlidingPanel<PanelContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let panelWidth: CGFloat
+    @ViewBuilder let panelContent: () -> PanelContent
+
+    func body(content: Content) -> some View {
+        ZStack(alignment: .topLeading) {
+            content
+                .disabled(isPresented)
+
+            Color.black.opacity(isPresented ? 0.1 : 0)
+                .ignoresSafeArea()
+                .allowsHitTesting(isPresented)
+                .onTapGesture {
+                    withAnimation(.smooth(duration: 0.3)) {
+                        isPresented = false
+                    }
+                }
+                .animation(.smooth(duration: 0.3), value: isPresented)
+                .zIndex(1)
+
+            if isPresented {
+                HStack(spacing: 0) {
+                    Spacer()
+
+                    panelContent()
+                        .frame(width: panelWidth)
+                        .frame(maxHeight: .infinity)
+                        .background(Color(NSColor.windowBackgroundColor))
+                        .overlay(Divider(), alignment: .leading)
+                        .shadow(color: .black.opacity(0.08), radius: 8, x: -2, y: 0)
+                }
+                .ignoresSafeArea()
+                .transition(.offset(x: panelWidth))
+                .zIndex(2)
+            }
+        }
+    }
+}
+
+extension View {
+    func slidingPanel<Content: View>(
+        isPresented: Binding<Bool>,
+        width: CGFloat = 450,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        modifier(SlidingPanel(isPresented: isPresented, panelWidth: width, panelContent: content))
+    }
+}

--- a/VoiceInk/Views/Dictionary/EditReplacementSheet.swift
+++ b/VoiceInk/Views/Dictionary/EditReplacementSheet.swift
@@ -24,7 +24,7 @@ struct EditReplacementSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
+                .overlay(Divider().opacity(0.5), alignment: .bottom)
             formContent
         }
         .frame(width: 460, height: 560)

--- a/VoiceInk/Views/EnhancementSettingsView.swift
+++ b/VoiceInk/Views/EnhancementSettingsView.swift
@@ -6,161 +6,144 @@ struct EnhancementSettingsView: View {
     @State private var isEditingPrompt = false
     @State private var isShortcutsExpanded = false
     @State private var selectedPromptForEdit: CustomPrompt?
-    
+    @State private var panelID = UUID()
+
+    private let panelWidth: CGFloat = 450
+
     private var isPanelOpen: Bool {
         isEditingPrompt || selectedPromptForEdit != nil
     }
-    
+
+    private func openPanel() {
+        panelID = UUID()
+    }
+
     private func closePanel() {
-        withAnimation(.spring(response: 0.4, dampingFraction: 0.9)) {
+        withAnimation(.smooth(duration: 0.3)) {
             isEditingPrompt = false
             selectedPromptForEdit = nil
         }
     }
     
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            Form {
-                Section {
-                    Toggle(isOn: $enhancementService.isEnhancementEnabled) {
+        Form {
+            Section {
+                Toggle(isOn: $enhancementService.isEnhancementEnabled) {
+                    HStack(spacing: 4) {
+                        Text("Enable Enhancement")
+                        InfoTip(
+                            "AI enhancement lets you pass the transcribed audio through LLMs to post-process using different prompts suitable for different use cases like e-mails, summary, writing, etc.",
+                            learnMoreURL: "https://tryvoiceink.com/docs/enhancements-configuring-models"
+                        )
+                    }
+                }
+                .toggleStyle(.switch)
+
+                HStack(spacing: 24) {
+                    Toggle(isOn: $enhancementService.useClipboardContext) {
                         HStack(spacing: 4) {
-                            Text("Enable Enhancement")
-                            InfoTip(
-                                "AI enhancement lets you pass the transcribed audio through LLMs to post-process using different prompts suitable for different use cases like e-mails, summary, writing, etc.",
-                                learnMoreURL: "https://tryvoiceink.com/docs/enhancements-configuring-models"
-                            )
+                            Text("Clipboard Context")
+                            InfoTip("Use clipboard text to understand context for better enhancement.")
                         }
                     }
                     .toggleStyle(.switch)
-                    
-                    HStack(spacing: 24) {
-                        Toggle(isOn: $enhancementService.useClipboardContext) {
-                            HStack(spacing: 4) {
-                                Text("Clipboard Context")
-                                InfoTip("Use clipboard text to understand context for better enhancement.")
-                            }
-                        }
-                        .toggleStyle(.switch)
 
-                        Toggle(isOn: $enhancementService.useScreenCaptureContext) {
-                            HStack(spacing: 4) {
-                                Text("Screen Context")
-                                InfoTip("Capture on-screen text to understand context for better enhancement.")
-                            }
+                    Toggle(isOn: $enhancementService.useScreenCaptureContext) {
+                        HStack(spacing: 4) {
+                            Text("Screen Context")
+                            InfoTip("Capture on-screen text to understand context for better enhancement.")
                         }
-                        .toggleStyle(.switch)
                     }
-                    .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
-                } header: {
-                    Text("General")
-                }
-                
-                APIKeyManagementView()
-                    .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
-                
-                Section {
-                    ReorderablePromptGrid(
-                        selectedPromptId: enhancementService.selectedPromptId,
-                        onPromptSelected: { prompt in
-                            enhancementService.setActivePrompt(prompt)
-                        },
-                        onEditPrompt: { prompt in
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.9)) {
-                                selectedPromptForEdit = prompt
-                            }
-                        },
-                        onDeletePrompt: { prompt in
-                            enhancementService.deletePrompt(prompt)
-                        }
-                    )
-                    .padding(.vertical, 8)
-                } header: {
-                    HStack {
-                        Text("Enhancement Prompts")
-                        Spacer()
-                        Button {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.9)) {
-                                isEditingPrompt = true
-                            }
-                        } label: {
-                            Image(systemName: "plus.circle.fill")
-                                .font(.system(size: 18))
-                                .symbolRenderingMode(.hierarchical)
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                        .help("Add new prompt")
-                    }
+                    .toggleStyle(.switch)
                 }
                 .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
-                
-                Section {
-                    DisclosureGroup(isExpanded: $isShortcutsExpanded) {
-                        EnhancementShortcutsView()
-                            .padding(.vertical, 8)
-                    } label: {
-                        HStack {
-                            Text("Shortcuts")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                            Spacer()
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation {
-                                isShortcutsExpanded.toggle()
-                            }
-                        }
-                    }
-                }
-                .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
+            } header: {
+                Text("General")
             }
-            .formStyle(.grouped)
-            .scrollContentBackground(.hidden)
-            .background(Color(NSColor.controlBackgroundColor))
-            .disabled(isPanelOpen)
-            .blur(radius: isPanelOpen ? 2 : 0)
-            .animation(.spring(response: 0.4, dampingFraction: 0.9), value: isPanelOpen)
-            
-            if isPanelOpen {
-                Color.black.opacity(0.2)
-                    .ignoresSafeArea()
+
+            APIKeyManagementView()
+                .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
+
+            Section {
+                ReorderablePromptGrid(
+                    selectedPromptId: enhancementService.selectedPromptId,
+                    onPromptSelected: { prompt in
+                        enhancementService.setActivePrompt(prompt)
+                    },
+                    onEditPrompt: { prompt in
+                        openPanel()
+                        withAnimation(.smooth(duration: 0.3)) {
+                            selectedPromptForEdit = prompt
+                        }
+                    },
+                    onDeletePrompt: { prompt in
+                        enhancementService.deletePrompt(prompt)
+                    }
+                )
+                .padding(.vertical, 8)
+            } header: {
+                HStack {
+                    Text("Enhancement Prompts")
+                    Spacer()
+                    Button {
+                        openPanel()
+                        withAnimation(.smooth(duration: 0.3)) {
+                            isEditingPrompt = true
+                        }
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 18))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Add new prompt")
+                }
+            }
+            .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
+
+            Section {
+                DisclosureGroup(isExpanded: $isShortcutsExpanded) {
+                    EnhancementShortcutsView()
+                        .padding(.vertical, 8)
+                } label: {
+                    HStack {
+                        Text("Shortcuts")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
                     .onTapGesture {
+                        withAnimation {
+                            isShortcutsExpanded.toggle()
+                        }
+                    }
+                }
+            }
+            .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .background(Color(NSColor.controlBackgroundColor))
+        .slidingPanel(isPresented: .init(
+            get: { isPanelOpen },
+            set: { newValue in
+                if !newValue { closePanel() }
+            }
+        ), width: panelWidth) {
+            Group {
+                if let prompt = selectedPromptForEdit {
+                    PromptEditorView(mode: .edit(prompt)) {
                         closePanel()
                     }
-                    .transition(.opacity)
-                    .zIndex(1)
-            }
-            
-            if isPanelOpen {
-                HStack(spacing: 0) {
-                    Spacer()
-                    
-                    Group {
-                        if let prompt = selectedPromptForEdit {
-                            PromptEditorView(mode: .edit(prompt)) {
-                                closePanel()
-                            }
-                        } else if isEditingPrompt {
-                            PromptEditorView(mode: .add) {
-                                closePanel()
-                            }
-                        }
+                } else if isEditingPrompt {
+                    PromptEditorView(mode: .add) {
+                        closePanel()
                     }
-                    .frame(width: 450)
-                    .frame(maxHeight: .infinity)
-                    .background(
-                        Color(NSColor.windowBackgroundColor)
-                    )
-                    .overlay(
-                        Divider(), alignment: .leading
-                    )
-                    .shadow(color: .black.opacity(0.15), radius: 12, x: -4, y: 0)
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
-                .ignoresSafeArea()
-                .zIndex(2)
             }
+            .id(panelID)
         }
         .frame(minWidth: 500, minHeight: 400)
     }

--- a/VoiceInk/Views/EnhancementSettingsView.swift
+++ b/VoiceInk/Views/EnhancementSettingsView.swift
@@ -4,17 +4,29 @@ import UniformTypeIdentifiers
 struct EnhancementSettingsView: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService
     @State private var isEditingPrompt = false
-    @State private var isShortcutsExpanded = false
+    @State private var isShowingSettings = false
     @State private var selectedPromptForEdit: CustomPrompt?
     @State private var panelID = UUID()
 
     private let panelWidth: CGFloat = 450
 
-    private var isPanelOpen: Bool {
-        isEditingPrompt || selectedPromptForEdit != nil
+    private enum PanelType {
+        case promptEditor
+        case settings
     }
 
-    private func openPanel() {
+    private var activePanel: PanelType? {
+        if isShowingSettings { return .settings }
+        if isEditingPrompt || selectedPromptForEdit != nil { return .promptEditor }
+        return nil
+    }
+
+    private var isPanelOpen: Bool {
+        activePanel != nil
+    }
+
+    private func openPromptPanel() {
+        isShowingSettings = false
         panelID = UUID()
     }
 
@@ -22,9 +34,10 @@ struct EnhancementSettingsView: View {
         withAnimation(.smooth(duration: 0.3)) {
             isEditingPrompt = false
             selectedPromptForEdit = nil
+            isShowingSettings = false
         }
     }
-    
+
     var body: some View {
         Form {
             Section {
@@ -38,27 +51,24 @@ struct EnhancementSettingsView: View {
                     }
                 }
                 .toggleStyle(.switch)
-
-                HStack(spacing: 24) {
-                    Toggle(isOn: $enhancementService.useClipboardContext) {
-                        HStack(spacing: 4) {
-                            Text("Clipboard Context")
-                            InfoTip("Use clipboard text to understand context for better enhancement.")
-                        }
-                    }
-                    .toggleStyle(.switch)
-
-                    Toggle(isOn: $enhancementService.useScreenCaptureContext) {
-                        HStack(spacing: 4) {
-                            Text("Screen Context")
-                            InfoTip("Capture on-screen text to understand context for better enhancement.")
-                        }
-                    }
-                    .toggleStyle(.switch)
-                }
-                .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
             } header: {
-                Text("General")
+                HStack {
+                    Text("General")
+                    Spacer()
+                    Button {
+                        withAnimation(.smooth(duration: 0.3)) {
+                            isEditingPrompt = false
+                            selectedPromptForEdit = nil
+                            isShowingSettings.toggle()
+                        }
+                    } label: {
+                        Image(systemName: "gear")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(isShowingSettings ? .accentColor : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Enhancement settings")
+                }
             }
 
             APIKeyManagementView()
@@ -71,7 +81,7 @@ struct EnhancementSettingsView: View {
                         enhancementService.setActivePrompt(prompt)
                     },
                     onEditPrompt: { prompt in
-                        openPanel()
+                        openPromptPanel()
                         withAnimation(.smooth(duration: 0.3)) {
                             selectedPromptForEdit = prompt
                         }
@@ -86,7 +96,7 @@ struct EnhancementSettingsView: View {
                     Text("Enhancement Prompts")
                     Spacer()
                     Button {
-                        openPanel()
+                        openPromptPanel()
                         withAnimation(.smooth(duration: 0.3)) {
                             isEditingPrompt = true
                         }
@@ -101,27 +111,6 @@ struct EnhancementSettingsView: View {
                 }
             }
             .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
-
-            Section {
-                DisclosureGroup(isExpanded: $isShortcutsExpanded) {
-                    EnhancementShortcutsView()
-                        .padding(.vertical, 8)
-                } label: {
-                    HStack {
-                        Text("Shortcuts")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                        Spacer()
-                    }
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        withAnimation {
-                            isShortcutsExpanded.toggle()
-                        }
-                    }
-                }
-            }
-            .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.8)
         }
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
@@ -133,17 +122,26 @@ struct EnhancementSettingsView: View {
             }
         ), width: panelWidth) {
             Group {
-                if let prompt = selectedPromptForEdit {
-                    PromptEditorView(mode: .edit(prompt)) {
-                        closePanel()
+                switch activePanel {
+                case .settings:
+                    EnhancementSettingsPanel(onDismiss: closePanel)
+                case .promptEditor:
+                    Group {
+                        if let prompt = selectedPromptForEdit {
+                            PromptEditorView(mode: .edit(prompt)) {
+                                closePanel()
+                            }
+                        } else if isEditingPrompt {
+                            PromptEditorView(mode: .add) {
+                                closePanel()
+                            }
+                        }
                     }
-                } else if isEditingPrompt {
-                    PromptEditorView(mode: .add) {
-                        closePanel()
-                    }
+                    .id(panelID)
+                case nil:
+                    EmptyView()
                 }
             }
-            .id(panelID)
         }
         .frame(minWidth: 500, minHeight: 400)
     }
@@ -152,14 +150,14 @@ struct EnhancementSettingsView: View {
 // MARK: - Reorderable Grid
 private struct ReorderablePromptGrid: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService
-    
+
     let selectedPromptId: UUID?
     let onPromptSelected: (CustomPrompt) -> Void
     let onEditPrompt: ((CustomPrompt) -> Void)?
     let onDeletePrompt: ((CustomPrompt) -> Void)?
-    
+
     @State private var draggingItem: CustomPrompt?
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             if enhancementService.customPrompts.isEmpty {
@@ -170,7 +168,7 @@ private struct ReorderablePromptGrid: View {
                 let columns = [
                     GridItem(.adaptive(minimum: 80, maximum: 100), spacing: 36)
                 ]
-                
+
                 LazyVGrid(columns: columns, spacing: 16) {
                     ForEach(enhancementService.customPrompts) { prompt in
                         prompt.promptIcon(
@@ -211,12 +209,12 @@ private struct ReorderablePromptGrid: View {
                 }
                 .padding(.vertical, 12)
                 .padding(.horizontal, 16)
-                
+
                 HStack {
                     Image(systemName: "info.circle")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                    
+
                     Text("Double-click to edit • Right-click for more options")
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -233,12 +231,12 @@ private struct PromptDropDelegate: DropDelegate {
     let item: CustomPrompt
     @Binding var prompts: [CustomPrompt]
     @Binding var draggingItem: CustomPrompt?
-    
+
     func dropEntered(info: DropInfo) {
         guard let draggingItem = draggingItem, draggingItem != item else { return }
         guard let fromIndex = prompts.firstIndex(of: draggingItem),
               let toIndex = prompts.firstIndex(of: item) else { return }
-        
+
         if prompts[toIndex].id != draggingItem.id {
             withAnimation(.easeInOut(duration: 0.12)) {
                 let from = fromIndex
@@ -247,11 +245,11 @@ private struct PromptDropDelegate: DropDelegate {
             }
         }
     }
-    
+
     func dropUpdated(info: DropInfo) -> DropProposal? {
         DropProposal(operation: .move)
     }
-    
+
     func performDrop(info: DropInfo) -> Bool {
         draggingItem = nil
         return true

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -13,32 +13,35 @@ struct ModelSettingsView: View {
     var body: some View {
         Form {
             Section {
-                if isEditing {
-                    TextEditor(text: $customPrompt)
-                        .font(.system(size: 12))
-                        .frame(height: 80)
-                        .scrollContentBackground(.hidden)
+                VStack(alignment: .leading, spacing: 8) {
+                    if isEditing {
+                        TextEditor(text: $customPrompt)
+                            .font(.system(size: 12))
+                            .frame(minHeight: 40, maxHeight: 80)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .scrollContentBackground(.hidden)
 
-                    Button("Save") {
-                        whisperPrompt.setCustomPrompt(customPrompt, for: selectedLanguage)
-                        isEditing = false
-                    }
-                } else {
-                    Text(whisperPrompt.getLanguagePrompt(for: selectedLanguage))
-                        .font(.system(size: 12))
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        Button("Save") {
+                            whisperPrompt.setCustomPrompt(customPrompt, for: selectedLanguage)
+                            isEditing = false
+                        }
+                    } else {
+                        Text(whisperPrompt.getLanguagePrompt(for: selectedLanguage))
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                    Button("Edit") {
-                        customPrompt = whisperPrompt.getLanguagePrompt(for: selectedLanguage)
-                        isEditing = true
+                        Button("Edit") {
+                            customPrompt = whisperPrompt.getLanguagePrompt(for: selectedLanguage)
+                            isEditing = true
+                        }
                     }
                 }
             } header: {
                 HStack(spacing: 4) {
                     Text("Output Format")
                     InfoTip(
-                        "Unlike GPT, Voice Models(whisper) follows the style of your prompt rather than instructions. Use examples of your desired output format instead of commands.",
+                        "Only supported for local Whisper models. Unlike GPT, Voice Models(whisper) follows the style of your prompt rather than instructions. Use examples of your desired output format instead of commands.",
                         learnMoreURL: "https://cookbook.openai.com/examples/whisper_prompting_guide#comparison-with-gpt-prompting"
                     )
                 }

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -102,9 +102,6 @@ struct ModelSettingsView: View {
             FillerWordsSettingsView()
 
         }
-        .padding()
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(10)
         // Reset the editor when language changes
         .onChange(of: selectedLanguage) { oldValue, newValue in
             if isEditing {

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -9,104 +9,84 @@ struct ModelSettingsView: View {
     @AppStorage("PrewarmModelOnWake") private var prewarmModelOnWake = true
     @State private var customPrompt: String = ""
     @State private var isEditing: Bool = false
-    
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Output Format")
-                    .font(.headline)
-                
-                InfoTip(
-                    "Unlike GPT, Voice Models(whisper) follows the style of your prompt rather than instructions. Use examples of your desired output format instead of commands.",
-                    learnMoreURL: "https://cookbook.openai.com/examples/whisper_prompting_guide#comparison-with-gpt-prompting"
-                )
-                
-                Spacer()
-                
-                Button(action: {
-                    if isEditing {
-                        // Save changes
+        Form {
+            Section {
+                if isEditing {
+                    TextEditor(text: $customPrompt)
+                        .font(.system(size: 12))
+                        .frame(height: 80)
+                        .scrollContentBackground(.hidden)
+
+                    Button("Save") {
                         whisperPrompt.setCustomPrompt(customPrompt, for: selectedLanguage)
                         isEditing = false
-                    } else {
-                        // Enter edit mode
+                    }
+                } else {
+                    Text(whisperPrompt.getLanguagePrompt(for: selectedLanguage))
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Button("Edit") {
                         customPrompt = whisperPrompt.getLanguagePrompt(for: selectedLanguage)
                         isEditing = true
                     }
-                }) {
-                    Text(isEditing ? "Save" : "Edit")
-                        .font(.caption)
+                }
+            } header: {
+                HStack(spacing: 4) {
+                    Text("Output Format")
+                    InfoTip(
+                        "Unlike GPT, Voice Models(whisper) follows the style of your prompt rather than instructions. Use examples of your desired output format instead of commands.",
+                        learnMoreURL: "https://cookbook.openai.com/examples/whisper_prompting_guide#comparison-with-gpt-prompting"
+                    )
                 }
             }
-            
-            if isEditing {
-                TextEditor(text: $customPrompt)
-                    .font(.system(size: 12))
-                    .padding(8)
-                    .frame(height: 80)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                    )
-                
-            } else {
-                Text(whisperPrompt.getLanguagePrompt(for: selectedLanguage))
-                    .font(.system(size: 12))
-                    .foregroundColor(.secondary)
-                    .padding(8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(Color(.windowBackgroundColor).opacity(0.4))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                    )
-            }
 
-            Divider().padding(.vertical, 4)
+            Section {
+                Toggle(isOn: $appendTrailingSpace) {
+                    Text("Add Space After Paste")
+                }
+                .toggleStyle(.switch)
 
-            Toggle(isOn: $appendTrailingSpace) {
-                Text("Add Space After Paste")
-            }
-            .toggleStyle(.switch)
-
-            HStack {
                 Toggle(isOn: $isTextFormattingEnabled) {
-                    Text("Automatic text formatting")
+                    HStack(spacing: 4) {
+                        Text("Automatic text formatting")
+                        InfoTip("Apply intelligent text formatting to break large block of text into paragraphs.")
+                    }
                 }
                 .toggleStyle(.switch)
-                
-                InfoTip("Apply intelligent text formatting to break large block of text into paragraphs.")
-            }
 
-            HStack {
                 Toggle(isOn: $isVADEnabled) {
-                    Text("Voice Activity Detection (VAD)")
+                    HStack(spacing: 4) {
+                        Text("Voice Activity Detection (VAD)")
+                        InfoTip("Detect speech segments and filter out silence to improve accuracy of local models.")
+                    }
                 }
                 .toggleStyle(.switch)
 
-                InfoTip("Detect speech segments and filter out silence to improve accuracy of local models.")
-            }
-
-            HStack {
                 Toggle(isOn: $prewarmModelOnWake) {
-                    Text("Prewarm model (Experimental)")
+                    HStack(spacing: 4) {
+                        Text("Prewarm model (Experimental)")
+                        InfoTip("Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization.")
+                    }
                 }
                 .toggleStyle(.switch)
-
-                InfoTip("Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization.")
+            } header: {
+                Text("Transcription")
             }
 
-            FillerWordsSettingsView()
-
+            Section {
+                FillerWordsSettingsView()
+            }
         }
-        // Reset the editor when language changes
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
         .onChange(of: selectedLanguage) { oldValue, newValue in
             if isEditing {
                 customPrompt = whisperPrompt.getLanguagePrompt(for: selectedLanguage)
             }
         }
     }
-} 
+}

--- a/VoiceInk/Views/PromptEditorView.swift
+++ b/VoiceInk/Views/PromptEditorView.swift
@@ -57,23 +57,26 @@ struct PromptEditorView: View {
         }
     }
     
+    private func dismissPanel() {
+        if let onDismiss = onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
+            // Header
             HStack(spacing: 12) {
                 Text(isEditingPredefinedPrompt ? "Edit Trigger Words" : (mode == .add ? "New Prompt" : "Edit Prompt"))
                     .font(.headline)
                     .fontWeight(.semibold)
                     .foregroundColor(.primary)
-                
+
                 Spacer()
-                
-                Button(action: {
-                    if let onDismiss = onDismiss {
-                        onDismiss()
-                    } else {
-                        dismiss()
-                    }
-                }) {
+
+                Button(action: dismissPanel) {
                     Image(systemName: "xmark")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundColor(.secondary)
@@ -87,198 +90,29 @@ struct PromptEditorView: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 16)
             .background(Color(NSColor.windowBackgroundColor))
-            .overlay(
-                Divider().opacity(0.5), alignment: .bottom
-            )
-            
-            ScrollView {
-                VStack(spacing: 24) {
-                    if isEditingPredefinedPrompt {
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text("Editing: \(title)")
-                                .font(.title3)
-                                .fontWeight(.medium)
-                                .foregroundColor(.primary)
-                            
-                            Text("You can only customize the trigger words for system prompts.")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                            
-                            TriggerWordsEditor(triggerWords: $triggerWords)
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 20)
-                        
-                    } else {
-                        VStack(spacing: 24) {
-                            HStack(alignment: .top, spacing: 16) {
-                                Button(action: { showingIconPicker = true }) {
-                                    Image(systemName: selectedIcon)
-                                        .font(.system(size: 24))
-                                        .foregroundColor(.primary)
-                                        .frame(width: 56, height: 56)
-                                        .background(Color(NSColor.controlBackgroundColor))
-                                        .cornerRadius(10)
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 10)
-                                                .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                                .popover(isPresented: $showingIconPicker, arrowEdge: .bottom) {
-                                    IconPickerPopover(selectedIcon: $selectedIcon, isPresented: $showingIconPicker)
-                                }
-                                
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Title")
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                    
-                                    TextField("Prompt Name", text: $title)
-                                        .textFieldStyle(.plain)
-                                        .font(.system(size: 14))
-                                        .padding(8)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 6)
-                                                .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                                                .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
-                                        )
-                                }
-                            }
-                            
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Description")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                
-                                TextField("Brief description of what this prompt does", text: $description)
-                                    .textFieldStyle(.plain)
-                                    .font(.system(size: 13))
-                                    .padding(8)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 6)
-                                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                                            .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
-                                    )
-                            }
-                            
-                            Divider().padding(.vertical, 4)
-                            
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Instructions")
-                                    .font(.headline)
-                                    .foregroundColor(.primary)
-                                
-                                ZStack(alignment: .topLeading) {
-                                    TextEditor(text: $promptText)
-                                        .font(.system(.body, design: .monospaced))
-                                        .frame(minHeight: 180)
-                                        .padding(8)
-                                        .background(Color(NSColor.controlBackgroundColor))
-                                        .cornerRadius(6)
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 6)
-                                                .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                                        )
-                                    
-                                    if promptText.isEmpty {
-                                        Text("Enter your custom prompt instructions here...")
-                                            .font(.system(.body, design: .monospaced))
-                                            .foregroundColor(.secondary.opacity(0.5))
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 12)
-                                            .allowsHitTesting(false                                        )
-                                    }
-                                }
-                                
-                                if !isEditingPredefinedPrompt {
-                                    HStack(spacing: 8) {
-                                        Toggle("Use System Template", isOn: $useSystemInstructions)
-                                            .toggleStyle(.switch)
-                                            .controlSize(.small)
-                                        
-                                        InfoTip("If enabled, your instructions are combined with a general-purpose template to improve transcription quality.\n\nDisable for full control over the AI's system prompt (for advanced users).")
-                                    }
-                                    .padding(.top, 4)
-                                }
-                            }
-                            
-                            Divider().padding(.vertical, 4)
-                            
-                            TriggerWordsEditor(triggerWords: $triggerWords)
-                            
-                            if case .add = mode, !isEditingPredefinedPrompt {
-                                HStack {
-                                    Menu {
-                                        ForEach(PromptTemplates.all, id: \.title) { template in
-                                            Button {
-                                                title = template.title
-                                                promptText = template.promptText
-                                                selectedIcon = template.icon
-                                                description = template.description
-                                            } label: {
-                                                HStack {
-                                                    Text(template.title)
-                                                    Spacer()
-                                                    Image(systemName: template.icon)
-                                                }
-                                            }
-                                        }
-                                    } label: {
-                                        HStack(spacing: 6) {
-                                            Image(systemName: "sparkles")
-                                                .foregroundColor(.accentColor)
-                                            Text("Start with Template")
-                                                .foregroundColor(.primary)
-                                            Image(systemName: "chevron.down")
-                                                .font(.caption)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        .padding(.vertical, 6)
-                                        .padding(.horizontal, 10)
-                                        .background(Color(NSColor.controlBackgroundColor))
-                                        .cornerRadius(6)
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 6)
-                                                .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
-                                        )
-                                    }
-                                    .menuStyle(.borderlessButton)
-                                    .fixedSize()
-                                    
-                                    Spacer()
-                                }
-                            }
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 20)
-                    }
-                }
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
+
+            // Content
+            if isEditingPredefinedPrompt {
+                predefinedPromptForm
+            } else {
+                customPromptForm
             }
-            
+
+            // Footer
             VStack(spacing: 0) {
                 Divider()
                 HStack {
-                    Button("Cancel") {
-                        if let onDismiss = onDismiss {
-                            onDismiss()
-                        } else {
-                            dismiss()
-                        }
-                    }
-                    .keyboardShortcut(.escape, modifiers: [])
-                    .buttonStyle(.plain)
-                    .foregroundColor(.secondary)
-                    
+                    Button("Cancel") { dismissPanel() }
+                        .keyboardShortcut(.escape, modifiers: [])
+                        .buttonStyle(.plain)
+                        .foregroundColor(.secondary)
+
                     Spacer()
-                    
+
                     Button {
                         save()
-                        if let onDismiss = onDismiss {
-                            onDismiss()
-                        } else {
-                            dismiss()
-                        }
+                        dismissPanel()
                     } label: {
                         Text("Save Changes")
                             .frame(minWidth: 100)
@@ -292,10 +126,119 @@ struct PromptEditorView: View {
                 .background(Color(NSColor.windowBackgroundColor))
             }
         }
-        .frame(minWidth: 400, minHeight: 500)
         .background(Color(NSColor.windowBackgroundColor))
     }
-    
+
+    // MARK: - Predefined Prompt Form
+
+    private var predefinedPromptForm: some View {
+        Form {
+            Section {
+                Text("You can only customize the trigger words for system prompts.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } header: {
+                Text("Editing: \(title)")
+            }
+
+            Section {
+                TriggerWordsEditor(triggerWords: $triggerWords)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Custom Prompt Form
+
+    private var customPromptForm: some View {
+        Form {
+            Section {
+                HStack(alignment: .center, spacing: 14) {
+                    Button(action: { showingIconPicker = true }) {
+                        Image(systemName: selectedIcon)
+                            .font(.system(size: 22))
+                            .foregroundColor(.primary)
+                            .frame(width: 44, height: 44)
+                            .background(Color(NSColor.controlBackgroundColor))
+                            .cornerRadius(10)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .popover(isPresented: $showingIconPicker, arrowEdge: .bottom) {
+                        IconPickerPopover(selectedIcon: $selectedIcon, isPresented: $showingIconPicker)
+                    }
+
+                    TextField("Prompt Name", text: $title)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                TextField("Brief description", text: $description)
+                    .textFieldStyle(.roundedBorder)
+            } header: {
+                Text("Details")
+            }
+
+            Section {
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $promptText)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 160)
+                        .scrollContentBackground(.hidden)
+
+                    if promptText.isEmpty {
+                        Text("Enter your custom prompt instructions here...")
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                            .padding(.leading, 5)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    Toggle("Use System Template", isOn: $useSystemInstructions)
+                        .toggleStyle(.switch)
+
+                    InfoTip("If enabled, your instructions are combined with a general-purpose template to improve transcription quality.\n\nDisable for full control over the AI's system prompt (for advanced users).")
+                }
+            } header: {
+                Text("Instructions")
+            }
+
+            Section {
+                TriggerWordsEditor(triggerWords: $triggerWords)
+            } header: {
+                HStack(spacing: 4) {
+                    Text("Trigger Words")
+                    InfoTip("Add words that automatically activate this prompt. For example, 'summarize', 'email', 'translate'.")
+                }
+            }
+
+            if case .add = mode {
+                Section {
+                    Menu {
+                        ForEach(PromptTemplates.all, id: \.title) { template in
+                            Button {
+                                title = template.title
+                                promptText = template.promptText
+                                selectedIcon = template.icon
+                                description = template.description
+                            } label: {
+                                Label(template.title, systemImage: template.icon)
+                            }
+                        }
+                    } label: {
+                        Label("Start with Template", systemImage: "sparkles")
+                    }
+                    .menuStyle(.borderlessButton)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
     private func save() {
         switch mode {
         case .add:
@@ -331,40 +274,21 @@ struct TriggerWordsEditor: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
-                Text("Trigger Words")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                
-                InfoTip("Add multiple words that can activate this prompt.")
-            }
-            
             HStack {
-                TextField("Add trigger word (e.g. 'summarize')", text: $newTriggerWord)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 13))
-                    .padding(6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                            .background(Color(NSColor.controlBackgroundColor).cornerRadius(6))
-                    )
-                    .onSubmit {
-                        addTriggerWord()
-                    }
-                
+                TextField("Add trigger word", text: $newTriggerWord)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { addTriggerWord() }
+
                 Button(action: { addTriggerWord() }) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .bold))
-                        .frame(width: 26, height: 26)
-                        .background(Color.accentColor.opacity(0.1))
-                        .foregroundColor(.accentColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    Image(systemName: "plus.circle.fill")
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(Color.accentColor)
+                        .font(.system(size: 18))
                 }
                 .buttonStyle(.plain)
                 .disabled(newTriggerWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
-            
+
             if !triggerWords.isEmpty {
                 TagLayout(alignment: .leading, spacing: 6) {
                     ForEach(triggerWords, id: \.self) { word in
@@ -373,13 +297,11 @@ struct TriggerWordsEditor: View {
                         }
                     }
                 }
-                .padding(.top, 4)
             } else {
                 Text("No trigger words added")
                     .font(.caption)
                     .foregroundColor(.secondary.opacity(0.7))
                     .italic()
-                    .padding(.top, 2)
             }
         }
     }

--- a/VoiceInk/Views/PromptEditorView.swift
+++ b/VoiceInk/Views/PromptEditorView.swift
@@ -90,7 +90,9 @@ struct PromptEditorView: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 16)
             .background(Color(NSColor.windowBackgroundColor))
-            .overlay(Divider().opacity(0.5), alignment: .bottom)
+            .overlay(
+                Divider().opacity(0.5), alignment: .bottom
+            )
 
             // Content
             if isEditingPredefinedPrompt {
@@ -101,7 +103,6 @@ struct PromptEditorView: View {
 
             // Footer
             VStack(spacing: 0) {
-                Divider()
                 HStack {
                     Button("Cancel") { dismissPanel() }
                         .keyboardShortcut(.escape, modifiers: [])
@@ -146,6 +147,7 @@ struct PromptEditorView: View {
             }
         }
         .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
     }
 
     // MARK: - Custom Prompt Form
@@ -197,12 +199,13 @@ struct PromptEditorView: View {
                     }
                 }
 
-                HStack(spacing: 8) {
-                    Toggle("Use System Template", isOn: $useSystemInstructions)
-                        .toggleStyle(.switch)
-
-                    InfoTip("If enabled, your instructions are combined with a general-purpose template to improve transcription quality.\n\nDisable for full control over the AI's system prompt (for advanced users).")
+                Toggle(isOn: $useSystemInstructions) {
+                    HStack(spacing: 4) {
+                        Text("Use System Template")
+                        InfoTip("If enabled, your instructions are combined with a general-purpose template to improve transcription quality.\n\nDisable for full control over the AI's system prompt (for advanced users).")
+                    }
                 }
+                .toggleStyle(.switch)
             } header: {
                 Text("Instructions")
             }
@@ -237,6 +240,7 @@ struct PromptEditorView: View {
             }
         }
         .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
     }
 
     private func save() {

--- a/VoiceInk/Whisper/TranscriptionPipeline.swift
+++ b/VoiceInk/Whisper/TranscriptionPipeline.swift
@@ -171,9 +171,9 @@ class TranscriptionPipeline {
                 CursorPaster.pasteAtCursor(textToPaste + (appendSpace ? " " : ""))
 
                 let powerMode = PowerModeManager.shared
-                if let activeConfig = powerMode.currentActiveConfiguration, activeConfig.isAutoSendEnabled {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        CursorPaster.pressEnter()
+                if let activeConfig = powerMode.currentActiveConfiguration, activeConfig.autoSendKey.isEnabled {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        CursorPaster.performAutoSend(activeConfig.autoSendKey)
                     }
                 }
             }

--- a/VoiceInk/Whisper/TranscriptionPipeline.swift
+++ b/VoiceInk/Whisper/TranscriptionPipeline.swift
@@ -113,7 +113,7 @@ class TranscriptionPipeline {
 
             let isSkipShortEnhancementEnabled = UserDefaults.standard.bool(forKey: "SkipShortEnhancement")
             let savedThreshold = UserDefaults.standard.integer(forKey: "ShortEnhancementWordThreshold")
-            let shortEnhancementWordThreshold = savedThreshold > 0 ? savedThreshold : 5
+            let shortEnhancementWordThreshold = savedThreshold > 0 ? savedThreshold : 3
             let shouldSkipEnhancement = isSkipShortEnhancementEnabled && WordCounter.count(in: text) <= shortEnhancementWordThreshold
 
             if let enhancementService,

--- a/VoiceInk/Whisper/TranscriptionPipeline.swift
+++ b/VoiceInk/Whisper/TranscriptionPipeline.swift
@@ -111,9 +111,15 @@ class TranscriptionPipeline {
                 await promptDetectionService.applyDetectionResult(detectionResult, to: enhancementService)
             }
 
+            let isSkipShortEnhancementEnabled = UserDefaults.standard.bool(forKey: "SkipShortEnhancement")
+            let savedThreshold = UserDefaults.standard.integer(forKey: "ShortEnhancementWordThreshold")
+            let shortEnhancementWordThreshold = savedThreshold > 0 ? savedThreshold : 5
+            let shouldSkipEnhancement = isSkipShortEnhancementEnabled && WordCounter.count(in: text) <= shortEnhancementWordThreshold
+
             if let enhancementService,
                enhancementService.isEnhancementEnabled,
-               enhancementService.isConfigured {
+               enhancementService.isConfigured,
+               !shouldSkipEnhancement {
                 if shouldCancel() { await onCleanup(); return }
 
                 onStateChange(.enhancing)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a reusable sliding panel and refactors settings and Power Mode flows for a faster, more consistent UI. Adds an auto‑send key picker and enables skipping enhancement on short transcriptions by default (≤3 words) to reduce latency.

- **New Features**
  - Reusable `SlidingPanel` modifier; Enhancement, Model Management, Power Mode config, and reorder now open in panels (0.3s animation, 0.1 overlay).
  - Enhancement Settings panel adds “Skip short transcriptions” with a word threshold; default ON at 3 words. `WordCounter` and `TranscriptionPipeline` skip enhancement when active.
  - Power Mode adds an auto‑send key picker (`None`, `Return`, `Shift+Return`, `Command+Return`); `CursorPaster` sends the selected combo. Decoding falls back to `none` for older configs.
  - `AIService` adds `availableModels(for:)` for provider‑specific lists.

- **Refactors**
  - Converted `PromptEditorView` and `ModelSettingsView` to macOS grouped forms and hosted them in sliding panels.
  - Replaced `AppPickerSheet` with `AppPickerPopover` and simplified header/search layout.
  - UI polish: standardized toggle + `InfoTip` layout, and unified panel headers/dividers (including reorder panel close button).

<sup>Written for commit 231ad6de0f2c8bd136144fc98f5a1997b14e2195. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

