### PR TITLE
feat(ai): add local CLI enhancement provider

### DIFF
--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -228,6 +228,19 @@ class AIEnhancementService: ObservableObject {
             }
         }
 
+        if aiService.selectedProvider == .localCLI {
+            do {
+                let result = try await aiService.enhanceWithLocalCLI(systemPrompt: systemMessage, userPrompt: formattedText)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch {
+                if let localError = error as? LocalCLIError {
+                    throw EnhancementError.customError(localError.errorDescription ?? "An unknown Local CLI error occurred.")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
         try await waitForRateLimit()
 
         do {

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -13,6 +13,7 @@ enum AIProvider: String, CaseIterable {
     case deepgram = "Deepgram"
     case soniox = "Soniox"
     case ollama = "Ollama"
+    case localCLI = "Local CLI"
     case custom = "Custom"
     
     
@@ -40,6 +41,8 @@ enum AIProvider: String, CaseIterable {
             return "https://api.soniox.com/v1"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
+        case .localCLI:
+            return ""
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderBaseURL") ?? ""
         }
@@ -67,6 +70,8 @@ enum AIProvider: String, CaseIterable {
             return "stt-async-v4"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
+        case .localCLI:
+            return "local-cli"
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderModel") ?? ""
         case .openRouter:
@@ -135,6 +140,8 @@ enum AIProvider: String, CaseIterable {
             return ["stt-async-v4"]
         case .ollama:
             return []
+        case .localCLI:
+            return []
         case .custom:
             return []
         case .openRouter:
@@ -144,7 +151,7 @@ enum AIProvider: String, CaseIterable {
     
     var requiresAPIKey: Bool {
         switch self {
-        case .ollama:
+        case .ollama, .localCLI:
             return false
         default:
             return true
@@ -178,7 +185,7 @@ class AIService: ObservableObject {
                 }
             } else {
                 self.apiKey = ""
-                self.isAPIKeyValid = true
+                self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
                 if selectedProvider == .ollama {
                     Task {
                         await ollamaService.checkConnection()
@@ -193,6 +200,7 @@ class AIService: ObservableObject {
     @Published private var selectedModels: [AIProvider: String] = [:]
     private let userDefaults = UserDefaults.standard
     private lazy var ollamaService = OllamaService()
+    private lazy var localCLIService = LocalCLIService()
     
     @Published private var openRouterModels: [String] = []
     
@@ -200,6 +208,8 @@ class AIService: ObservableObject {
         AIProvider.allCases.filter { provider in
             if provider == .ollama {
                 return ollamaService.isConnected
+            } else if provider == .localCLI {
+                return localCLIService.isConfigured
             } else if provider.requiresAPIKey {
                 return APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue)
             }
@@ -218,6 +228,18 @@ class AIService: ObservableObject {
     
     var availableModels: [String] {
         availableModels(for: selectedProvider)
+    }
+
+    var localCLICommandTemplate: String {
+        localCLIService.commandTemplate
+    }
+
+    var localCLITemplateSelection: LocalCLITemplate {
+        localCLIService.selectedTemplate
+    }
+
+    var localCLITimeoutSeconds: Double {
+        localCLIService.timeoutSeconds
     }
 
     func availableModels(for provider: AIProvider) -> [String] {
@@ -247,7 +269,7 @@ class AIService: ObservableObject {
                 self.isAPIKeyValid = true
             }
         } else {
-            self.isAPIKeyValid = true
+            self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
         }
 
         loadSavedModelSelections()
@@ -393,6 +415,33 @@ class AIService: ObservableObject {
     func updateSelectedOllamaModel(_ modelName: String) {
         ollamaService.selectedModel = modelName
         userDefaults.set(modelName, forKey: "ollamaSelectedModel")
+    }
+
+    func loadLocalCLITemplate(_ template: LocalCLITemplate) {
+        localCLIService.loadTemplate(template)
+        refreshLocalCLIConfigurationState()
+    }
+
+    func updateLocalCLICommandTemplate(_ command: String) {
+        localCLIService.commandTemplate = command
+        refreshLocalCLIConfigurationState()
+    }
+
+    func updateLocalCLITimeoutSeconds(_ timeout: Double) {
+        localCLIService.timeoutSeconds = timeout
+        refreshLocalCLIConfigurationState()
+    }
+
+    func enhanceWithLocalCLI(systemPrompt: String, userPrompt: String) async throws -> String {
+        try await localCLIService.enhance(systemPrompt: systemPrompt, userPrompt: userPrompt)
+    }
+
+    private func refreshLocalCLIConfigurationState() {
+        if selectedProvider == .localCLI {
+            isAPIKeyValid = localCLIService.isConfigured
+        }
+        objectWillChange.send()
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
     }
     
     func fetchOpenRouterModels() async {

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -1,0 +1,288 @@
+import Foundation
+
+enum LocalCLITemplate: String, CaseIterable, Identifiable {
+    case pi
+    case claude
+    case codex
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .pi: return "Pi"
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        }
+    }
+
+    var commandTemplate: String {
+        switch self {
+        case .pi:
+            return "pi -ne -ns -p --no-tools --system-prompt \"$VOICEINK_SYSTEM_PROMPT\" \"$VOICEINK_USER_PROMPT\""
+        case .claude:
+            return "claude -p \"$VOICEINK_FULL_PROMPT\""
+        case .codex:
+            return "codex exec \"$VOICEINK_FULL_PROMPT\""
+        }
+    }
+}
+
+final class LocalCLIService {
+    static let commandTemplateKey = "localCLICommandTemplate"
+    static let selectedTemplateKey = "localCLISelectedTemplate"
+    static let timeoutSecondsKey = "localCLITimeoutSeconds"
+    static let defaultTimeoutSeconds: Double = 45
+    private static let shellPathQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.localcli.path")
+    private static var cachedInteractiveLoginPATH: String?
+
+    var commandTemplate: String {
+        didSet {
+            UserDefaults.standard.set(commandTemplate, forKey: Self.commandTemplateKey)
+        }
+    }
+
+    var selectedTemplate: LocalCLITemplate {
+        didSet {
+            UserDefaults.standard.set(selectedTemplate.rawValue, forKey: Self.selectedTemplateKey)
+        }
+    }
+
+    var timeoutSeconds: Double {
+        didSet {
+            let clamped = max(5, timeoutSeconds)
+            if clamped != timeoutSeconds {
+                timeoutSeconds = clamped
+                return
+            }
+            UserDefaults.standard.set(timeoutSeconds, forKey: Self.timeoutSecondsKey)
+        }
+    }
+
+    var isConfigured: Bool {
+        !commandTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    init() {
+        let savedTemplateRaw = UserDefaults.standard.string(forKey: Self.selectedTemplateKey) ?? ""
+        selectedTemplate = LocalCLITemplate(rawValue: savedTemplateRaw) ?? .pi
+
+        commandTemplate = UserDefaults.standard.string(forKey: Self.commandTemplateKey) ?? ""
+
+        let savedTimeout = UserDefaults.standard.double(forKey: Self.timeoutSecondsKey)
+        timeoutSeconds = savedTimeout > 0 ? savedTimeout : Self.defaultTimeoutSeconds
+    }
+
+    func loadTemplate(_ template: LocalCLITemplate) {
+        selectedTemplate = template
+        commandTemplate = template.commandTemplate
+    }
+
+    func enhance(systemPrompt: String, userPrompt: String) async throws -> String {
+        guard isConfigured else {
+            throw LocalCLIError.commandNotConfigured
+        }
+
+        let fullPrompt = Self.makeFullPrompt(systemPrompt: systemPrompt, userPrompt: userPrompt)
+        return try await executeCommand(
+            commandTemplate: commandTemplate,
+            systemPrompt: systemPrompt,
+            userPrompt: userPrompt,
+            fullPrompt: fullPrompt,
+            timeout: timeoutSeconds
+        )
+    }
+
+    static func makeFullPrompt(systemPrompt: String, userPrompt: String) -> String {
+        """
+        <SYSTEM_PROMPT>
+        \(systemPrompt)
+        </SYSTEM_PROMPT>
+
+        <USER_PROMPT>
+        \(userPrompt)
+        </USER_PROMPT>
+        """
+    }
+
+    private func executeCommand(
+        commandTemplate: String,
+        systemPrompt: String,
+        userPrompt: String,
+        fullPrompt: String,
+        timeout: Double
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+                process.arguments = ["-lc", commandTemplate]
+
+                var environment = ProcessInfo.processInfo.environment
+                environment["PATH"] = Self.preferredPATH(fallback: environment["PATH"])
+                environment["VOICEINK_SYSTEM_PROMPT"] = systemPrompt
+                environment["VOICEINK_USER_PROMPT"] = userPrompt
+                environment["VOICEINK_FULL_PROMPT"] = fullPrompt
+                process.environment = environment
+
+                let inputPipe = Pipe()
+                let outputPipe = Pipe()
+                let errorPipe = Pipe()
+                process.standardInput = inputPipe
+                process.standardOutput = outputPipe
+                process.standardError = errorPipe
+
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: LocalCLIError.executionFailed(error.localizedDescription))
+                    return
+                }
+
+                if let inputData = fullPrompt.data(using: .utf8) {
+                    inputPipe.fileHandleForWriting.write(inputData)
+                }
+                try? inputPipe.fileHandleForWriting.close()
+
+                let semaphore = DispatchSemaphore(value: 0)
+                process.terminationHandler = { _ in
+                    semaphore.signal()
+                }
+
+                let waitResult = semaphore.wait(timeout: .now() + timeout)
+                if waitResult == .timedOut {
+                    if process.isRunning {
+                        process.terminate()
+                        _ = semaphore.wait(timeout: .now() + 2)
+                    }
+                    continuation.resume(throwing: LocalCLIError.timeout(seconds: timeout))
+                    return
+                }
+
+                let stdoutData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+                let stdout = Self.cleanOutput(String(data: stdoutData, encoding: .utf8) ?? "")
+                let stderr = Self.cleanOutput(String(data: stderrData, encoding: .utf8) ?? "")
+
+                if process.terminationStatus != 0 {
+                    let looksLikeCommandNotFound = process.terminationStatus == 127 ||
+                        stderr.lowercased().contains("command not found")
+                    if looksLikeCommandNotFound {
+                        continuation.resume(throwing: LocalCLIError.commandNotFound(stderr.isEmpty ? commandTemplate : stderr))
+                    } else {
+                        continuation.resume(throwing: LocalCLIError.nonZeroExit(status: Int(process.terminationStatus), stderr: stderr))
+                    }
+                    return
+                }
+
+                guard !stdout.isEmpty else {
+                    continuation.resume(throwing: LocalCLIError.emptyOutput)
+                    return
+                }
+
+                continuation.resume(returning: stdout)
+            }
+        }
+    }
+
+    private static func preferredPATH(fallback: String?) -> String {
+        shellPathQueue.sync {
+            if let cachedInteractiveLoginPATH {
+                return cachedInteractiveLoginPATH
+            }
+
+            if let discovered = discoverPATHFromInteractiveLoginShell() {
+                cachedInteractiveLoginPATH = discovered
+                return discovered
+            }
+
+            return fallback?.isEmpty == false ? fallback! : "/usr/bin:/bin:/usr/sbin:/sbin"
+        }
+    }
+
+    private static func discoverPATHFromInteractiveLoginShell() -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [
+            "-ilc",
+            "echo __VOICEINK_PATH_START__; print -r -- $PATH; echo __VOICEINK_PATH_END__"
+        ]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in semaphore.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let waitResult = semaphore.wait(timeout: .now() + 3)
+        if waitResult == .timedOut {
+            if process.isRunning {
+                process.terminate()
+            }
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let output = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let startMarker = "__VOICEINK_PATH_START__"
+        let endMarker = "__VOICEINK_PATH_END__"
+
+        guard let startRange = output.range(of: startMarker),
+              let endRange = output.range(of: endMarker, range: startRange.upperBound..<output.endIndex)
+        else {
+            return nil
+        }
+
+        let pathSection = output[startRange.upperBound..<endRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !pathSection.isEmpty else {
+            return nil
+        }
+
+        return pathSection
+    }
+
+    private static func cleanOutput(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum LocalCLIError: Error, LocalizedError {
+    case commandNotConfigured
+    case commandNotFound(String)
+    case timeout(seconds: Double)
+    case nonZeroExit(status: Int, stderr: String)
+    case emptyOutput
+    case executionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandNotConfigured:
+            return "Local CLI command is not configured. Load a template or enter a command first."
+        case .commandNotFound(let details):
+            return "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: \(details)"
+        case .timeout(let seconds):
+            return "Local CLI command timed out after \(Int(seconds)) seconds."
+        case .nonZeroExit(let status, let stderr):
+            if stderr.isEmpty {
+                return "Local CLI command failed with exit code \(status)."
+            }
+            return "Local CLI command failed with exit code \(status): \(stderr)"
+        case .emptyOutput:
+            return "Local CLI command returned empty output."
+        case .executionFailed(let message):
+            return "Failed to execute Local CLI command: \(message)"
+        }
+    }
+}

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -12,6 +12,9 @@ struct APIKeyManagementView: View {
     @State private var selectedOllamaModel: String = UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
     @State private var isCheckingOllama = false
     @State private var isEditingURL = false
+    @State private var localCLICommandTemplate: String = ""
+    @State private var localCLITimeoutSeconds: Double = LocalCLIService.defaultTimeoutSeconds
+    @State private var isSyncingLocalCLIState = false
     
     var body: some View {
         Section("AI Provider Integration") {
@@ -57,6 +60,9 @@ struct APIKeyManagementView: View {
             .onChange(of: aiService.selectedProvider) { oldValue, newValue in
                 if aiService.selectedProvider == .ollama {
                     checkOllamaConnection()
+                }
+                if aiService.selectedProvider == .localCLI {
+                    syncLocalCLIStateFromService()
                 }
             }
 
@@ -112,8 +118,6 @@ struct APIKeyManagementView: View {
                     }
                 }
 
-                Divider()
-
                 if aiService.selectedProvider == .ollama {
                     if isEditingURL {
                         HStack {
@@ -153,6 +157,68 @@ struct APIKeyManagementView: View {
                         .onChange(of: selectedOllamaModel) { oldValue, newValue in
                             aiService.updateSelectedOllamaModel(newValue)
                         }
+                    }
+
+                } else if aiService.selectedProvider == .localCLI {
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Command")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            Menu("Load Template") {
+                                ForEach(LocalCLITemplate.allCases) { template in
+                                    Button(template.displayName) {
+                                        aiService.loadLocalCLITemplate(template)
+                                        syncLocalCLIStateFromService()
+                                    }
+                                }
+                            }
+                        }
+
+                        TextEditor(text: $localCLICommandTemplate)
+                            .font(.system(.body, design: .monospaced))
+                            .multilineTextAlignment(.leading)
+                            .frame(minHeight: 100)
+                            .padding(4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color(NSColor.textBackgroundColor))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.secondary.opacity(0.25), lineWidth: 1)
+                            )
+                            .onChange(of: localCLICommandTemplate) { _, newValue in
+                                guard !isSyncingLocalCLIState else { return }
+                                if newValue != aiService.localCLICommandTemplate {
+                                    aiService.updateLocalCLICommandTemplate(newValue)
+                                }
+                            }
+                    }
+
+                    Picker("Timeout", selection: $localCLITimeoutSeconds) {
+                        Text("15s").tag(15.0)
+                        Text("30s").tag(30.0)
+                        Text("45s").tag(45.0)
+                        Text("60s").tag(60.0)
+                        Text("90s").tag(90.0)
+                        Text("120s").tag(120.0)
+                        Text("180s").tag(180.0)
+                        Text("300s").tag(300.0)
+                    }
+                    .onChange(of: localCLITimeoutSeconds) { _, newValue in
+                        aiService.updateLocalCLITimeoutSeconds(newValue)
+                    }
+
+                    Text("Environment variables available: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk also writes VOICEINK_FULL_PROMPT to stdin for every command.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    if !aiService.isAPIKeyValid {
+                        Text("Load a template or enter a command to enable Local CLI enhancement.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
                     }
 
                 } else if aiService.selectedProvider == .custom {
@@ -259,6 +325,18 @@ struct APIKeyManagementView: View {
             if aiService.selectedProvider == .ollama {
                 checkOllamaConnection()
             }
+            if aiService.selectedProvider == .localCLI {
+                syncLocalCLIStateFromService()
+            }
+        }
+    }
+
+    private func syncLocalCLIStateFromService() {
+        isSyncingLocalCLIState = true
+        localCLICommandTemplate = aiService.localCLICommandTemplate
+        localCLITimeoutSeconds = aiService.localCLITimeoutSeconds
+        DispatchQueue.main.async {
+            isSyncingLocalCLIState = false
         }
     }
     

--- a/VoiceInk/Whisper/TranscriptionPipeline.swift
+++ b/VoiceInk/Whisper/TranscriptionPipeline.swift
@@ -136,10 +136,12 @@ class TranscriptionPipeline {
                     transcription.aiRequestUserMessage = enhancementService.lastUserMessageSent
                     finalPastedText = enhancedText
                 } catch {
-                    transcription.enhancedText = "Enhancement failed: \(error)"
+                    let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                    transcription.enhancedText = "Enhancement failed: \(errorDescription)"
+                    let shortReason = String(errorDescription.prefix(80))
                     await MainActor.run {
                         NotificationManager.shared.showNotification(
-                            title: "Enhancement failed",
+                            title: "Enhancement failed: \(shortReason)",
                             type: .warning
                         )
                     }


### PR DESCRIPTION
Feel free to close this as this might be too sloppy for inclusion.

This is my attempt to implement post processing via local coding agents #591.  It works quite well for me but it might not be generalizable.

This has the benefit that you can use your Codex or Claude subscriptions for it.

<img width="1062" height="944" alt="image" src="https://github.com/user-attachments/assets/2af46a5b-72f9-4daf-a0b0-513bb2b6967a" />

These environment variables are available to the script:

* `VOICEINK_SYSTEM_PROMPT`: the system prompt
* `VOICEINK_USER_PROMPT`: the user prompt (transcribed text)
* `VOICEINK_FULL_PROMPT`: combined system + user prompt
* `VOICEINK_ACTIVE_APP_NAME`: name of the frontmost application
* `VOICEINK_ACTIVE_APP_BUNDLE_ID`: bundle identifier of the frontmost app
* `VOICEINK_ACTIVE_APP_PID`: process ID of the frontmost app
* `VOICEINK_BROWSER_URL`: current browser URL (if applicable)
* `VOICEINK_PROMPT_NAME`: name of the active prompt profile
* `VOICEINK_SCREENSHOT`: path to a screenshot of the active window (if captured)
* `VOICEINK_CLIPBOARD_TEXT`: current clipboard contents
* `VOICEINK_SELECTED_TEXT`: currently selected text in the frontmost app
* `VOICEINK_LOCALE`: system locale (e.g. en_US)
* `VOICEINK_POWER_MODE`: name of the active Power Mode (if any)
* `VOICEINK_RAW_SYSTEM_PROMPT`: the prompt text without added context section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Local CLI enhancement provider that runs your own command-line tools to post‑process transcriptions. Includes templates for `pi`, `claude`, and `codex`, a settings UI, and clearer error messages.

- **New Features**
  - New provider `.localCLI` (no API key). Considered connected when a command is set.
  - Command templates for `pi`, `claude`, `codex` with an editor and timeout picker in settings.
  - Executes via zsh login shell and injects VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT; also writes the full prompt to stdin.
  - PATH auto-discovery for CLI binaries, output cleanup, and detailed errors (not configured, command not found, timeout, non‑zero exit, empty output).
  - Integrated into enhancement flow; errors surface with a short reason in notifications.

- **Migration**
  - In Settings, select “Local CLI” as the provider.
  - Load a template or paste your command; use absolute paths if needed.
  - Adjust timeout as needed.
  - Verify your CLI (`pi`, `claude`, `codex`, etc.) is installed and available on your PATH.

<sup>Written for commit 1dc5c8f4d300224ae08d25d5b9265fca5a387f50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

