### PR TITLE
Fix race condition in hotkey monitor setup

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -87,6 +87,7 @@ class HotkeyManager: ObservableObject {
     private var shortcutCurrentKeyState = false
     private var lastShortcutTriggerTime: Date?
     private let shortcutCooldownInterval: TimeInterval = 0.5
+    private var didFinishLaunching = false
 
     private static let hybridPressThreshold: TimeInterval = 0.5
 
@@ -198,13 +199,22 @@ class HotkeyManager: ObservableObject {
             }
         }
 
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            self.setupHotkeyMonitoring()
-        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidFinishLaunching),
+            name: NSApplication.didFinishLaunchingNotification,
+            object: nil
+        )
     }
-    
+
+    @objc private func appDidFinishLaunching(_ notification: Notification) {
+        NotificationCenter.default.removeObserver(self, name: NSApplication.didFinishLaunchingNotification, object: nil)
+        didFinishLaunching = true
+        setupHotkeyMonitoring()
+    }
+
     private func setupHotkeyMonitoring() {
+        guard didFinishLaunching else { return }
         removeAllMonitoring()
         
         setupModifierKeyMonitoring()
@@ -508,6 +518,8 @@ class HotkeyManager: ObservableObject {
     }
     
     deinit {
+        NotificationCenter.default.removeObserver(self)
+
         Task { @MainActor in
             removeAllMonitoring()
         }


### PR DESCRIPTION
## Summary
- `setupHotkeyMonitoring()` creates `NSEvent` monitors which require an active run loop. Currently it is deferred during init via `Task.sleep(100ms)`, which works but is a latent race condition — any code path that calls `setupHotkeyMonitoring()` synchronously during `App.init()` (before the run loop is active) will silently corrupt event delivery.
- Replaces the `Task.sleep` with `NSApplication.didFinishLaunchingNotification`, which is the proper lifecycle hook guaranteeing the run loop is ready.
- `setupHotkeyMonitoring()` now self-guards via a `didFinishLaunching` flag, so it can be safely called from any context (init, profile switch, settings change) without the caller needing to worry about timing.

This is a correctness change — the current code works, but the 100ms sleep is fragile and will break if future code adds `setupHotkeyMonitoring()` calls during init.

## Test plan
- [ ] Launch app, click menu bar icon — all items should be interactive
- [ ] Change hotkey settings — modifier key and custom shortcut monitoring should work
- [ ] Verify hotkeys (push-to-talk, toggle, hybrid) still function after app launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves hotkey monitor setup to run on app launch completion to guarantee the run loop is active, removing the fragile 100ms sleep. Adds a guard so `setupHotkeyMonitoring()` is safe to call from any context.

- **Bug Fixes**
  - Use `NSApplication.didFinishLaunchingNotification` to start `NSEvent` monitoring, eliminating a race that could corrupt event delivery.
  - Add `didFinishLaunching` flag to guard `setupHotkeyMonitoring()` and allow safe calls during init, profile switches, or settings changes.
  - Remove the notification observer after it fires and in `deinit`, and clean up monitors reliably.

<sup>Written for commit f51a1a98b3d6f3b74ea7dca9931c328582035f9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

