### PR TITLE
Add profiles to quick-switch modifier keys for different keyboard setups (e.g. work, mobile)

### DIFF
--- a/VoiceInk/ActivationShortcutProfile.swift
+++ b/VoiceInk/ActivationShortcutProfile.swift
@@ -1,0 +1,148 @@
+import Foundation
+import KeyboardShortcuts
+
+struct ActivationShortcutProfile: Codable, Identifiable {
+    var id: UUID
+    var name: String
+    var selectedHotkey1: HotkeyManager.HotkeyOption
+    var selectedHotkey2: HotkeyManager.HotkeyOption
+    var hotkeyMode1: HotkeyManager.HotkeyMode
+    var hotkeyMode2: HotkeyManager.HotkeyMode
+    var toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?
+    var toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        selectedHotkey1: HotkeyManager.HotkeyOption,
+        selectedHotkey2: HotkeyManager.HotkeyOption,
+        hotkeyMode1: HotkeyManager.HotkeyMode,
+        hotkeyMode2: HotkeyManager.HotkeyMode,
+        toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?,
+        toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
+    ) {
+        self.id = id
+        self.name = name
+        self.selectedHotkey1 = selectedHotkey1
+        self.selectedHotkey2 = selectedHotkey2
+        self.hotkeyMode1 = hotkeyMode1
+        self.hotkeyMode2 = hotkeyMode2
+        self.toggleMiniRecorderShortcut = toggleMiniRecorderShortcut
+        self.toggleMiniRecorderShortcut2 = toggleMiniRecorderShortcut2
+    }
+}
+
+struct LegacyActivationShortcutSettings {
+    var selectedHotkey1: HotkeyManager.HotkeyOption
+    var selectedHotkey2: HotkeyManager.HotkeyOption
+    var hotkeyMode1: HotkeyManager.HotkeyMode
+    var hotkeyMode2: HotkeyManager.HotkeyMode
+    var toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?
+    var toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
+
+    func makeDefaultProfile() -> ActivationShortcutProfile {
+        ActivationShortcutProfile(
+            name: "Default",
+            selectedHotkey1: selectedHotkey1,
+            selectedHotkey2: selectedHotkey2,
+            hotkeyMode1: hotkeyMode1,
+            hotkeyMode2: hotkeyMode2,
+            toggleMiniRecorderShortcut: toggleMiniRecorderShortcut,
+            toggleMiniRecorderShortcut2: toggleMiniRecorderShortcut2
+        )
+    }
+}
+
+struct ActivationShortcutProfilesState {
+    var profiles: [ActivationShortcutProfile]
+    var activeProfileID: UUID
+
+    var activeProfile: ActivationShortcutProfile? {
+        profiles.first { $0.id == activeProfileID } ?? profiles.first
+    }
+
+    init(profiles: [ActivationShortcutProfile], activeProfileID: UUID?) {
+        let normalized = Self.normalize(profiles: profiles, activeProfileID: activeProfileID)
+        self.profiles = normalized.profiles
+        self.activeProfileID = normalized.activeProfileID
+    }
+
+    private init(normalizedProfiles: [ActivationShortcutProfile], activeProfileID: UUID) {
+        self.profiles = normalizedProfiles
+        self.activeProfileID = activeProfileID
+    }
+
+    static func makeDefaultState(from legacySettings: LegacyActivationShortcutSettings) -> Self {
+        let profile = legacySettings.makeDefaultProfile()
+        return Self(normalizedProfiles: [profile], activeProfileID: profile.id)
+    }
+
+    static func fromImportedSettings(
+        shortcutProfiles: [ActivationShortcutProfile]?,
+        activeProfileID: UUID?,
+        legacySettings: LegacyActivationShortcutSettings
+    ) -> Self {
+        if let shortcutProfiles, !shortcutProfiles.isEmpty {
+            return Self(profiles: shortcutProfiles, activeProfileID: activeProfileID)
+        }
+
+        return makeDefaultState(from: legacySettings)
+    }
+
+    static func normalize(profiles: [ActivationShortcutProfile], activeProfileID: UUID?) -> Self {
+        var normalizedProfiles = profiles
+
+        if normalizedProfiles.isEmpty {
+            let profile = LegacyActivationShortcutSettings(
+                selectedHotkey1: .rightCommand,
+                selectedHotkey2: .none,
+                hotkeyMode1: .hybrid,
+                hotkeyMode2: .hybrid,
+                toggleMiniRecorderShortcut: nil,
+                toggleMiniRecorderShortcut2: nil
+            ).makeDefaultProfile()
+            return Self(normalizedProfiles: [profile], activeProfileID: profile.id)
+        }
+
+        var usedNames = Set<String>()
+        var usedIDs = Set<UUID>()
+
+        for index in normalizedProfiles.indices {
+            if usedIDs.contains(normalizedProfiles[index].id) {
+                normalizedProfiles[index].id = UUID()
+            }
+            usedIDs.insert(normalizedProfiles[index].id)
+
+            let fallbackName = index == 0 ? "Default" : "Profile \(index + 1)"
+            let baseName = normalizedProfiles[index].name
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let sanitizedBaseName = baseName.isEmpty ? fallbackName : baseName
+            normalizedProfiles[index].name = makeUniqueName(
+                base: sanitizedBaseName,
+                usedNames: &usedNames
+            )
+        }
+
+        let resolvedActiveProfileID = normalizedProfiles.contains(where: { $0.id == activeProfileID }) ?
+            activeProfileID ?? normalizedProfiles[0].id :
+            normalizedProfiles[0].id
+
+        return Self(
+            normalizedProfiles: normalizedProfiles,
+            activeProfileID: resolvedActiveProfileID
+        )
+    }
+
+    private static func makeUniqueName(base: String, usedNames: inout Set<String>) -> String {
+        var candidate = base
+        var suffix = 2
+
+        while usedNames.contains(candidate.lowercased()) {
+            candidate = "\(base) \(suffix)"
+            suffix += 1
+        }
+
+        usedNames.insert(candidate.lowercased())
+        return candidate
+    }
+}

--- a/VoiceInk/ActivationShortcutProfile.swift
+++ b/VoiceInk/ActivationShortcutProfile.swift
@@ -30,6 +30,17 @@ struct ActivationShortcutProfile: Codable, Identifiable {
         self.toggleMiniRecorderShortcut = toggleMiniRecorderShortcut
         self.toggleMiniRecorderShortcut2 = toggleMiniRecorderShortcut2
     }
+
+    func makeLegacySettings() -> LegacyActivationShortcutSettings {
+        LegacyActivationShortcutSettings(
+            selectedHotkey1: selectedHotkey1,
+            selectedHotkey2: selectedHotkey2,
+            hotkeyMode1: hotkeyMode1,
+            hotkeyMode2: hotkeyMode2,
+            toggleMiniRecorderShortcut: toggleMiniRecorderShortcut,
+            toggleMiniRecorderShortcut2: toggleMiniRecorderShortcut2
+        )
+    }
 }
 
 struct LegacyActivationShortcutSettings {

--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -36,6 +36,7 @@ enum AppDefaults {
             // UI & Behavior
             "IsMenuBarOnly": false,
             "powerModeAutoRestoreEnabled": false,
+            "shortcutProfilesEnabled": false,
             // Hotkey
             "isMiddleClickToggleEnabled": false,
             "middleClickActivationDelay": 200,

--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -22,6 +22,7 @@ class HotkeyManager: ObservableObject {
 
     @Published private(set) var profiles: [ActivationShortcutProfile]
     @Published private(set) var activeProfileID: UUID?
+    @Published private(set) var shortcutProfilesEnabled: Bool
     @Published var selectedHotkey1: HotkeyOption {
         didSet {
             handleActivationConfigurationDidChange()
@@ -89,7 +90,8 @@ class HotkeyManager: ObservableObject {
     private var shortcutCurrentKeyState = false
     private var lastShortcutTriggerTime: Date?
     private let shortcutCooldownInterval: TimeInterval = 0.5
-    private var isApplyingProfile = false
+    private var legacySettings: LegacyActivationShortcutSettings
+    private var isApplyingActivationSettings = false
     private var didFinishLaunching = false
 
     private static let hybridPressThreshold: TimeInterval = 0.5
@@ -152,22 +154,36 @@ class HotkeyManager: ObservableObject {
     }
     
     init(engine: VoiceInkEngine, recorderUIManager: RecorderUIManager) {
-        let initialProfileState = Self.loadInitialProfileState()
-        let initialProfile = initialProfileState.activeProfile ?? LegacyActivationShortcutSettings(
-            selectedHotkey1: .rightCommand,
-            selectedHotkey2: .none,
-            hotkeyMode1: .hybrid,
-            hotkeyMode2: .hybrid,
-            toggleMiniRecorderShortcut: nil,
-            toggleMiniRecorderShortcut2: nil
-        ).makeDefaultProfile()
+        let initialLegacySettings = Self.loadLegacyActivationSettings()
+        let initialProfilesState = Self.loadPersistedProfilesState()
+        let initialShortcutProfilesEnabled = UserDefaults.standard.shortcutProfilesEnabled
 
-        self.profiles = initialProfileState.profiles
-        self.activeProfileID = initialProfileState.activeProfileID
-        self.selectedHotkey1 = initialProfile.selectedHotkey1
-        self.selectedHotkey2 = initialProfile.selectedHotkey2
-        self.hotkeyMode1 = initialProfile.hotkeyMode1
-        self.hotkeyMode2 = initialProfile.hotkeyMode2
+        var initialProfiles = initialProfilesState?.profiles ?? []
+        var initialActiveProfileID = initialProfilesState?.activeProfileID
+
+        let initialEffectiveSettings: LegacyActivationShortcutSettings
+        if initialShortcutProfilesEnabled {
+            if initialProfiles.isEmpty {
+                let seededState = ActivationShortcutProfilesState.makeDefaultState(from: initialLegacySettings)
+                initialProfiles = seededState.profiles
+                initialActiveProfileID = seededState.activeProfileID
+            }
+
+            let initialActiveProfile =
+                initialProfiles.first(where: { $0.id == initialActiveProfileID }) ?? initialProfiles.first
+            initialEffectiveSettings = initialActiveProfile?.makeLegacySettings() ?? initialLegacySettings
+        } else {
+            initialEffectiveSettings = initialLegacySettings
+        }
+
+        self.legacySettings = initialLegacySettings
+        self.profiles = initialProfiles
+        self.activeProfileID = initialActiveProfileID
+        self.shortcutProfilesEnabled = initialShortcutProfilesEnabled
+        self.selectedHotkey1 = initialEffectiveSettings.selectedHotkey1
+        self.selectedHotkey2 = initialEffectiveSettings.selectedHotkey2
+        self.hotkeyMode1 = initialEffectiveSettings.hotkeyMode1
+        self.hotkeyMode2 = initialEffectiveSettings.hotkeyMode2
 
         self.isMiddleClickToggleEnabled = UserDefaults.standard.bool(forKey: "isMiddleClickToggleEnabled")
         self.middleClickActivationDelay = UserDefaults.standard.integer(forKey: "middleClickActivationDelay")
@@ -213,11 +229,9 @@ class HotkeyManager: ObservableObject {
             }
         }
 
-        applyProfile(
-            initialProfile,
-            shouldPersist: true,
-            shouldPostSettingsChange: false
-        )
+        persistLegacySettings()
+        persistProfilesState()
+        applyEffectiveSettings(initialEffectiveSettings, shouldPostSettingsChange: false)
 
         NotificationCenter.default.addObserver(
             self,
@@ -250,38 +264,61 @@ class HotkeyManager: ObservableObject {
     }
 
     var primaryCustomShortcut: KeyboardShortcuts.Shortcut? {
-        activeProfile?.toggleMiniRecorderShortcut
+        currentCustomShortcut(for: .primary)
     }
 
     var secondaryCustomShortcut: KeyboardShortcuts.Shortcut? {
-        activeProfile?.toggleMiniRecorderShortcut2
+        currentCustomShortcut(for: .secondary)
+    }
+
+    var legacyActivationSettings: LegacyActivationShortcutSettings {
+        legacySettings
+    }
+
+    func setShortcutProfilesEnabled(_ enabled: Bool) {
+        guard shortcutProfilesEnabled != enabled else { return }
+        shortcutProfilesEnabled = enabled
+        applyCurrentModeSettings()
     }
 
     func switchProfile(to id: UUID) {
         guard let profile = profiles.first(where: { $0.id == id }) else { return }
-        applyProfile(profile)
+
+        if shortcutProfilesEnabled {
+            applyProfile(profile)
+        } else {
+            activeProfileID = profile.id
+            persistProfilesState()
+        }
     }
 
     func createProfileFromCurrent(name: String? = nil) {
-        guard let activeProfile else { return }
-
-        var newProfile = activeProfile
+        var newProfile = currentEffectiveSettings().makeDefaultProfile()
         newProfile.id = UUID()
         newProfile.name = uniqueProfileName(for: name ?? "New Profile")
 
         profiles.append(newProfile)
-        applyProfile(newProfile)
+        if shortcutProfilesEnabled {
+            applyProfile(newProfile)
+        } else {
+            activeProfileID = newProfile.id
+            persistProfilesState()
+        }
     }
 
     func duplicateActiveProfile() {
-        guard let activeProfile else { return }
-
-        var duplicatedProfile = activeProfile
+        let sourceProfile = activeProfile ?? currentEffectiveSettings().makeDefaultProfile()
+        var duplicatedProfile = sourceProfile
         duplicatedProfile.id = UUID()
-        duplicatedProfile.name = uniqueProfileName(for: "\(activeProfile.name) Copy")
+        duplicatedProfile.name = uniqueProfileName(for: "\(sourceProfile.name) Copy")
 
         profiles.append(duplicatedProfile)
-        applyProfile(duplicatedProfile)
+        if shortcutProfilesEnabled {
+            applyProfile(duplicatedProfile)
+        } else {
+            activeProfileID = duplicatedProfile.id
+            persistProfilesState()
+        }
     }
 
     func renameActiveProfile(to name: String) {
@@ -305,83 +342,101 @@ class HotkeyManager: ObservableObject {
             return
         }
 
-        let fallbackProfile: ActivationShortcutProfile?
-        if activeProfileID == id {
-            if index < profiles.count - 1 {
-                fallbackProfile = profiles[index + 1]
-            } else {
-                fallbackProfile = profiles[index - 1]
-            }
-        } else {
-            fallbackProfile = activeProfile
-        }
+        let deletingActiveProfile = activeProfileID == id
 
         var updatedProfiles = profiles
         updatedProfiles.remove(at: index)
-        profiles = updatedProfiles
 
-        if let fallbackProfile {
-            applyProfile(fallbackProfile)
+        let fallbackProfileID: UUID?
+        if deletingActiveProfile {
+            if index < updatedProfiles.count {
+                fallbackProfileID = updatedProfiles[index].id
+            } else {
+                fallbackProfileID = updatedProfiles.last?.id
+            }
         } else {
-            persistProfilesState()
+            fallbackProfileID = activeProfileID
+        }
+
+        let normalizedState = ActivationShortcutProfilesState(
+            profiles: updatedProfiles,
+            activeProfileID: fallbackProfileID
+        )
+        profiles = normalizedState.profiles
+        activeProfileID = normalizedState.activeProfileID
+        persistProfilesState()
+
+        if shortcutProfilesEnabled && deletingActiveProfile,
+           let fallbackProfile = activeProfile {
+            applyProfile(fallbackProfile)
         }
     }
 
     func setCustomShortcut(_ shortcut: KeyboardShortcuts.Shortcut?, for slot: ActivationSlot) {
-        guard let activeProfileIndex else { return }
-
-        var updatedProfiles = profiles
         switch slot {
         case .primary:
-            updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut = shortcut
             if selectedHotkey1 == .custom {
                 KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder)
             }
         case .secondary:
-            updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut2 = shortcut
             if selectedHotkey2 == .custom {
                 KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder2)
             }
         }
 
-        profiles = updatedProfiles
-        persistProfilesState()
+        if shortcutProfilesEnabled {
+            ensureSavedProfilesState()
+            guard let activeProfileIndex else { return }
+
+            var updatedProfiles = profiles
+            switch slot {
+            case .primary:
+                updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut = shortcut
+            case .secondary:
+                updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut2 = shortcut
+            }
+
+            profiles = updatedProfiles
+            persistProfilesState()
+        } else {
+            switch slot {
+            case .primary:
+                legacySettings.toggleMiniRecorderShortcut = shortcut
+            case .secondary:
+                legacySettings.toggleMiniRecorderShortcut2 = shortcut
+            }
+
+            persistLegacySettings()
+        }
+
         setupHotkeyMonitoring()
         NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
     }
 
-    func importProfiles(_ importedProfiles: [ActivationShortcutProfile], activeProfileID: UUID?) {
-        let importedState = ActivationShortcutProfilesState(
-            profiles: importedProfiles,
-            activeProfileID: activeProfileID
-        )
-
-        profiles = importedState.profiles
-        if let profile = importedState.activeProfile {
-            applyProfile(profile)
-        }
-    }
-
-    func importLegacyActivationSettings(
-        selectedHotkey1: HotkeyOption,
-        selectedHotkey2: HotkeyOption,
-        hotkeyMode1: HotkeyMode,
-        hotkeyMode2: HotkeyMode,
-        toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?,
-        toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
+    func importActivationSettings(
+        legacySettings: LegacyActivationShortcutSettings,
+        shortcutProfiles: [ActivationShortcutProfile],
+        activeProfileID: UUID?,
+        shortcutProfilesEnabled: Bool
     ) {
-        guard let activeProfileIndex else { return }
+        self.legacySettings = legacySettings
 
-        var updatedProfiles = profiles
-        updatedProfiles[activeProfileIndex].selectedHotkey1 = selectedHotkey1
-        updatedProfiles[activeProfileIndex].selectedHotkey2 = selectedHotkey2
-        updatedProfiles[activeProfileIndex].hotkeyMode1 = hotkeyMode1
-        updatedProfiles[activeProfileIndex].hotkeyMode2 = hotkeyMode2
-        updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut = toggleMiniRecorderShortcut
-        updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut2 = toggleMiniRecorderShortcut2
-        profiles = updatedProfiles
+        if shortcutProfiles.isEmpty {
+            profiles = []
+            self.activeProfileID = nil
+        } else {
+            let importedState = ActivationShortcutProfilesState(
+                profiles: shortcutProfiles,
+                activeProfileID: activeProfileID
+            )
+            profiles = importedState.profiles
+            self.activeProfileID = importedState.activeProfileID
+        }
 
-        applyProfile(updatedProfiles[activeProfileIndex])
+        self.shortcutProfilesEnabled = shortcutProfilesEnabled
+        persistLegacySettings()
+        persistProfilesState()
+        applyCurrentModeSettings(shouldPersistModeFlag: true, shouldPostSettingsChange: true)
     }
 
     private func setupHotkeyMonitoring() {
@@ -402,24 +457,31 @@ class HotkeyManager: ObservableObject {
     }
 
     private func handleActivationConfigurationDidChange() {
-        guard !isApplyingProfile else { return }
+        guard !isApplyingActivationSettings else { return }
 
         updateLiveCustomShortcutsForCurrentState()
-        syncActiveProfileFromCurrentState()
-        persistProfilesState()
+        if shortcutProfilesEnabled {
+            ensureSavedProfilesState()
+            syncActiveProfileFromCurrentState()
+            persistProfilesState()
+        } else {
+            syncLegacySettingsFromCurrentState()
+            persistLegacySettings()
+        }
         setupHotkeyMonitoring()
         NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
     }
 
     private func updateLiveCustomShortcutsForCurrentState() {
-        let primaryShortcut = selectedHotkey1 == .custom ? activeProfile?.toggleMiniRecorderShortcut : nil
-        let secondaryShortcut = selectedHotkey2 == .custom ? activeProfile?.toggleMiniRecorderShortcut2 : nil
+        let primaryShortcut = selectedHotkey1 == .custom ? currentCustomShortcut(for: .primary) : nil
+        let secondaryShortcut = selectedHotkey2 == .custom ? currentCustomShortcut(for: .secondary) : nil
 
         KeyboardShortcuts.setShortcut(primaryShortcut, for: .toggleMiniRecorder)
         KeyboardShortcuts.setShortcut(secondaryShortcut, for: .toggleMiniRecorder2)
     }
 
     private func syncActiveProfileFromCurrentState() {
+        ensureSavedProfilesState()
         guard let activeProfileIndex else { return }
 
         var updatedProfiles = profiles
@@ -439,33 +501,100 @@ class HotkeyManager: ObservableObject {
         profiles = updatedProfiles
     }
 
+    private func syncLegacySettingsFromCurrentState() {
+        legacySettings.selectedHotkey1 = selectedHotkey1
+        legacySettings.selectedHotkey2 = selectedHotkey2
+        legacySettings.hotkeyMode1 = hotkeyMode1
+        legacySettings.hotkeyMode2 = hotkeyMode2
+
+        if selectedHotkey1 == .custom {
+            legacySettings.toggleMiniRecorderShortcut = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder)
+        }
+
+        if selectedHotkey2 == .custom {
+            legacySettings.toggleMiniRecorderShortcut2 = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2)
+        }
+    }
+
     private func applyProfile(
         _ profile: ActivationShortcutProfile,
         shouldPersist: Bool = true,
         shouldPostSettingsChange: Bool = true
     ) {
-        isApplyingProfile = true
         activeProfileID = profile.id
-        selectedHotkey1 = profile.selectedHotkey1
-        selectedHotkey2 = profile.selectedHotkey2
-        hotkeyMode1 = profile.hotkeyMode1
-        hotkeyMode2 = profile.hotkeyMode2
-        isApplyingProfile = false
-
-        KeyboardShortcuts.setShortcut(
-            profile.selectedHotkey1 == .custom ? profile.toggleMiniRecorderShortcut : nil,
-            for: .toggleMiniRecorder
-        )
-        KeyboardShortcuts.setShortcut(
-            profile.selectedHotkey2 == .custom ? profile.toggleMiniRecorderShortcut2 : nil,
-            for: .toggleMiniRecorder2
-        )
-
-        mirrorActiveProfileToLegacyDefaults()
+        applyEffectiveSettings(profile.makeLegacySettings(), shouldPostSettingsChange: false)
 
         if shouldPersist {
             persistProfilesState()
         }
+
+        if shouldPostSettingsChange {
+            NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+        }
+    }
+
+    private func applyLegacySettings(
+        _ settings: LegacyActivationShortcutSettings,
+        shouldPersist: Bool = true,
+        shouldPostSettingsChange: Bool = true
+    ) {
+        legacySettings = settings
+        applyEffectiveSettings(settings, shouldPostSettingsChange: false)
+
+        if shouldPersist {
+            persistLegacySettings()
+        }
+
+        if shouldPostSettingsChange {
+            NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+        }
+    }
+
+    private func applyCurrentModeSettings(
+        shouldPersistModeFlag: Bool = true,
+        shouldPostSettingsChange: Bool = true
+    ) {
+        if shouldPersistModeFlag {
+            UserDefaults.standard.shortcutProfilesEnabled = shortcutProfilesEnabled
+        }
+
+        if shortcutProfilesEnabled {
+            ensureSavedProfilesState()
+            if let profile = activeProfile {
+                applyProfile(
+                    profile,
+                    shouldPersist: true,
+                    shouldPostSettingsChange: shouldPostSettingsChange
+                )
+            }
+        } else {
+            applyLegacySettings(
+                legacySettings,
+                shouldPersist: true,
+                shouldPostSettingsChange: shouldPostSettingsChange
+            )
+        }
+    }
+
+    private func applyEffectiveSettings(
+        _ settings: LegacyActivationShortcutSettings,
+        shouldPostSettingsChange: Bool = true
+    ) {
+        isApplyingActivationSettings = true
+        selectedHotkey1 = settings.selectedHotkey1
+        selectedHotkey2 = settings.selectedHotkey2
+        hotkeyMode1 = settings.hotkeyMode1
+        hotkeyMode2 = settings.hotkeyMode2
+        isApplyingActivationSettings = false
+
+        KeyboardShortcuts.setShortcut(
+            settings.selectedHotkey1 == .custom ? settings.toggleMiniRecorderShortcut : nil,
+            for: .toggleMiniRecorder
+        )
+        KeyboardShortcuts.setShortcut(
+            settings.selectedHotkey2 == .custom ? settings.toggleMiniRecorderShortcut2 : nil,
+            for: .toggleMiniRecorder2
+        )
 
         setupHotkeyMonitoring()
 
@@ -474,19 +603,78 @@ class HotkeyManager: ObservableObject {
         }
     }
 
-    private func mirrorActiveProfileToLegacyDefaults() {
-        UserDefaults.standard.set(selectedHotkey1.rawValue, forKey: "selectedHotkey1")
-        UserDefaults.standard.set(selectedHotkey2.rawValue, forKey: "selectedHotkey2")
-        UserDefaults.standard.set(hotkeyMode1.rawValue, forKey: "hotkeyMode1")
-        UserDefaults.standard.set(hotkeyMode2.rawValue, forKey: "hotkeyMode2")
+    private func ensureSavedProfilesState() {
+        if profiles.isEmpty {
+            let seededState = ActivationShortcutProfilesState.makeDefaultState(from: legacySettings)
+            profiles = seededState.profiles
+            activeProfileID = seededState.activeProfileID
+            return
+        }
+
+        let normalizedState = ActivationShortcutProfilesState(
+            profiles: profiles,
+            activeProfileID: activeProfileID
+        )
+        profiles = normalizedState.profiles
+        activeProfileID = normalizedState.activeProfileID
+    }
+
+    private func persistLegacySettings() {
+        UserDefaults.standard.set(legacySettings.selectedHotkey1.rawValue, forKey: "selectedHotkey1")
+        UserDefaults.standard.set(legacySettings.selectedHotkey2.rawValue, forKey: "selectedHotkey2")
+        UserDefaults.standard.set(legacySettings.hotkeyMode1.rawValue, forKey: "hotkeyMode1")
+        UserDefaults.standard.set(legacySettings.hotkeyMode2.rawValue, forKey: "hotkeyMode2")
+        UserDefaults.standard.legacyToggleMiniRecorderShortcutData = Self.encodeShortcutData(legacySettings.toggleMiniRecorderShortcut)
+        UserDefaults.standard.legacyToggleMiniRecorderShortcut2Data = Self.encodeShortcutData(legacySettings.toggleMiniRecorderShortcut2)
     }
 
     private func persistProfilesState() {
-        if let data = try? JSONEncoder().encode(profiles) {
+        guard !profiles.isEmpty else {
+            UserDefaults.standard.activationShortcutProfilesData = nil
+            UserDefaults.standard.activeActivationShortcutProfileID = nil
+            return
+        }
+
+        let normalizedState = ActivationShortcutProfilesState(
+            profiles: profiles,
+            activeProfileID: activeProfileID
+        )
+        profiles = normalizedState.profiles
+        activeProfileID = normalizedState.activeProfileID
+
+        if let data = try? JSONEncoder().encode(normalizedState.profiles) {
             UserDefaults.standard.activationShortcutProfilesData = data
         }
-        UserDefaults.standard.activeActivationShortcutProfileID = activeProfileID?.uuidString
-        mirrorActiveProfileToLegacyDefaults()
+        UserDefaults.standard.activeActivationShortcutProfileID = normalizedState.activeProfileID.uuidString
+    }
+
+    private func currentCustomShortcut(for slot: ActivationSlot) -> KeyboardShortcuts.Shortcut? {
+        if shortcutProfilesEnabled {
+            switch slot {
+            case .primary:
+                return activeProfile?.toggleMiniRecorderShortcut
+            case .secondary:
+                return activeProfile?.toggleMiniRecorderShortcut2
+            }
+        }
+
+        switch slot {
+        case .primary:
+            return legacySettings.toggleMiniRecorderShortcut
+        case .secondary:
+            return legacySettings.toggleMiniRecorderShortcut2
+        }
+    }
+
+    private func currentEffectiveSettings() -> LegacyActivationShortcutSettings {
+        LegacyActivationShortcutSettings(
+            selectedHotkey1: selectedHotkey1,
+            selectedHotkey2: selectedHotkey2,
+            hotkeyMode1: hotkeyMode1,
+            hotkeyMode2: hotkeyMode2,
+            toggleMiniRecorderShortcut: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder),
+            toggleMiniRecorderShortcut2: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2)
+        )
     }
 
     private func uniqueProfileName(for baseName: String, excluding profileID: UUID? = nil) -> String {
@@ -531,7 +719,7 @@ class HotkeyManager: ObservableObject {
         }
     }
 
-    private static func loadInitialProfileState() -> ActivationShortcutProfilesState {
+    private static func loadPersistedProfilesState() -> ActivationShortcutProfilesState? {
         if let data = UserDefaults.standard.activationShortcutProfilesData,
            let decodedProfiles = try? JSONDecoder().decode([ActivationShortcutProfile].self, from: data),
            !decodedProfiles.isEmpty {
@@ -541,9 +729,7 @@ class HotkeyManager: ObservableObject {
             )
         }
 
-        return ActivationShortcutProfilesState.makeDefaultState(
-            from: loadLegacyActivationSettings()
-        )
+        return nil
     }
 
     private static func loadLegacyActivationSettings() -> LegacyActivationShortcutSettings {
@@ -552,9 +738,23 @@ class HotkeyManager: ObservableObject {
             selectedHotkey2: HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey2") ?? "") ?? .none,
             hotkeyMode1: HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode1") ?? "") ?? .hybrid,
             hotkeyMode2: HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode2") ?? "") ?? .hybrid,
-            toggleMiniRecorderShortcut: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder),
-            toggleMiniRecorderShortcut2: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2)
+            toggleMiniRecorderShortcut: decodeShortcutData(
+                UserDefaults.standard.legacyToggleMiniRecorderShortcutData
+            ) ?? KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder),
+            toggleMiniRecorderShortcut2: decodeShortcutData(
+                UserDefaults.standard.legacyToggleMiniRecorderShortcut2Data
+            ) ?? KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2)
         )
+    }
+
+    private static func encodeShortcutData(_ shortcut: KeyboardShortcuts.Shortcut?) -> Data? {
+        guard let shortcut else { return nil }
+        return try? JSONEncoder().encode(shortcut)
+    }
+
+    private static func decodeShortcutData(_ data: Data?) -> KeyboardShortcuts.Shortcut? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode(KeyboardShortcuts.Shortcut.self, from: data)
     }
 
     private func setupModifierKeyMonitoring() {

--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -87,6 +87,7 @@ class HotkeyManager: ObservableObject {
     private var shortcutCurrentKeyState = false
     private var lastShortcutTriggerTime: Date?
     private let shortcutCooldownInterval: TimeInterval = 0.5
+    private var didFinishLaunching = false
 
     private static let hybridPressThreshold: TimeInterval = 0.5
 
@@ -198,13 +199,22 @@ class HotkeyManager: ObservableObject {
             }
         }
 
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            self.setupHotkeyMonitoring()
-        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidFinishLaunching),
+            name: NSApplication.didFinishLaunchingNotification,
+            object: nil
+        )
     }
-    
+
+    @objc private func appDidFinishLaunching(_ notification: Notification) {
+        NotificationCenter.default.removeObserver(self, name: NSApplication.didFinishLaunchingNotification, object: nil)
+        didFinishLaunching = true
+        setupHotkeyMonitoring()
+    }
+
     private func setupHotkeyMonitoring() {
+        guard didFinishLaunching else { return }
         removeAllMonitoring()
         
         setupModifierKeyMonitoring()
@@ -508,6 +518,8 @@ class HotkeyManager: ObservableObject {
     }
     
     deinit {
+        NotificationCenter.default.removeObserver(self)
+
         Task { @MainActor in
             removeAllMonitoring()
         }

--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -15,29 +15,31 @@ extension KeyboardShortcuts.Name {
 
 @MainActor
 class HotkeyManager: ObservableObject {
+    enum ActivationSlot {
+        case primary
+        case secondary
+    }
+
+    @Published private(set) var profiles: [ActivationShortcutProfile]
+    @Published private(set) var activeProfileID: UUID?
     @Published var selectedHotkey1: HotkeyOption {
         didSet {
-            UserDefaults.standard.set(selectedHotkey1.rawValue, forKey: "selectedHotkey1")
-            setupHotkeyMonitoring()
+            handleActivationConfigurationDidChange()
         }
     }
     @Published var selectedHotkey2: HotkeyOption {
         didSet {
-            if selectedHotkey2 == .none {
-                KeyboardShortcuts.setShortcut(nil, for: .toggleMiniRecorder2)
-            }
-            UserDefaults.standard.set(selectedHotkey2.rawValue, forKey: "selectedHotkey2")
-            setupHotkeyMonitoring()
+            handleActivationConfigurationDidChange()
         }
     }
     @Published var hotkeyMode1: HotkeyMode {
         didSet {
-            UserDefaults.standard.set(hotkeyMode1.rawValue, forKey: "hotkeyMode1")
+            handleActivationConfigurationDidChange()
         }
     }
     @Published var hotkeyMode2: HotkeyMode {
         didSet {
-            UserDefaults.standard.set(hotkeyMode2.rawValue, forKey: "hotkeyMode2")
+            handleActivationConfigurationDidChange()
         }
     }
     @Published var isMiddleClickToggleEnabled: Bool {
@@ -87,11 +89,12 @@ class HotkeyManager: ObservableObject {
     private var shortcutCurrentKeyState = false
     private var lastShortcutTriggerTime: Date?
     private let shortcutCooldownInterval: TimeInterval = 0.5
+    private var isApplyingProfile = false
     private var didFinishLaunching = false
 
     private static let hybridPressThreshold: TimeInterval = 0.5
 
-    enum HotkeyMode: String, CaseIterable {
+    enum HotkeyMode: String, CaseIterable, Codable {
         case toggle = "toggle"
         case pushToTalk = "pushToTalk"
         case hybrid = "hybrid"
@@ -105,7 +108,7 @@ class HotkeyManager: ObservableObject {
         }
     }
 
-    enum HotkeyOption: String, CaseIterable {
+    enum HotkeyOption: String, CaseIterable, Codable {
         case none = "none"
         case rightOption = "rightOption"
         case leftOption = "leftOption"
@@ -149,11 +152,22 @@ class HotkeyManager: ObservableObject {
     }
     
     init(engine: VoiceInkEngine, recorderUIManager: RecorderUIManager) {
-        self.selectedHotkey1 = HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey1") ?? "") ?? .rightCommand
-        self.selectedHotkey2 = HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey2") ?? "") ?? .none
+        let initialProfileState = Self.loadInitialProfileState()
+        let initialProfile = initialProfileState.activeProfile ?? LegacyActivationShortcutSettings(
+            selectedHotkey1: .rightCommand,
+            selectedHotkey2: .none,
+            hotkeyMode1: .hybrid,
+            hotkeyMode2: .hybrid,
+            toggleMiniRecorderShortcut: nil,
+            toggleMiniRecorderShortcut2: nil
+        ).makeDefaultProfile()
 
-        self.hotkeyMode1 = HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode1") ?? "") ?? .hybrid
-        self.hotkeyMode2 = HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode2") ?? "") ?? .hybrid
+        self.profiles = initialProfileState.profiles
+        self.activeProfileID = initialProfileState.activeProfileID
+        self.selectedHotkey1 = initialProfile.selectedHotkey1
+        self.selectedHotkey2 = initialProfile.selectedHotkey2
+        self.hotkeyMode1 = initialProfile.hotkeyMode1
+        self.hotkeyMode2 = initialProfile.hotkeyMode2
 
         self.isMiddleClickToggleEnabled = UserDefaults.standard.bool(forKey: "isMiddleClickToggleEnabled")
         self.middleClickActivationDelay = UserDefaults.standard.integer(forKey: "middleClickActivationDelay")
@@ -199,6 +213,12 @@ class HotkeyManager: ObservableObject {
             }
         }
 
+        applyProfile(
+            initialProfile,
+            shouldPersist: true,
+            shouldPostSettingsChange: false
+        )
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(appDidFinishLaunching),
@@ -213,6 +233,157 @@ class HotkeyManager: ObservableObject {
         setupHotkeyMonitoring()
     }
 
+    var activeProfile: ActivationShortcutProfile? {
+        guard let activeProfileID else {
+            return profiles.first
+        }
+
+        return profiles.first { $0.id == activeProfileID } ?? profiles.first
+    }
+
+    var activeProfileName: String {
+        activeProfile?.name ?? "Default"
+    }
+
+    var hasAnyActivationShortcut: Bool {
+        isActivationSlotConfigured(.primary) || isActivationSlotConfigured(.secondary)
+    }
+
+    var primaryCustomShortcut: KeyboardShortcuts.Shortcut? {
+        activeProfile?.toggleMiniRecorderShortcut
+    }
+
+    var secondaryCustomShortcut: KeyboardShortcuts.Shortcut? {
+        activeProfile?.toggleMiniRecorderShortcut2
+    }
+
+    func switchProfile(to id: UUID) {
+        guard let profile = profiles.first(where: { $0.id == id }) else { return }
+        applyProfile(profile)
+    }
+
+    func createProfileFromCurrent(name: String? = nil) {
+        guard let activeProfile else { return }
+
+        var newProfile = activeProfile
+        newProfile.id = UUID()
+        newProfile.name = uniqueProfileName(for: name ?? "New Profile")
+
+        profiles.append(newProfile)
+        applyProfile(newProfile)
+    }
+
+    func duplicateActiveProfile() {
+        guard let activeProfile else { return }
+
+        var duplicatedProfile = activeProfile
+        duplicatedProfile.id = UUID()
+        duplicatedProfile.name = uniqueProfileName(for: "\(activeProfile.name) Copy")
+
+        profiles.append(duplicatedProfile)
+        applyProfile(duplicatedProfile)
+    }
+
+    func renameActiveProfile(to name: String) {
+        guard let activeProfileIndex else { return }
+
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+
+        let currentProfile = profiles[activeProfileIndex]
+        let uniqueName = uniqueProfileName(for: trimmedName, excluding: currentProfile.id)
+
+        var updatedProfiles = profiles
+        updatedProfiles[activeProfileIndex].name = uniqueName
+        profiles = updatedProfiles
+        persistProfilesState()
+    }
+
+    func deleteProfile(with id: UUID) {
+        guard profiles.count > 1,
+              let index = profiles.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let fallbackProfile: ActivationShortcutProfile?
+        if activeProfileID == id {
+            if index < profiles.count - 1 {
+                fallbackProfile = profiles[index + 1]
+            } else {
+                fallbackProfile = profiles[index - 1]
+            }
+        } else {
+            fallbackProfile = activeProfile
+        }
+
+        var updatedProfiles = profiles
+        updatedProfiles.remove(at: index)
+        profiles = updatedProfiles
+
+        if let fallbackProfile {
+            applyProfile(fallbackProfile)
+        } else {
+            persistProfilesState()
+        }
+    }
+
+    func setCustomShortcut(_ shortcut: KeyboardShortcuts.Shortcut?, for slot: ActivationSlot) {
+        guard let activeProfileIndex else { return }
+
+        var updatedProfiles = profiles
+        switch slot {
+        case .primary:
+            updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut = shortcut
+            if selectedHotkey1 == .custom {
+                KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder)
+            }
+        case .secondary:
+            updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut2 = shortcut
+            if selectedHotkey2 == .custom {
+                KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder2)
+            }
+        }
+
+        profiles = updatedProfiles
+        persistProfilesState()
+        setupHotkeyMonitoring()
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+    }
+
+    func importProfiles(_ importedProfiles: [ActivationShortcutProfile], activeProfileID: UUID?) {
+        let importedState = ActivationShortcutProfilesState(
+            profiles: importedProfiles,
+            activeProfileID: activeProfileID
+        )
+
+        profiles = importedState.profiles
+        if let profile = importedState.activeProfile {
+            applyProfile(profile)
+        }
+    }
+
+    func importLegacyActivationSettings(
+        selectedHotkey1: HotkeyOption,
+        selectedHotkey2: HotkeyOption,
+        hotkeyMode1: HotkeyMode,
+        hotkeyMode2: HotkeyMode,
+        toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?,
+        toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
+    ) {
+        guard let activeProfileIndex else { return }
+
+        var updatedProfiles = profiles
+        updatedProfiles[activeProfileIndex].selectedHotkey1 = selectedHotkey1
+        updatedProfiles[activeProfileIndex].selectedHotkey2 = selectedHotkey2
+        updatedProfiles[activeProfileIndex].hotkeyMode1 = hotkeyMode1
+        updatedProfiles[activeProfileIndex].hotkeyMode2 = hotkeyMode2
+        updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut = toggleMiniRecorderShortcut
+        updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut2 = toggleMiniRecorderShortcut2
+        profiles = updatedProfiles
+
+        applyProfile(updatedProfiles[activeProfileIndex])
+    }
+
     private func setupHotkeyMonitoring() {
         guard didFinishLaunching else { return }
         removeAllMonitoring()
@@ -222,6 +393,170 @@ class HotkeyManager: ObservableObject {
         setupMiddleClickMonitoring()
     }
     
+    private var activeProfileIndex: Int? {
+        guard let activeProfileID else {
+            return profiles.isEmpty ? nil : 0
+        }
+
+        return profiles.firstIndex(where: { $0.id == activeProfileID }) ?? (profiles.isEmpty ? nil : 0)
+    }
+
+    private func handleActivationConfigurationDidChange() {
+        guard !isApplyingProfile else { return }
+
+        updateLiveCustomShortcutsForCurrentState()
+        syncActiveProfileFromCurrentState()
+        persistProfilesState()
+        setupHotkeyMonitoring()
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+    }
+
+    private func updateLiveCustomShortcutsForCurrentState() {
+        let primaryShortcut = selectedHotkey1 == .custom ? activeProfile?.toggleMiniRecorderShortcut : nil
+        let secondaryShortcut = selectedHotkey2 == .custom ? activeProfile?.toggleMiniRecorderShortcut2 : nil
+
+        KeyboardShortcuts.setShortcut(primaryShortcut, for: .toggleMiniRecorder)
+        KeyboardShortcuts.setShortcut(secondaryShortcut, for: .toggleMiniRecorder2)
+    }
+
+    private func syncActiveProfileFromCurrentState() {
+        guard let activeProfileIndex else { return }
+
+        var updatedProfiles = profiles
+        updatedProfiles[activeProfileIndex].selectedHotkey1 = selectedHotkey1
+        updatedProfiles[activeProfileIndex].selectedHotkey2 = selectedHotkey2
+        updatedProfiles[activeProfileIndex].hotkeyMode1 = hotkeyMode1
+        updatedProfiles[activeProfileIndex].hotkeyMode2 = hotkeyMode2
+
+        if selectedHotkey1 == .custom {
+            updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder)
+        }
+
+        if selectedHotkey2 == .custom {
+            updatedProfiles[activeProfileIndex].toggleMiniRecorderShortcut2 = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2)
+        }
+
+        profiles = updatedProfiles
+    }
+
+    private func applyProfile(
+        _ profile: ActivationShortcutProfile,
+        shouldPersist: Bool = true,
+        shouldPostSettingsChange: Bool = true
+    ) {
+        isApplyingProfile = true
+        activeProfileID = profile.id
+        selectedHotkey1 = profile.selectedHotkey1
+        selectedHotkey2 = profile.selectedHotkey2
+        hotkeyMode1 = profile.hotkeyMode1
+        hotkeyMode2 = profile.hotkeyMode2
+        isApplyingProfile = false
+
+        KeyboardShortcuts.setShortcut(
+            profile.selectedHotkey1 == .custom ? profile.toggleMiniRecorderShortcut : nil,
+            for: .toggleMiniRecorder
+        )
+        KeyboardShortcuts.setShortcut(
+            profile.selectedHotkey2 == .custom ? profile.toggleMiniRecorderShortcut2 : nil,
+            for: .toggleMiniRecorder2
+        )
+
+        mirrorActiveProfileToLegacyDefaults()
+
+        if shouldPersist {
+            persistProfilesState()
+        }
+
+        setupHotkeyMonitoring()
+
+        if shouldPostSettingsChange {
+            NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+        }
+    }
+
+    private func mirrorActiveProfileToLegacyDefaults() {
+        UserDefaults.standard.set(selectedHotkey1.rawValue, forKey: "selectedHotkey1")
+        UserDefaults.standard.set(selectedHotkey2.rawValue, forKey: "selectedHotkey2")
+        UserDefaults.standard.set(hotkeyMode1.rawValue, forKey: "hotkeyMode1")
+        UserDefaults.standard.set(hotkeyMode2.rawValue, forKey: "hotkeyMode2")
+    }
+
+    private func persistProfilesState() {
+        if let data = try? JSONEncoder().encode(profiles) {
+            UserDefaults.standard.activationShortcutProfilesData = data
+        }
+        UserDefaults.standard.activeActivationShortcutProfileID = activeProfileID?.uuidString
+        mirrorActiveProfileToLegacyDefaults()
+    }
+
+    private func uniqueProfileName(for baseName: String, excluding profileID: UUID? = nil) -> String {
+        let trimmedBaseName = baseName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitizedBaseName = trimmedBaseName.isEmpty ? "Profile" : trimmedBaseName
+        let excludedID = profileID
+
+        var candidate = sanitizedBaseName
+        var suffix = 2
+        let existingNames = profiles
+            .filter { $0.id != excludedID }
+            .map { $0.name.lowercased() }
+
+        while existingNames.contains(candidate.lowercased()) {
+            candidate = "\(sanitizedBaseName) \(suffix)"
+            suffix += 1
+        }
+
+        return candidate
+    }
+
+    private func isActivationSlotConfigured(_ slot: ActivationSlot) -> Bool {
+        switch slot {
+        case .primary:
+            switch selectedHotkey1 {
+            case .none:
+                return false
+            case .custom:
+                return KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder) != nil
+            default:
+                return true
+            }
+        case .secondary:
+            switch selectedHotkey2 {
+            case .none:
+                return false
+            case .custom:
+                return KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2) != nil
+            default:
+                return true
+            }
+        }
+    }
+
+    private static func loadInitialProfileState() -> ActivationShortcutProfilesState {
+        if let data = UserDefaults.standard.activationShortcutProfilesData,
+           let decodedProfiles = try? JSONDecoder().decode([ActivationShortcutProfile].self, from: data),
+           !decodedProfiles.isEmpty {
+            return ActivationShortcutProfilesState(
+                profiles: decodedProfiles,
+                activeProfileID: UserDefaults.standard.activeActivationShortcutProfileID.flatMap(UUID.init(uuidString:))
+            )
+        }
+
+        return ActivationShortcutProfilesState.makeDefaultState(
+            from: loadLegacyActivationSettings()
+        )
+    }
+
+    private static func loadLegacyActivationSettings() -> LegacyActivationShortcutSettings {
+        LegacyActivationShortcutSettings(
+            selectedHotkey1: HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey1") ?? "") ?? .rightCommand,
+            selectedHotkey2: HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "selectedHotkey2") ?? "") ?? .none,
+            hotkeyMode1: HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode1") ?? "") ?? .hybrid,
+            hotkeyMode2: HotkeyMode(rawValue: UserDefaults.standard.string(forKey: "hotkeyMode2") ?? "") ?? .hybrid,
+            toggleMiniRecorderShortcut: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder),
+            toggleMiniRecorderShortcut2: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2)
+        )
+    }
+
     private func setupModifierKeyMonitoring() {
         // Only set up if at least one hotkey is a modifier key
         guard (selectedHotkey1.isModifierKey && selectedHotkey1 != .none) || (selectedHotkey2.isModifierKey && selectedHotkey2 != .none) else { return }
@@ -505,15 +840,17 @@ class HotkeyManager: ObservableObject {
     
     // Computed property for backward compatibility with UI
     var isShortcutConfigured: Bool {
-        let isHotkey1Configured = (selectedHotkey1 == .custom) ? (KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder) != nil) : true
-        let isHotkey2Configured = (selectedHotkey2 == .custom) ? (KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2) != nil) : true
-        return isHotkey1Configured && isHotkey2Configured
+        hasAnyActivationShortcut
     }
     
     func updateShortcutStatus() {
         // Called when a custom shortcut changes
-        if selectedHotkey1 == .custom || selectedHotkey2 == .custom {
-            setupHotkeyMonitoring()
+        if selectedHotkey1 == .custom {
+            setCustomShortcut(KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder), for: .primary)
+        }
+
+        if selectedHotkey2 == .custom {
+            setCustomShortcut(KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2), for: .secondary)
         }
     }
     

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -11,6 +11,10 @@ struct GeneralSettings: Codable {
     let retryLastTranscriptionShortcut: KeyboardShortcuts.Shortcut?
     let selectedHotkey1RawValue: String?
     let selectedHotkey2RawValue: String?
+    let hotkeyMode1RawValue: String?
+    let hotkeyMode2RawValue: String?
+    let shortcutProfiles: [ActivationShortcutProfile]?
+    let activeShortcutProfileId: UUID?
     let launchAtLoginEnabled: Bool?
     let isMenuBarOnly: Bool?
     let recorderType: String?
@@ -104,6 +108,10 @@ class ImportExportService {
             retryLastTranscriptionShortcut: KeyboardShortcuts.getShortcut(for: .retryLastTranscription),
             selectedHotkey1RawValue: hotkeyManager.selectedHotkey1.rawValue,
             selectedHotkey2RawValue: hotkeyManager.selectedHotkey2.rawValue,
+            hotkeyMode1RawValue: hotkeyManager.hotkeyMode1.rawValue,
+            hotkeyMode2RawValue: hotkeyManager.hotkeyMode2.rawValue,
+            shortcutProfiles: hotkeyManager.profiles,
+            activeShortcutProfileId: hotkeyManager.activeProfileID,
             launchAtLoginEnabled: LaunchAtLogin.isEnabled,
             isMenuBarOnly: menuBarManager.isMenuBarOnly,
             recorderType: recorderUIManager.recorderType,
@@ -272,23 +280,33 @@ class ImportExportService {
                     }
 
                     if let general = importedSettings.generalSettings {
-                        if let shortcut = general.toggleMiniRecorderShortcut {
-                            KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder)
-                        }
-                        if let shortcut2 = general.toggleMiniRecorderShortcut2 {
-                            KeyboardShortcuts.setShortcut(shortcut2, for: .toggleMiniRecorder2)
-                        }
                         if let retryShortcut = general.retryLastTranscriptionShortcut {
                             KeyboardShortcuts.setShortcut(retryShortcut, for: .retryLastTranscription)
                         }
-                        if let hotkeyRaw = general.selectedHotkey1RawValue,
-                           let hotkey = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw) {
-                            hotkeyManager.selectedHotkey1 = hotkey
-                        }
-                        if let hotkeyRaw2 = general.selectedHotkey2RawValue,
-                           let hotkey2 = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw2) {
-                            hotkeyManager.selectedHotkey2 = hotkey2
-                        }
+
+                        let importedLegacyHotkeySettings = LegacyActivationShortcutSettings(
+                            selectedHotkey1: general.selectedHotkey1RawValue
+                                .flatMap(HotkeyManager.HotkeyOption.init(rawValue:)) ?? hotkeyManager.selectedHotkey1,
+                            selectedHotkey2: general.selectedHotkey2RawValue
+                                .flatMap(HotkeyManager.HotkeyOption.init(rawValue:)) ?? hotkeyManager.selectedHotkey2,
+                            hotkeyMode1: general.hotkeyMode1RawValue
+                                .flatMap(HotkeyManager.HotkeyMode.init(rawValue:)) ?? hotkeyManager.hotkeyMode1,
+                            hotkeyMode2: general.hotkeyMode2RawValue
+                                .flatMap(HotkeyManager.HotkeyMode.init(rawValue:)) ?? hotkeyManager.hotkeyMode2,
+                            toggleMiniRecorderShortcut: general.toggleMiniRecorderShortcut,
+                            toggleMiniRecorderShortcut2: general.toggleMiniRecorderShortcut2
+                        )
+
+                        let importedProfileState = ActivationShortcutProfilesState.fromImportedSettings(
+                            shortcutProfiles: general.shortcutProfiles,
+                            activeProfileID: general.activeShortcutProfileId,
+                            legacySettings: importedLegacyHotkeySettings
+                        )
+                        hotkeyManager.importProfiles(
+                            importedProfileState.profiles,
+                            activeProfileID: importedProfileState.activeProfileID
+                        )
+
                         if let launch = general.launchAtLoginEnabled {
                             LaunchAtLogin.isEnabled = launch
                         }

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -13,6 +13,7 @@ struct GeneralSettings: Codable {
     let selectedHotkey2RawValue: String?
     let hotkeyMode1RawValue: String?
     let hotkeyMode2RawValue: String?
+    let shortcutProfilesEnabled: Bool?
     let shortcutProfiles: [ActivationShortcutProfile]?
     let activeShortcutProfileId: UUID?
     let launchAtLoginEnabled: Bool?
@@ -102,14 +103,16 @@ class ImportExportService {
             exportedWordReplacements = Dictionary(uniqueKeysWithValues: replacements.map { ($0.originalText, $0.replacementText) })
         }
 
+        let legacyHotkeySettings = hotkeyManager.legacyActivationSettings
         let generalSettingsToExport = GeneralSettings(
-            toggleMiniRecorderShortcut: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder),
-            toggleMiniRecorderShortcut2: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2),
+            toggleMiniRecorderShortcut: legacyHotkeySettings.toggleMiniRecorderShortcut,
+            toggleMiniRecorderShortcut2: legacyHotkeySettings.toggleMiniRecorderShortcut2,
             retryLastTranscriptionShortcut: KeyboardShortcuts.getShortcut(for: .retryLastTranscription),
-            selectedHotkey1RawValue: hotkeyManager.selectedHotkey1.rawValue,
-            selectedHotkey2RawValue: hotkeyManager.selectedHotkey2.rawValue,
-            hotkeyMode1RawValue: hotkeyManager.hotkeyMode1.rawValue,
-            hotkeyMode2RawValue: hotkeyManager.hotkeyMode2.rawValue,
+            selectedHotkey1RawValue: legacyHotkeySettings.selectedHotkey1.rawValue,
+            selectedHotkey2RawValue: legacyHotkeySettings.selectedHotkey2.rawValue,
+            hotkeyMode1RawValue: legacyHotkeySettings.hotkeyMode1.rawValue,
+            hotkeyMode2RawValue: legacyHotkeySettings.hotkeyMode2.rawValue,
+            shortcutProfilesEnabled: hotkeyManager.shortcutProfilesEnabled,
             shortcutProfiles: hotkeyManager.profiles,
             activeShortcutProfileId: hotkeyManager.activeProfileID,
             launchAtLoginEnabled: LaunchAtLogin.isEnabled,
@@ -297,14 +300,19 @@ class ImportExportService {
                             toggleMiniRecorderShortcut2: general.toggleMiniRecorderShortcut2
                         )
 
-                        let importedProfileState = ActivationShortcutProfilesState.fromImportedSettings(
-                            shortcutProfiles: general.shortcutProfiles,
-                            activeProfileID: general.activeShortcutProfileId,
-                            legacySettings: importedLegacyHotkeySettings
-                        )
-                        hotkeyManager.importProfiles(
-                            importedProfileState.profiles,
-                            activeProfileID: importedProfileState.activeProfileID
+                        let importedProfiles = general.shortcutProfiles ?? []
+                        let importedProfileState: ActivationShortcutProfilesState? =
+                            importedProfiles.isEmpty
+                            ? nil
+                            : ActivationShortcutProfilesState(
+                                profiles: importedProfiles,
+                                activeProfileID: general.activeShortcutProfileId
+                            )
+                        hotkeyManager.importActivationSettings(
+                            legacySettings: importedLegacyHotkeySettings,
+                            shortcutProfiles: importedProfileState?.profiles ?? [],
+                            activeProfileID: importedProfileState?.activeProfileID,
+                            shortcutProfilesEnabled: general.shortcutProfilesEnabled ?? false
                         )
 
                         if let launch = general.launchAtLoginEnabled {

--- a/VoiceInk/Services/SystemInfoService.swift
+++ b/VoiceInk/Services/SystemInfoService.swift
@@ -32,6 +32,7 @@ class SystemInfoService {
         Available Audio Devices: \(getAvailableAudioDevices())
 
         HOTKEY SETTINGS:
+        Active Hotkey Profile: \(getActiveHotkeyProfile())
         Primary Hotkey: \(getPrimaryHotkey())
         Secondary Hotkey: \(getSecondaryHotkey())
 
@@ -140,6 +141,21 @@ class SystemInfoService {
             return hotkey.displayName
         }
         return "Right Command"
+    }
+
+    private func getActiveHotkeyProfile() -> String {
+        if let data = UserDefaults.standard.activationShortcutProfilesData,
+           let profiles = try? JSONDecoder().decode([ActivationShortcutProfile].self, from: data),
+           !profiles.isEmpty {
+            let activeProfileID = UserDefaults.standard.activeActivationShortcutProfileID.flatMap(UUID.init(uuidString:))
+            if let activeProfileID,
+               let activeProfile = profiles.first(where: { $0.id == activeProfileID }) {
+                return activeProfile.name
+            }
+            return profiles[0].name
+        }
+
+        return "Default"
     }
 
     private func getSecondaryHotkey() -> String {

--- a/VoiceInk/Services/SystemInfoService.swift
+++ b/VoiceInk/Services/SystemInfoService.swift
@@ -32,6 +32,7 @@ class SystemInfoService {
         Available Audio Devices: \(getAvailableAudioDevices())
 
         HOTKEY SETTINGS:
+        Shortcut Profiles Enabled: \(UserDefaults.standard.shortcutProfilesEnabled)
         Active Hotkey Profile: \(getActiveHotkeyProfile())
         Primary Hotkey: \(getPrimaryHotkey())
         Secondary Hotkey: \(getSecondaryHotkey())
@@ -136,6 +137,11 @@ class SystemInfoService {
     }
 
     private func getPrimaryHotkey() -> String {
+        if UserDefaults.standard.shortcutProfilesEnabled,
+           let activeProfile = loadPersistedProfilesState()?.activeProfile {
+            return activeProfile.selectedHotkey1.displayName
+        }
+
         if let hotkeyRaw = UserDefaults.standard.string(forKey: "selectedHotkey1"),
            let hotkey = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw) {
             return hotkey.displayName
@@ -144,26 +150,41 @@ class SystemInfoService {
     }
 
     private func getActiveHotkeyProfile() -> String {
-        if let data = UserDefaults.standard.activationShortcutProfilesData,
-           let profiles = try? JSONDecoder().decode([ActivationShortcutProfile].self, from: data),
-           !profiles.isEmpty {
-            let activeProfileID = UserDefaults.standard.activeActivationShortcutProfileID.flatMap(UUID.init(uuidString:))
-            if let activeProfileID,
-               let activeProfile = profiles.first(where: { $0.id == activeProfileID }) {
-                return activeProfile.name
-            }
-            return profiles[0].name
+        guard UserDefaults.standard.shortcutProfilesEnabled else {
+            return "Single Profile Mode"
+        }
+
+        if let activeProfile = loadPersistedProfilesState()?.activeProfile {
+            return activeProfile.name
         }
 
         return "Default"
     }
 
     private func getSecondaryHotkey() -> String {
+        if UserDefaults.standard.shortcutProfilesEnabled,
+           let activeProfile = loadPersistedProfilesState()?.activeProfile {
+            return activeProfile.selectedHotkey2.displayName
+        }
+
         if let hotkeyRaw = UserDefaults.standard.string(forKey: "selectedHotkey2"),
            let hotkey = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw) {
             return hotkey.displayName
         }
         return "None"
+    }
+
+    private func loadPersistedProfilesState() -> ActivationShortcutProfilesState? {
+        guard let data = UserDefaults.standard.activationShortcutProfilesData,
+              let profiles = try? JSONDecoder().decode([ActivationShortcutProfile].self, from: data),
+              !profiles.isEmpty else {
+            return nil
+        }
+
+        return ActivationShortcutProfilesState(
+            profiles: profiles,
+            activeProfileID: UserDefaults.standard.activeActivationShortcutProfileID.flatMap(UUID.init(uuidString:))
+        )
     }
 
     private func getCurrentTranscriptionModel() -> String {

--- a/VoiceInk/Services/UserDefaultsManager.swift
+++ b/VoiceInk/Services/UserDefaultsManager.swift
@@ -6,6 +6,8 @@ extension UserDefaults {
         static let selectedAudioDeviceUID = "selectedAudioDeviceUID"
         static let prioritizedDevices = "prioritizedDevices"
         static let affiliatePromotionDismissed = "VoiceInkAffiliatePromotionDismissed"
+        static let activationShortcutProfiles = "activationShortcutProfiles"
+        static let activeActivationShortcutProfileID = "activeActivationShortcutProfileID"
     }
 
     // MARK: - Audio Input Mode
@@ -30,5 +32,16 @@ extension UserDefaults {
     var affiliatePromotionDismissed: Bool {
         get { bool(forKey: Keys.affiliatePromotionDismissed) }
         set { setValue(newValue, forKey: Keys.affiliatePromotionDismissed) }
+    }
+
+    // MARK: - Activation Shortcut Profiles
+    var activationShortcutProfilesData: Data? {
+        get { data(forKey: Keys.activationShortcutProfiles) }
+        set { setValue(newValue, forKey: Keys.activationShortcutProfiles) }
+    }
+
+    var activeActivationShortcutProfileID: String? {
+        get { string(forKey: Keys.activeActivationShortcutProfileID) }
+        set { setValue(newValue, forKey: Keys.activeActivationShortcutProfileID) }
     }
 }

--- a/VoiceInk/Services/UserDefaultsManager.swift
+++ b/VoiceInk/Services/UserDefaultsManager.swift
@@ -8,6 +8,9 @@ extension UserDefaults {
         static let affiliatePromotionDismissed = "VoiceInkAffiliatePromotionDismissed"
         static let activationShortcutProfiles = "activationShortcutProfiles"
         static let activeActivationShortcutProfileID = "activeActivationShortcutProfileID"
+        static let shortcutProfilesEnabled = "shortcutProfilesEnabled"
+        static let legacyToggleMiniRecorderShortcut = "legacyToggleMiniRecorderShortcut"
+        static let legacyToggleMiniRecorderShortcut2 = "legacyToggleMiniRecorderShortcut2"
     }
 
     // MARK: - Audio Input Mode
@@ -43,5 +46,20 @@ extension UserDefaults {
     var activeActivationShortcutProfileID: String? {
         get { string(forKey: Keys.activeActivationShortcutProfileID) }
         set { setValue(newValue, forKey: Keys.activeActivationShortcutProfileID) }
+    }
+
+    var shortcutProfilesEnabled: Bool {
+        get { bool(forKey: Keys.shortcutProfilesEnabled) }
+        set { setValue(newValue, forKey: Keys.shortcutProfilesEnabled) }
+    }
+
+    var legacyToggleMiniRecorderShortcutData: Data? {
+        get { data(forKey: Keys.legacyToggleMiniRecorderShortcut) }
+        set { setValue(newValue, forKey: Keys.legacyToggleMiniRecorderShortcut) }
+    }
+
+    var legacyToggleMiniRecorderShortcut2Data: Data? {
+        get { data(forKey: Keys.legacyToggleMiniRecorderShortcut2) }
+        set { setValue(newValue, forKey: Keys.legacyToggleMiniRecorderShortcut2) }
     }
 }

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -15,7 +15,6 @@ struct MenuBarView: View {
     @State private var launchAtLoginEnabled = LaunchAtLogin.isEnabled
     @State private var menuRefreshTrigger = false
     @State private var isHovered = false
-    @AppStorage("shortcutProfilesEnabled") private var shortcutProfilesEnabled = false
 
     var body: some View {
         VStack {
@@ -54,7 +53,7 @@ struct MenuBarView: View {
                 }
             }
 
-            if shortcutProfilesEnabled && hotkeyManager.profiles.count > 1 {
+            if hotkeyManager.shortcutProfilesEnabled && hotkeyManager.profiles.count > 1 {
                 Menu {
                     ForEach(hotkeyManager.profiles) { profile in
                         Button {

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -15,38 +15,12 @@ struct MenuBarView: View {
     @State private var launchAtLoginEnabled = LaunchAtLogin.isEnabled
     @State private var menuRefreshTrigger = false
     @State private var isHovered = false
-    
+    @AppStorage("shortcutProfilesEnabled") private var shortcutProfilesEnabled = false
+
     var body: some View {
         VStack {
             Button("Toggle Recorder") {
                 recorderUIManager.handleToggleMiniRecorder()
-            }
-
-            Menu {
-                ForEach(hotkeyManager.profiles) { profile in
-                    Button {
-                        hotkeyManager.switchProfile(to: profile.id)
-                    } label: {
-                        HStack {
-                            Text(profile.name)
-                            if hotkeyManager.activeProfileID == profile.id {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-
-                Divider()
-
-                Button("Manage Profiles") {
-                    menuBarManager.openMainWindowAndNavigate(to: "Settings")
-                }
-            } label: {
-                HStack {
-                    Text("Keyboard Profile: \(hotkeyManager.activeProfileName)")
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.system(size: 10))
-                }
             }
 
             Divider()
@@ -79,9 +53,38 @@ struct MenuBarView: View {
                         .font(.system(size: 10))
                 }
             }
-            
+
+            if shortcutProfilesEnabled && hotkeyManager.profiles.count > 1 {
+                Menu {
+                    ForEach(hotkeyManager.profiles) { profile in
+                        Button {
+                            hotkeyManager.switchProfile(to: profile.id)
+                        } label: {
+                            HStack {
+                                Text(profile.name)
+                                if hotkeyManager.activeProfileID == profile.id {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+
+                    Divider()
+
+                    Button("Manage Profiles") {
+                        menuBarManager.openMainWindowAndNavigate(to: "Settings")
+                    }
+                } label: {
+                    HStack {
+                        Text("Keyboard Profile: \(hotkeyManager.activeProfileName)")
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: 10))
+                    }
+                }
+            }
+
             Divider()
-            
+
             Toggle("AI Enhancement", isOn: $enhancementService.isEnhancementEnabled)
             
             Menu {

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -22,6 +22,33 @@ struct MenuBarView: View {
                 recorderUIManager.handleToggleMiniRecorder()
             }
 
+            Menu {
+                ForEach(hotkeyManager.profiles) { profile in
+                    Button {
+                        hotkeyManager.switchProfile(to: profile.id)
+                    } label: {
+                        HStack {
+                            Text(profile.name)
+                            if hotkeyManager.activeProfileID == profile.id {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+
+                Divider()
+
+                Button("Manage Profiles") {
+                    menuBarManager.openMainWindowAndNavigate(to: "Settings")
+                }
+            } label: {
+                HStack {
+                    Text("Keyboard Profile: \(hotkeyManager.activeProfileName)")
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10))
+                }
+            }
+
             Divider()
 
             Menu {

--- a/VoiceInk/Views/Metrics/MetricsSetupView.swift
+++ b/VoiceInk/Views/Metrics/MetricsSetupView.swift
@@ -68,7 +68,7 @@ struct MetricsSetupView: View {
         switch index {
         case 0:
             stepInfo = (
-                isCompleted: hotkeyManager.selectedHotkey1 != .none,
+                isCompleted: hotkeyManager.hasAnyActivationShortcut,
                 icon: "command",
                 title: "Set Keyboard Shortcut",
                 description: "Use VoiceInk anywhere with a shortcut."
@@ -150,7 +150,7 @@ struct MetricsSetupView: View {
             openModelManagement()
         } else {
             // Handle different permission requests based on which one is missing
-            if hotkeyManager.selectedHotkey1 == .none {
+            if !hotkeyManager.hasAnyActivationShortcut {
                 openSettings()
             } else if !AXIsProcessTrusted() {
                 if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
@@ -167,7 +167,7 @@ struct MetricsSetupView: View {
     }
     
     private func getActionButtonTitle() -> String {
-        if hotkeyManager.selectedHotkey1 == .none {
+        if !hotkeyManager.hasAnyActivationShortcut {
             return "Configure Shortcut"
         } else if !AXIsProcessTrusted() {
             return "Enable Accessibility"
@@ -186,7 +186,7 @@ struct MetricsSetupView: View {
     }
     
     private var isShortcutAndAccessibilityGranted: Bool {
-        hotkeyManager.selectedHotkey1 != .none &&
+        hotkeyManager.hasAnyActivationShortcut &&
         AXIsProcessTrusted() && 
         CGPreflightScreenCaptureAccess()
     }
@@ -207,4 +207,3 @@ struct MetricsSetupView: View {
         )
     }
 }
-

--- a/VoiceInk/Views/Onboarding/OnboardingPermissionsView.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingPermissionsView.swift
@@ -472,6 +472,7 @@ struct OnboardingPermissionsView: View {
 
             if binding.wrappedValue == .custom {
                 KeyboardShortcuts.Recorder(for: shortcutName) { newShortcut in
+                    hotkeyManager.setCustomShortcut(newShortcut, for: .primary)
                     onConfigured(newShortcut != nil)
                 }
                 .controlSize(.large)

--- a/VoiceInk/Views/PermissionsView.swift
+++ b/VoiceInk/Views/PermissionsView.swift
@@ -214,7 +214,7 @@ struct PermissionsView: View {
                         icon: "keyboard",
                         title: "Keyboard Shortcut",
                         description: "Set up a keyboard shortcut to use VoiceInk anywhere",
-                        isGranted: hotkeyManager.selectedHotkey1 != .none,
+                        isGranted: hotkeyManager.hasAnyActivationShortcut,
                         buttonTitle: "Configure Shortcut",
                         buttonAction: {
                             NotificationCenter.default.post(

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -27,72 +27,18 @@ struct SettingsView: View {
     @State private var activeProfileNameDraft = ""
     @State private var isCustomCancelEnabled = KeyboardShortcuts.getShortcut(for: .cancelRecorder) != nil
 
+    @AppStorage("shortcutProfilesEnabled") private var shortcutProfilesEnabled = false
+
     // Expansion states - all collapsed by default
     @State private var isCustomCancelExpanded = false
     @State private var isMiddleClickExpanded = false
     @State private var isSoundFeedbackExpanded = false
     @State private var isMuteSystemExpanded = false
     @State private var isRestoreClipboardExpanded = false
+    @State private var isProfilesExpanded = false
 
     var body: some View {
         Form {
-            Section {
-                LabeledContent("Active Profile") {
-                    HStack(spacing: 8) {
-                        Picker(
-                            "",
-                            selection: Binding(
-                                get: { hotkeyManager.activeProfileID ?? hotkeyManager.profiles.first?.id },
-                                set: { newValue in
-                                    commitActiveProfileName()
-                                    if let newValue {
-                                        hotkeyManager.switchProfile(to: newValue)
-                                    }
-                                }
-                            )
-                        ) {
-                            ForEach(hotkeyManager.profiles) { profile in
-                                Text(profile.name).tag(Optional(profile.id))
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(maxWidth: 220)
-
-                        Button("New From Current") {
-                            commitActiveProfileName()
-                            hotkeyManager.createProfileFromCurrent()
-                        }
-
-                        Button("Duplicate") {
-                            commitActiveProfileName()
-                            hotkeyManager.duplicateActiveProfile()
-                        }
-
-                        Button("Delete") {
-                            commitActiveProfileName()
-                            if let activeProfileID = hotkeyManager.activeProfileID {
-                                hotkeyManager.deleteProfile(with: activeProfileID)
-                            }
-                        }
-                        .disabled(hotkeyManager.profiles.count == 1)
-                    }
-                }
-
-                LabeledContent("Profile Name") {
-                    TextField("Profile Name", text: $activeProfileNameDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(maxWidth: 220)
-                        .focused($isProfileNameFocused)
-                        .onSubmit {
-                            commitActiveProfileName()
-                        }
-                }
-            } header: {
-                Text("Shortcut Profiles")
-            } footer: {
-                Text("Profiles let you keep different activation shortcuts for different keyboards. Only the active profile is registered at a time.")
-            }
-
             // MARK: - Shortcuts
             Section {
                 LabeledContent("Shortcut 1") {
@@ -198,6 +144,69 @@ struct SettingsView: View {
                         }
                     }
                 }
+            }
+
+            // MARK: - Shortcut Profiles
+            Section {
+                ExpandableSettingsRow(
+                    isExpanded: $isProfilesExpanded,
+                    isEnabled: $shortcutProfilesEnabled,
+                    label: "Shortcut Profiles",
+                    infoMessage: "Keep different activation shortcuts for different keyboards. Only the active profile is registered at a time."
+                ) {
+                    LabeledContent("Active Profile") {
+                        HStack(spacing: 8) {
+                            Picker(
+                                "",
+                                selection: Binding(
+                                    get: { hotkeyManager.activeProfileID ?? hotkeyManager.profiles.first?.id },
+                                    set: { newValue in
+                                        commitActiveProfileName()
+                                        if let newValue {
+                                            hotkeyManager.switchProfile(to: newValue)
+                                        }
+                                    }
+                                )
+                            ) {
+                                ForEach(hotkeyManager.profiles) { profile in
+                                    Text(profile.name).tag(Optional(profile.id))
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(maxWidth: 220)
+
+                            Button("New From Current") {
+                                commitActiveProfileName()
+                                hotkeyManager.createProfileFromCurrent()
+                            }
+
+                            Button("Duplicate") {
+                                commitActiveProfileName()
+                                hotkeyManager.duplicateActiveProfile()
+                            }
+
+                            Button("Delete") {
+                                commitActiveProfileName()
+                                if let activeProfileID = hotkeyManager.activeProfileID {
+                                    hotkeyManager.deleteProfile(with: activeProfileID)
+                                }
+                            }
+                            .disabled(hotkeyManager.profiles.count == 1)
+                        }
+                    }
+
+                    LabeledContent("Profile Name") {
+                        TextField("Profile Name", text: $activeProfileNameDraft)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: 220)
+                            .focused($isProfileNameFocused)
+                            .onSubmit {
+                                commitActiveProfileName()
+                            }
+                    }
+                }
+            } header: {
+                Text("Shortcut Profiles")
             }
 
             // MARK: - Recording Feedback

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -22,8 +22,9 @@ struct SettingsView: View {
     @AppStorage("restoreClipboardAfterPaste") private var restoreClipboardAfterPaste = true
     @AppStorage("clipboardRestoreDelay") private var clipboardRestoreDelay = 2.0
     @AppStorage("useAppleScriptPaste") private var useAppleScriptPaste = false
+    @FocusState private var isProfileNameFocused: Bool
     @State private var showResetOnboardingAlert = false
-    @State private var currentShortcut = KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder)
+    @State private var activeProfileNameDraft = ""
     @State private var isCustomCancelEnabled = KeyboardShortcuts.getShortcut(for: .cancelRecorder) != nil
 
     // Expansion states - all collapsed by default
@@ -35,6 +36,63 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+            Section {
+                LabeledContent("Active Profile") {
+                    HStack(spacing: 8) {
+                        Picker(
+                            "",
+                            selection: Binding(
+                                get: { hotkeyManager.activeProfileID ?? hotkeyManager.profiles.first?.id },
+                                set: { newValue in
+                                    commitActiveProfileName()
+                                    if let newValue {
+                                        hotkeyManager.switchProfile(to: newValue)
+                                    }
+                                }
+                            )
+                        ) {
+                            ForEach(hotkeyManager.profiles) { profile in
+                                Text(profile.name).tag(Optional(profile.id))
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: 220)
+
+                        Button("New From Current") {
+                            commitActiveProfileName()
+                            hotkeyManager.createProfileFromCurrent()
+                        }
+
+                        Button("Duplicate") {
+                            commitActiveProfileName()
+                            hotkeyManager.duplicateActiveProfile()
+                        }
+
+                        Button("Delete") {
+                            commitActiveProfileName()
+                            if let activeProfileID = hotkeyManager.activeProfileID {
+                                hotkeyManager.deleteProfile(with: activeProfileID)
+                            }
+                        }
+                        .disabled(hotkeyManager.profiles.count == 1)
+                    }
+                }
+
+                LabeledContent("Profile Name") {
+                    TextField("Profile Name", text: $activeProfileNameDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 220)
+                        .focused($isProfileNameFocused)
+                        .onSubmit {
+                            commitActiveProfileName()
+                        }
+                }
+            } header: {
+                Text("Shortcut Profiles")
+            } footer: {
+                Text("Profiles let you keep different activation shortcuts for different keyboards. Only the active profile is registered at a time.")
+            }
+
             // MARK: - Shortcuts
             Section {
                 LabeledContent("Shortcut 1") {
@@ -45,7 +103,9 @@ struct SettingsView: View {
                         }
                         hotkeyPicker(binding: $hotkeyManager.selectedHotkey1)
                         if hotkeyManager.selectedHotkey1 == .custom {
-                            KeyboardShortcuts.Recorder(for: .toggleMiniRecorder)
+                            KeyboardShortcuts.Recorder(for: .toggleMiniRecorder) { newShortcut in
+                                hotkeyManager.setCustomShortcut(newShortcut, for: .primary)
+                            }
                                 .controlSize(.small)
                         }
                     }
@@ -58,7 +118,9 @@ struct SettingsView: View {
                             hotkeyModePicker(binding: $hotkeyManager.hotkeyMode2)
                             hotkeyPicker(binding: $hotkeyManager.selectedHotkey2)
                             if hotkeyManager.selectedHotkey2 == .custom {
-                                KeyboardShortcuts.Recorder(for: .toggleMiniRecorder2)
+                                KeyboardShortcuts.Recorder(for: .toggleMiniRecorder2) { newShortcut in
+                                    hotkeyManager.setCustomShortcut(newShortcut, for: .secondary)
+                                }
                                     .controlSize(.small)
                             }
                             Button {
@@ -296,6 +358,17 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
         .background(Color(NSColor.controlBackgroundColor))
+        .onAppear {
+            syncActiveProfileNameDraft()
+        }
+        .onChange(of: hotkeyManager.activeProfileID) { _, _ in
+            syncActiveProfileNameDraft()
+        }
+        .onChange(of: isProfileNameFocused) { _, isFocused in
+            if !isFocused {
+                commitActiveProfileName()
+            }
+        }
         .alert("Reset Onboarding", isPresented: $showResetOnboardingAlert) {
             Button("Cancel", role: .cancel) { }
             Button("Reset", role: .destructive) {
@@ -328,6 +401,21 @@ struct SettingsView: View {
         }
         .labelsHidden()
         .fixedSize()
+    }
+
+    private func syncActiveProfileNameDraft() {
+        activeProfileNameDraft = hotkeyManager.activeProfileName
+    }
+
+    private func commitActiveProfileName() {
+        let trimmedName = activeProfileNameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            syncActiveProfileNameDraft()
+            return
+        }
+
+        hotkeyManager.renameActiveProfile(to: trimmedName)
+        syncActiveProfileNameDraft()
     }
 }
 

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -27,8 +27,6 @@ struct SettingsView: View {
     @State private var activeProfileNameDraft = ""
     @State private var isCustomCancelEnabled = KeyboardShortcuts.getShortcut(for: .cancelRecorder) != nil
 
-    @AppStorage("shortcutProfilesEnabled") private var shortcutProfilesEnabled = false
-
     // Expansion states - all collapsed by default
     @State private var isCustomCancelExpanded = false
     @State private var isMiddleClickExpanded = false
@@ -150,7 +148,10 @@ struct SettingsView: View {
             Section {
                 ExpandableSettingsRow(
                     isExpanded: $isProfilesExpanded,
-                    isEnabled: $shortcutProfilesEnabled,
+                    isEnabled: Binding(
+                        get: { hotkeyManager.shortcutProfilesEnabled },
+                        set: { hotkeyManager.setShortcutProfilesEnabled($0) }
+                    ),
                     label: "Shortcut Profiles",
                     infoMessage: "Keep different activation shortcuts for different keyboards. Only the active profile is registered at a time."
                 ) {

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -1,17 +1,148 @@
-//
-//  VoiceInkTests.swift
-//  VoiceInkTests
-//
-//  Created by Prakash Joshi on 15/10/2024.
-//
-
+import AppKit
+import KeyboardShortcuts
 import Testing
 @testable import VoiceInk
 
 struct VoiceInkTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test
+    func legacyHotkeyMigrationCreatesDefaultProfile() {
+        let legacyShortcut = KeyboardShortcuts.Shortcut(.r, modifiers: .command)
+
+        let state = ActivationShortcutProfilesState.makeDefaultState(
+            from: LegacyActivationShortcutSettings(
+                selectedHotkey1: .rightOption,
+                selectedHotkey2: .rightCommand,
+                hotkeyMode1: .pushToTalk,
+                hotkeyMode2: .toggle,
+                toggleMiniRecorderShortcut: legacyShortcut,
+                toggleMiniRecorderShortcut2: nil
+            )
+        )
+
+        #expect(state.profiles.count == 1)
+
+        guard let activeProfile = state.activeProfile else {
+            Issue.record("Expected an active profile after legacy migration")
+            return
+        }
+
+        #expect(activeProfile.name == "Default")
+        #expect(activeProfile.selectedHotkey1 == .rightOption)
+        #expect(activeProfile.selectedHotkey2 == .rightCommand)
+        #expect(activeProfile.hotkeyMode1 == .pushToTalk)
+        #expect(activeProfile.hotkeyMode2 == .toggle)
+        #expect(activeProfile.toggleMiniRecorderShortcut?.key == legacyShortcut.key)
+        #expect(activeProfile.toggleMiniRecorderShortcut?.modifiers == legacyShortcut.modifiers)
+        #expect(state.activeProfileID == activeProfile.id)
     }
 
+    @Test
+    func profileNormalizationDeduplicatesIDsAndNames() {
+        let duplicatedID = UUID()
+        let profiles = [
+            ActivationShortcutProfile(
+                id: duplicatedID,
+                name: " Home ",
+                selectedHotkey1: .rightCommand,
+                selectedHotkey2: .none,
+                hotkeyMode1: .hybrid,
+                hotkeyMode2: .hybrid,
+                toggleMiniRecorderShortcut: nil,
+                toggleMiniRecorderShortcut2: nil
+            ),
+            ActivationShortcutProfile(
+                id: duplicatedID,
+                name: "Home",
+                selectedHotkey1: .rightOption,
+                selectedHotkey2: .none,
+                hotkeyMode1: .toggle,
+                hotkeyMode2: .hybrid,
+                toggleMiniRecorderShortcut: nil,
+                toggleMiniRecorderShortcut2: nil
+            )
+        ]
+
+        let state = ActivationShortcutProfilesState(profiles: profiles, activeProfileID: UUID())
+
+        #expect(state.profiles.count == 2)
+        #expect(state.profiles[0].name == "Home")
+        #expect(state.profiles[1].name == "Home 2")
+        #expect(state.profiles[0].id != state.profiles[1].id)
+        #expect(state.activeProfileID == state.profiles[0].id)
+    }
+
+    @Test
+    func activationShortcutProfileRoundTripsThroughCodable() throws {
+        let primaryShortcut = KeyboardShortcuts.Shortcut(.m, modifiers: [.command, .shift])
+        let secondaryShortcut = KeyboardShortcuts.Shortcut(.space, modifiers: .option)
+        let profile = ActivationShortcutProfile(
+            name: "Laptop",
+            selectedHotkey1: .custom,
+            selectedHotkey2: .custom,
+            hotkeyMode1: .hybrid,
+            hotkeyMode2: .pushToTalk,
+            toggleMiniRecorderShortcut: primaryShortcut,
+            toggleMiniRecorderShortcut2: secondaryShortcut
+        )
+
+        let data = try JSONEncoder().encode([profile])
+        let decodedProfiles = try JSONDecoder().decode([ActivationShortcutProfile].self, from: data)
+
+        #expect(decodedProfiles.count == 1)
+
+        guard let decodedProfile = decodedProfiles.first else {
+            Issue.record("Expected one decoded shortcut profile")
+            return
+        }
+
+        #expect(decodedProfile.name == profile.name)
+        #expect(decodedProfile.selectedHotkey1 == .custom)
+        #expect(decodedProfile.selectedHotkey2 == .custom)
+        #expect(decodedProfile.hotkeyMode2 == .pushToTalk)
+        #expect(decodedProfile.toggleMiniRecorderShortcut?.key == primaryShortcut.key)
+        #expect(decodedProfile.toggleMiniRecorderShortcut?.modifiers == primaryShortcut.modifiers)
+        #expect(decodedProfile.toggleMiniRecorderShortcut2?.key == secondaryShortcut.key)
+        #expect(decodedProfile.toggleMiniRecorderShortcut2?.modifiers == secondaryShortcut.modifiers)
+    }
+
+    @Test
+    func importedSettingsPreferProfilesAndFallbackToLegacy() {
+        let legacySettings = LegacyActivationShortcutSettings(
+            selectedHotkey1: .rightOption,
+            selectedHotkey2: .none,
+            hotkeyMode1: .toggle,
+            hotkeyMode2: .hybrid,
+            toggleMiniRecorderShortcut: nil,
+            toggleMiniRecorderShortcut2: nil
+        )
+
+        let importedProfile = ActivationShortcutProfile(
+            name: "Work Wired",
+            selectedHotkey1: .rightCommand,
+            selectedHotkey2: .none,
+            hotkeyMode1: .hybrid,
+            hotkeyMode2: .hybrid,
+            toggleMiniRecorderShortcut: nil,
+            toggleMiniRecorderShortcut2: nil
+        )
+
+        let preferredState = ActivationShortcutProfilesState.fromImportedSettings(
+            shortcutProfiles: [importedProfile],
+            activeProfileID: importedProfile.id,
+            legacySettings: legacySettings
+        )
+
+        let fallbackState = ActivationShortcutProfilesState.fromImportedSettings(
+            shortcutProfiles: nil,
+            activeProfileID: nil,
+            legacySettings: legacySettings
+        )
+
+        #expect(preferredState.activeProfile?.name == "Work Wired")
+        #expect(preferredState.activeProfile?.selectedHotkey1 == .rightCommand)
+        #expect(fallbackState.activeProfile?.name == "Default")
+        #expect(fallbackState.activeProfile?.selectedHotkey1 == .rightOption)
+        #expect(fallbackState.activeProfile?.hotkeyMode1 == .toggle)
+    }
 }

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -145,4 +145,65 @@ struct VoiceInkTests {
         #expect(fallbackState.activeProfile?.selectedHotkey1 == .rightOption)
         #expect(fallbackState.activeProfile?.hotkeyMode1 == .toggle)
     }
+
+    @Test
+    func activationShortcutProfileConvertsBackToLegacySettings() {
+        let shortcut = KeyboardShortcuts.Shortcut(.v, modifiers: [.command, .option])
+        let profile = ActivationShortcutProfile(
+            name: "Desk",
+            selectedHotkey1: .custom,
+            selectedHotkey2: .rightShift,
+            hotkeyMode1: .toggle,
+            hotkeyMode2: .pushToTalk,
+            toggleMiniRecorderShortcut: shortcut,
+            toggleMiniRecorderShortcut2: nil
+        )
+
+        let legacySettings = profile.makeLegacySettings()
+
+        #expect(legacySettings.selectedHotkey1 == .custom)
+        #expect(legacySettings.selectedHotkey2 == .rightShift)
+        #expect(legacySettings.hotkeyMode1 == .toggle)
+        #expect(legacySettings.hotkeyMode2 == .pushToTalk)
+        #expect(legacySettings.toggleMiniRecorderShortcut?.key == shortcut.key)
+        #expect(legacySettings.toggleMiniRecorderShortcut?.modifiers == shortcut.modifiers)
+    }
+
+    @Test
+    func generalSettingsRoundTripPreservesShortcutProfilesFlag() throws {
+        let settings = GeneralSettings(
+            toggleMiniRecorderShortcut: nil,
+            toggleMiniRecorderShortcut2: nil,
+            retryLastTranscriptionShortcut: nil,
+            selectedHotkey1RawValue: HotkeyManager.HotkeyOption.rightCommand.rawValue,
+            selectedHotkey2RawValue: HotkeyManager.HotkeyOption.none.rawValue,
+            hotkeyMode1RawValue: HotkeyManager.HotkeyMode.hybrid.rawValue,
+            hotkeyMode2RawValue: HotkeyManager.HotkeyMode.toggle.rawValue,
+            shortcutProfilesEnabled: true,
+            shortcutProfiles: nil,
+            activeShortcutProfileId: nil,
+            launchAtLoginEnabled: nil,
+            isMenuBarOnly: nil,
+            recorderType: nil,
+            isTranscriptionCleanupEnabled: nil,
+            transcriptionRetentionMinutes: nil,
+            isAudioCleanupEnabled: nil,
+            audioRetentionPeriod: nil,
+            isSoundFeedbackEnabled: nil,
+            isSystemMuteEnabled: nil,
+            isPauseMediaEnabled: nil,
+            audioResumptionDelay: nil,
+            isTextFormattingEnabled: nil,
+            isExperimentalFeaturesEnabled: nil,
+            restoreClipboardAfterPaste: nil,
+            clipboardRestoreDelay: nil,
+            useAppleScriptPaste: nil
+        )
+
+        let data = try JSONEncoder().encode(settings)
+        let decodedSettings = try JSONDecoder().decode(GeneralSettings.self, from: data)
+
+        #expect(decodedSettings.shortcutProfilesEnabled == true)
+        #expect(decodedSettings.selectedHotkey1RawValue == HotkeyManager.HotkeyOption.rightCommand.rawValue)
+    }
 }


### PR DESCRIPTION
## Summary
Different keyboards have different layouts and different "free" modifier keys. I use Right Option on my MacBook Pro keyboard on the go, but Right Command on my Kinesis Advantage 360 at my desk. Switching activation shortcuts manually in Settings every time I change keyboards is tedious, so this adds profiles that let you save configurations and switch with two clicks from the menu bar.

- Add profiles that store activation shortcut selections, modes, and custom keyboard shortcuts
- Each profile persists independently; only the active profile's shortcuts are registered
- Manage profiles in Settings: create, duplicate, rename, delete
- Quick-switch from the menu bar when profiles are enabled
- Profiles are off by default so users who do not need them never see them
- Treat the profiles toggle as a real runtime mode switch: disabling profiles applies a separate legacy single-profile configuration immediately instead of leaving a hidden saved profile active
- Preserve `shortcutProfilesEnabled` in backup/import and keep legacy single-profile settings separate from saved profile-mode state

## Test plan
- [x] `xcodebuild -scheme VoiceInk -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- [ ] `xcodebuild test -scheme VoiceInk -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
  - currently fails on upstream `main` with a project-level `@testable import VoiceInk` module resolution issue in `VoiceInkTests`

## Notes
- This PR replaces #606, which was accidentally opened from `joncooper:main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add keyboard shortcut profiles to quickly switch activation shortcuts for different keyboards. Profiles are managed in Settings and can be switched from the menu bar; they’re off by default and included in backups.

- **New Features**
  - Activation shortcut profiles store hotkey selections, modes, and custom `KeyboardShortcuts`; only the active profile is registered.
  - Profiles are disabled by default; when enabled, quick-switch from the menu bar and manage in Settings (create, duplicate, rename, delete).
  - Names/IDs are normalized; a default profile is seeded from existing settings when profiles are first enabled.
  - Import/export now includes profiles, the active profile ID, and the profiles-enabled flag; legacy single-profile settings are preserved separately.

- **Refactors**
  - Reworked HotkeyManager to apply/sync activation settings across legacy mode and profiles, with safe persistence and UI updates.
  - Deferred event monitor setup to NSApplication.didFinishLaunching to avoid run-loop races; monitors are installed only after launch.

<sup>Written for commit 89aa4716648a820ffa01864dad7c8cf621aea55f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

