### PR TITLE
Add voice conversation mode with ElevenLabs TTS

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -11,6 +11,7 @@ extension KeyboardShortcuts.Name {
     static let pasteLastEnhancement = Self("pasteLastEnhancement")
     static let retryLastTranscription = Self("retryLastTranscription")
     static let openHistoryWindow = Self("openHistoryWindow")
+    static let voiceConversation = Self("voiceConversation")
 }
 
 @MainActor
@@ -57,6 +58,11 @@ class HotkeyManager: ObservableObject {
     private var recorderUIManager: RecorderUIManager
     private var miniRecorderShortcutManager: MiniRecorderShortcutManager
     private var powerModeShortcutManager: PowerModeShortcutManager
+    private(set) var voiceConversationManager: VoiceConversationManager?
+
+    func setVoiceConversationManager(_ manager: VoiceConversationManager) {
+        voiceConversationManager = manager
+    }
 
     // MARK: - Helper Properties
     private var canProcessHotkeyAction: Bool {
@@ -195,6 +201,18 @@ class HotkeyManager: ObservableObject {
                     modelContainer: self.engine.modelContext.container,
                     engine: self.engine
                 )
+            }
+        }
+
+        // Voice Conversation: hold-to-talk
+        KeyboardShortcuts.onKeyDown(for: .voiceConversation) { [weak self] in
+            Task { @MainActor in
+                self?.voiceConversationManager?.onKeyDown()
+            }
+        }
+        KeyboardShortcuts.onKeyUp(for: .voiceConversation) { [weak self] in
+            Task { @MainActor in
+                self?.voiceConversationManager?.onKeyUp()
             }
         }
 

--- a/VoiceInk/Services/VoiceConversation/ConversationHistory.swift
+++ b/VoiceInk/Services/VoiceConversation/ConversationHistory.swift
@@ -1,0 +1,53 @@
+import Foundation
+import LLMkit
+
+enum ConversationRole: String, Codable {
+    case user
+    case assistant
+}
+
+struct ConversationMessage: Identifiable {
+    let id = UUID()
+    let role: ConversationRole
+    let content: String
+    let timestamp: Date
+}
+
+@MainActor
+class ConversationHistory: ObservableObject {
+    @Published var messages: [ConversationMessage] = []
+    let maxTurns: Int
+
+    init(maxTurns: Int = 10) {
+        self.maxTurns = maxTurns
+    }
+
+    func append(role: ConversationRole, content: String) {
+        messages.append(ConversationMessage(role: role, content: content, timestamp: Date()))
+        // Trim to maxTurns, preserving complete user/assistant pairs
+        let maxMessages = maxTurns * 2
+        if messages.count > maxMessages {
+            var trimmed = Array(messages.suffix(maxMessages))
+            // Ensure first message is from user (don't start with orphaned assistant)
+            while let first = trimmed.first, first.role == .assistant, trimmed.count > 1 {
+                trimmed.removeFirst()
+            }
+            messages = trimmed
+        }
+    }
+
+    func clear() {
+        messages.removeAll()
+    }
+
+    func asLLMMessages() -> [ChatMessage] {
+        messages.map { msg in
+            switch msg.role {
+            case .user:
+                return .user(msg.content)
+            case .assistant:
+                return .assistant(msg.content)
+            }
+        }
+    }
+}

--- a/VoiceInk/Services/VoiceConversation/TTSService.swift
+++ b/VoiceInk/Services/VoiceConversation/TTSService.swift
@@ -1,0 +1,260 @@
+import Foundation
+import AVFoundation
+import os
+
+@MainActor
+class TTSService: ObservableObject {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TTSService")
+
+    @Published var isPlaying = false
+
+    private var audioEngine = AVAudioEngine()
+    private var playerNode = AVAudioPlayerNode()
+    private var currentTask: Task<Void, Never>?
+    private var synthesizer: AVSpeechSynthesizer?
+
+    // MVP defaults — ElevenLabs "Rachel" voice + Turbo v2.5 model
+    private let defaultVoiceId = "21m00Tcm4TlvDq8ikWAM"
+    private let ttsModelId = "eleven_turbo_v2_5"
+
+    // PCM format matching ElevenLabs pcm_16000 output: 16kHz, 16-bit signed LE, mono
+    private let pcmFormat = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: 16000,
+        channels: 1,
+        interleaved: true
+    )!
+
+    // Float format for AVAudioPlayerNode (requires float)
+    private let floatFormat = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: 16000,
+        channels: 1,
+        interleaved: false
+    )!
+
+    init() {
+        setupAudioEngine()
+    }
+
+    private func setupAudioEngine() {
+        audioEngine.attach(playerNode)
+        audioEngine.connect(playerNode, to: audioEngine.mainMixerNode, format: floatFormat)
+    }
+
+    func speak(text: String) async {
+        guard !text.isEmpty else { return }
+
+        // Check for ElevenLabs API key, fall back to system TTS
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "ElevenLabs"), !apiKey.isEmpty else {
+            logger.info("No ElevenLabs API key, falling back to system TTS")
+            await speakWithSystemTTS(text: text)
+            return
+        }
+
+        stop()
+
+        isPlaying = true
+
+        let task = Task {
+            do {
+                try await streamElevenLabsTTS(text: text, apiKey: apiKey)
+            } catch {
+                if !Task.isCancelled {
+                    logger.error("ElevenLabs TTS failed: \(error.localizedDescription, privacy: .public). Falling back to system TTS.")
+                    await speakWithSystemTTS(text: text)
+                }
+            }
+            if audioEngine.isRunning {
+                audioEngine.stop()
+            }
+            await MainActor.run {
+                self.isPlaying = false
+            }
+        }
+        currentTask = task
+
+        // Wait for playback to actually finish before returning
+        await task.value
+    }
+
+    func stop() {
+        currentTask?.cancel()
+        currentTask = nil
+
+        playerNode.stop()
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+
+        synthesizer?.stopSpeaking(at: .immediate)
+
+        isPlaying = false
+    }
+
+    // MARK: - ElevenLabs Streaming
+
+    private func streamElevenLabsTTS(text: String, apiKey: String) async throws {
+        let urlString = "https://api.elevenlabs.io/v1/text-to-speech/\(defaultVoiceId)/stream"
+        guard let url = URL(string: urlString) else {
+            throw TTSError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+
+        let body: [String: Any] = [
+            "text": text,
+            "model_id": ttsModelId,
+            "output_format": "pcm_16000",
+            "voice_settings": [
+                "stability": 0.5,
+                "similarity_boost": 0.75
+            ]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        // Start audio engine
+        if !audioEngine.isRunning {
+            try audioEngine.start()
+        }
+        playerNode.play()
+
+        // Stream the response
+        let (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw TTSError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            // Read error body
+            var errorData = Data()
+            for try await byte in asyncBytes {
+                errorData.append(byte)
+                if errorData.count > 1024 { break }
+            }
+            let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            throw TTSError.apiError(statusCode: httpResponse.statusCode, message: errorMessage)
+        }
+
+        // Buffer PCM bytes and schedule in chunks
+        var pcmBuffer = Data()
+        let chunkSize = 16000 * 2 // 1 second of 16kHz 16-bit mono audio (32000 bytes)
+
+        for try await byte in asyncBytes {
+            try Task.checkCancellation()
+
+            pcmBuffer.append(byte)
+
+            if pcmBuffer.count >= chunkSize {
+                scheduleBuffer(pcmData: pcmBuffer)
+                pcmBuffer = Data()
+            }
+        }
+
+        // Schedule remaining bytes with completion handler
+        if !pcmBuffer.isEmpty {
+            await scheduleBufferAndWait(pcmData: pcmBuffer)
+        } else {
+            // Wait for last scheduled buffer to finish
+            await waitForPlaybackCompletion()
+        }
+    }
+
+    private func scheduleBufferAndWait(pcmData: Data) async {
+        let usableBytes = pcmData.count & ~1
+        let sampleCount = usableBytes / 2
+        guard sampleCount > 0 else { return }
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: floatFormat, frameCapacity: AVAudioFrameCount(sampleCount)) else { return }
+        buffer.frameLength = AVAudioFrameCount(sampleCount)
+
+        guard let floatData = buffer.floatChannelData?[0] else { return }
+        pcmData.withUnsafeBytes { rawBuffer in
+            guard let int16Ptr = rawBuffer.bindMemory(to: Int16.self).baseAddress else { return }
+            for i in 0..<sampleCount {
+                floatData[i] = Float(int16Ptr[i]) / Float(Int16.max)
+            }
+        }
+
+        await withCheckedContinuation { continuation in
+            playerNode.scheduleBuffer(buffer) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func scheduleBuffer(pcmData: Data) {
+        let usableBytes = pcmData.count & ~1 // Ensure even byte count for Int16 alignment
+        let sampleCount = usableBytes / 2 // 16-bit = 2 bytes per sample
+        guard sampleCount > 0 else { return }
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: floatFormat, frameCapacity: AVAudioFrameCount(sampleCount)) else {
+            logger.error("Failed to create audio buffer")
+            return
+        }
+        buffer.frameLength = AVAudioFrameCount(sampleCount)
+
+        // Convert Int16 PCM to Float32
+        guard let floatData = buffer.floatChannelData?[0] else { return }
+        pcmData.withUnsafeBytes { rawBuffer in
+            guard let int16Ptr = rawBuffer.bindMemory(to: Int16.self).baseAddress else { return }
+            for i in 0..<sampleCount {
+                floatData[i] = Float(int16Ptr[i]) / Float(Int16.max)
+            }
+        }
+
+        playerNode.scheduleBuffer(buffer)
+    }
+
+    private func waitForPlaybackCompletion() async {
+        // Brief wait for any remaining audio to drain
+        try? await Task.sleep(nanoseconds: 500_000_000) // 500ms grace period
+    }
+
+    // MARK: - System TTS Fallback
+
+    private func speakWithSystemTTS(text: String) async {
+        await MainActor.run {
+            isPlaying = true
+        }
+
+        let synth = AVSpeechSynthesizer()
+        self.synthesizer = synth
+
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+
+        synth.speak(utterance)
+
+        // Wait for completion
+        while synth.isSpeaking && !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        }
+
+        await MainActor.run {
+            self.isPlaying = false
+            self.synthesizer = nil
+        }
+    }
+}
+
+enum TTSError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case apiError(statusCode: Int, message: String)
+    case noAPIKey
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid TTS URL"
+        case .invalidResponse: return "Invalid TTS response"
+        case .apiError(let code, let msg): return "TTS API error \(code): \(msg)"
+        case .noAPIKey: return "No ElevenLabs API key configured"
+        }
+    }
+}

--- a/VoiceInk/Services/VoiceConversation/VoiceConversationManager.swift
+++ b/VoiceInk/Services/VoiceConversation/VoiceConversationManager.swift
@@ -1,0 +1,261 @@
+import Foundation
+import AVFoundation
+import SwiftData
+import LLMkit
+import os
+
+enum VoiceConversationState: String {
+    case idle
+    case listening
+    case thinking
+    case speaking
+}
+
+@MainActor
+class VoiceConversationManager: ObservableObject {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "VoiceConversationManager")
+
+    @Published var state: VoiceConversationState = .idle
+    @Published var currentTranscript = ""
+    @Published var lastAssistantResponse = ""
+
+    let history = ConversationHistory()
+    let ttsService = TTSService()
+
+    private let aiService: AIService
+    private let transcriptionModelManager: TranscriptionModelManager
+    private let serviceRegistry: TranscriptionServiceRegistry
+    private let recorder = Recorder()
+
+    var windowManager: VoiceLoopWindowManager?
+
+    private var currentTask: Task<Void, Never>?
+    private var currentRecordingURL: URL?
+
+    var systemPrompt = """
+        You are a patient, thorough teacher. The user is a developer who wants to deeply \
+        understand concepts. Explain clearly, use analogies, and build understanding step by step. \
+        Keep answers focused but don't oversimplify. If the user seems to understand, go deeper. \
+        Respond conversationally — this will be spoken aloud.
+        """
+
+    private let recordingsDirectory: URL
+
+    init(
+        aiService: AIService,
+        transcriptionModelManager: TranscriptionModelManager,
+        whisperModelManager: WhisperModelManager,
+        modelContext: ModelContext
+    ) {
+        self.aiService = aiService
+        self.transcriptionModelManager = transcriptionModelManager
+        self.serviceRegistry = TranscriptionServiceRegistry(
+            modelProvider: whisperModelManager,
+            modelsDirectory: whisperModelManager.modelsDirectory,
+            modelContext: modelContext
+        )
+
+        let appSupportDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.prakashjoshipax.VoiceInk")
+        self.recordingsDirectory = appSupportDirectory.appendingPathComponent("ConversationRecordings")
+
+        // Ensure recordings directory exists
+        try? FileManager.default.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Hotkey Handlers
+
+    func onKeyDown() {
+        windowManager?.show()
+
+        switch state {
+        case .idle:
+            startListening()
+        case .speaking:
+            // Interrupt TTS, start listening
+            ttsService.stop()
+            startListening()
+        case .thinking:
+            // Cancel current LLM request, start listening
+            currentTask?.cancel()
+            currentTask = nil
+            startListening()
+        case .listening:
+            // Already listening, ignore
+            break
+        }
+    }
+
+    func onKeyUp() {
+        guard state == .listening, isRecorderReady else { return }
+        stopListeningAndProcess()
+    }
+
+    func cancel() {
+        currentTask?.cancel()
+        currentTask = nil
+        ttsService.stop()
+        recorder.stopRecording()
+        state = .idle
+        currentTranscript = ""
+        lastAssistantResponse = ""
+        history.clear()
+        windowManager?.hide()
+    }
+
+    // MARK: - State Transitions
+
+    private var isRecorderReady = false
+
+    private func startListening() {
+        state = .listening
+        currentTranscript = ""
+        isRecorderReady = false
+
+        let url = recordingsDirectory.appendingPathComponent("conversation_\(UUID().uuidString).m4a")
+        currentRecordingURL = url
+
+        Task {
+            do {
+                try await recorder.startRecording(toOutputFile: url)
+                isRecorderReady = true
+                logger.info("Conversation recording started")
+            } catch {
+                logger.error("Failed to start recording: \(error.localizedDescription, privacy: .public)")
+                state = .idle
+            }
+        }
+    }
+
+    private func stopListeningAndProcess() {
+        recorder.stopRecording()
+        state = .thinking
+
+        guard let audioURL = currentRecordingURL else {
+            logger.error("No recording URL available")
+            state = .idle
+            return
+        }
+
+        currentTask = Task {
+            await runPipeline(audioURL: audioURL)
+        }
+    }
+
+    // MARK: - Pipeline
+
+    private func runPipeline(audioURL: URL) async {
+        defer {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+
+        do {
+            // 1. Transcribe
+            guard let model = transcriptionModelManager.currentTranscriptionModel else {
+                logger.error("No transcription model selected")
+                state = .idle
+                return
+            }
+
+            let transcript = try await serviceRegistry.transcribe(audioURL: audioURL, model: model)
+
+            guard !Task.isCancelled else { return }
+
+            let trimmed = transcript.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                logger.info("Empty transcription, returning to idle")
+                state = .idle
+                return
+            }
+
+            currentTranscript = trimmed
+            logger.info("Transcribed: \(trimmed, privacy: .public)")
+
+            // 2. Add to history
+            history.append(role: .user, content: trimmed)
+
+            // 3. LLM call with conversation history
+            let response = try await callLLM(messages: history.asLLMMessages())
+
+            guard !Task.isCancelled else { return }
+
+            let trimmedResponse = response.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            guard !trimmedResponse.isEmpty else {
+                logger.warning("Empty LLM response")
+                state = .idle
+                return
+            }
+
+            // 4. Add assistant response to history
+            history.append(role: .assistant, content: trimmedResponse)
+            lastAssistantResponse = trimmedResponse
+
+            // 5. Speak the response
+            state = .speaking
+            await ttsService.speak(text: trimmedResponse)
+
+            guard !Task.isCancelled else { return }
+
+            // 6. Done speaking, return to idle (HUD stays with transcript)
+            state = .idle
+
+        } catch {
+            if !Task.isCancelled {
+                logger.error("Pipeline error: \(error.localizedDescription, privacy: .public)")
+                state = .idle
+            }
+        }
+    }
+
+    // MARK: - LLM Call
+
+    private func callLLM(messages: [ChatMessage]) async throws -> String {
+        let timeout: TimeInterval = 60 // Longer timeout for conversational responses
+
+        switch aiService.selectedProvider {
+        case .anthropic:
+            return try await AnthropicLLMClient.chatCompletion(
+                apiKey: aiService.apiKey,
+                model: aiService.currentModel,
+                messages: messages,
+                systemPrompt: systemPrompt,
+                timeout: timeout
+            )
+        case .ollama:
+            // Build a combined prompt for Ollama
+            let combinedPrompt = messages.map { msg in
+                if msg.role == "user" {
+                    return "User: \(msg.content)"
+                } else {
+                    return "Assistant: \(msg.content)"
+                }
+            }.joined(separator: "\n")
+            return try await aiService.enhanceWithOllama(text: combinedPrompt, systemPrompt: systemPrompt)
+        default:
+            guard let baseURL = URL(string: aiService.selectedProvider.baseURL) else {
+                throw VoiceConversationError.invalidProviderURL
+            }
+            return try await OpenAILLMClient.chatCompletion(
+                baseURL: baseURL,
+                apiKey: aiService.apiKey,
+                model: aiService.currentModel,
+                messages: messages,
+                systemPrompt: systemPrompt,
+                temperature: 0.7,
+                timeout: timeout
+            )
+        }
+    }
+}
+
+enum VoiceConversationError: LocalizedError {
+    case invalidProviderURL
+    case noModel
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidProviderURL: return "Invalid AI provider URL"
+        case .noModel: return "No transcription model selected"
+        }
+    }
+}

--- a/VoiceInk/Views/VoiceConversation/VoiceLoopHUD.swift
+++ b/VoiceInk/Views/VoiceConversation/VoiceLoopHUD.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct VoiceLoopHUD: View {
+    @ObservedObject var manager: VoiceConversationManager
+
+    @State private var isTranscriptExpanded = false
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // State indicator row
+            HStack(spacing: 8) {
+                stateIcon
+                    .font(.title2)
+                    .foregroundStyle(stateColor)
+
+                Text(stateLabel)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                // Expand/collapse transcript
+                if !manager.history.messages.isEmpty {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isTranscriptExpanded.toggle()
+                        }
+                    } label: {
+                        Image(systemName: isTranscriptExpanded ? "chevron.down" : "chevron.up")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            // Current activity text
+            if !currentDisplayText.isEmpty {
+                Text(currentDisplayText)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.primary)
+                    .lineLimit(isTranscriptExpanded ? nil : 3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Expanded transcript
+            if isTranscriptExpanded {
+                Divider()
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(manager.history.messages) { message in
+                            HStack(alignment: .top, spacing: 6) {
+                                Image(systemName: message.role == .user ? "person.fill" : "brain")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(message.role == .user ? .blue : .purple)
+                                    .frame(width: 14)
+
+                                Text(message.content)
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.primary)
+                                    .textSelection(.enabled)
+
+                                if message.role == .assistant {
+                                    Button {
+                                        NSPasteboard.general.clearContents()
+                                        NSPasteboard.general.setString(message.content, forType: .string)
+                                    } label: {
+                                        Image(systemName: "doc.on.doc")
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .help("Copy response")
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxHeight: 200)
+            }
+        }
+        .padding(12)
+        .frame(width: 300)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: - Computed Properties
+
+    private var stateIcon: some View {
+        Group {
+            switch manager.state {
+            case .idle:
+                Image(systemName: "waveform")
+            case .listening:
+                Image(systemName: "mic.fill")
+            case .thinking:
+                ProgressView()
+                    .controlSize(.small)
+            case .speaking:
+                Image(systemName: "speaker.wave.2.fill")
+            }
+        }
+    }
+
+    private var stateLabel: String {
+        switch manager.state {
+        case .idle: return "Ready"
+        case .listening: return "Listening..."
+        case .thinking: return "Thinking..."
+        case .speaking: return "Speaking..."
+        }
+    }
+
+    private var stateColor: Color {
+        switch manager.state {
+        case .idle: return .secondary
+        case .listening: return .red
+        case .thinking: return .orange
+        case .speaking: return .blue
+        }
+    }
+
+    private var currentDisplayText: String {
+        switch manager.state {
+        case .listening:
+            return manager.currentTranscript.isEmpty ? "" : manager.currentTranscript
+        case .thinking:
+            return manager.currentTranscript
+        case .speaking:
+            return manager.lastAssistantResponse
+        case .idle:
+            return manager.lastAssistantResponse
+        }
+    }
+}

--- a/VoiceInk/Views/VoiceConversation/VoiceLoopPanel.swift
+++ b/VoiceInk/Views/VoiceConversation/VoiceLoopPanel.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import AppKit
+
+class VoiceLoopPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        configurePanel()
+    }
+
+    private func configurePanel() {
+        isFloatingPanel = true
+        level = .floating
+        hidesOnDeactivate = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isMovable = true
+        isMovableByWindowBackground = true
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = true
+        titlebarAppearsTransparent = true
+        titleVisibility = .hidden
+        standardWindowButton(.closeButton)?.isHidden = true
+    }
+
+    static func calculateWindowMetrics() -> NSRect {
+        guard let screen = NSScreen.main else {
+            return NSRect(x: 0, y: 0, width: 320, height: 140)
+        }
+
+        let width: CGFloat = 320
+        let height: CGFloat = 140
+        let padding: CGFloat = 80
+
+        let visibleFrame = screen.visibleFrame
+        let xPosition = visibleFrame.midX - (width / 2)
+        let yPosition = visibleFrame.minY + padding
+
+        return NSRect(x: xPosition, y: yPosition, width: width, height: height)
+    }
+
+    func show() {
+        let metrics = VoiceLoopPanel.calculateWindowMetrics()
+        setFrame(metrics, display: true)
+        orderFrontRegardless()
+    }
+}

--- a/VoiceInk/Views/VoiceConversation/VoiceLoopWindowManager.swift
+++ b/VoiceInk/Views/VoiceConversation/VoiceLoopWindowManager.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import AppKit
+
+@MainActor
+class VoiceLoopWindowManager: ObservableObject {
+    @Published var isVisible = false
+
+    private var windowController: NSWindowController?
+    private var panel: VoiceLoopPanel?
+    private let manager: VoiceConversationManager
+
+    init(manager: VoiceConversationManager) {
+        self.manager = manager
+    }
+
+    func show() {
+        if isVisible { return }
+
+        if panel == nil {
+            initializeWindow()
+        }
+
+        isVisible = true
+        panel?.show()
+    }
+
+    func hide() {
+        guard isVisible else { return }
+        isVisible = false
+        panel?.orderOut(nil)
+    }
+
+    func toggle() {
+        if isVisible {
+            hide()
+        } else {
+            show()
+        }
+    }
+
+    private func initializeWindow() {
+        deinitializeWindow()
+
+        let metrics = VoiceLoopPanel.calculateWindowMetrics()
+        let newPanel = VoiceLoopPanel(contentRect: metrics)
+
+        let hudView = VoiceLoopHUD(manager: manager)
+        let hostingController = NSHostingController(rootView: hudView)
+        newPanel.contentView = hostingController.view
+
+        self.panel = newPanel
+        self.windowController = NSWindowController(window: newPanel)
+
+        newPanel.orderFrontRegardless()
+    }
+
+    private func deinitializeWindow() {
+        panel?.orderOut(nil)
+        windowController?.close()
+        windowController = nil
+        panel = nil
+    }
+}

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -23,6 +23,7 @@ struct VoiceInkApp: App {
     @StateObject private var aiService = AIService()
     @StateObject private var enhancementService: AIEnhancementService
     @StateObject private var activeWindowService = ActiveWindowService.shared
+    @StateObject private var voiceConversationManager: VoiceConversationManager
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("enableAnnouncements") private var enableAnnouncements = true
     @State private var showMenuBarIcon = true
@@ -144,6 +145,18 @@ struct VoiceInkApp: App {
         let hotkeyManager = HotkeyManager(engine: engine, recorderUIManager: recorderUIManager)
         _hotkeyManager = StateObject(wrappedValue: hotkeyManager)
 
+        // Voice Conversation Mode
+        let voiceConversationManager = VoiceConversationManager(
+            aiService: aiService,
+            transcriptionModelManager: transcriptionModelManager,
+            whisperModelManager: whisperModelManager,
+            modelContext: container.mainContext
+        )
+        let voiceLoopWindowManager = VoiceLoopWindowManager(manager: voiceConversationManager)
+        voiceConversationManager.windowManager = voiceLoopWindowManager
+        hotkeyManager.setVoiceConversationManager(voiceConversationManager)
+        _voiceConversationManager = StateObject(wrappedValue: voiceConversationManager)
+
         let menuBarManager = MenuBarManager()
         _menuBarManager = StateObject(wrappedValue: menuBarManager)
         menuBarManager.configure(modelContainer: container, engine: engine)
@@ -260,6 +273,7 @@ struct VoiceInkApp: App {
                     .environmentObject(menuBarManager)
                     .environmentObject(aiService)
                     .environmentObject(enhancementService)
+                    .environmentObject(voiceConversationManager)
                     .modelContainer(container)
                     .onAppear {
                         // Check if container initialization failed


### PR DESCRIPTION
## Summary

- Adds a voice-first conversation mode: hold hotkey → speak → release → AI responds via ElevenLabs TTS → hold again to interrupt and follow up
- Multi-turn conversation history maintained across turns (last 10 turns)
- Floating HUD shows state (Listening/Thinking/Speaking) + expandable transcript with copy
- Falls back to system TTS (AVSpeechSynthesizer) when no ElevenLabs API key configured
- Fully parallel to existing transcription flow — no changes to existing recording/paste pipeline

## New files
- `VoiceConversationManager` — state machine orchestrating the listen→think→speak loop
- `TTSService` — ElevenLabs streaming PCM playback via AVAudioEngine + system fallback
- `ConversationHistory` — multi-turn message store with LLMKit integration
- `VoiceLoopHUD` / `VoiceLoopPanel` / `VoiceLoopWindowManager` — floating panel UI

## Test plan
- [ ] Build succeeds with no errors (verified: `xcodebuild` passes)
- [ ] Existing transcription hotkey still works normally
- [ ] Set voice conversation shortcut in Settings → Keyboard Shortcuts
- [ ] Hold shortcut → HUD appears → speak → release → hear TTS response
- [ ] Hold shortcut during speech → interrupts → starts new recording
- [ ] Follow-up questions maintain conversation context
- [ ] Works with system TTS when ElevenLabs key not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a voice conversation mode with a hold-to-talk loop. Hold the new shortcut to speak, release to send, hear the assistant’s spoken reply via `ElevenLabs` TTS with system TTS fallback.

- **New Features**
  - Hold-to-talk loop: Listening → Thinking → Speaking; press again to interrupt
  - Keeps context for the last 10 turns
  - Floating HUD shows state and an expandable transcript with copy
  - Streaming 16k PCM TTS via `ElevenLabs`; falls back to system TTS if no key
  - New `.voiceConversation` hotkey; existing transcription and paste flows are unchanged

- **Migration**
  - Set the Voice Conversation shortcut in Settings → Keyboard Shortcuts
  - Optional: add an `ElevenLabs` API key to enable neural TTS; otherwise system TTS is used
  - No changes needed for current recording or paste workflows

<sup>Written for commit ba487d241e3969431521f019fdb7ab9139c8bfea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

