### PR TITLE
Fix: Recreate transcription session on Power Mode switch mid-recording

### DIFF
--- a/VoiceInk/Whisper/VoiceInkEngine.swift
+++ b/VoiceInk/Whisper/VoiceInkEngine.swift
@@ -277,6 +277,12 @@ class VoiceInkEngine: NSObject, ObservableObject {
             name: .promptDidChange,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePowerModeConfigApplied),
+            name: .powerModeConfigurationApplied,
+            object: nil
+        )
     }
 
     @objc func handleLicenseStatusChanged() {
@@ -289,6 +295,43 @@ class VoiceInkEngine: NSObject, ObservableObject {
                 ?? whisperModelManager.whisperPrompt.transcriptionPrompt
             if let context = whisperModelManager.whisperContext {
                 await context.setPrompt(currentPrompt)
+            }
+        }
+    }
+
+    /// When a Power Mode switch happens mid-recording, recreate the transcription
+    /// session with the new model so streaming/batch mode matches the selected model.
+    @objc func handlePowerModeConfigApplied() {
+        Task { @MainActor in
+            guard recordingState == .recording,
+                  let model = transcriptionModelManager.currentTranscriptionModel else { return }
+
+            // Cancel the old session without stopping the recording
+            currentSession?.cancel()
+            currentSession = nil
+            partialTranscript = ""
+
+            let session = serviceRegistry.createSession(
+                for: model,
+                onPartialTranscript: { [weak self] partial in
+                    Task { @MainActor in
+                        self?.partialTranscript = partial
+                    }
+                }
+            )
+            currentSession = session
+
+            do {
+                let realCallback = try await session.prepare(model: model)
+                if let realCallback {
+                    recorder.onAudioChunk = realCallback
+                } else {
+                    recorder.onAudioChunk = nil
+                }
+                logger.notice("Session recreated for \(model.displayName, privacy: .public)")
+            } catch {
+                logger.error("Failed to recreate session: \(error.localizedDescription, privacy: .public)")
+                recorder.onAudioChunk = nil
             }
         }
     }


### PR DESCRIPTION
## Summary

- When switching Power Mode during an active recording (e.g. pressing ⌥3 to switch from a local model to a cloud streaming model), the transcription session was not recreated
- The session stayed locked to whatever model was active when recording started, so the new model's capabilities (like streaming transcription) never activated
- This fix listens for `.powerModeConfigurationApplied` and recreates the session with the updated model while preserving the ongoing recording

## How it works

1. Observes `.powerModeConfigurationApplied` notification in `VoiceInkEngine`
2. If recording is active, cancels the old session and creates a new one with `transcriptionModelManager.currentTranscriptionModel`
3. Routes audio chunks to the new session immediately via `recorder.onAudioChunk`
4. Enables features like live streaming transcription to activate mid-recording

## Test plan

- [ ] Start recording with a local model (e.g. Parakeet V2)
- [ ] While recording, press ⌥3 (or any Power Mode shortcut) to switch to a streaming model (e.g. Deepgram Nova 3)
- [ ] Verify live partial transcripts appear in the notch recorder
- [ ] Verify final transcription uses the new model
- [ ] Verify switching back to a local model mid-recording also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recreates the transcription session when switching Power Mode mid-recording so the newly selected model’s features (e.g., streaming) activate without stopping the recording.

- **Bug Fixes**
  - Observes power mode changes and, if recording, cancels the old session and creates a new one with the current model.
  - Immediately wires `recorder.onAudioChunk` to the new session so live partials and streaming start right away.

<sup>Written for commit f0c5c5c89e85f44ac3a19a2b914a1bbc37043875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

