### PR TITLE
Improve auto-send reliability with AX-based paste detection

### DIFF
--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -100,6 +100,79 @@ class CursorPaster {
         logger.notice("CGEvents posted for Cmd+V")
     }
 
+    // MARK: - Paste then Auto Send
+
+    /// Pastes text, then uses AX to detect when the paste has landed before sending the auto-send key.
+    ///
+    /// Strategy: snapshot the focused field's AXValue before pasting, then poll until it changes.
+    /// This works for any text length and doesn't depend on matching specific content.
+    /// For apps where AXValue isn't readable (Electron, web), falls back to a short fixed delay.
+    static func pasteAndAutoSend(_ text: String, autoSendKey: AutoSendKey) {
+        let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
+        let fullText = text + (appendSpace ? " " : "")
+
+        guard autoSendKey.isEnabled else {
+            pasteAtCursor(fullText)
+            return
+        }
+
+        // Snapshot the field value BEFORE pasting
+        let baselineValue = getFocusedElementValue()
+        let canReadField = baselineValue != nil
+
+        pasteAtCursor(fullText)
+
+        Task.detached {
+            if canReadField {
+                // Strategy A: AX-based — poll until field value changes from baseline
+                let maxWait: TimeInterval = 3.0
+                let pollInterval: UInt64 = 50_000_000 // 50ms
+                let startTime = Date()
+
+                // Wait for paste keystroke to fire (pasteAtCursor has internal 50ms delay)
+                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+                while Date().timeIntervalSince(startTime) < maxWait {
+                    let currentValue = await Self.getFocusedElementValue()
+                    if currentValue != baselineValue {
+                        // Field changed — paste landed
+                        await MainActor.run { performAutoSend(autoSendKey) }
+                        return
+                    }
+                    try? await Task.sleep(nanoseconds: pollInterval)
+                }
+
+                // Timeout — send anyway
+                logger.warning("Auto-send: AX poll timed out, sending anyway")
+                await MainActor.run { performAutoSend(autoSendKey) }
+            } else {
+                // Strategy B: fixed delay for apps where AXValue isn't readable
+                // 300ms after paste keystroke (50ms internal + 250ms buffer)
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                await MainActor.run { performAutoSend(autoSendKey) }
+            }
+        }
+    }
+
+    // MARK: - Accessibility Helpers
+
+    /// Reads the AXValue of the currently focused UI element. Returns nil if not readable.
+    private static func getFocusedElementValue() -> String? {
+        guard AXIsProcessTrusted() else { return nil }
+
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedElement: AnyObject?
+        let result = AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focusedElement)
+
+        guard result == .success, let element = focusedElement else { return nil }
+
+        var value: AnyObject?
+        let valueResult = AXUIElementCopyAttributeValue(element as! AXUIElement, kAXValueAttribute as CFString, &value)
+
+        guard valueResult == .success, let stringValue = value as? String else { return nil }
+        return stringValue
+    }
+
     // MARK: - Auto Send Keys
 
     static func performAutoSend(_ key: AutoSendKey) {

--- a/VoiceInk/Whisper/TranscriptionPipeline.swift
+++ b/VoiceInk/Whisper/TranscriptionPipeline.swift
@@ -163,6 +163,19 @@ class TranscriptionPipeline {
 
         if shouldCancel() { await onCleanup(); return }
 
+        if let result = promptDetectionResult,
+           let enhancementService,
+           result.shouldEnableAI {
+            await promptDetectionService.restoreOriginalSettings(result, to: enhancementService)
+        }
+
+        // Capture auto-send key before dismiss clears the Power Mode config.
+        let autoSendKey = PowerModeManager.shared.currentActiveConfiguration?.autoSendKey
+
+        // Dismiss the recorder first so macOS refocuses the target window,
+        // then paste after a short delay to ensure focus has settled.
+        await onDismiss()
+
         if var textToPaste = finalPastedText,
            transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue {
             if case .trialExpired = licenseViewModel.licenseState {
@@ -172,25 +185,14 @@ class TranscriptionPipeline {
                     """
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
-                CursorPaster.pasteAtCursor(textToPaste + (appendSpace ? " " : ""))
-
-                let powerMode = PowerModeManager.shared
-                if let activeConfig = powerMode.currentActiveConfiguration, activeConfig.autoSendKey.isEnabled {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        CursorPaster.performAutoSend(activeConfig.autoSendKey)
-                    }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                if let autoSendKey, autoSendKey.isEnabled {
+                    CursorPaster.pasteAndAutoSend(textToPaste, autoSendKey: autoSendKey)
+                } else {
+                    let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
+                    CursorPaster.pasteAtCursor(textToPaste + (appendSpace ? " " : ""))
                 }
             }
         }
-
-        if let result = promptDetectionResult,
-           let enhancementService,
-           result.shouldEnableAI {
-            await promptDetectionService.restoreOriginalSettings(result, to: enhancementService)
-        }
-
-        await onDismiss()
     }
 }


### PR DESCRIPTION
## Summary

- **Dismiss recorder before pasting** so macOS refocuses the target window first — previously paste keystrokes could miss the target window because the recorder panel was still visible
- **Capture auto-send key before dismiss** — `dismissMiniRecorder` clears the Power Mode config, so the auto-send key was always nil by the time it was read
- **Replace fixed delay with AX-based detection** — polls the focused text field's `AXValue` every 50ms (up to 3s) to confirm the paste has landed before sending the auto-send keystroke. Works for any text length. Falls back to a timeout for apps where `AXValue` isn't readable (e.g. some web apps)

## Problem

The auto-send feature (sending Enter/Shift+Enter/Cmd+Enter after paste) was unreliable:
1. The recorder panel was still visible when paste fired, so keystrokes sometimes went to the wrong window
2. The Power Mode config was cleared during dismiss before the auto-send key could be read
3. The fixed 100ms delay between paste and auto-send was too short for long texts — the target app hadn't finished processing the paste

## Test plan

- [ ] Record with a Power Mode that has auto-send enabled (e.g. Return key)
- [ ] Verify paste lands in the correct window
- [ ] Verify Enter fires after the text appears (not before)
- [ ] Test with short text ("yes") — Enter should fire almost immediately
- [ ] Test with long text (30+ seconds of dictation) — Enter should wait for the full text to appear
- [ ] Test with apps where AXValue may not be readable (e.g. browser text fields) — should fall back to 3s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves auto-send reliability by dismissing the recorder before paste, capturing the auto-send key earlier, and using AX-based detection to wait for the paste to land. Prevents misdirected keystrokes and sends Enter only after text appears.

- **Bug Fixes**
  - Dismiss mini recorder before paste so macOS refocuses the target window; wait ~150ms before pasting to let focus settle.
  - Capture the auto-send key before dismiss clears the Power Mode config.
  - Replace fixed delay with AX polling of the focused field’s value (snapshot pre-paste, poll every 50ms up to 3s); fall back to a short 300ms delay when AX isn’t readable.

<sup>Written for commit 6dc3f129baf0c8e418bb5e884238e05af7938d93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

