### PR TITLE
fix: auto-send in terminal emulators (Ghostty, Terminal.app)

### DIFF
--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -106,6 +106,11 @@ class CursorPaster {
         guard key.isEnabled else { return }
         guard AXIsProcessTrusted() else { return }
 
+        if UserDefaults.standard.bool(forKey: "useAppleScriptPaste") {
+            autoSendUsingAppleScript(key)
+            return
+        }
+
         let source = CGEventSource(stateID: .privateState)
         let enterDown = CGEvent(keyboardEventSource: source, virtualKey: 0x24, keyDown: true)
         let enterUp   = CGEvent(keyboardEventSource: source, virtualKey: 0x24, keyDown: false)
@@ -123,5 +128,38 @@ class CursorPaster {
 
         enterDown?.post(tap: .cghidEventTap)
         enterUp?.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - AppleScript Auto Send
+
+    // Pre-compiled scripts to avoid per-send overhead.
+    private static let autoSendScriptEnter: NSAppleScript? = makeAutoSendScript("")
+    private static let autoSendScriptShiftEnter: NSAppleScript? = makeAutoSendScript("using shift down")
+    private static let autoSendScriptCommandEnter: NSAppleScript? = makeAutoSendScript("using command down")
+
+    private static func makeAutoSendScript(_ modifier: String) -> NSAppleScript? {
+        let script = NSAppleScript(source: """
+            tell application "System Events"
+                key code 36 \(modifier)
+            end tell
+            """)
+        var error: NSDictionary?
+        script?.compileAndReturnError(&error)
+        return script
+    }
+
+    private static func autoSendUsingAppleScript(_ key: AutoSendKey) {
+        let script: NSAppleScript?
+        switch key {
+        case .none: return
+        case .enter: script = autoSendScriptEnter
+        case .shiftEnter: script = autoSendScriptShiftEnter
+        case .commandEnter: script = autoSendScriptCommandEnter
+        }
+        var error: NSDictionary?
+        script?.executeAndReturnError(&error)
+        if let error = error {
+            logger.error("AppleScript auto-send failed: \(error, privacy: .public)")
+        }
     }
 }

--- a/VoiceInk/Transcription/Core/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionPipeline.swift
@@ -178,7 +178,8 @@ class TranscriptionPipeline {
 
                 let powerMode = PowerModeManager.shared
                 if let activeConfig = powerMode.currentActiveConfiguration, activeConfig.autoSendKey.isEnabled {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    let autoSendDelay = UserDefaults.standard.bool(forKey: "useAppleScriptPaste") ? 0.3 : 0.1
+                    DispatchQueue.main.asyncAfter(deadline: .now() + autoSendDelay) {
                         CursorPaster.performAutoSend(activeConfig.autoSendKey)
                     }
                 }


### PR DESCRIPTION
## Problem

Auto-send (pressing Return after dictation) does not work in terminal emulators like Ghostty or Terminal.app, even though it works correctly in GUI apps (browsers, text editors, etc.).

## Root Cause

`CursorPaster.performAutoSend` uses `CGEvent.post(tap: .cghidEventTap)` to simulate the Return keypress. Terminal emulators use custom input stacks and filter HID-level synthetic events, so the event is never delivered.

Additionally, the auto-send fires only 0.1s after `pasteAtCursor` is called. When AppleScript paste is active, the paste itself takes ~100–150ms, causing Return to arrive *before* the text — a race condition.

## Changes

**`CursorPaster.swift`**
- `performAutoSend`: when `useAppleScriptPaste` is enabled, send the keystroke via `System Events` AppleScript (`key code 36`) instead of CGEvent
- Pre-compiles three scripts (enter, shift+enter, command+enter) at startup to avoid per-send overhead

**`TranscriptionPipeline.swift`**
- Increases auto-send delay from `0.1s` → `0.3s` when AppleScript paste is active, giving the paste enough time to complete

## Behaviour

| Setting | Before | After |
|---|---|---|
| CGEvent paste (default) | Auto-send works in GUI, not terminals | Unchanged |
| AppleScript paste | Auto-send broken everywhere | Auto-send works in GUI and terminals |

No changes to behaviour when using the default CGEvent paste mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-send after dictation in Ghostty and Terminal.app by sending the Enter key via AppleScript when AppleScript paste is enabled and by increasing the delay to avoid races. Behavior with the default CGEvent paste in GUI apps is unchanged.

- **Bug Fixes**
  - In `CursorPaster.performAutoSend`, use System Events AppleScript (`key code 36`) for Enter/Shift+Enter/Command+Enter when `useAppleScriptPaste` is true; scripts are precompiled to reduce overhead.
  - In `TranscriptionPipeline`, use a 0.3s auto-send delay when AppleScript paste is active (0.1s otherwise) to ensure text arrives before Enter.

- **Migration**
  - To enable auto-send in terminals, turn on “Use AppleScript paste” in settings.

<sup>Written for commit 823b3a4789df40d91451bd4a7887d403f0d05d90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

