### PR TITLE
Configure AI enhancement timeout and retry settings

### DIFF
--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,15 +11,6 @@
       }
     },
     {
-      "identity" : "eventsource",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
-      "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
-      }
-    },
-    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio",
@@ -61,7 +52,7 @@
       "location" : "https://github.com/Beingpax/LLMkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e9908b1af7bbad0f4ad34850ca0bc4d5d1d70e31"
+        "revision" : "1fde8fe8d63e292f24a23093030b7f6d09c5bdca"
       }
     },
     {
@@ -92,93 +83,12 @@
       }
     },
     {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
-      }
-    },
-    {
-      "identity" : "swift-huggingface",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-huggingface.git",
-      "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
-        "version" : "2.3.1"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "bdf004b44f77c56fca752cd1cf243c802f8469c9",
-        "version" : "2.97.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     },
     {

--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -44,6 +44,8 @@ enum AppDefaults {
             "isToggleEnhancementShortcutEnabled": true,
             "SkipShortEnhancement": true,
             "ShortEnhancementWordThreshold": 3,
+            "EnhancementTimeoutSeconds": 7,
+            "EnhancementRetryOnTimeout": true,
 
             // Model
             "PrewarmModelOnWake": true,

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -69,7 +69,7 @@ class AIEnhancementService: ObservableObject {
     private let customVocabularyService: CustomVocabularyService
     private var baseTimeout: TimeInterval {
         let stored = UserDefaults.standard.integer(forKey: "EnhancementTimeoutSeconds")
-        return stored > 0 ? TimeInterval(stored) : 10
+        return stored > 0 ? TimeInterval(stored) : 7
     }
     private let rateLimitInterval: TimeInterval = 1.0
     private var lastRequestTime: Date?

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -67,7 +67,10 @@ class AIEnhancementService: ObservableObject {
     private let aiService: AIService
     private let screenCaptureService: ScreenCaptureService
     private let customVocabularyService: CustomVocabularyService
-    private let baseTimeout: TimeInterval = 30
+    private var baseTimeout: TimeInterval {
+        let stored = UserDefaults.standard.integer(forKey: "EnhancementTimeoutSeconds")
+        return stored > 0 ? TimeInterval(stored) : 10
+    }
     private let rateLimitInterval: TimeInterval = 1.0
     private var lastRequestTime: Date?
     private let modelContext: ModelContext
@@ -282,9 +285,15 @@ class AIEnhancementService: ObservableObject {
             return .enhancementFailed
         case .networkError:
             return .networkError
-        case .invalidURL, .decodingError, .encodingError, .timeout:
+        case .timeout:
+            return .timeout
+        case .invalidURL, .decodingError, .encodingError:
             return .customError(error.localizedDescription ?? "An unknown error occurred.")
         }
+    }
+
+    private var retryOnTimeout: Bool {
+        UserDefaults.standard.bool(forKey: "EnhancementRetryOnTimeout")
     }
 
     private func makeRequestWithRetry(text: String, mode: EnhancementPrompt, maxRetries: Int = 3, initialDelay: TimeInterval = 1.0) async throws -> String {
@@ -304,6 +313,19 @@ class AIEnhancementService: ObservableObject {
                         currentDelay *= 2
                     } else {
                         logger.error("Request failed after \(maxRetries, privacy: .public) retries.")
+                        throw error
+                    }
+                case .timeout:
+                    if retryOnTimeout {
+                        retries += 1
+                        if retries < maxRetries {
+                            logger.warning("Request timed out, retrying immediately... (Attempt \(retries, privacy: .public)/\(maxRetries, privacy: .public))")
+                        } else {
+                            logger.error("Request timed out after \(maxRetries, privacy: .public) retries.")
+                            throw error
+                        }
+                    } else {
+                        logger.error("Request timed out, failing immediately (retry disabled).")
                         throw error
                     }
                 default:
@@ -423,6 +445,7 @@ enum EnhancementError: Error {
     case networkError
     case serverError
     case rateLimitExceeded
+    case timeout
     case customError(String)
 }
 
@@ -441,6 +464,8 @@ extension EnhancementError: LocalizedError {
             return "The AI provider's server encountered an error. Please try again later."
         case .rateLimitExceeded:
             return "Rate limit exceeded. Please try again later."
+        case .timeout:
+            return "Enhancement request timed out. Check your connection or increase the timeout duration."
         case .customError(let message):
             return message
         }

--- a/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
+++ b/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
@@ -4,6 +4,8 @@ struct EnhancementSettingsPanel: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService
     @AppStorage("SkipShortEnhancement") private var isSkipShortEnhancementEnabled = true
     @AppStorage("ShortEnhancementWordThreshold") private var shortEnhancementWordThreshold = 3
+    @AppStorage("EnhancementTimeoutSeconds") private var enhancementTimeoutSeconds = 10
+    @AppStorage("EnhancementRetryOnTimeout") private var retryOnTimeout = false
     @State private var isShortEnhancementExpanded = false
     @State private var isHandlingToggleChange = false
 
@@ -119,6 +121,26 @@ struct EnhancementSettingsPanel: View {
                         }
                     }
                     .animation(.easeInOut(duration: 0.2), value: isShortEnhancementExpanded)
+                }
+
+                Section {
+                    Picker("Timeout duration", selection: $enhancementTimeoutSeconds) {
+                        ForEach([3, 5, 7, 10, 15, 20, 30, 40, 50, 60], id: \.self) { seconds in
+                            Text("\(seconds) seconds").tag(seconds)
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    Picker("On timeout", selection: $retryOnTimeout) {
+                        Text("Fail immediately").tag(false)
+                        Text("Retry").tag(true)
+                    }
+                    .pickerStyle(.menu)
+                } header: {
+                    HStack(spacing: 4) {
+                        Text("Request Timeout")
+                        InfoTip("Set how long to wait for the AI provider to respond. If no response is received within this duration, you can either fail immediately and paste the original transcription, or retry the request (up to 3 attempts).")
+                    }
                 }
 
                 Section {

--- a/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
+++ b/VoiceInk/Views/Components/EnhancementSettingsPanel.swift
@@ -4,8 +4,8 @@ struct EnhancementSettingsPanel: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService
     @AppStorage("SkipShortEnhancement") private var isSkipShortEnhancementEnabled = true
     @AppStorage("ShortEnhancementWordThreshold") private var shortEnhancementWordThreshold = 3
-    @AppStorage("EnhancementTimeoutSeconds") private var enhancementTimeoutSeconds = 10
-    @AppStorage("EnhancementRetryOnTimeout") private var retryOnTimeout = false
+    @AppStorage("EnhancementTimeoutSeconds") private var enhancementTimeoutSeconds = 7
+    @AppStorage("EnhancementRetryOnTimeout") private var retryOnTimeout = true
     @State private var isShortEnhancementExpanded = false
     @State private var isHandlingToggleChange = false
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds user-configurable enhancement request timeout and retry behavior, defaulting to 7s with retry enabled. Improves reliability by handling timeouts explicitly and allowing quick retries.

- **New Features**
  - Settings panel: add timeout duration (3–60s) and “On timeout” option (Retry or Fail immediately).
  - Service: reads `EnhancementTimeoutSeconds` and `EnhancementRetryOnTimeout`, adds `.timeout` error with message, and retries timeouts up to 3 times when enabled.
  - Defaults: register `EnhancementTimeoutSeconds` = 7 and `EnhancementRetryOnTimeout` = true for new installs.

- **Dependencies**
  - Cleanup `Package.resolved` and update `LLMkit` revision.

<sup>Written for commit 8a76771dcee1b5b5f479079f1e9d838bf96c3b8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

