### PR TITLE
Add re-enhance only button to audio player

### DIFF
--- a/VoiceInk/Views/AudioPlayerView.swift
+++ b/VoiceInk/Views/AudioPlayerView.swift
@@ -154,6 +154,12 @@ class AudioPlayerManager: ObservableObject {
     }
 }
 
+private func formatTime(_ time: TimeInterval) -> String {
+    let minutes = Int(time) / 60
+    let seconds = Int(time) % 60
+    return String(format: "%d:%02d", minutes, seconds)
+}
+
 struct WaveformView: View {
     let samples: [Float]
     let currentTime: TimeInterval
@@ -162,7 +168,7 @@ struct WaveformView: View {
     var onSeek: (Double) -> Void
     @State private var isHovering = false
     @State private var hoverLocation: CGFloat = 0
-    
+
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
@@ -238,12 +244,6 @@ struct WaveformView: View {
         }
         .frame(height: 32)
     }
-    
-    private func formatTime(_ time: TimeInterval) -> String {
-        let minutes = Int(time) / 60
-        let seconds = Int(time) % 60
-        return String(format: "%d:%02d", minutes, seconds)
-    }
 }
 
 struct WaveformBar: View {
@@ -281,23 +281,115 @@ struct WaveformBar: View {
     }
 }
 
+// MARK: - Reusable Components
+
+private struct CircleIconButton: View {
+    let icon: String
+    let action: () -> Void
+    var fillOpacity: Double = 0.06
+    var iconFont: Font = .system(size: 14, weight: .semibold)
+
+    var body: some View {
+        Button(action: action) {
+            Circle()
+                .fill(Color.primary.opacity(fillOpacity))
+                .frame(width: 32, height: 32)
+                .overlay(
+                    Image(systemName: icon)
+                        .font(iconFont)
+                        .foregroundStyle(.primary)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct AsyncCircleButton: View {
+    let defaultIcon: String
+    let isLoading: Bool
+    let showSuccess: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Circle()
+                .fill(Color.primary.opacity(0.06))
+                .frame(width: 32, height: 32)
+                .overlay(
+                    Group {
+                        if isLoading {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else if showSuccess {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color.green)
+                        } else {
+                            Image(systemName: defaultIcon)
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(.primary)
+                        }
+                    }
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct StatusBanner: View {
+    let message: String
+    let isError: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: isError ? "exclamationmark.circle.fill" : "checkmark.circle.fill")
+                .foregroundColor(isError ? .red : .green)
+            Text(message)
+                .font(.system(size: 14, weight: .medium))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isError ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
+                .stroke(isError ? Color.red.opacity(0.2) : Color.green.opacity(0.2), lineWidth: 1)
+        )
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}
+
+// MARK: - Banner State
+
+private enum BannerState: Equatable {
+    case retranscribeSuccess
+    case reEnhanceSuccess
+    case retranscribeError(String)
+    case reEnhanceError(String)
+}
+
+// MARK: - AudioPlayerView
+
 struct AudioPlayerView: View {
     let url: URL
+    let transcription: Transcription?
     @StateObject private var playerManager = AudioPlayerManager()
     @State private var isHovering = false
     @State private var isRetranscribing = false
-    @State private var showRetranscribeSuccess = false
-    @State private var showRetranscribeError = false
-    @State private var errorMessage = ""
+    @State private var isReEnhancing = false
+    @State private var bannerState: BannerState?
     @State private var showPromptPopover = false
     @EnvironmentObject private var engine: VoiceInkEngine
     @EnvironmentObject private var enhancementService: AIEnhancementService
     @Environment(\.modelContext) private var modelContext
 
+    private var isOperationInProgress: Bool {
+        isRetranscribing || isReEnhancing
+    }
+
     private var transcriptionService: AudioTranscriptionService {
         AudioTranscriptionService(modelContext: modelContext, engine: engine)
     }
-    
+
     var body: some View {
         VStack(spacing: 8) {
             WaveformView(
@@ -318,18 +410,8 @@ struct AudioPlayerView: View {
                 Spacer()
 
                 HStack(spacing: 8) {
-                    Button(action: showInFinder) {
-                        Circle()
-                            .fill(Color.primary.opacity(0.06))
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Image(systemName: "folder")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(.primary)
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .help("Show in Finder")
+                    CircleIconButton(icon: "folder", action: showInFinder)
+                        .help("Show in Finder")
 
                     Button(action: { playerManager.cyclePlaybackRate() }) {
                         Circle()
@@ -344,24 +426,10 @@ struct AudioPlayerView: View {
                     .buttonStyle(.plain)
                     .help("Playback speed")
 
-                    Button(action: {
-                        if playerManager.isPlaying {
-                            playerManager.pause()
-                        } else {
-                            playerManager.play()
-                        }
-                    }) {
-                        Circle()
-                            .fill(Color.primary.opacity(0.06))
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Image(systemName: playerManager.isPlaying ? "pause.fill" : "play.fill")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(.primary)
-                                    .contentTransition(.symbolEffect(.replace.downUp))
-                            )
-                    }
-                    .buttonStyle(.plain)
+                    CircleIconButton(
+                        icon: playerManager.isPlaying ? "pause.fill" : "play.fill",
+                        action: { playerManager.isPlaying ? playerManager.pause() : playerManager.play() }
+                    )
                     .scaleEffect(isHovering ? 1.05 : 1.0)
                     .onHover { hovering in
                         withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
@@ -369,19 +437,10 @@ struct AudioPlayerView: View {
                         }
                     }
 
-                    Button(action: {
-                        showPromptPopover.toggle()
-                    }) {
-                        Circle()
-                            .fill(Color.primary.opacity(0.06))
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Image(systemName: enhancementService.activePrompt?.icon ?? "sparkles")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(.primary)
-                            )
-                    }
-                    .buttonStyle(.plain)
+                    CircleIconButton(
+                        icon: enhancementService.activePrompt?.icon ?? "sparkles",
+                        action: { showPromptPopover.toggle() }
+                    )
                     .opacity(enhancementService.isEnhancementEnabled ? 1.0 : 0.4)
                     .help("Select enhancement prompt")
                     .popover(isPresented: $showPromptPopover, arrowEdge: .bottom) {
@@ -389,30 +448,26 @@ struct AudioPlayerView: View {
                             .environmentObject(enhancementService)
                     }
 
-                    Button(action: retranscribeAudio) {
-                        Circle()
-                            .fill(Color.primary.opacity(0.06))
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Group {
-                                    if isRetranscribing {
-                                        ProgressView()
-                                            .controlSize(.small)
-                                    } else if showRetranscribeSuccess {
-                                        Image(systemName: "checkmark")
-                                            .font(.system(size: 14, weight: .semibold))
-                                            .foregroundStyle(Color.green)
-                                    } else {
-                                        Image(systemName: "arrow.clockwise")
-                                            .font(.system(size: 14, weight: .semibold))
-                                            .foregroundStyle(.primary)
-                                    }
-                                }
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(isRetranscribing)
+                    AsyncCircleButton(
+                        defaultIcon: "arrow.clockwise",
+                        isLoading: isRetranscribing,
+                        showSuccess: bannerState == .retranscribeSuccess,
+                        action: retranscribeAudio
+                    )
+                    .disabled(isOperationInProgress)
                     .help("Retranscribe this audio")
+
+                    if transcription != nil {
+                        AsyncCircleButton(
+                            defaultIcon: "wand.and.stars",
+                            isLoading: isReEnhancing,
+                            showSuccess: bannerState == .reEnhanceSuccess,
+                            action: reEnhanceOnly
+                        )
+                        .disabled(isOperationInProgress || !enhancementService.isEnhancementEnabled || !enhancementService.isConfigured)
+                        .opacity(enhancementService.isEnhancementEnabled && enhancementService.isConfigured ? 1.0 : 0.4)
+                        .help("Re-enhance with selected prompt")
+                    }
                 }
 
                 Spacer()
@@ -434,88 +489,91 @@ struct AudioPlayerView: View {
         }
         .overlay(
             VStack {
-                if showRetranscribeSuccess {
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                        Text("Retranscription successful")
-                            .font(.system(size: 14, weight: .medium))
+                if let state = bannerState {
+                    switch state {
+                    case .retranscribeSuccess:
+                        StatusBanner(message: "Retranscription successful", isError: false)
+                    case .reEnhanceSuccess:
+                        StatusBanner(message: "Re-enhancement successful", isError: false)
+                    case .retranscribeError(let message):
+                        StatusBanner(message: message.isEmpty ? "Retranscription failed" : message, isError: true)
+                    case .reEnhanceError(let message):
+                        StatusBanner(message: message.isEmpty ? "Re-enhancement failed" : message, isError: true)
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.green.opacity(0.1))
-                            .stroke(Color.green.opacity(0.2), lineWidth: 1)
-                    )
-                    .transition(.move(edge: .top).combined(with: .opacity))
                 }
-                
-                if showRetranscribeError {
-                    HStack(spacing: 8) {
-                        Image(systemName: "exclamationmark.circle.fill")
-                            .foregroundColor(.red)
-                        Text(errorMessage.isEmpty ? "Retranscription failed" : errorMessage)
-                            .font(.system(size: 14, weight: .medium))
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.red.opacity(0.1))
-                            .stroke(Color.red.opacity(0.2), lineWidth: 1)
-                    )
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                }
-                
                 Spacer()
             }
             .padding(.top, 16)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: showRetranscribeSuccess)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: showRetranscribeError)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: bannerState)
         )
     }
-    
-    private func formatTime(_ time: TimeInterval) -> String {
-        let minutes = Int(time) / 60
-        let seconds = Int(time) % 60
-        return String(format: "%d:%02d", minutes, seconds)
-    }
-    
+
     private func showInFinder() {
         NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: url.deletingLastPathComponent().path)
     }
-    
-    private func retranscribeAudio() {
-        guard let currentTranscriptionModel = engine.transcriptionModelManager.currentTranscriptionModel else {
-            errorMessage = "No transcription model selected"
-            showRetranscribeError = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                withAnimation { showRetranscribeError = false }
-            }
+
+    private func showTemporaryBanner(_ state: BannerState) {
+        bannerState = state
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            withAnimation { bannerState = nil }
+        }
+    }
+
+    private func reEnhanceOnly() {
+        guard let transcription = transcription else { return }
+
+        guard enhancementService.isEnhancementEnabled, enhancementService.isConfigured else {
+            showTemporaryBanner(.reEnhanceError("AI Enhancement is not enabled or configured"))
             return
         }
-        
+
+        isReEnhancing = true
+        bannerState = nil
+
+        Task {
+            do {
+                let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(transcription.text)
+                await MainActor.run {
+                    transcription.enhancedText = enhancedText
+                    transcription.aiEnhancementModelName = enhancementService.getAIService()?.currentModel
+                    transcription.promptName = promptName
+                    transcription.enhancementDuration = enhancementDuration
+                    transcription.aiRequestSystemMessage = enhancementService.lastSystemMessageSent
+                    transcription.aiRequestUserMessage = enhancementService.lastUserMessageSent
+                    try? modelContext.save()
+
+                    isReEnhancing = false
+                    showTemporaryBanner(.reEnhanceSuccess)
+                }
+            } catch {
+                await MainActor.run {
+                    isReEnhancing = false
+                    showTemporaryBanner(.reEnhanceError(error.localizedDescription))
+                }
+            }
+        }
+    }
+
+    private func retranscribeAudio() {
+        guard let currentTranscriptionModel = engine.transcriptionModelManager.currentTranscriptionModel else {
+            showTemporaryBanner(.retranscribeError("No transcription model selected"))
+            return
+        }
+
         isRetranscribing = true
-        
+        bannerState = nil
+
         Task {
             do {
                 let _ = try await transcriptionService.retranscribeAudio(from: url, using: currentTranscriptionModel)
                 await MainActor.run {
                     isRetranscribing = false
-                    showRetranscribeSuccess = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        withAnimation { showRetranscribeSuccess = false }
-                    }
+                    showTemporaryBanner(.retranscribeSuccess)
                 }
             } catch {
                 await MainActor.run {
                     isRetranscribing = false
-                    errorMessage = error.localizedDescription
-                    showRetranscribeError = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        withAnimation { showRetranscribeError = false }
-                    }
+                    showTemporaryBanner(.retranscribeError(error.localizedDescription))
                 }
             }
         }

--- a/VoiceInk/Views/History/TranscriptionDetailView.swift
+++ b/VoiceInk/Views/History/TranscriptionDetailView.swift
@@ -38,7 +38,7 @@ struct TranscriptionDetailView: View {
                 VStack(spacing: 0) {
                     Divider()
 
-                    AudioPlayerView(url: url)
+                    AudioPlayerView(url: url, transcription: transcription)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 6)
                         .background(


### PR DESCRIPTION
## Summary
- Add a **re-enhance** button (wand icon) in the audio player that re-runs AI enhancement on the original transcription using the currently selected prompt, without retranscribing the audio
- Refactor AudioPlayerView: extract reusable `CircleIconButton`, `AsyncCircleButton`, and `StatusBanner` components
- Consolidate success/error banner state into a single `BannerState` enum
- Deduplicate `formatTime` helper (was duplicated in both `WaveformView` and `AudioPlayerView`)

## Test plan
- [ ] Open a transcription detail with an audio file
- [ ] Verify the new re-enhance button (wand icon) appears next to the retranscribe button
- [ ] Re-enhance with a different prompt and confirm `enhancedText` updates without retranscribing
- [ ] Verify the button is disabled/dimmed when AI enhancement is not enabled or configured
- [ ] Verify both retranscribe and re-enhance buttons are disabled while an operation is in progress
- [ ] Confirm success/error banners display correctly for both operations
- [ ] Test play/pause, seek, playback speed, and show-in-Finder still work correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a re‑enhance button to the audio player to run enhancement on the existing transcript with the selected prompt, without retranscribing. Also extracts reusable UI components and unifies status banners for clearer feedback.

- **New Features**
  - Re‑enhance (wand) button updates `enhancedText` using the active prompt, no new transcription.
  - Button is disabled when enhancement is off or not configured; both actions lock while in progress.
  - Unified success/error banners for retranscribe and re‑enhance.

- **Refactors**
  - Extracted `CircleIconButton`, `AsyncCircleButton`, and `StatusBanner`.
  - Replaced multiple banner flags with a single `BannerState` enum.
  - Deduplicated `formatTime`.
  - `TranscriptionDetailView` now passes `transcription` into `AudioPlayerView`.

<sup>Written for commit ac6ce5e96063b5aa96a283a144ad25a9b3bda1f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

