### PR TITLE
Rename Parakeet to FluidAudio, add version mapping

### DIFF
--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -102,7 +102,7 @@ import Foundation
         ),
         
         // Parakeet Models
-        ParakeetModel(
+        FluidAudioModel(
             name: "parakeet-tdt-0.6b-v2",
             displayName: "Parakeet V2",
             description: "NVIDIA's Parakeet V2 model optimized for lightning-fast English-only transcription",
@@ -110,9 +110,9 @@ import Foundation
             speed: 0.99,
             accuracy: 0.94,
             ramUsage: 0.8,
-            supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .parakeet)
+            supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .fluidAudio)
         ),
-        ParakeetModel(
+        FluidAudioModel(
             name: "parakeet-tdt-0.6b-v3",
             displayName: "Parakeet V3",
             description: "NVIDIA's Parakeet V3 model with multilingual support across English and 25 European languages",
@@ -120,7 +120,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.94,
             ramUsage: 0.8,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .parakeet)
+            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .fluidAudio)
         ),
 
          // Local Models

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -3,7 +3,7 @@ import Foundation
 // Enum to differentiate between model providers
 enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case local = "Local"
-    case parakeet = "Parakeet"
+    case fluidAudio = "Parakeet"
     case groq = "Groq"
     case elevenLabs = "ElevenLabs"
     case deepgram = "Deepgram"
@@ -50,13 +50,13 @@ struct NativeAppleModel: TranscriptionModel {
     let supportedLanguages: [String: String]
 }
 
-// A new struct for Parakeet models
-struct ParakeetModel: TranscriptionModel {
+// A new struct for FluidAudio models
+struct FluidAudioModel: TranscriptionModel {
     let id = UUID()
     let name: String
     let displayName: String
     let description: String
-    let provider: ModelProvider = .parakeet
+    let provider: ModelProvider = .fluidAudio
     let size: String
     let speed: Double
     let accuracy: Double

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -51,7 +51,7 @@ struct ConfigurationView: View {
         guard let selectedModelName = effectiveModelName,
               let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName })
         else { return false }
-        return model.provider == .parakeet || model.provider == .gemini
+        return model.provider == .fluidAudio || model.provider == .gemini
     }
 
     init(mode: ConfigurationMode, powerModeManager: PowerModeManager, onDismiss: @escaping () -> Void) {
@@ -278,7 +278,7 @@ struct ConfigurationView: View {
                             // Auto-set language to "auto" for models that only support auto-detection
                             if let modelName = newModelName ?? transcriptionModelManager.currentTranscriptionModel?.name,
                                let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }),
-                               model.provider == .parakeet || model.provider == .gemini {
+                               model.provider == .fluidAudio || model.provider == .gemini {
                                 selectedLanguage = "auto"
                             }
                         }

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -193,7 +193,7 @@ class PowerModeSessionManager {
                     print("Power Mode: Failed to load local model '\(localModel.name)': \(error)")
                 }
             }
-        case .parakeet:
+        case .fluidAudio:
             await stateProvider.cleanupModelResources()
         default:
             await stateProvider.cleanupModelResources()

--- a/VoiceInk/Services/ModelPrewarmService.swift
+++ b/VoiceInk/Services/ModelPrewarmService.swift
@@ -106,7 +106,7 @@ final class ModelPrewarmService: ObservableObject {
         }
 
         switch model.provider {
-        case .local, .parakeet:
+        case .local, .fluidAudio:
             return true
         default:
             logger.notice("Skipping prewarm - cloud models don't need it")

--- a/VoiceInk/Transcription/Batch/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/Batch/FluidAudioTranscriptionService.swift
@@ -10,7 +10,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
     private var activeVersion: AsrModelVersion?
     private var cachedModels: AsrModels?
     private var loadingTask: (version: AsrModelVersion, task: Task<AsrModels, Error>)?
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink.parakeet", category: "FluidAudioTranscriptionService")
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink.fluidaudio", category: "FluidAudioTranscriptionService")
 
     private func version(for model: any TranscriptionModel) -> AsrModelVersion {
         FluidAudioModelManager.asrVersion(for: model.name)

--- a/VoiceInk/Transcription/Batch/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/Batch/FluidAudioTranscriptionService.swift
@@ -4,16 +4,16 @@ import AVFoundation
 import FluidAudio
 import os.log
 
-class ParakeetTranscriptionService: TranscriptionService {
+class FluidAudioTranscriptionService: TranscriptionService {
     private var asrManager: AsrManager?
     private var vadManager: VadManager?
     private var activeVersion: AsrModelVersion?
     private var cachedModels: AsrModels?
     private var loadingTask: (version: AsrModelVersion, task: Task<AsrModels, Error>)?
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink.parakeet", category: "ParakeetTranscriptionService")
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink.parakeet", category: "FluidAudioTranscriptionService")
 
     private func version(for model: any TranscriptionModel) -> AsrModelVersion {
-        model.name.lowercased().contains("v2") ? .v2 : .v3
+        FluidAudioModelManager.asrVersion(for: model.name)
     }
 
     private func ensureModelsLoaded(for version: AsrModelVersion) async throws {
@@ -71,7 +71,7 @@ class ParakeetTranscriptionService: TranscriptionService {
         }
     }
 
-    func loadModel(for model: ParakeetModel) async throws {
+    func loadModel(for model: FluidAudioModel) async throws {
         try await ensureModelsLoaded(for: version(for: model))
     }
 

--- a/VoiceInk/Transcription/Core/FluidAudio/FluidAudioModelManager.swift
+++ b/VoiceInk/Transcription/Core/FluidAudio/FluidAudioModelManager.swift
@@ -4,40 +4,45 @@ import AppKit
 import os
 
 @MainActor
-class ParakeetModelManager: ObservableObject {
+class FluidAudioModelManager: ObservableObject {
     @Published var parakeetDownloadStates: [String: Bool] = [:]
     @Published var downloadProgress: [String: Double] = [:]
 
-    /// Called when a model is deleted, passing the model name.
-    /// TranscriptionModelManager listens to clear currentTranscriptionModel if needed.
     var onModelDeleted: ((String) -> Void)?
-
-    /// Called after a model is successfully downloaded so TranscriptionModelManager
-    /// can rebuild allAvailableModels.
     var onModelsChanged: (() -> Void)?
 
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ParakeetModelManager")
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "FluidAudioModelManager")
+
+    // Add new Fluid Audio models here when support is added.
+    static let modelVersionMap: [String: AsrModelVersion] = [
+        "parakeet-tdt-0.6b-v2": .v2,
+        "parakeet-tdt-0.6b-v3": .v3,
+    ]
+
+    static func asrVersion(for modelName: String) -> AsrModelVersion {
+        modelVersionMap[modelName] ?? .v3
+    }
 
     init() {}
 
     // MARK: - Query helpers
 
-    func isParakeetModelDownloaded(named modelName: String) -> Bool {
+    func isFluidAudioModelDownloaded(named modelName: String) -> Bool {
         UserDefaults.standard.bool(forKey: parakeetDefaultsKey(for: modelName))
     }
 
-    func isParakeetModelDownloaded(_ model: ParakeetModel) -> Bool {
-        isParakeetModelDownloaded(named: model.name)
+    func isFluidAudioModelDownloaded(_ model: FluidAudioModel) -> Bool {
+        isFluidAudioModelDownloaded(named: model.name)
     }
 
-    func isParakeetModelDownloading(_ model: ParakeetModel) -> Bool {
+    func isFluidAudioModelDownloading(_ model: FluidAudioModel) -> Bool {
         parakeetDownloadStates[model.name] ?? false
     }
 
     // MARK: - Download
 
-    func downloadParakeetModel(_ model: ParakeetModel) async {
-        if isParakeetModelDownloaded(model) {
+    func downloadFluidAudioModel(_ model: FluidAudioModel) async {
+        if isFluidAudioModelDownloaded(model) {
             return
         }
 
@@ -53,7 +58,7 @@ class ParakeetModelManager: ObservableObject {
             }
         }
 
-        let version = parakeetVersion(for: modelName)
+        let version = FluidAudioModelManager.asrVersion(for: modelName)
 
         do {
             _ = try await AsrModels.downloadAndLoad(version: version)
@@ -63,7 +68,7 @@ class ParakeetModelManager: ObservableObject {
             downloadProgress[modelName] = 1.0
         } catch {
             UserDefaults.standard.set(false, forKey: parakeetDefaultsKey(for: modelName))
-            logger.error("❌ Parakeet download failed for \(modelName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ FluidAudio download failed for \(modelName, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
 
         timer.invalidate()
@@ -75,8 +80,8 @@ class ParakeetModelManager: ObservableObject {
 
     // MARK: - Delete
 
-    func deleteParakeetModel(_ model: ParakeetModel) {
-        let version = parakeetVersion(for: model.name)
+    func deleteFluidAudioModel(_ model: FluidAudioModel) {
+        let version = FluidAudioModelManager.asrVersion(for: model.name)
         let cacheDirectory = parakeetCacheDirectory(for: version)
 
         do {
@@ -94,8 +99,8 @@ class ParakeetModelManager: ObservableObject {
 
     // MARK: - Finder
 
-    func showParakeetModelInFinder(_ model: ParakeetModel) {
-        let cacheDirectory = parakeetCacheDirectory(for: parakeetVersion(for: model.name))
+    func showFluidAudioModelInFinder(_ model: FluidAudioModel) {
+        let cacheDirectory = parakeetCacheDirectory(for: FluidAudioModelManager.asrVersion(for: model.name))
 
         if FileManager.default.fileExists(atPath: cacheDirectory.path) {
             NSWorkspace.shared.selectFile(cacheDirectory.path, inFileViewerRootedAtPath: "")
@@ -106,10 +111,6 @@ class ParakeetModelManager: ObservableObject {
 
     private func parakeetDefaultsKey(for modelName: String) -> String {
         "ParakeetModelDownloaded_\(modelName)"
-    }
-
-    private func parakeetVersion(for modelName: String) -> AsrModelVersion {
-        modelName.lowercased().contains("v2") ? .v2 : .v3
     }
 
     private func parakeetCacheDirectory(for version: AsrModelVersion) -> URL {

--- a/VoiceInk/Transcription/Core/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionModelManager.swift
@@ -8,19 +8,19 @@ class TranscriptionModelManager: ObservableObject {
     @Published var allAvailableModels: [any TranscriptionModel] = PredefinedModels.models
 
     private weak var whisperModelManager: WhisperModelManager?
-    private weak var parakeetModelManager: ParakeetModelManager?
+    private weak var fluidAudioModelManager: FluidAudioModelManager?
 
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionModelManager")
 
-    init(whisperModelManager: WhisperModelManager, parakeetModelManager: ParakeetModelManager) {
+    init(whisperModelManager: WhisperModelManager, fluidAudioModelManager: FluidAudioModelManager) {
         self.whisperModelManager = whisperModelManager
-        self.parakeetModelManager = parakeetModelManager
+        self.fluidAudioModelManager = fluidAudioModelManager
 
         // Wire up deletion callbacks so each manager notifies this manager.
         whisperModelManager.onModelDeleted = { [weak self] modelName in
             self?.handleModelDeleted(modelName)
         }
-        parakeetModelManager.onModelDeleted = { [weak self] modelName in
+        fluidAudioModelManager.onModelDeleted = { [weak self] modelName in
             self?.handleModelDeleted(modelName)
         }
 
@@ -28,7 +28,7 @@ class TranscriptionModelManager: ObservableObject {
         whisperModelManager.onModelsChanged = { [weak self] in
             self?.refreshAllAvailableModels()
         }
-        parakeetModelManager.onModelsChanged = { [weak self] in
+        fluidAudioModelManager.onModelsChanged = { [weak self] in
             self?.refreshAllAvailableModels()
         }
     }
@@ -40,8 +40,8 @@ class TranscriptionModelManager: ObservableObject {
             switch model.provider {
             case .local:
                 return whisperModelManager?.availableModels.contains { $0.name == model.name } ?? false
-            case .parakeet:
-                return parakeetModelManager?.isParakeetModelDownloaded(named: model.name) ?? false
+            case .fluidAudio:
+                return fluidAudioModelManager?.isFluidAudioModelDownloaded(named: model.name) ?? false
             case .nativeApple:
                 if #available(macOS 26, *) {
                     return true
@@ -120,7 +120,7 @@ class TranscriptionModelManager: ObservableObject {
 
     // MARK: - Handle model deletion callback
 
-    /// Called by WhisperModelManager.onModelDeleted or ParakeetModelManager.onModelDeleted.
+    /// Called by WhisperModelManager.onModelDeleted or FluidAudioModelManager.onModelDeleted.
     func handleModelDeleted(_ modelName: String) {
         if currentTranscriptionModel?.name == modelName {
             currentTranscriptionModel = nil

--- a/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
@@ -16,7 +16,7 @@ class TranscriptionServiceRegistry {
     )
     private(set) lazy var cloudTranscriptionService = CloudTranscriptionService(modelContext: modelContext)
     private(set) lazy var nativeAppleTranscriptionService = NativeAppleTranscriptionService()
-    private(set) lazy var parakeetTranscriptionService = ParakeetTranscriptionService()
+    private(set) lazy var fluidAudioTranscriptionService = FluidAudioTranscriptionService()
 
     init(modelProvider: any LocalModelProvider, modelsDirectory: URL, modelContext: ModelContext) {
         self.modelProvider = modelProvider
@@ -28,8 +28,8 @@ class TranscriptionServiceRegistry {
         switch provider {
         case .local:
             return localTranscriptionService
-        case .parakeet:
-            return parakeetTranscriptionService
+        case .fluidAudio:
+            return fluidAudioTranscriptionService
         case .nativeApple:
             return nativeAppleTranscriptionService
         default:
@@ -49,7 +49,7 @@ class TranscriptionServiceRegistry {
         if supportsStreaming(model: model) {
             let streamingService = StreamingTranscriptionService(
                 modelContext: modelContext,
-                parakeetService: model.provider == .parakeet ? parakeetTranscriptionService : nil,
+                fluidAudioService: model.provider == .fluidAudio ? fluidAudioTranscriptionService : nil,
                 onPartialTranscript: onPartialTranscript
             )
             let fallback = service(for: model.provider)
@@ -83,7 +83,7 @@ class TranscriptionServiceRegistry {
             return model.name == "voxtral-mini-transcribe-realtime-2602"
         case .soniox:
             return model.name == "stt-rt-v4"
-        case .parakeet:
+        case .fluidAudio:
             return UserDefaults.standard.object(forKey: "parakeet-streaming-enabled") as? Bool ?? true
         default:
             return false
@@ -91,6 +91,6 @@ class TranscriptionServiceRegistry {
     }
 
     func cleanup() async {
-        await parakeetTranscriptionService.cleanup()
+        await fluidAudioTranscriptionService.cleanup()
     }
 }

--- a/VoiceInk/Transcription/Core/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Core/VoiceInkEngine.swift
@@ -191,8 +191,8 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                             await self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
                                         }
                                     }
-                                } else if let parakeetModel = await self.transcriptionModelManager.currentTranscriptionModel as? ParakeetModel {
-                                    try? await self.serviceRegistry.parakeetTranscriptionService.loadModel(for: parakeetModel)
+                                } else if let fluidAudioModel = await self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
+                                    try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
                                 }
 
                                 if let enhancementService = await self.enhancementService {

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -2,11 +2,11 @@ import FluidAudio
 import Foundation
 import os
 
-/// Agreement-based on-device streaming transcription using Parakeet ASR.
-final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
+/// Agreement-based on-device streaming transcription using FluidAudio ASR.
+final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ParakeetStreaming")
-    private let parakeetService: ParakeetTranscriptionService
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "FluidAudioStreaming")
+    private let fluidAudioService: FluidAudioTranscriptionService
     private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
 
     private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
@@ -26,8 +26,8 @@ final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
     private var lastTranscribedSampleCount = 0
     private let minNewSamples = 8000 // ~0.5s
 
-    init(parakeetService: ParakeetTranscriptionService, config: AgreementConfig = AgreementConfig()) {
-        self.parakeetService = parakeetService
+    init(fluidAudioService: FluidAudioTranscriptionService, config: AgreementConfig = AgreementConfig()) {
+        self.fluidAudioService = fluidAudioService
         self.config = config
         self.agreementEngine = WordAgreementEngine(config: config)
 
@@ -42,8 +42,8 @@ final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
     }
 
     func connect(model: any TranscriptionModel, language: String?) async throws {
-        let version: AsrModelVersion = model.name.lowercased().contains("v2") ? .v2 : .v3
-        let models = try await parakeetService.getOrLoadModels(for: version)
+        let version: AsrModelVersion = FluidAudioModelManager.asrVersion(for: model.name)
+        let models = try await fluidAudioService.getOrLoadModels(for: version)
 
         let manager = AsrManager(config: .default)
         try await manager.initialize(models: models)
@@ -57,7 +57,7 @@ final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
         startTranscriptionLoop()
 
         eventsContinuation?.yield(.sessionStarted)
-        logger.notice("Parakeet agreement streaming started for \(model.displayName, privacy: .public)")
+        logger.notice("FluidAudio agreement streaming started for \(model.displayName, privacy: .public)")
     }
 
     func sendAudioChunk(_ data: Data) async throws {
@@ -92,7 +92,7 @@ final class ParakeetStreamingProvider: StreamingTranscriptionProvider {
         agreementEngine.reset()
 
         eventsContinuation?.finish()
-        logger.notice("Parakeet agreement streaming disconnected")
+        logger.notice("FluidAudio agreement streaming disconnected")
     }
 
     // MARK: - Private

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -49,12 +49,12 @@ class StreamingTranscriptionService {
     private var state: StreamingState = .idle
     private var committedSegments: [String] = []
     private let modelContext: ModelContext
-    private let parakeetService: ParakeetTranscriptionService?
+    private let fluidAudioService: FluidAudioTranscriptionService?
     private var onPartialTranscript: ((String) -> Void)?
 
-    init(modelContext: ModelContext, parakeetService: ParakeetTranscriptionService? = nil, onPartialTranscript: ((String) -> Void)? = nil) {
+    init(modelContext: ModelContext, fluidAudioService: FluidAudioTranscriptionService? = nil, onPartialTranscript: ((String) -> Void)? = nil) {
         self.modelContext = modelContext
-        self.parakeetService = parakeetService
+        self.fluidAudioService = fluidAudioService
         self.onPartialTranscript = onPartialTranscript
     }
 
@@ -176,11 +176,11 @@ class StreamingTranscriptionService {
             return MistralStreamingProvider()
         case .soniox:
             return SonioxStreamingProvider(modelContext: modelContext)
-        case .parakeet:
-            guard let parakeetService else {
-                fatalError("ParakeetTranscriptionService required for Parakeet streaming. Ensure it is passed to StreamingTranscriptionService.")
+        case .fluidAudio:
+            guard let fluidAudioService else {
+                fatalError("FluidAudioTranscriptionService required for FluidAudio streaming. Ensure it is passed to StreamingTranscriptionService.")
             }
-            return ParakeetStreamingProvider(parakeetService: parakeetService)
+            return FluidAudioStreamingProvider(fluidAudioService: fluidAudioService)
         default:
             fatalError("Unsupported streaming provider: \(model.provider). Check supportsStreaming() before calling startStreaming().")
         }

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import Combine
 import AppKit
 
-struct ParakeetModelCardRowView: View {
-    let model: ParakeetModel
-    @ObservedObject var parakeetModelManager: ParakeetModelManager
+struct FluidAudioModelCardRowView: View {
+    let model: FluidAudioModel
+    @ObservedObject var fluidAudioModelManager: FluidAudioModelManager
     @ObservedObject var transcriptionModelManager: TranscriptionModelManager
     @AppStorage("parakeet-streaming-enabled") private var streamingEnabled = true
 
@@ -13,11 +13,11 @@ struct ParakeetModelCardRowView: View {
     }
 
     var isDownloaded: Bool {
-        parakeetModelManager.isParakeetModelDownloaded(model)
+        fluidAudioModelManager.isFluidAudioModelDownloaded(model)
     }
 
     var isDownloading: Bool {
-        parakeetModelManager.isParakeetModelDownloading(model)
+        fluidAudioModelManager.isFluidAudioModelDownloading(model)
     }
 
     var body: some View {
@@ -99,7 +99,7 @@ struct ParakeetModelCardRowView: View {
     private var progressSection: some View {
         Group {
             if isDownloading {
-                let progress = parakeetModelManager.downloadProgress[model.name] ?? 0.0
+                let progress = fluidAudioModelManager.downloadProgress[model.name] ?? 0.0
                 ProgressView(value: progress)
                     .progressViewStyle(LinearProgressViewStyle())
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -128,7 +128,7 @@ struct ParakeetModelCardRowView: View {
             } else {
                 Button(action: {
                     Task {
-                        await parakeetModelManager.downloadParakeetModel(model)
+                        await fluidAudioModelManager.downloadFluidAudioModel(model)
                     }
                 }) {
                     HStack(spacing: 4) {
@@ -148,13 +148,13 @@ struct ParakeetModelCardRowView: View {
             if isDownloaded {
                 Menu {
                     Button(action: {
-                        parakeetModelManager.deleteParakeetModel(model)
+                        fluidAudioModelManager.deleteFluidAudioModel(model)
                     }) {
                         Label("Delete Model", systemImage: "trash")
                     }
 
                     Button {
-                        parakeetModelManager.showParakeetModelInFinder(model)
+                        fluidAudioModelManager.showFluidAudioModelInFinder(model)
                     } label: {
                         Label("Show in Finder", systemImage: "folder")
                     }

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -37,7 +37,7 @@ struct LanguageSelectionView: View {
         guard let provider = transcriptionModelManager.currentTranscriptionModel?.provider else {
             return false
         }
-        return provider == .parakeet || provider == .gemini
+        return provider == .fluidAudio || provider == .gemini
     }
 
     // Function to get current model's supported languages

--- a/VoiceInk/Views/AI Models/ModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/ModelCardRowView.swift
@@ -3,7 +3,7 @@ import AppKit
 
 struct ModelCardRowView: View {
     let model: any TranscriptionModel
-    let parakeetModelManager: ParakeetModelManager
+    let fluidAudioModelManager: FluidAudioModelManager
     let transcriptionModelManager: TranscriptionModelManager
     let isDownloaded: Bool
     let isCurrent: Bool
@@ -42,11 +42,11 @@ struct ModelCardRowView: View {
                         setDefaultAction: setDefaultAction
                     )
                 }
-            case .parakeet:
-                if let parakeetModel = model as? ParakeetModel {
-                    ParakeetModelCardRowView(
-                        model: parakeetModel,
-                        parakeetModelManager: parakeetModelManager,
+            case .fluidAudio:
+                if let fluidAudioModel = model as? FluidAudioModel {
+                    FluidAudioModelCardRowView(
+                        model: fluidAudioModel,
+                        fluidAudioModelManager: fluidAudioModelManager,
                         transcriptionModelManager: transcriptionModelManager
                     )
                 }

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -13,7 +13,7 @@ enum ModelFilter: String, CaseIterable, Identifiable {
 
 struct ModelManagementView: View {
     @EnvironmentObject private var whisperModelManager: WhisperModelManager
-    @EnvironmentObject private var parakeetModelManager: ParakeetModelManager
+    @EnvironmentObject private var fluidAudioModelManager: FluidAudioModelManager
     @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
     @State private var customModelToEdit: CustomCloudModel?
     @StateObject private var aiService = AIService()
@@ -173,7 +173,7 @@ struct ModelManagementView: View {
 
                         ModelCardRowView(
                             model: model,
-                            parakeetModelManager: parakeetModelManager,
+                            fluidAudioModelManager: fluidAudioModelManager,
                             transcriptionModelManager: transcriptionModelManager,
                             isDownloaded: whisperModelManager.availableModels.contains { $0.name == model.name },
                             isCurrent: transcriptionModelManager.currentTranscriptionModel?.name == model.name,
@@ -308,7 +308,7 @@ struct ModelManagementView: View {
                 return index1 < index2
             }
         case .local:
-            return transcriptionModelManager.allAvailableModels.filter { $0.provider == .local || $0.provider == .nativeApple || $0.provider == .parakeet }
+            return transcriptionModelManager.allAvailableModels.filter { $0.provider == .local || $0.provider == .nativeApple || $0.provider == .fluidAudio }
         case .cloud:
             let cloudProviders: [ModelProvider] = [.groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox]
             return transcriptionModelManager.allAvailableModels.filter { cloudProviders.contains($0.provider) }

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -14,7 +14,7 @@ struct VoiceInkApp: App {
 
     @StateObject private var engine: VoiceInkEngine
     @StateObject private var whisperModelManager: WhisperModelManager
-    @StateObject private var parakeetModelManager: ParakeetModelManager
+    @StateObject private var fluidAudioModelManager: FluidAudioModelManager
     @StateObject private var transcriptionModelManager: TranscriptionModelManager
     @StateObject private var recorderUIManager: RecorderUIManager
     @StateObject private var hotkeyManager: HotkeyManager
@@ -106,10 +106,10 @@ struct VoiceInkApp: App {
 
         // 2. Create model managers
         let whisperModelManager = WhisperModelManager(modelsDirectory: modelsDirectory)
-        let parakeetModelManager = ParakeetModelManager()
+        let fluidAudioModelManager = FluidAudioModelManager()
         let transcriptionModelManager = TranscriptionModelManager(
             whisperModelManager: whisperModelManager,
-            parakeetModelManager: parakeetModelManager
+            fluidAudioModelManager: fluidAudioModelManager
         )
 
         // 3. Create UI manager
@@ -135,7 +135,7 @@ struct VoiceInkApp: App {
         transcriptionModelManager.loadCurrentTranscriptionModel()
 
         _whisperModelManager = StateObject(wrappedValue: whisperModelManager)
-        _parakeetModelManager = StateObject(wrappedValue: parakeetModelManager)
+        _fluidAudioModelManager = StateObject(wrappedValue: fluidAudioModelManager)
         _transcriptionModelManager = StateObject(wrappedValue: transcriptionModelManager)
         _recorderUIManager = StateObject(wrappedValue: recorderUIManager)
         _engine = StateObject(wrappedValue: engine)
@@ -252,7 +252,7 @@ struct VoiceInkApp: App {
                 ContentView()
                     .environmentObject(engine)
                     .environmentObject(whisperModelManager)
-                    .environmentObject(parakeetModelManager)
+                    .environmentObject(fluidAudioModelManager)
                     .environmentObject(transcriptionModelManager)
                     .environmentObject(recorderUIManager)
                     .environmentObject(hotkeyManager)
@@ -312,7 +312,7 @@ struct VoiceInkApp: App {
                     .environmentObject(hotkeyManager)
                     .environmentObject(engine)
                     .environmentObject(whisperModelManager)
-                    .environmentObject(parakeetModelManager)
+                    .environmentObject(fluidAudioModelManager)
                     .environmentObject(transcriptionModelManager)
                     .environmentObject(recorderUIManager)
                     .environmentObject(aiService)
@@ -340,7 +340,7 @@ struct VoiceInkApp: App {
             MenuBarView()
                 .environmentObject(engine)
                 .environmentObject(whisperModelManager)
-                .environmentObject(parakeetModelManager)
+                .environmentObject(fluidAudioModelManager)
                 .environmentObject(transcriptionModelManager)
                 .environmentObject(recorderUIManager)
                 .environmentObject(hotkeyManager)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the Parakeet integration to FluidAudio and added explicit ASR version mapping (v2/v3) by model name. Also updated logger subsystem/category names to `fluidaudio`.

- **New Features**
  - Add `FluidAudioModelManager.modelVersionMap` and `asrVersion(for:)` to map model names (e.g., "parakeet-tdt-0.6b-v2"/"v3") to `AsrModelVersion` with a v3 fallback.
  - Use the mapping in `FluidAudioTranscriptionService` and `FluidAudioStreamingProvider` for correct model loading.

- **Refactors**
  - Rename Parakeet to FluidAudio across models, providers, managers, services, streaming, registry, and UI; update logger subsystem/category to `fluidaudio`.
  - Replace `.parakeet` with `.fluidAudio` in `ModelProvider` and across Power Mode, prewarm, language, and cleanup logic. Keep `@AppStorage("parakeet-streaming-enabled")` for compatibility.

<sup>Written for commit 479a50bb866ee50313b419e26ef751ca74f9200c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

