### PR TITLE
Add Speechmatics cloud transcription with streaming and batch support

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = E11BBA4D2E5DC555000AB839 /* FluidAudio */; };
 		E1342C1F2EB4844800CED8A2 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = E1342C1E2EB4844800CED8A2 /* Atomics */; };
-		E1438ED22F3F3D5E00DBE2A1 /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E1438ED12F3F3D5E00DBE2A1 /* LLMkit */; };
+		E15433AB2F86A73C0083437A /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E15433AA2F86A73C0083437A /* LLMkit */; };
 		E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E161D4A02F41ECB90086F83D /* CloudKit.framework */; };
 		E1A261122CC143AC00B233D1 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = E1A261112CC143AC00B233D1 /* KeyboardShortcuts */; };
 		E1ADD45A2CC5352A00303ECB /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD4592CC5352A00303ECB /* LaunchAtLogin */; };
@@ -92,10 +92,10 @@
 				E1ECEC162E44591300DFFBA8 /* Zip in Frameworks */,
 				E1ADD45A2CC5352A00303ECB /* LaunchAtLogin in Frameworks */,
 				E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */,
-				E1438ED22F3F3D5E00DBE2A1 /* LLMkit in Frameworks */,
 				E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */,
 				E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */,
 				E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */,
+				E15433AB2F86A73C0083437A /* LLMkit in Frameworks */,
 				E1F1037B2EF85FC700A4FF94 /* SelectedTextKit in Frameworks */,
 				E1A261122CC143AC00B233D1 /* KeyboardShortcuts in Frameworks */,
 			);
@@ -179,7 +179,7 @@
 				E11BBA4D2E5DC555000AB839 /* FluidAudio */,
 				E1342C1E2EB4844800CED8A2 /* Atomics */,
 				E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */,
-				E1438ED12F3F3D5E00DBE2A1 /* LLMkit */,
+				E15433AA2F86A73C0083437A /* LLMkit */,
 			);
 			productName = VoiceInk;
 			productReference = E11473B02CBE0F0A00318EE4 /* VoiceInk.app */;
@@ -272,7 +272,7 @@
 				E11BBA4C2E5DC555000AB839 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */,
 				E1F103792EF85FC700A4FF94 /* XCRemoteSwiftPackageReference "SelectedTextKit" */,
-				E1438ED02F3F3D5E00DBE2A1 /* XCRemoteSwiftPackageReference "LLMkit" */,
+				E15433A92F86A73C0083437A /* XCRemoteSwiftPackageReference "LLMkit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -661,7 +661,7 @@
 				minimumVersion = 1.3.0;
 			};
 		};
-		E1438ED02F3F3D5E00DBE2A1 /* XCRemoteSwiftPackageReference "LLMkit" */ = {
+		E15433A92F86A73C0083437A /* XCRemoteSwiftPackageReference "LLMkit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Beingpax/LLMkit.git";
 			requirement = {
@@ -730,9 +730,9 @@
 			package = E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */;
 			productName = Atomics;
 		};
-		E1438ED12F3F3D5E00DBE2A1 /* LLMkit */ = {
+		E15433AA2F86A73C0083437A /* LLMkit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E1438ED02F3F3D5E00DBE2A1 /* XCRemoteSwiftPackageReference "LLMkit" */;
+			package = E15433A92F86A73C0083437A /* XCRemoteSwiftPackageReference "LLMkit" */;
 			productName = LLMkit;
 		};
 		E1A261112CC143AC00B233D1 /* KeyboardShortcuts */ = {

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/Beingpax/LLMkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "1fde8fe8d63e292f24a23093030b7f6d09c5bdca"
+        "revision" : "c4ed80007e15e53a89e9bc464264d1194b8c0e3c"
       }
     },
     {

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -10,6 +10,20 @@ import Foundation
                 let appleSupportedCodes = ["ar", "de", "en", "es", "fr", "it", "ja", "ko", "pt", "yue", "zh"]
                 return allLanguages.filter { appleSupportedCodes.contains($0.key) }
             }
+            // For Speechmatics, return only supported languages
+            if provider == .speechmatics {
+                let speechmaticsSupportedCodes = [
+                    "ar", "ba", "eu", "be", "bn", "bg", "yue", "ca", "hr", "cs", "da",
+                    "nl", "en", "et", "fi", "fr", "gl", "de", "el", "he", "hi",
+                    "hu", "id", "it", "ja", "ko", "lv", "lt", "ms", "mt", "mr",
+                    "mn", "no", "fa", "pl", "pt", "ro", "ru", "sk", "sl", "es",
+                    "sw", "sv", "tl", "ta", "th", "tr", "uk", "ur", "vi", "cy",
+                    "zh"
+                ]
+                var filtered = allLanguages.filter { speechmaticsSupportedCodes.contains($0.key) }
+                filtered["auto"] = "Auto-detect"
+                return filtered
+            }
             // For Soniox, return only the 60 languages supported by stt-async-v4
             if provider == .soniox {
                 let sonioxSupportedCodes = [
@@ -339,6 +353,18 @@ import Foundation
             accuracy: 0.97,
             isMultilingual: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
+        ),
+
+        // Speechmatics Models
+        CloudModel(
+            name: "speechmatics-enhanced",
+            displayName: "Speechmatics Realtime",
+            description: "Speechmatics enhanced accuracy transcription with real-time streaming and 50+ language support",
+            provider: .speechmatics,
+            speed: 0.99,
+            accuracy: 0.98,
+            isMultilingual: true,
+            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .speechmatics)
         )
      ]
  

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -10,6 +10,7 @@ enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case mistral = "Mistral"
     case gemini = "Gemini"
     case soniox = "Soniox"
+    case speechmatics = "Speechmatics"
     case custom = "Custom"
     case nativeApple = "Native Apple"
     // Future providers can be added here

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -12,6 +12,7 @@ enum AIProvider: String, CaseIterable {
     case elevenLabs = "ElevenLabs"
     case deepgram = "Deepgram"
     case soniox = "Soniox"
+    case speechmatics = "Speechmatics"
     case ollama = "Ollama"
     case custom = "Custom"
     
@@ -38,6 +39,8 @@ enum AIProvider: String, CaseIterable {
             return "https://api.deepgram.com/v1/listen"
         case .soniox:
             return "https://api.soniox.com/v1"
+        case .speechmatics:
+            return "https://asr.api.speechmatics.com/v2"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         case .custom:
@@ -65,6 +68,8 @@ enum AIProvider: String, CaseIterable {
             return "whisper-1"
         case .soniox:
             return "stt-async-v4"
+        case .speechmatics:
+            return "speechmatics-enhanced"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
         case .custom:
@@ -133,6 +138,8 @@ enum AIProvider: String, CaseIterable {
             return ["whisper-1"]
         case .soniox:
             return ["stt-async-v4"]
+        case .speechmatics:
+            return ["speechmatics-enhanced"]
         case .ollama:
             return []
         case .custom:
@@ -329,6 +336,8 @@ class AIService: ObservableObject {
                 result = await MistralTranscriptionClient.verifyAPIKey(key)
             case .soniox:
                 result = await SonioxClient.verifyAPIKey(key)
+            case .speechmatics:
+                result = await SpeechmaticsClient.verifyAPIKey(key)
             case .openRouter:
                 result = await OpenRouterClient.verifyAPIKey(key, model: currentModel)
             case .gemini:

--- a/VoiceInk/Services/APIKeyManager.swift
+++ b/VoiceInk/Services/APIKeyManager.swift
@@ -20,6 +20,7 @@ final class APIKeyManager {
         "mistral": "mistralAPIKey",
         "elevenlabs": "elevenLabsAPIKey",
         "soniox": "sonioxAPIKey",
+        "speechmatics": "speechmaticsAPIKey",
         "openai": "openAIAPIKey",
         "anthropic": "anthropicAPIKey",
         "openrouter": "openRouterAPIKey"
@@ -34,6 +35,7 @@ final class APIKeyManager {
         "MistralAPIKey": "mistralAPIKey",
         "ElevenLabsAPIKey": "elevenLabsAPIKey",
         "SonioxAPIKey": "sonioxAPIKey",
+        "SpeechmaticsAPIKey": "speechmaticsAPIKey",
         "OpenAIAPIKey": "openAIAPIKey",
         "AnthropicAPIKey": "anthropicAPIKey",
         "OpenRouterAPIKey": "openRouterAPIKey"
@@ -202,6 +204,8 @@ final class APIKeyManager {
             return "ElevenLabsAPIKey"
         case "soniox":
             return "SonioxAPIKey"
+        case "speechmatics":
+            return "SpeechmaticsAPIKey"
         case "openai":
             return "OpenAIAPIKey"
         case "anthropic":

--- a/VoiceInk/Transcription/Batch/CloudTranscriptionService.swift
+++ b/VoiceInk/Transcription/Batch/CloudTranscriptionService.swift
@@ -110,6 +110,17 @@ class CloudTranscriptionService: TranscriptionService {
                     customVocabulary: customVocabulary
                 )
 
+            case .speechmatics:
+                let apiKey = try requireAPIKey(forProvider: "Speechmatics")
+                let customVocabulary = getCustomDictionaryTerms()
+                return try await SpeechmaticsClient.transcribe(
+                    audioData: audioData,
+                    fileName: fileName,
+                    apiKey: apiKey,
+                    language: language,
+                    customVocabulary: customVocabulary
+                )
+
             case .custom:
                 guard let customModel = model as? CustomCloudModel else {
                     throw CloudTranscriptionError.unsupportedProvider

--- a/VoiceInk/Transcription/Core/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionModelManager.swift
@@ -60,6 +60,8 @@ class TranscriptionModelManager: ObservableObject {
                 return APIKeyManager.shared.hasAPIKey(forProvider: "Gemini")
             case .soniox:
                 return APIKeyManager.shared.hasAPIKey(forProvider: "Soniox")
+            case .speechmatics:
+                return APIKeyManager.shared.hasAPIKey(forProvider: "Speechmatics")
             case .custom:
                 return true
             }

--- a/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
@@ -83,6 +83,8 @@ class TranscriptionServiceRegistry {
             return model.name == "voxtral-mini-transcribe-realtime-2602"
         case .soniox:
             return model.name == "stt-rt-v4"
+        case .speechmatics:
+            return model.name == "speechmatics-enhanced"
         case .fluidAudio:
             return UserDefaults.standard.object(forKey: "parakeet-streaming-enabled") as? Bool ?? true
         default:

--- a/VoiceInk/Transcription/Streaming/SpeechmaticsStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/SpeechmaticsStreamingProvider.swift
@@ -1,0 +1,124 @@
+import Foundation
+import SwiftData
+import LLMkit
+
+/// Speechmatics streaming provider wrapping `LLMkit.SpeechmaticsStreamingClient`.
+final class SpeechmaticsStreamingProvider: StreamingTranscriptionProvider {
+
+    private let client = LLMkit.SpeechmaticsStreamingClient()
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var forwardingTask: Task<Void, Never>?
+    private let modelContext: ModelContext
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    deinit {
+        forwardingTask?.cancel()
+        eventsContinuation?.finish()
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "Speechmatics"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        let vocabulary = getCustomVocabularyTerms()
+
+        // Cancel any existing forwarding task before starting a new one
+        forwardingTask?.cancel()
+        startEventForwarding()
+
+        do {
+            let operatingPoint = model.name.contains("standard") ? "standard" : "enhanced"
+            try await client.connect(apiKey: apiKey, model: operatingPoint, language: language, customVocabulary: vocabulary)
+        } catch {
+            // Clean up forwarding task on connection failure
+            forwardingTask?.cancel()
+            forwardingTask = nil
+            throw mapError(error)
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        do {
+            try await client.sendAudioChunk(data)
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func commit() async throws {
+        do {
+            try await client.commit()
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func disconnect() async {
+        forwardingTask?.cancel()
+        forwardingTask = nil
+        await client.disconnect()
+        eventsContinuation?.finish()
+    }
+
+    // MARK: - Private
+
+    private func startEventForwarding() {
+        forwardingTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.client.transcriptionEvents {
+                switch event {
+                case .sessionStarted:
+                    self.eventsContinuation?.yield(.sessionStarted)
+                case .partial(let text):
+                    self.eventsContinuation?.yield(.partial(text: text))
+                case .committed(let text):
+                    self.eventsContinuation?.yield(.committed(text: text))
+                case .error(let message):
+                    self.eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(message)))
+                }
+            }
+        }
+    }
+
+    private func getCustomVocabularyTerms() -> [String] {
+        let descriptor = FetchDescriptor<VocabularyWord>(sortBy: [SortDescriptor(\.word)])
+        guard let vocabularyWords = try? modelContext.fetch(descriptor) else {
+            return []
+        }
+        var seen = Set<String>()
+        var unique: [String] = []
+        for word in vocabularyWords {
+            let trimmed = word.word.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let key = trimmed.lowercased()
+            if !seen.contains(key) {
+                seen.insert(key)
+                unique.append(trimmed)
+            }
+        }
+        return unique
+    }
+
+    private func mapError(_ error: Error) -> Error {
+        guard let llmError = error as? LLMKitError else { return error }
+        switch llmError {
+        case .missingAPIKey:
+            return StreamingTranscriptionError.missingAPIKey
+        case .httpError(_, let message):
+            return StreamingTranscriptionError.serverError(message)
+        case .networkError(let detail):
+            return StreamingTranscriptionError.connectionFailed(detail)
+        default:
+            return StreamingTranscriptionError.serverError(llmError.localizedDescription ?? "Unknown error")
+        }
+    }
+}

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -176,6 +176,8 @@ class StreamingTranscriptionService {
             return MistralStreamingProvider()
         case .soniox:
             return SonioxStreamingProvider(modelContext: modelContext)
+        case .speechmatics:
+            return SpeechmaticsStreamingProvider(modelContext: modelContext)
         case .fluidAudio:
             guard let fluidAudioService else {
                 fatalError("FluidAudioTranscriptionService required for FluidAudio streaming. Ensure it is passed to StreamingTranscriptionService.")

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -17,7 +17,7 @@ struct APIKeyManagementView: View {
         Section("AI Provider Integration") {
             HStack {
                 Picker("Provider", selection: $aiService.selectedProvider) {
-                    ForEach(AIProvider.allCases.filter { $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox }, id: \.self) { provider in
+                    ForEach(AIProvider.allCases.filter { $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox && $0 != .speechmatics }, id: \.self) { provider in
                         Text(provider.rawValue).tag(provider)
                     }
                 }
@@ -289,6 +289,7 @@ struct APIKeyManagementView: View {
         case .elevenLabs: return URL(string: "https://elevenlabs.io/speech-synthesis")
         case .deepgram: return URL(string: "https://console.deepgram.com/api-keys")
         case .soniox: return URL(string: "https://console.soniox.com/")
+        case .speechmatics: return URL(string: "https://portal.speechmatics.com/manage-access/")
         case .openRouter: return URL(string: "https://openrouter.ai/keys")
         case .cerebras: return URL(string: "https://cloud.cerebras.ai/")
         default: return nil

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -1,19 +1,18 @@
 import SwiftUI
 import AppKit
+import LLMkit
 
 // MARK: - Cloud Model Card View
 struct CloudModelCardView: View {
     let model: CloudModel
     let isCurrent: Bool
     var setDefaultAction: () -> Void
-    
+
     @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
-    @StateObject private var aiService = AIService()
     @State private var isExpanded = false
     @State private var apiKey = ""
     @State private var isVerifying = false
     @State private var verificationStatus: VerificationStatus = .none
-    @State private var isConfiguredState: Bool = false
     @State private var verificationError: String? = nil
     
     enum VerificationStatus {
@@ -38,6 +37,8 @@ struct CloudModelCardView: View {
             return "Gemini"
         case .soniox:
             return "Soniox"
+        case .speechmatics:
+            return "Speechmatics"
         default:
             return model.provider.rawValue
         }
@@ -70,7 +71,6 @@ struct CloudModelCardView: View {
         .background(CardBackground(isSelected: isCurrent, useAccentGradientWhenSelected: isCurrent))
         .onAppear {
             loadSavedAPIKey()
-            isConfiguredState = isConfigured
         }
     }
     
@@ -95,7 +95,7 @@ struct CloudModelCardView: View {
                     .padding(.vertical, 2)
                     .background(Capsule().fill(Color.accentColor))
                     .foregroundColor(.white)
-            } else if isConfiguredState {
+            } else if isConfigured {
                 Text("Configured")
                     .font(.system(size: 11, weight: .medium))
                     .padding(.horizontal, 6)
@@ -165,7 +165,7 @@ struct CloudModelCardView: View {
                 Text("Default Model")
                     .font(.system(size: 12))
                     .foregroundColor(Color(.secondaryLabelColor))
-            } else if isConfiguredState {
+            } else if isConfigured {
                 Button(action: setDefaultAction) {
                     Text("Set as Default")
                         .font(.system(size: 12))
@@ -196,7 +196,7 @@ struct CloudModelCardView: View {
                 .buttonStyle(.plain)
             }
             
-            if isConfiguredState {
+            if isConfigured {
                 Menu {
                     Button {
                         clearAPIKey()
@@ -277,48 +277,54 @@ struct CloudModelCardView: View {
     
     private func verifyAPIKey() {
         guard !apiKey.isEmpty else { return }
-        
+
         isVerifying = true
         verificationStatus = .verifying
-        
-        switch model.provider {
-        case .groq:
-            aiService.selectedProvider = .groq
-        case .elevenLabs:
-            aiService.selectedProvider = .elevenLabs
-        case .deepgram:
-            aiService.selectedProvider = .deepgram
-        case .mistral:
-            aiService.selectedProvider = .mistral
-        case .gemini:
-            aiService.selectedProvider = .gemini
-        case .soniox:
-            aiService.selectedProvider = .soniox
-        default:
-            // This case should ideally not be hit for cloud models in this view
-            print("Warning: verifyAPIKey called for unsupported provider \(model.provider.rawValue)")
-            isVerifying = false
-            verificationStatus = .failure
-            return
-        }
-        
-        aiService.saveAPIKey(apiKey) { isValid, errorMessage in
-            DispatchQueue.main.async {
-                self.isVerifying = false
-                if isValid {
-                    self.verificationStatus = .success
-                    self.verificationError = nil
-                    // Save the API key to Keychain
-                    APIKeyManager.shared.saveAPIKey(self.apiKey, forProvider: self.providerKey)
-                    self.isConfiguredState = true
+        let key = apiKey
 
-                    // Collapse the configuration section after successful verification
+        Task {
+            let result: (isValid: Bool, errorMessage: String?)
+            switch model.provider {
+            case .groq:
+                result = await OpenAILLMClient.verifyAPIKey(
+                    baseURL: URL(string: "https://api.groq.com/openai/v1/chat/completions")!,
+                    apiKey: key,
+                    model: model.name
+                )
+            case .elevenLabs:
+                result = await ElevenLabsClient.verifyAPIKey(key)
+            case .deepgram:
+                result = await DeepgramClient.verifyAPIKey(key)
+            case .mistral:
+                result = await MistralTranscriptionClient.verifyAPIKey(key)
+            case .gemini:
+                result = await GeminiTranscriptionClient.verifyAPIKey(key)
+            case .soniox:
+                result = await SonioxClient.verifyAPIKey(key)
+            case .speechmatics:
+                result = await SpeechmaticsClient.verifyAPIKey(key)
+            default:
+                await MainActor.run {
+                    isVerifying = false
+                    verificationStatus = .failure
+                    verificationError = "Unsupported provider"
+                }
+                return
+            }
+
+            await MainActor.run {
+                isVerifying = false
+                if result.isValid {
+                    verificationStatus = .success
+                    verificationError = nil
+                    APIKeyManager.shared.saveAPIKey(key, forProvider: providerKey)
+                    transcriptionModelManager.refreshAllAvailableModels()
                     withAnimation(.easeInOut(duration: 0.3)) {
-                        self.isExpanded = false
+                        isExpanded = false
                     }
                 } else {
-                    self.verificationStatus = .failure
-                    self.verificationError = errorMessage
+                    verificationStatus = .failure
+                    verificationError = result.errorMessage
                 }
             }
         }
@@ -329,16 +335,12 @@ struct CloudModelCardView: View {
         apiKey = ""
         verificationStatus = .none
         verificationError = nil
-        isConfiguredState = false
 
-        // If this model is currently the default, clear it
         if isCurrent {
-            Task {
-                await MainActor.run {
-                    transcriptionModelManager.clearCurrentTranscriptionModel()
-                }
-            }
+            transcriptionModelManager.clearCurrentTranscriptionModel()
         }
+
+        transcriptionModelManager.refreshAllAvailableModels()
 
         withAnimation(.easeInOut(duration: 0.3)) {
             isExpanded = false

--- a/VoiceInk/Views/AI Models/ModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/ModelCardRowView.swift
@@ -58,7 +58,7 @@ struct ModelCardRowView: View {
                         setDefaultAction: setDefaultAction
                     )
                 }
-            case .groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox:
+            case .groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox, .speechmatics:
                 if let cloudModel = model as? CloudModel {
                     CloudModelCardView(
                         model: cloudModel,

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -241,7 +241,15 @@ struct ModelManagementView: View {
                     }
                     
                     if selectedFilter == .custom {
-                        // Add Custom Model Card at the bottom
+                        HStack(spacing: 6) {
+                            Image(systemName: "info.circle")
+                                .font(.system(size: 12))
+                            Text("Only OpenAI-compatible transcription APIs are supported.")
+                                .font(.system(size: 12))
+                        }
+                        .foregroundColor(.secondary)
+                        .padding(.bottom, 4)
+
                         AddCustomModelCardView(
                             customModelManager: customModelManager,
                             editingModel: customModelToEdit
@@ -310,7 +318,7 @@ struct ModelManagementView: View {
         case .local:
             return transcriptionModelManager.allAvailableModels.filter { $0.provider == .local || $0.provider == .nativeApple || $0.provider == .fluidAudio }
         case .cloud:
-            let cloudProviders: [ModelProvider] = [.groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox]
+            let cloudProviders: [ModelProvider] = [.groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox, .speechmatics]
             return transcriptionModelManager.allAvailableModels.filter { cloudProviders.contains($0.provider) }
         case .custom:
             return transcriptionModelManager.allAvailableModels.filter { $0.provider == .custom }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Speechmatics as a cloud transcription provider with real-time streaming and batch support. This enables 50+ languages, API key management, and updated UI for model selection and verification.

- **New Features**
  - Streaming and batch transcription via `SpeechmaticsStreamingProvider` and `SpeechmaticsClient` (custom vocabulary, robust error mapping) integrated into existing services.
  - New cloud model `speechmatics-enhanced` with provider enums, endpoints, and registry routing for real-time use.
  - Language list filters for Speechmatics (50+ supported) with Auto-detect.
  - API key storage and verification added for Speechmatics, plus a help link to the portal.
  - UI updates: model cards and filters include Speechmatics; verification now calls provider clients directly; `LLMkit` updated to latest revision.

<sup>Written for commit b46f13cbd1aac8ad7d8c2ec7809b720fd4b31f4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

