### PR TITLE
Feature/local cli enhancement

### DIFF
--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -231,6 +231,19 @@ class AIEnhancementService: ObservableObject {
             }
         }
 
+        if aiService.selectedProvider == .localCLI {
+            do {
+                let result = try await aiService.enhanceWithLocalCLI(systemPrompt: systemMessage, userPrompt: formattedText)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch {
+                if let localError = error as? LocalCLIError {
+                    throw EnhancementError.customError(localError.errorDescription ?? "An unknown Local CLI error occurred.")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
         try await waitForRateLimit()
 
         do {

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -14,6 +14,7 @@ enum AIProvider: String, CaseIterable {
     case soniox = "Soniox"
     case speechmatics = "Speechmatics"
     case ollama = "Ollama"
+    case localCLI = "Local CLI"
     case custom = "Custom"
     
     
@@ -43,6 +44,8 @@ enum AIProvider: String, CaseIterable {
             return "https://asr.api.speechmatics.com/v2"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
+        case .localCLI:
+            return ""
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderBaseURL") ?? ""
         }
@@ -72,6 +75,8 @@ enum AIProvider: String, CaseIterable {
             return "speechmatics-enhanced"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
+        case .localCLI:
+            return "local-cli"
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderModel") ?? ""
         case .openRouter:
@@ -142,6 +147,8 @@ enum AIProvider: String, CaseIterable {
             return ["speechmatics-enhanced"]
         case .ollama:
             return []
+        case .localCLI:
+            return []
         case .custom:
             return []
         case .openRouter:
@@ -151,7 +158,7 @@ enum AIProvider: String, CaseIterable {
     
     var requiresAPIKey: Bool {
         switch self {
-        case .ollama:
+        case .ollama, .localCLI:
             return false
         default:
             return true
@@ -185,7 +192,7 @@ class AIService: ObservableObject {
                 }
             } else {
                 self.apiKey = ""
-                self.isAPIKeyValid = true
+                self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
                 if selectedProvider == .ollama {
                     Task {
                         await ollamaService.checkConnection()
@@ -200,6 +207,7 @@ class AIService: ObservableObject {
     @Published private var selectedModels: [AIProvider: String] = [:]
     private let userDefaults = UserDefaults.standard
     private lazy var ollamaService = OllamaService()
+    private lazy var localCLIService = LocalCLIService()
     
     @Published private var openRouterModels: [String] = []
     
@@ -207,6 +215,8 @@ class AIService: ObservableObject {
         AIProvider.allCases.filter { provider in
             if provider == .ollama {
                 return ollamaService.isConnected
+            } else if provider == .localCLI {
+                return localCLIService.isConfigured
             } else if provider.requiresAPIKey {
                 return APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue)
             }
@@ -225,6 +235,18 @@ class AIService: ObservableObject {
     
     var availableModels: [String] {
         availableModels(for: selectedProvider)
+    }
+
+    var localCLICommandTemplate: String {
+        localCLIService.commandTemplate
+    }
+
+    var localCLITemplateSelection: LocalCLITemplate {
+        localCLIService.selectedTemplate
+    }
+
+    var localCLITimeoutSeconds: Double {
+        localCLIService.timeoutSeconds
     }
 
     func availableModels(for provider: AIProvider) -> [String] {
@@ -254,7 +276,7 @@ class AIService: ObservableObject {
                 self.isAPIKeyValid = true
             }
         } else {
-            self.isAPIKeyValid = true
+            self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
         }
 
         loadSavedModelSelections()
@@ -402,6 +424,33 @@ class AIService: ObservableObject {
     func updateSelectedOllamaModel(_ modelName: String) {
         ollamaService.selectedModel = modelName
         userDefaults.set(modelName, forKey: "ollamaSelectedModel")
+    }
+
+    func loadLocalCLITemplate(_ template: LocalCLITemplate) {
+        localCLIService.loadTemplate(template)
+        refreshLocalCLIConfigurationState()
+    }
+
+    func updateLocalCLICommandTemplate(_ command: String) {
+        localCLIService.commandTemplate = command
+        refreshLocalCLIConfigurationState()
+    }
+
+    func updateLocalCLITimeoutSeconds(_ timeout: Double) {
+        localCLIService.timeoutSeconds = timeout
+        refreshLocalCLIConfigurationState()
+    }
+
+    func enhanceWithLocalCLI(systemPrompt: String, userPrompt: String) async throws -> String {
+        try await localCLIService.enhance(systemPrompt: systemPrompt, userPrompt: userPrompt)
+    }
+
+    private func refreshLocalCLIConfigurationState() {
+        if selectedProvider == .localCLI {
+            isAPIKeyValid = localCLIService.isConfigured
+        }
+        objectWillChange.send()
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
     }
     
     func fetchOpenRouterModels() async {

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -22,7 +22,7 @@ enum LocalCLITemplate: String, CaseIterable, Identifiable {
         case .claude:
             return "claude -p \"$VOICEINK_FULL_PROMPT\""
         case .codex:
-            return "codex exec \"$VOICEINK_FULL_PROMPT\""
+            return "TMPFILE=$(mktemp) && codex exec --skip-git-repo-check --output-last-message \"$TMPFILE\" \"$VOICEINK_FULL_PROMPT\" > /dev/null 2>&1 && cat \"$TMPFILE\" && rm \"$TMPFILE\""
         }
     }
 }

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -1,0 +1,288 @@
+import Foundation
+
+enum LocalCLITemplate: String, CaseIterable, Identifiable {
+    case pi
+    case claude
+    case codex
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .pi: return "Pi"
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        }
+    }
+
+    var commandTemplate: String {
+        switch self {
+        case .pi:
+            return "pi -ne -ns -p --no-tools --system-prompt \"$VOICEINK_SYSTEM_PROMPT\" \"$VOICEINK_USER_PROMPT\""
+        case .claude:
+            return "claude -p \"$VOICEINK_FULL_PROMPT\""
+        case .codex:
+            return "codex exec \"$VOICEINK_FULL_PROMPT\""
+        }
+    }
+}
+
+final class LocalCLIService {
+    static let commandTemplateKey = "localCLICommandTemplate"
+    static let selectedTemplateKey = "localCLISelectedTemplate"
+    static let timeoutSecondsKey = "localCLITimeoutSeconds"
+    static let defaultTimeoutSeconds: Double = 45
+    private static let shellPathQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.localcli.path")
+    private static var cachedInteractiveLoginPATH: String?
+
+    var commandTemplate: String {
+        didSet {
+            UserDefaults.standard.set(commandTemplate, forKey: Self.commandTemplateKey)
+        }
+    }
+
+    var selectedTemplate: LocalCLITemplate {
+        didSet {
+            UserDefaults.standard.set(selectedTemplate.rawValue, forKey: Self.selectedTemplateKey)
+        }
+    }
+
+    var timeoutSeconds: Double {
+        didSet {
+            let clamped = max(5, timeoutSeconds)
+            if clamped != timeoutSeconds {
+                timeoutSeconds = clamped
+                return
+            }
+            UserDefaults.standard.set(timeoutSeconds, forKey: Self.timeoutSecondsKey)
+        }
+    }
+
+    var isConfigured: Bool {
+        !commandTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    init() {
+        let savedTemplateRaw = UserDefaults.standard.string(forKey: Self.selectedTemplateKey) ?? ""
+        selectedTemplate = LocalCLITemplate(rawValue: savedTemplateRaw) ?? .pi
+
+        commandTemplate = UserDefaults.standard.string(forKey: Self.commandTemplateKey) ?? ""
+
+        let savedTimeout = UserDefaults.standard.double(forKey: Self.timeoutSecondsKey)
+        timeoutSeconds = savedTimeout > 0 ? savedTimeout : Self.defaultTimeoutSeconds
+    }
+
+    func loadTemplate(_ template: LocalCLITemplate) {
+        selectedTemplate = template
+        commandTemplate = template.commandTemplate
+    }
+
+    func enhance(systemPrompt: String, userPrompt: String) async throws -> String {
+        guard isConfigured else {
+            throw LocalCLIError.commandNotConfigured
+        }
+
+        let fullPrompt = Self.makeFullPrompt(systemPrompt: systemPrompt, userPrompt: userPrompt)
+        return try await executeCommand(
+            commandTemplate: commandTemplate,
+            systemPrompt: systemPrompt,
+            userPrompt: userPrompt,
+            fullPrompt: fullPrompt,
+            timeout: timeoutSeconds
+        )
+    }
+
+    static func makeFullPrompt(systemPrompt: String, userPrompt: String) -> String {
+        """
+        <SYSTEM_PROMPT>
+        \(systemPrompt)
+        </SYSTEM_PROMPT>
+
+        <USER_PROMPT>
+        \(userPrompt)
+        </USER_PROMPT>
+        """
+    }
+
+    private func executeCommand(
+        commandTemplate: String,
+        systemPrompt: String,
+        userPrompt: String,
+        fullPrompt: String,
+        timeout: Double
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+                process.arguments = ["-lc", commandTemplate]
+
+                var environment = ProcessInfo.processInfo.environment
+                environment["PATH"] = Self.preferredPATH(fallback: environment["PATH"])
+                environment["VOICEINK_SYSTEM_PROMPT"] = systemPrompt
+                environment["VOICEINK_USER_PROMPT"] = userPrompt
+                environment["VOICEINK_FULL_PROMPT"] = fullPrompt
+                process.environment = environment
+
+                let inputPipe = Pipe()
+                let outputPipe = Pipe()
+                let errorPipe = Pipe()
+                process.standardInput = inputPipe
+                process.standardOutput = outputPipe
+                process.standardError = errorPipe
+
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: LocalCLIError.executionFailed(error.localizedDescription))
+                    return
+                }
+
+                if let inputData = fullPrompt.data(using: .utf8) {
+                    inputPipe.fileHandleForWriting.write(inputData)
+                }
+                try? inputPipe.fileHandleForWriting.close()
+
+                let semaphore = DispatchSemaphore(value: 0)
+                process.terminationHandler = { _ in
+                    semaphore.signal()
+                }
+
+                let waitResult = semaphore.wait(timeout: .now() + timeout)
+                if waitResult == .timedOut {
+                    if process.isRunning {
+                        process.terminate()
+                        _ = semaphore.wait(timeout: .now() + 2)
+                    }
+                    continuation.resume(throwing: LocalCLIError.timeout(seconds: timeout))
+                    return
+                }
+
+                let stdoutData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+                let stdout = Self.cleanOutput(String(data: stdoutData, encoding: .utf8) ?? "")
+                let stderr = Self.cleanOutput(String(data: stderrData, encoding: .utf8) ?? "")
+
+                if process.terminationStatus != 0 {
+                    let looksLikeCommandNotFound = process.terminationStatus == 127 ||
+                        stderr.lowercased().contains("command not found")
+                    if looksLikeCommandNotFound {
+                        continuation.resume(throwing: LocalCLIError.commandNotFound(stderr.isEmpty ? commandTemplate : stderr))
+                    } else {
+                        continuation.resume(throwing: LocalCLIError.nonZeroExit(status: Int(process.terminationStatus), stderr: stderr))
+                    }
+                    return
+                }
+
+                guard !stdout.isEmpty else {
+                    continuation.resume(throwing: LocalCLIError.emptyOutput)
+                    return
+                }
+
+                continuation.resume(returning: stdout)
+            }
+        }
+    }
+
+    private static func preferredPATH(fallback: String?) -> String {
+        shellPathQueue.sync {
+            if let cachedInteractiveLoginPATH {
+                return cachedInteractiveLoginPATH
+            }
+
+            if let discovered = discoverPATHFromInteractiveLoginShell() {
+                cachedInteractiveLoginPATH = discovered
+                return discovered
+            }
+
+            return fallback?.isEmpty == false ? fallback! : "/usr/bin:/bin:/usr/sbin:/sbin"
+        }
+    }
+
+    private static func discoverPATHFromInteractiveLoginShell() -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [
+            "-ilc",
+            "echo __VOICEINK_PATH_START__; print -r -- $PATH; echo __VOICEINK_PATH_END__"
+        ]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in semaphore.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let waitResult = semaphore.wait(timeout: .now() + 3)
+        if waitResult == .timedOut {
+            if process.isRunning {
+                process.terminate()
+            }
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let output = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let startMarker = "__VOICEINK_PATH_START__"
+        let endMarker = "__VOICEINK_PATH_END__"
+
+        guard let startRange = output.range(of: startMarker),
+              let endRange = output.range(of: endMarker, range: startRange.upperBound..<output.endIndex)
+        else {
+            return nil
+        }
+
+        let pathSection = output[startRange.upperBound..<endRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !pathSection.isEmpty else {
+            return nil
+        }
+
+        return pathSection
+    }
+
+    private static func cleanOutput(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum LocalCLIError: Error, LocalizedError {
+    case commandNotConfigured
+    case commandNotFound(String)
+    case timeout(seconds: Double)
+    case nonZeroExit(status: Int, stderr: String)
+    case emptyOutput
+    case executionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandNotConfigured:
+            return "Local CLI command is not configured. Load a template or enter a command first."
+        case .commandNotFound(let details):
+            return "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: \(details)"
+        case .timeout(let seconds):
+            return "Local CLI command timed out after \(Int(seconds)) seconds."
+        case .nonZeroExit(let status, let stderr):
+            if stderr.isEmpty {
+                return "Local CLI command failed with exit code \(status)."
+            }
+            return "Local CLI command failed with exit code \(status): \(stderr)"
+        case .emptyOutput:
+            return "Local CLI command returned empty output."
+        case .executionFailed(let message):
+            return "Failed to execute Local CLI command: \(message)"
+        }
+    }
+}

--- a/VoiceInk/Transcription/Core/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionPipeline.swift
@@ -136,10 +136,12 @@ class TranscriptionPipeline {
                     transcription.aiRequestUserMessage = enhancementService.lastUserMessageSent
                     finalPastedText = enhancedText
                 } catch {
-                    transcription.enhancedText = "Enhancement failed: \(error)"
+                    let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                    transcription.enhancedText = "Enhancement failed: \(errorDescription)"
+                    let shortReason = String(errorDescription.prefix(80))
                     await MainActor.run {
                         NotificationManager.shared.showNotification(
-                            title: "Enhancement failed",
+                            title: "Enhancement failed: \(shortReason)",
                             type: .warning
                         )
                     }

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -12,6 +12,9 @@ struct APIKeyManagementView: View {
     @State private var selectedOllamaModel: String = UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
     @State private var isCheckingOllama = false
     @State private var isEditingURL = false
+    @State private var localCLICommandTemplate: String = ""
+    @State private var localCLITimeoutSeconds: Double = LocalCLIService.defaultTimeoutSeconds
+    @State private var isSyncingLocalCLIState = false
     
     var body: some View {
         Section("AI Provider Integration") {
@@ -57,6 +60,9 @@ struct APIKeyManagementView: View {
             .onChange(of: aiService.selectedProvider) { oldValue, newValue in
                 if aiService.selectedProvider == .ollama {
                     checkOllamaConnection()
+                }
+                if aiService.selectedProvider == .localCLI {
+                    syncLocalCLIStateFromService()
                 }
             }
 
@@ -112,8 +118,6 @@ struct APIKeyManagementView: View {
                     }
                 }
 
-                Divider()
-
                 if aiService.selectedProvider == .ollama {
                     if isEditingURL {
                         HStack {
@@ -153,6 +157,68 @@ struct APIKeyManagementView: View {
                         .onChange(of: selectedOllamaModel) { oldValue, newValue in
                             aiService.updateSelectedOllamaModel(newValue)
                         }
+                    }
+
+                } else if aiService.selectedProvider == .localCLI {
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Command")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            Menu("Load Template") {
+                                ForEach(LocalCLITemplate.allCases) { template in
+                                    Button(template.displayName) {
+                                        aiService.loadLocalCLITemplate(template)
+                                        syncLocalCLIStateFromService()
+                                    }
+                                }
+                            }
+                        }
+
+                        TextEditor(text: $localCLICommandTemplate)
+                            .font(.system(.body, design: .monospaced))
+                            .multilineTextAlignment(.leading)
+                            .frame(minHeight: 100)
+                            .padding(4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color(NSColor.textBackgroundColor))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.secondary.opacity(0.25), lineWidth: 1)
+                            )
+                            .onChange(of: localCLICommandTemplate) { _, newValue in
+                                guard !isSyncingLocalCLIState else { return }
+                                if newValue != aiService.localCLICommandTemplate {
+                                    aiService.updateLocalCLICommandTemplate(newValue)
+                                }
+                            }
+                    }
+
+                    Picker("Timeout", selection: $localCLITimeoutSeconds) {
+                        Text("15s").tag(15.0)
+                        Text("30s").tag(30.0)
+                        Text("45s").tag(45.0)
+                        Text("60s").tag(60.0)
+                        Text("90s").tag(90.0)
+                        Text("120s").tag(120.0)
+                        Text("180s").tag(180.0)
+                        Text("300s").tag(300.0)
+                    }
+                    .onChange(of: localCLITimeoutSeconds) { _, newValue in
+                        aiService.updateLocalCLITimeoutSeconds(newValue)
+                    }
+
+                    Text("Environment variables available: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk also writes VOICEINK_FULL_PROMPT to stdin for every command.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    if !aiService.isAPIKeyValid {
+                        Text("Load a template or enter a command to enable Local CLI enhancement.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
                     }
 
                 } else if aiService.selectedProvider == .custom {
@@ -259,6 +325,18 @@ struct APIKeyManagementView: View {
             if aiService.selectedProvider == .ollama {
                 checkOllamaConnection()
             }
+            if aiService.selectedProvider == .localCLI {
+                syncLocalCLIStateFromService()
+            }
+        }
+    }
+
+    private func syncLocalCLIStateFromService() {
+        isSyncingLocalCLIState = true
+        localCLICommandTemplate = aiService.localCLICommandTemplate
+        localCLITimeoutSeconds = aiService.localCLITimeoutSeconds
+        DispatchQueue.main.async {
+            isSyncingLocalCLIState = false
         }
     }
     


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Local CLI enhancement provider that runs a shell command with injected prompts for offline or custom workflows. Includes ready-made templates, a command editor with timeout control, and clearer error messages.

- **New Features**
  - New provider `.localCLI` with no API key; considered “connected” when a command is set.
  - `LocalCLIService` executes `zsh` commands, injects VOICEINK_SYSTEM_PROMPT/VOICEINK_USER_PROMPT/VOICEINK_FULL_PROMPT, writes FULL to stdin, discovers PATH from an interactive login shell, and supports timeouts with detailed errors.
  - API settings UI: load templates (Pi, Claude, Codex), edit the command, pick a timeout, and see validation state.
  - Enhancement flow calls Local CLI when selected; notifications show a concise failure reason; empty or non-zero exits are handled.

- **Migration**
  - In Settings > AI Provider Integration, select “Local CLI”.
  - Load a template or paste your command, then set a timeout.

<sup>Written for commit b681adc165a0949da0d799a8101751349a9774b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

