### PR TITLE
Add multi-API-key support with auto-rotation for ElevenLabs

### DIFF
--- a/VoiceInk/Services/APIKeyRotation.swift
+++ b/VoiceInk/Services/APIKeyRotation.swift
@@ -1,0 +1,367 @@
+import Foundation
+import os
+
+/// A single API key entry for a provider. Multiple entries per provider enable
+/// auto-rotation when one key hits quota / auth errors.
+struct APIKeyEntry: Codable, Identifiable, Equatable {
+    let id: UUID
+    var label: String
+    var key: String
+    var disabled: Bool
+    var lastFailureAt: Date?
+    var lastFailureReason: String?
+
+    init(
+        id: UUID = UUID(),
+        label: String,
+        key: String,
+        disabled: Bool = false,
+        lastFailureAt: Date? = nil,
+        lastFailureReason: String? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.key = key
+        self.disabled = disabled
+        self.lastFailureAt = lastFailureAt
+        self.lastFailureReason = lastFailureReason
+    }
+}
+
+/// Classifies an error as either a "key-level" failure (rotate) or a transient
+/// failure (do not rotate). Used by streaming and batch retry loops.
+enum APIKeyFailureClass {
+    /// Unambiguous key problem: auth, quota, rate-limited, forbidden.
+    case keyLevel(reason: String)
+    /// Transient or non-key failure: network, 5xx, timeout.
+    case transient(reason: String)
+
+    /// ElevenLabs-specific WebSocket error keywords that indicate a key-level failure.
+    static let elevenLabsKeyLevelKeywords: [String] = [
+        "auth_error",
+        "quota_exceeded",
+        "rate_limited",
+        "resource_exhausted",
+        "unauthorized",
+        "invalid_api_key",
+        "invalid api key"
+    ]
+
+    /// HTTP status codes that indicate a key-level failure across providers.
+    static let keyLevelHTTPStatusCodes: Set<Int> = [401, 402, 403, 429]
+
+    /// Classifies an ElevenLabs WebSocket error message string.
+    static func classifyElevenLabsWSError(_ message: String) -> APIKeyFailureClass {
+        let lowered = message.lowercased()
+        for keyword in elevenLabsKeyLevelKeywords where lowered.contains(keyword) {
+            return .keyLevel(reason: message)
+        }
+        return .transient(reason: message)
+    }
+
+    /// Classifies an HTTP status code + message into a failure class.
+    static func classifyHTTP(statusCode: Int, message: String) -> APIKeyFailureClass {
+        if keyLevelHTTPStatusCodes.contains(statusCode) {
+            return .keyLevel(reason: "HTTP \(statusCode): \(message)")
+        }
+        return .transient(reason: "HTTP \(statusCode): \(message)")
+    }
+}
+
+/// Multi-key rotation extensions on APIKeyManager.
+extension APIKeyManager {
+
+    private static let rotationLogger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "APIKeyRotation"
+    )
+
+    // MARK: - Keychain / UserDefaults identifier helpers
+
+    /// Keychain identifier that holds the JSON-encoded `[APIKeyEntry]` for a provider.
+    fileprivate static func multiKeyKeychainIdentifier(forProvider provider: String) -> String {
+        "\(provider.lowercased())APIKeys_v1"
+    }
+
+    /// UserDefaults key that persists the active rotation index for a provider.
+    fileprivate static func activeIndexDefaultsKey(forProvider provider: String) -> String {
+        "APIKeyRotation_activeIndex_\(provider.lowercased())"
+    }
+
+    // MARK: - Public multi-key API
+
+    /// Returns all keys for a provider. Auto-migrates a legacy single key if the
+    /// multi-key store is empty but a legacy key exists.
+    func getAPIKeys(forProvider provider: String) -> [APIKeyEntry] {
+        let identifier = Self.multiKeyKeychainIdentifier(forProvider: provider)
+
+        if let data = KeychainService.shared.getData(forKey: identifier),
+           let decoded = try? JSONDecoder().decode([APIKeyEntry].self, from: data) {
+            return decoded
+        }
+
+        // Legacy migration path: pull the old single key (if any) into a new
+        // single-entry array without deleting the legacy record, so failed
+        // migrations don't lose data.
+        if let legacyKey = getAPIKey(forProvider: provider), !legacyKey.isEmpty {
+            let migrated = [APIKeyEntry(label: "Primary", key: legacyKey)]
+            if saveAPIKeysInternal(migrated, forProvider: provider) {
+                Self.rotationLogger.info(
+                    "Migrated legacy single key to multi-key store for provider: \(provider, privacy: .public)"
+                )
+            }
+            return migrated
+        }
+
+        return []
+    }
+
+    /// Persists the full list of keys for a provider. Returns true on success.
+    /// Also keeps the legacy single-key Keychain entry in sync with the currently
+    /// active key so unchanged call sites (`getAPIKey(forProvider:)`) keep working.
+    @discardableResult
+    func saveAPIKeys(_ keys: [APIKeyEntry], forProvider provider: String) -> Bool {
+        guard saveAPIKeysInternal(keys, forProvider: provider) else { return false }
+        clampActiveIndex(forProvider: provider)
+        syncLegacyActiveKey(forProvider: provider)
+        return true
+    }
+
+    /// Adds a new key entry. Returns the created entry. Duplicate raw keys are
+    /// silently ignored (returns nil) so the user can't add the same key twice.
+    @discardableResult
+    func addAPIKey(_ key: String, label: String, forProvider provider: String) -> APIKeyEntry? {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLabel = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return nil }
+
+        var existing = getAPIKeys(forProvider: provider)
+        if existing.contains(where: { $0.key == trimmedKey }) {
+            return nil
+        }
+
+        let entry = APIKeyEntry(
+            label: trimmedLabel.isEmpty ? defaultLabel(forIndex: existing.count) : trimmedLabel,
+            key: trimmedKey
+        )
+        existing.append(entry)
+        guard saveAPIKeys(existing, forProvider: provider) else { return nil }
+        return entry
+    }
+
+    /// Removes a key by id. Adjusts the active index so it still points at a
+    /// valid entry (or 0 if the list is now empty).
+    @discardableResult
+    func removeAPIKey(id: UUID, forProvider provider: String) -> Bool {
+        var existing = getAPIKeys(forProvider: provider)
+        guard let removedIndex = existing.firstIndex(where: { $0.id == id }) else { return false }
+
+        existing.remove(at: removedIndex)
+
+        let currentIndex = activeIndex(forProvider: provider)
+        let newIndex: Int
+        if existing.isEmpty {
+            newIndex = 0
+        } else if removedIndex < currentIndex {
+            newIndex = currentIndex - 1
+        } else if removedIndex == currentIndex {
+            newIndex = currentIndex % existing.count
+        } else {
+            newIndex = currentIndex
+        }
+        setActiveIndex(newIndex, forProvider: provider)
+
+        // If we just emptied the list, also clear the legacy single-key entry
+        // so stale data doesn't leak into unchanged call sites.
+        if existing.isEmpty {
+            deleteAPIKey(forProvider: provider)
+            KeychainService.shared.delete(forKey: Self.multiKeyKeychainIdentifier(forProvider: provider))
+            UserDefaults.standard.removeObject(forKey: Self.activeIndexDefaultsKey(forProvider: provider))
+            return true
+        }
+
+        return saveAPIKeys(existing, forProvider: provider)
+    }
+
+    /// Updates label / disabled / failure fields on an existing entry. The raw
+    /// key value is not replaced here (use remove + add for that, so verification
+    /// is re-run by the UI).
+    @discardableResult
+    func updateAPIKey(
+        id: UUID,
+        label: String? = nil,
+        disabled: Bool? = nil,
+        clearFailure: Bool = false,
+        forProvider provider: String
+    ) -> Bool {
+        var existing = getAPIKeys(forProvider: provider)
+        guard let idx = existing.firstIndex(where: { $0.id == id }) else { return false }
+
+        if let label = label?.trimmingCharacters(in: .whitespacesAndNewlines), !label.isEmpty {
+            existing[idx].label = label
+        }
+        if let disabled = disabled {
+            existing[idx].disabled = disabled
+        }
+        if clearFailure {
+            existing[idx].lastFailureAt = nil
+            existing[idx].lastFailureReason = nil
+        }
+
+        return saveAPIKeys(existing, forProvider: provider)
+    }
+
+    /// Returns the currently active enabled key entry, or nil if none is usable.
+    /// Automatically advances past disabled entries (without mutating state) when
+    /// the stored active index happens to land on one.
+    func activeAPIKey(forProvider provider: String) -> APIKeyEntry? {
+        let keys = getAPIKeys(forProvider: provider)
+        guard !keys.isEmpty else { return nil }
+
+        let startIndex = activeIndex(forProvider: provider) % keys.count
+        for offset in 0..<keys.count {
+            let idx = (startIndex + offset) % keys.count
+            if !keys[idx].disabled {
+                return keys[idx]
+            }
+        }
+        return nil
+    }
+
+    /// Advances the active index to the next enabled key, skipping disabled
+    /// entries. Marks the currently-active key as failed with the given reason.
+    /// Returns the new active entry (nil if no enabled keys remain).
+    @discardableResult
+    func rotateToNextKey(forProvider provider: String, reason: String) -> APIKeyEntry? {
+        var keys = getAPIKeys(forProvider: provider)
+        guard !keys.isEmpty else { return nil }
+
+        let currentIndex = activeIndex(forProvider: provider) % keys.count
+
+        // Stamp failure on the key we're rotating AWAY from, if it was enabled.
+        if !keys[currentIndex].disabled {
+            keys[currentIndex].lastFailureAt = Date()
+            keys[currentIndex].lastFailureReason = reason
+        }
+
+        // Find the next enabled index after currentIndex.
+        var nextIndex: Int? = nil
+        for offset in 1...keys.count {
+            let idx = (currentIndex + offset) % keys.count
+            if idx == currentIndex { break } // wrapped fully, no other enabled
+            if !keys[idx].disabled {
+                nextIndex = idx
+                break
+            }
+        }
+
+        saveAPIKeysInternal(keys, forProvider: provider)
+
+        guard let nextIndex = nextIndex else {
+            // Only the current (now-marked-failed) key is enabled — no rotation possible.
+            Self.rotationLogger.warning(
+                "No alternate enabled key available for provider: \(provider, privacy: .public)"
+            )
+            syncLegacyActiveKey(forProvider: provider)
+            return nil
+        }
+
+        setActiveIndex(nextIndex, forProvider: provider)
+        syncLegacyActiveKey(forProvider: provider)
+
+        Self.rotationLogger.notice(
+            "Rotated API key for provider \(provider, privacy: .public): \(keys[currentIndex].label, privacy: .public) → \(keys[nextIndex].label, privacy: .public) (reason: \(reason, privacy: .public))"
+        )
+
+        return keys[nextIndex]
+    }
+
+    /// Marks a specific key entry as having failed with a reason, without
+    /// rotating. Useful when the failure is surfaced mid-session and we want the
+    /// *next* session to rotate automatically.
+    @discardableResult
+    func markKeyFailed(id: UUID, reason: String, forProvider provider: String) -> Bool {
+        var keys = getAPIKeys(forProvider: provider)
+        guard let idx = keys.firstIndex(where: { $0.id == id }) else { return false }
+        keys[idx].lastFailureAt = Date()
+        keys[idx].lastFailureReason = reason
+        return saveAPIKeys(keys, forProvider: provider)
+    }
+
+    /// Sets the active index to a specific key id, if it exists and is enabled.
+    @discardableResult
+    func setActiveKey(id: UUID, forProvider provider: String) -> Bool {
+        let keys = getAPIKeys(forProvider: provider)
+        guard let idx = keys.firstIndex(where: { $0.id == id }), !keys[idx].disabled else {
+            return false
+        }
+        setActiveIndex(idx, forProvider: provider)
+        syncLegacyActiveKey(forProvider: provider)
+        return true
+    }
+
+    /// Returns how many keys are present + how many are currently enabled.
+    func apiKeyCounts(forProvider provider: String) -> (total: Int, enabled: Int) {
+        let keys = getAPIKeys(forProvider: provider)
+        return (keys.count, keys.filter { !$0.disabled }.count)
+    }
+
+    // MARK: - Private
+
+    @discardableResult
+    private func saveAPIKeysInternal(_ keys: [APIKeyEntry], forProvider provider: String) -> Bool {
+        let identifier = Self.multiKeyKeychainIdentifier(forProvider: provider)
+
+        if keys.isEmpty {
+            return KeychainService.shared.delete(forKey: identifier)
+        }
+
+        do {
+            let data = try JSONEncoder().encode(keys)
+            return KeychainService.shared.save(data: data, forKey: identifier)
+        } catch {
+            Self.rotationLogger.error(
+                "Failed to encode APIKeyEntry array for provider \(provider, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+    }
+
+    /// Keeps the legacy single-key Keychain entry in sync with the currently
+    /// active multi-key entry. This preserves backward-compat for every call
+    /// site that reads via `getAPIKey(forProvider:)`. When no enabled key
+    /// exists, the legacy entry is cleared so callers see the same
+    /// "no key configured" state the multi-key UI shows.
+    private func syncLegacyActiveKey(forProvider provider: String) {
+        if let active = activeAPIKey(forProvider: provider), !active.key.isEmpty {
+            saveAPIKey(active.key, forProvider: provider)
+        } else {
+            deleteAPIKey(forProvider: provider)
+        }
+    }
+
+    private func activeIndex(forProvider provider: String) -> Int {
+        let raw = UserDefaults.standard.integer(forKey: Self.activeIndexDefaultsKey(forProvider: provider))
+        return max(0, raw)
+    }
+
+    private func setActiveIndex(_ index: Int, forProvider provider: String) {
+        UserDefaults.standard.set(max(0, index), forKey: Self.activeIndexDefaultsKey(forProvider: provider))
+    }
+
+    private func clampActiveIndex(forProvider provider: String) {
+        let keys = getAPIKeys(forProvider: provider)
+        let current = activeIndex(forProvider: provider)
+        if keys.isEmpty {
+            UserDefaults.standard.removeObject(forKey: Self.activeIndexDefaultsKey(forProvider: provider))
+            return
+        }
+        if current >= keys.count {
+            setActiveIndex(0, forProvider: provider)
+        }
+    }
+
+    private func defaultLabel(forIndex index: Int) -> String {
+        "Key \(index + 1)"
+    }
+}

--- a/VoiceInk/Transcription/Batch/CloudTranscriptionService.swift
+++ b/VoiceInk/Transcription/Batch/CloudTranscriptionService.swift
@@ -11,6 +11,10 @@ enum CloudTranscriptionError: Error, LocalizedError {
     case networkError(Error)
     case noTranscriptionReturned
     case dataEncodingError
+    /// Every configured API key for the provider failed with a key-level error
+    /// (auth / quota / rate-limited). `lastReason` carries the most recent
+    /// failure message.
+    case allKeysExhausted(provider: String, lastReason: String)
 
     var errorDescription: String? {
         switch self {
@@ -30,6 +34,8 @@ enum CloudTranscriptionError: Error, LocalizedError {
             return "The API returned an empty or invalid response."
         case .dataEncodingError:
             return "Failed to encode the request body."
+        case .allKeysExhausted(let provider, let lastReason):
+            return "All configured \(provider) API keys failed. Last error: \(lastReason)"
         }
     }
 }
@@ -63,12 +69,10 @@ class CloudTranscriptionService: TranscriptionService {
                 )
 
             case .elevenLabs:
-                let apiKey = try requireAPIKey(forProvider: "ElevenLabs")
-                return try await ElevenLabsClient.transcribe(
+                return try await transcribeElevenLabsWithRotation(
                     audioData: audioData,
                     fileName: fileName,
-                    apiKey: apiKey,
-                    model: model.name,
+                    modelName: model.name,
                     language: language
                 )
 
@@ -136,6 +140,97 @@ class CloudTranscriptionService: TranscriptionService {
             throw mapLLMKitError(error)
         } catch {
             throw CloudTranscriptionError.networkError(error)
+        }
+    }
+
+    // MARK: - ElevenLabs rotation
+
+    /// Transcribes via ElevenLabs batch API, auto-rotating through configured
+    /// API keys on key-level failures (HTTP 401/403/429 / invalid / quota).
+    /// Transient failures (network, timeout, 5xx) surface immediately without
+    /// burning through other keys.
+    private func transcribeElevenLabsWithRotation(
+        audioData: Data,
+        fileName: String,
+        modelName: String,
+        language: String?
+    ) async throws -> String {
+        let providerKey = "ElevenLabs"
+        let keys = APIKeyManager.shared.getAPIKeys(forProvider: providerKey)
+        let enabledKeys = keys.filter { !$0.disabled && !$0.key.isEmpty }
+
+        guard !enabledKeys.isEmpty else {
+            throw CloudTranscriptionError.missingAPIKey
+        }
+
+        // Build ordered attempt list starting from the currently active key.
+        let firstActive = APIKeyManager.shared.activeAPIKey(forProvider: providerKey)
+        var attemptOrder: [APIKeyEntry] = []
+        var seen = Set<UUID>()
+        if let firstActive, !firstActive.disabled {
+            attemptOrder.append(firstActive)
+            seen.insert(firstActive.id)
+        }
+        for entry in enabledKeys where !seen.contains(entry.id) {
+            attemptOrder.append(entry)
+            seen.insert(entry.id)
+        }
+
+        var lastReason = "unknown"
+        for entry in attemptOrder {
+            do {
+                let result = try await ElevenLabsClient.transcribe(
+                    audioData: audioData,
+                    fileName: fileName,
+                    apiKey: entry.key,
+                    model: modelName,
+                    language: language
+                )
+                APIKeyManager.shared.setActiveKey(id: entry.id, forProvider: providerKey)
+                APIKeyManager.shared.updateAPIKey(
+                    id: entry.id,
+                    clearFailure: true,
+                    forProvider: providerKey
+                )
+                return result
+            } catch let error as LLMKitError {
+                let classification = classifyLLMKitError(error)
+                switch classification {
+                case .keyLevel(let reason):
+                    lastReason = reason
+                    APIKeyManager.shared.markKeyFailed(
+                        id: entry.id,
+                        reason: reason,
+                        forProvider: providerKey
+                    )
+                    continue
+                case .transient:
+                    throw mapLLMKitError(error)
+                }
+            } catch {
+                // Non-LLMkit errors are treated as transient — don't rotate.
+                throw CloudTranscriptionError.networkError(error)
+            }
+        }
+
+        throw CloudTranscriptionError.allKeysExhausted(
+            provider: "ElevenLabs",
+            lastReason: lastReason
+        )
+    }
+
+    private func classifyLLMKitError(_ error: LLMKitError) -> APIKeyFailureClass {
+        switch error {
+        case .missingAPIKey:
+            return .keyLevel(reason: "missing API key")
+        case .httpError(let statusCode, let message):
+            return APIKeyFailureClass.classifyHTTP(statusCode: statusCode, message: message)
+        case .networkError(let detail):
+            return .transient(reason: detail)
+        case .timeout:
+            return .transient(reason: "timeout")
+        case .invalidURL, .decodingError, .encodingError, .noResultReturned:
+            return .transient(reason: error.errorDescription ?? "unknown")
         }
     }
 

--- a/VoiceInk/Transcription/Streaming/ElevenLabsStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/ElevenLabsStreamingProvider.swift
@@ -1,12 +1,31 @@
 import Foundation
 import LLMkit
+import os
 
 /// ElevenLabs streaming provider wrapping `LLMkit.ElevenLabsStreamingClient`.
+///
+/// Supports multiple API keys with automatic rotation on key-level failures
+/// (auth_error, quota_exceeded, rate_limited, HTTP 401/403/429). Rotation
+/// happens at connect time; mid-session quota errors surface as
+/// `.keyQuotaExceeded` so the UI can inform the user and the next session
+/// will pick up the next enabled key.
 final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
 
-    private let client = LLMkit.ElevenLabsStreamingClient()
+    private static let providerKey = "ElevenLabs"
+    private static let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "ElevenLabsStreamingProvider"
+    )
+
+    private var client = LLMkit.ElevenLabsStreamingClient()
     private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
     private var forwardingTask: Task<Void, Never>?
+
+    /// The key id currently in use for the live connection, so mid-session
+    /// failures can be reported with the correct label and future sessions
+    /// rotate past it automatically.
+    private var activeKeyId: UUID?
+    private var activeKeyLabel: String?
 
     private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
 
@@ -22,22 +41,101 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
     }
 
     func connect(model: any TranscriptionModel, language: String?) async throws {
-        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "ElevenLabs"), !apiKey.isEmpty else {
+        let keys = APIKeyManager.shared.getAPIKeys(forProvider: Self.providerKey)
+        let enabledKeys = keys.filter { !$0.disabled && !$0.key.isEmpty }
+
+        guard !enabledKeys.isEmpty else {
             throw StreamingTranscriptionError.missingAPIKey
         }
 
-        // Cancel any existing forwarding task before starting a new one
-        forwardingTask?.cancel()
-        startEventForwarding()
-
-        do {
-            try await client.connect(apiKey: apiKey, model: "scribe_v2_realtime", language: language)
-        } catch {
-            // Clean up forwarding task on connection failure
-            forwardingTask?.cancel()
-            forwardingTask = nil
-            throw mapError(error)
+        // Determine the starting key (the currently active one if it's still
+        // enabled, otherwise the first enabled one).
+        guard let firstActive = APIKeyManager.shared.activeAPIKey(forProvider: Self.providerKey) else {
+            throw StreamingTranscriptionError.missingAPIKey
         }
+
+        // Build an ordered attempt list starting from the active key, without
+        // duplicates, bounded to the enabled key count so we never infinite-loop.
+        var attemptOrder: [APIKeyEntry] = []
+        var seenIds = Set<UUID>()
+        attemptOrder.append(firstActive)
+        seenIds.insert(firstActive.id)
+        for key in enabledKeys where !seenIds.contains(key.id) {
+            attemptOrder.append(key)
+            seenIds.insert(key.id)
+        }
+
+        var lastReason = "unknown"
+        for (attemptIndex, entry) in attemptOrder.enumerated() {
+            // Cancel any existing forwarding task before starting a new one.
+            forwardingTask?.cancel()
+            // Ensure the client is fresh for each attempt (the previous attempt
+            // may have partially connected before failing).
+            await client.disconnect()
+            client = LLMkit.ElevenLabsStreamingClient()
+
+            activeKeyId = entry.id
+            activeKeyLabel = entry.label
+            startEventForwarding(forKeyId: entry.id, keyLabel: entry.label)
+
+            do {
+                try await client.connect(
+                    apiKey: entry.key,
+                    model: "scribe_v2_realtime",
+                    language: language
+                )
+                // Connect succeeded — make sure this key is the persisted active
+                // one (in case we advanced past earlier failing keys).
+                APIKeyManager.shared.setActiveKey(id: entry.id, forProvider: Self.providerKey)
+                APIKeyManager.shared.updateAPIKey(
+                    id: entry.id,
+                    clearFailure: true,
+                    forProvider: Self.providerKey
+                )
+                if attemptIndex > 0 {
+                    Self.logger.notice(
+                        "Rotated to key \(entry.label, privacy: .public) after \(attemptIndex, privacy: .public) failed attempt(s)"
+                    )
+                }
+                return
+            } catch {
+                let mapped = mapConnectError(error)
+                lastReason = mapped.reason
+
+                // Always tear down the forwarding task on a failed attempt so we
+                // don't leak event streams from a partial connection.
+                forwardingTask?.cancel()
+                forwardingTask = nil
+
+                switch mapped.classification {
+                case .keyLevel(let reason):
+                    Self.logger.warning(
+                        "Key \(entry.label, privacy: .public) failed with key-level error: \(reason, privacy: .public). Trying next key."
+                    )
+                    APIKeyManager.shared.markKeyFailed(
+                        id: entry.id,
+                        reason: reason,
+                        forProvider: Self.providerKey
+                    )
+                    // Continue to the next key in the attempt order.
+                    continue
+
+                case .transient(let reason):
+                    // Don't burn through other keys for a network blip — fail fast.
+                    Self.logger.error(
+                        "Key \(entry.label, privacy: .public) hit a transient failure: \(reason, privacy: .public). Not rotating."
+                    )
+                    activeKeyId = nil
+                    activeKeyLabel = nil
+                    throw mapped.surfaceError
+                }
+            }
+        }
+
+        // Exhausted the attempt list with key-level failures on every key.
+        activeKeyId = nil
+        activeKeyLabel = nil
+        throw StreamingTranscriptionError.allKeysExhausted(lastReason: lastReason)
     }
 
     func sendAudioChunk(_ data: Data) async throws {
@@ -61,26 +159,106 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
         forwardingTask = nil
         await client.disconnect()
         eventsContinuation?.finish()
+        activeKeyId = nil
+        activeKeyLabel = nil
     }
 
     // MARK: - Private
 
-    private func startEventForwarding() {
-        forwardingTask = Task { [weak self] in
-            guard let self else { return }
-            for await event in self.client.transcriptionEvents {
+    private func startEventForwarding(forKeyId keyId: UUID, keyLabel: String) {
+        // Capture the client reference locally so the task doesn't read mutable
+        // `self.client` from a non-isolated context. `keyId` and `keyLabel` are
+        // captured by value so mid-session rotation logic uses the correct key.
+        let client = self.client
+        let continuation = self.eventsContinuation
+        forwardingTask = Task {
+            for await event in client.transcriptionEvents {
                 switch event {
                 case .sessionStarted:
-                    self.eventsContinuation?.yield(.sessionStarted)
+                    continuation?.yield(.sessionStarted)
                 case .partial(let text):
-                    self.eventsContinuation?.yield(.partial(text: text))
+                    continuation?.yield(.partial(text: text))
                 case .committed(let text):
-                    self.eventsContinuation?.yield(.committed(text: text))
+                    continuation?.yield(.committed(text: text))
                 case .error(let message):
-                    self.eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(message)))
+                    // Distinguish key-level from transient errors even in
+                    // mid-session messages so higher layers can show the right
+                    // error and future sessions rotate.
+                    let classification = APIKeyFailureClass.classifyElevenLabsWSError(message)
+                    switch classification {
+                    case .keyLevel(let reason):
+                        APIKeyManager.shared.markKeyFailed(
+                            id: keyId,
+                            reason: reason,
+                            forProvider: Self.providerKey
+                        )
+                        // Advance the active index so the next session
+                        // automatically rotates to the next enabled key.
+                        _ = APIKeyManager.shared.rotateToNextKey(
+                            forProvider: Self.providerKey,
+                            reason: reason
+                        )
+                        continuation?.yield(
+                            .error(StreamingTranscriptionError.keyQuotaExceeded(
+                                keyLabel: keyLabel,
+                                reason: reason
+                            ))
+                        )
+                    case .transient(let reason):
+                        continuation?.yield(
+                            .error(StreamingTranscriptionError.serverError(reason))
+                        )
+                    }
                 }
             }
         }
+    }
+
+    /// Classifies a connect-time error and returns both the classification and
+    /// the error to surface if we stop retrying.
+    private func mapConnectError(_ error: Error) -> (
+        classification: APIKeyFailureClass,
+        surfaceError: Error,
+        reason: String
+    ) {
+        if let llmError = error as? LLMKitError {
+            switch llmError {
+            case .missingAPIKey:
+                let reason = "missing API key"
+                return (.keyLevel(reason: reason), StreamingTranscriptionError.missingAPIKey, reason)
+            case .httpError(let statusCode, let message):
+                let classification = APIKeyFailureClass.classifyHTTP(statusCode: statusCode, message: message)
+                let surface = StreamingTranscriptionError.serverError("HTTP \(statusCode): \(message)")
+                return (classification, surface, "HTTP \(statusCode): \(message)")
+            case .networkError(let detail):
+                return (
+                    .transient(reason: detail),
+                    StreamingTranscriptionError.connectionFailed(detail),
+                    detail
+                )
+            case .timeout:
+                return (
+                    .transient(reason: "timeout"),
+                    StreamingTranscriptionError.timeout,
+                    "timeout"
+                )
+            default:
+                let msg = llmError.errorDescription ?? "Unknown error"
+                return (
+                    .transient(reason: msg),
+                    StreamingTranscriptionError.serverError(msg),
+                    msg
+                )
+            }
+        }
+        // Non-LLMkit errors are treated as transient (connection-level) so we
+        // don't rotate keys when e.g. the user has no internet.
+        let reason = error.localizedDescription
+        return (
+            .transient(reason: reason),
+            StreamingTranscriptionError.connectionFailed(reason),
+            reason
+        )
     }
 
     private func mapError(_ error: Error) -> Error {
@@ -93,7 +271,7 @@ final class ElevenLabsStreamingProvider: StreamingTranscriptionProvider {
         case .networkError(let detail):
             return StreamingTranscriptionError.connectionFailed(detail)
         default:
-            return StreamingTranscriptionError.serverError(llmError.localizedDescription ?? "Unknown error")
+            return StreamingTranscriptionError.serverError(llmError.errorDescription ?? "Unknown error")
         }
     }
 }

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift
@@ -15,6 +15,12 @@ enum StreamingTranscriptionError: LocalizedError {
     case timeout
     case serverError(String)
     case notConnected
+    /// All configured API keys for this provider have been tried and failed.
+    /// `lastReason` describes the most recent key-level failure.
+    case allKeysExhausted(lastReason: String)
+    /// The currently-active key hit a quota / auth error mid-session. The next
+    /// session will automatically rotate to the next enabled key.
+    case keyQuotaExceeded(keyLabel: String, reason: String)
 
     var errorDescription: String? {
         switch self {
@@ -28,6 +34,10 @@ enum StreamingTranscriptionError: LocalizedError {
             return "Streaming server error: \(message)"
         case .notConnected:
             return "Not connected to streaming transcription service"
+        case .allKeysExhausted(let reason):
+            return "All configured API keys failed. Last error: \(reason)"
+        case .keyQuotaExceeded(let label, let reason):
+            return "API key \"\(label)\" hit a quota/auth error mid-session (\(reason)). The next recording will use the next configured key."
         }
     }
 }

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -20,7 +20,28 @@ struct CloudModelCardView: View {
     }
     
     private var isConfigured: Bool {
+        if supportsMultiKey {
+            return APIKeyManager.shared.apiKeyCounts(forProvider: providerKey).enabled > 0
+        }
         return APIKeyManager.shared.hasAPIKey(forProvider: providerKey)
+    }
+
+    /// Providers that opt in to the multi-key rotation UI. Extend as more
+    /// providers are wired through `APIKeyManager`'s rotation helpers.
+    private var supportsMultiKey: Bool {
+        return model.provider == .elevenLabs
+    }
+
+    private var configuredKeyCount: Int {
+        APIKeyManager.shared.apiKeyCounts(forProvider: providerKey).enabled
+    }
+
+    private var configuredBadgeText: String {
+        if supportsMultiKey {
+            let count = configuredKeyCount
+            return count > 1 ? "Configured (\(count) keys)" : "Configured"
+        }
+        return "Configured"
     }
     
     private var providerKey: String {
@@ -96,7 +117,7 @@ struct CloudModelCardView: View {
                     .background(Capsule().fill(Color.accentColor))
                     .foregroundColor(.white)
             } else if isConfigured {
-                Text("Configured")
+                Text(configuredBadgeText)
                     .font(.system(size: 11, weight: .medium))
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
@@ -198,10 +219,25 @@ struct CloudModelCardView: View {
             
             if isConfigured {
                 Menu {
-                    Button {
-                        clearAPIKey()
-                    } label: {
-                        Label("Remove API Key", systemImage: "trash")
+                    if supportsMultiKey {
+                        Button {
+                            withAnimation(.interpolatingSpring(stiffness: 170, damping: 20)) {
+                                isExpanded.toggle()
+                            }
+                        } label: {
+                            Label(isExpanded ? "Hide Keys" : "Manage Keys", systemImage: "key.horizontal")
+                        }
+                        Button(role: .destructive) {
+                            clearAllKeys()
+                        } label: {
+                            Label("Remove All Keys", systemImage: "trash")
+                        }
+                    } else {
+                        Button {
+                            clearAPIKey()
+                        } label: {
+                            Label("Remove API Key", systemImage: "trash")
+                        }
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
@@ -214,61 +250,75 @@ struct CloudModelCardView: View {
         }
     }
     
+    @ViewBuilder
     private var configurationSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("API Key Configuration")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(Color(.labelColor))
-            
-            HStack(spacing: 8) {
-                SecureField("Enter your \(model.provider.rawValue) API key", text: $apiKey)
-                    .textFieldStyle(.roundedBorder)
-                    .disabled(isVerifying)
-                
-                Button(action: verifyAPIKey) {
-                    HStack(spacing: 4) {
-                        if isVerifying {
-                            ProgressView()
-                                .scaleEffect(0.7)
-                                .frame(width: 12, height: 12)
-                        } else {
-                            Image(systemName: verificationStatus == .success ? "checkmark" : "checkmark.shield")
+        if supportsMultiKey {
+            MultiAPIKeyConfigurationView(
+                providerKey: providerKey,
+                providerDisplayName: model.provider.rawValue,
+                onKeysChanged: {
+                    transcriptionModelManager.refreshAllAvailableModels()
+                }
+            )
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("API Key Configuration")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(Color(.labelColor))
+
+                HStack(spacing: 8) {
+                    SecureField("Enter your \(model.provider.rawValue) API key", text: $apiKey)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(isVerifying)
+
+                    Button(action: verifyAPIKey) {
+                        HStack(spacing: 4) {
+                            if isVerifying {
+                                ProgressView()
+                                    .scaleEffect(0.7)
+                                    .frame(width: 12, height: 12)
+                            } else {
+                                Image(systemName: verificationStatus == .success ? "checkmark" : "checkmark.shield")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            Text(isVerifying ? "Verifying..." : "Verify")
                                 .font(.system(size: 12, weight: .medium))
                         }
-                        Text(isVerifying ? "Verifying..." : "Verify")
-                            .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule()
+                                .fill(verificationStatus == .success ? Color(.systemGreen) : Color(.controlAccentColor))
+                        )
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(
-                        Capsule()
-                            .fill(verificationStatus == .success ? Color(.systemGreen) : Color(.controlAccentColor))
-                    )
+                    .buttonStyle(.plain)
+                    .disabled(apiKey.isEmpty || isVerifying)
                 }
-                .buttonStyle(.plain)
-                .disabled(apiKey.isEmpty || isVerifying)
-            }
-            
-            if verificationStatus == .failure {
-                if let error = verificationError {
-                    Text(error)
+
+                if verificationStatus == .failure {
+                    if let error = verificationError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(Color(.systemRed))
+                    } else {
+                        Text("Verification failed")
+                            .font(.caption)
+                            .foregroundColor(Color(.systemRed))
+                    }
+                } else if verificationStatus == .success {
+                    Text("API key verified successfully!")
                         .font(.caption)
-                        .foregroundColor(Color(.systemRed))
-                } else {
-                    Text("Verification failed")
-                        .font(.caption)
-                        .foregroundColor(Color(.systemRed))
+                        .foregroundColor(Color(.systemGreen))
                 }
-            } else if verificationStatus == .success {
-                Text("API key verified successfully!")
-                    .font(.caption)
-                    .foregroundColor(Color(.systemGreen))
             }
         }
     }
     
     private func loadSavedAPIKey() {
+        // For multi-key providers, the expanded view pulls its own state from
+        // APIKeyManager, so we don't prefill a single `apiKey` state here.
+        guard !supportsMultiKey else { return }
         if let savedKey = APIKeyManager.shared.getAPIKey(forProvider: providerKey) {
             apiKey = savedKey
             verificationStatus = .success
@@ -340,6 +390,25 @@ struct CloudModelCardView: View {
             transcriptionModelManager.clearCurrentTranscriptionModel()
         }
 
+        transcriptionModelManager.refreshAllAvailableModels()
+
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isExpanded = false
+        }
+    }
+
+    /// Removes every stored key for a multi-key provider and resets rotation
+    /// state, so the card falls back to "Setup Required".
+    private func clearAllKeys() {
+        let keys = APIKeyManager.shared.getAPIKeys(forProvider: providerKey)
+        for entry in keys {
+            APIKeyManager.shared.removeAPIKey(id: entry.id, forProvider: providerKey)
+        }
+        APIKeyManager.shared.deleteAPIKey(forProvider: providerKey)
+
+        if isCurrent {
+            transcriptionModelManager.clearCurrentTranscriptionModel()
+        }
         transcriptionModelManager.refreshAllAvailableModels()
 
         withAnimation(.easeInOut(duration: 0.3)) {

--- a/VoiceInk/Views/AI Models/MultiAPIKeyConfigurationView.swift
+++ b/VoiceInk/Views/AI Models/MultiAPIKeyConfigurationView.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+import LLMkit
+
+/// Multi-API-key configuration view used inside `CloudModelCardView` for
+/// providers that opt in to key rotation (currently ElevenLabs).
+///
+/// Lets the user add/remove/label multiple keys, toggle them on/off, see which
+/// one is active, manually rotate, and see last-failure state at a glance.
+struct MultiAPIKeyConfigurationView: View {
+    let providerKey: String
+    let providerDisplayName: String
+    /// Called when the set of keys changes so the parent card can refresh its
+    /// "Configured" badge and trigger model list refreshes.
+    var onKeysChanged: () -> Void = {}
+
+    @State private var keys: [APIKeyEntry] = []
+    @State private var activeKeyId: UUID? = nil
+    @State private var newKeyLabel: String = ""
+    @State private var newKeyValue: String = ""
+    @State private var isVerifying: Bool = false
+    @State private var verificationError: String? = nil
+    @State private var showGlobalError: Bool = false
+    @State private var globalErrorMessage: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            headerRow
+
+            if keys.isEmpty {
+                Text("No keys configured. Add your first \(providerDisplayName) API key below.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                VStack(spacing: 6) {
+                    ForEach(keys) { key in
+                        keyRow(for: key)
+                    }
+                }
+            }
+
+            Divider().padding(.vertical, 4)
+
+            addKeySection
+
+            if let verificationError = verificationError {
+                Text(verificationError)
+                    .font(.caption)
+                    .foregroundColor(Color(.systemRed))
+            }
+
+            rotationFooter
+        }
+        .onAppear(perform: reload)
+        .alert("Error", isPresented: $showGlobalError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(globalErrorMessage)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var headerRow: some View {
+        HStack {
+            Text("API Keys")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(Color(.labelColor))
+            Spacer()
+            if keys.count > 1 {
+                Button(action: rotateManually) {
+                    Label("Rotate Now", systemImage: "arrow.triangle.2.circlepath")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Switch to the next enabled key")
+            }
+        }
+    }
+
+    private func keyRow(for key: APIKeyEntry) -> some View {
+        let isActive = key.id == activeKeyId
+        return HStack(spacing: 10) {
+            // Active indicator
+            Circle()
+                .fill(isActive && !key.disabled ? Color.accentColor : Color.secondary.opacity(0.25))
+                .frame(width: 8, height: 8)
+                .help(isActive ? "Active key" : "Inactive key")
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    TextField(
+                        "Label",
+                        text: Binding(
+                            get: { key.label },
+                            set: { newValue in
+                                APIKeyManager.shared.updateAPIKey(
+                                    id: key.id,
+                                    label: newValue,
+                                    forProvider: providerKey
+                                )
+                                reload()
+                            }
+                        )
+                    )
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+
+                    if isActive {
+                        Text("Active")
+                            .font(.system(size: 10, weight: .medium))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(Color.accentColor.opacity(0.2)))
+                            .foregroundColor(Color.accentColor)
+                    }
+                    if key.disabled {
+                        Text("Disabled")
+                            .font(.system(size: 10, weight: .medium))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(Color.secondary.opacity(0.2)))
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                HStack(spacing: 6) {
+                    Text(maskedKey(key.key))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary)
+                    if let reason = key.lastFailureReason {
+                        Text("⚠︎ \(reason)")
+                            .font(.system(size: 10))
+                            .foregroundColor(Color(.systemOrange))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .help(reason + (key.lastFailureAt.map { " (\(Self.relativeDateFormatter.localizedString(for: $0, relativeTo: Date())))" } ?? ""))
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Make-active button
+            if !isActive && !key.disabled {
+                Button("Use") {
+                    APIKeyManager.shared.setActiveKey(id: key.id, forProvider: providerKey)
+                    reload()
+                    onKeysChanged()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Set this key as the active key")
+            }
+
+            // Enable/disable toggle
+            Toggle(
+                "",
+                isOn: Binding(
+                    get: { !key.disabled },
+                    set: { newValue in
+                        APIKeyManager.shared.updateAPIKey(
+                            id: key.id,
+                            disabled: !newValue,
+                            forProvider: providerKey
+                        )
+                        reload()
+                        onKeysChanged()
+                    }
+                )
+            )
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            .help(key.disabled ? "Enable this key" : "Disable this key")
+
+            // Remove
+            Button(action: { remove(key) }) {
+                Image(systemName: "trash")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.borderless)
+            .foregroundColor(Color(.systemRed))
+            .help("Remove this key")
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isActive ? Color.accentColor.opacity(0.06) : Color.clear)
+        )
+    }
+
+    private var addKeySection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Add a new key")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 6) {
+                TextField("Label (e.g. \"Account 2\")", text: $newKeyLabel)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 160)
+
+                SecureField("\(providerDisplayName) API key", text: $newKeyValue)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(isVerifying)
+
+                Button(action: addKey) {
+                    HStack(spacing: 4) {
+                        if isVerifying {
+                            ProgressView().scaleEffect(0.6).frame(width: 12, height: 12)
+                        } else {
+                            Image(systemName: "checkmark.shield")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        Text(isVerifying ? "Verifying…" : "Verify & Add")
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(Color(.controlAccentColor)))
+                }
+                .buttonStyle(.plain)
+                .disabled(newKeyValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+            }
+        }
+    }
+
+    private var rotationFooter: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Auto-rotation")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.secondary)
+            Text("When \(providerDisplayName) returns an auth or quota error (401 / 403 / 429 / quota_exceeded / rate_limited), VoiceInk automatically tries the next enabled key. Network failures do not trigger rotation.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func reload() {
+        keys = APIKeyManager.shared.getAPIKeys(forProvider: providerKey)
+        activeKeyId = APIKeyManager.shared.activeAPIKey(forProvider: providerKey)?.id
+    }
+
+    private func addKey() {
+        let trimmedKey = newKeyValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLabel = newKeyLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        // Reject duplicate keys up front with a friendly message rather than
+        // silently failing.
+        if keys.contains(where: { $0.key == trimmedKey }) {
+            verificationError = "This key is already configured."
+            return
+        }
+
+        isVerifying = true
+        verificationError = nil
+
+        Task {
+            let result: (isValid: Bool, errorMessage: String?)
+            switch providerKey.lowercased() {
+            case "elevenlabs":
+                result = await ElevenLabsClient.verifyAPIKey(trimmedKey)
+            default:
+                result = (false, "Multi-key verification is not yet implemented for \(providerDisplayName).")
+            }
+
+            await MainActor.run {
+                isVerifying = false
+                if result.isValid {
+                    guard APIKeyManager.shared.addAPIKey(
+                        trimmedKey,
+                        label: trimmedLabel,
+                        forProvider: providerKey
+                    ) != nil else {
+                        verificationError = "Failed to store the key. Please try again."
+                        return
+                    }
+                    newKeyLabel = ""
+                    newKeyValue = ""
+                    verificationError = nil
+                    reload()
+                    onKeysChanged()
+                } else {
+                    verificationError = result.errorMessage ?? "Verification failed"
+                }
+            }
+        }
+    }
+
+    private func remove(_ key: APIKeyEntry) {
+        APIKeyManager.shared.removeAPIKey(id: key.id, forProvider: providerKey)
+        reload()
+        onKeysChanged()
+    }
+
+    private func rotateManually() {
+        guard keys.filter({ !$0.disabled }).count > 1 else {
+            globalErrorMessage = "You need at least two enabled keys to rotate."
+            showGlobalError = true
+            return
+        }
+        _ = APIKeyManager.shared.rotateToNextKey(
+            forProvider: providerKey,
+            reason: "Manual rotation"
+        )
+        reload()
+        onKeysChanged()
+    }
+
+    // MARK: - Formatting
+
+    private func maskedKey(_ key: String) -> String {
+        guard key.count > 8 else { return String(repeating: "•", count: max(key.count, 4)) }
+        let prefix = key.prefix(4)
+        let suffix = key.suffix(4)
+        return "\(prefix)••••••\(suffix)"
+    }
+
+    private static let relativeDateFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+}

--- a/VoiceInkTests/APIKeyRotationTests.swift
+++ b/VoiceInkTests/APIKeyRotationTests.swift
@@ -1,0 +1,303 @@
+import Testing
+import Foundation
+@testable import VoiceInk
+
+/// Tests for multi-API-key rotation. Uses unique per-test provider keys so
+/// parallel runs never collide on shared Keychain/UserDefaults state.
+struct APIKeyRotationTests {
+
+    /// Produces a unique provider key for each test so state is isolated.
+    /// A `_test_` prefix prevents any accidental collision with real providers.
+    private func makeProviderKey(_ suffix: String = #function) -> String {
+        // #function includes parentheses like "testAddKey()" — strip them and
+        // add a UUID so re-runs within the same process don't see stale state.
+        let clean = suffix
+            .replacingOccurrences(of: "(", with: "")
+            .replacingOccurrences(of: ")", with: "")
+        return "_test_\(clean)_\(UUID().uuidString)"
+    }
+
+    private func cleanup(_ provider: String) {
+        let manager = APIKeyManager.shared
+        for entry in manager.getAPIKeys(forProvider: provider) {
+            manager.removeAPIKey(id: entry.id, forProvider: provider)
+        }
+        manager.deleteAPIKey(forProvider: provider)
+    }
+
+    // MARK: - Basic CRUD
+
+    @Test func addKeyCreatesEntry() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let entry = manager.addAPIKey("sk-aaa", label: "First", forProvider: provider)
+
+        #expect(entry != nil)
+        #expect(entry?.label == "First")
+        #expect(entry?.disabled == false)
+        #expect(manager.getAPIKeys(forProvider: provider).count == 1)
+    }
+
+    @Test func addKeyUsesDefaultLabelWhenBlank() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        _ = manager.addAPIKey("sk-aaa", label: "", forProvider: provider)
+        _ = manager.addAPIKey("sk-bbb", label: "", forProvider: provider)
+
+        let keys = manager.getAPIKeys(forProvider: provider)
+        #expect(keys[0].label == "Key 1")
+        #expect(keys[1].label == "Key 2")
+    }
+
+    @Test func addKeyRejectsEmptyKey() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        #expect(manager.addAPIKey("   ", label: "blank", forProvider: provider) == nil)
+        #expect(manager.getAPIKeys(forProvider: provider).isEmpty)
+    }
+
+    @Test func addKeyRejectsDuplicate() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let first = manager.addAPIKey("sk-dup", label: "A", forProvider: provider)
+        let duplicate = manager.addAPIKey("sk-dup", label: "B", forProvider: provider)
+
+        #expect(first != nil)
+        #expect(duplicate == nil)
+        #expect(manager.getAPIKeys(forProvider: provider).count == 1)
+    }
+
+    @Test func removeKeyAdjustsActiveIndex() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        let k2 = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)!
+        let k3 = manager.addAPIKey("sk-3", label: "Three", forProvider: provider)!
+
+        // Make k2 the active one.
+        _ = manager.setActiveKey(id: k2.id, forProvider: provider)
+        #expect(manager.activeAPIKey(forProvider: provider)?.id == k2.id)
+
+        // Removing the active key should move activation to the next enabled entry.
+        _ = manager.removeAPIKey(id: k2.id, forProvider: provider)
+        let remaining = manager.getAPIKeys(forProvider: provider)
+        #expect(remaining.count == 2)
+        // Active should now be one of the survivors (k1 or k3), not nil.
+        #expect(manager.activeAPIKey(forProvider: provider) != nil)
+
+        // Removing a key BEFORE the active index should keep the same active entry.
+        _ = manager.setActiveKey(id: k3.id, forProvider: provider)
+        _ = manager.removeAPIKey(id: k1.id, forProvider: provider)
+        #expect(manager.activeAPIKey(forProvider: provider)?.id == k3.id)
+    }
+
+    @Test func removeLastKeyClearsEverything() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k = manager.addAPIKey("sk-only", label: "Only", forProvider: provider)!
+        _ = manager.removeAPIKey(id: k.id, forProvider: provider)
+
+        #expect(manager.getAPIKeys(forProvider: provider).isEmpty)
+        #expect(manager.activeAPIKey(forProvider: provider) == nil)
+        #expect(manager.getAPIKey(forProvider: provider) == nil)
+    }
+
+    // MARK: - Rotation
+
+    @Test func rotateAdvancesAndSkipsDisabled() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        let k2 = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)!
+        let k3 = manager.addAPIKey("sk-3", label: "Three", forProvider: provider)!
+
+        // Disable k2 so rotation should skip over it.
+        _ = manager.updateAPIKey(id: k2.id, disabled: true, forProvider: provider)
+
+        // Start on k1, rotate → should land on k3 (k2 skipped).
+        _ = manager.setActiveKey(id: k1.id, forProvider: provider)
+        let next = manager.rotateToNextKey(forProvider: provider, reason: "test")
+        #expect(next?.id == k3.id)
+        #expect(manager.activeAPIKey(forProvider: provider)?.id == k3.id)
+
+        // The key we rotated AWAY from should have a failure stamp now.
+        let updated = manager.getAPIKeys(forProvider: provider).first(where: { $0.id == k1.id })!
+        #expect(updated.lastFailureReason == "test")
+        #expect(updated.lastFailureAt != nil)
+    }
+
+    @Test func rotateWrapsAround() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        let k2 = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)!
+
+        _ = manager.setActiveKey(id: k2.id, forProvider: provider)
+        let next = manager.rotateToNextKey(forProvider: provider, reason: "wrap")
+        #expect(next?.id == k1.id)
+    }
+
+    @Test func rotateReturnsNilWhenOnlyOneEnabledKey() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        let k2 = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)!
+        _ = manager.updateAPIKey(id: k2.id, disabled: true, forProvider: provider)
+
+        _ = manager.setActiveKey(id: k1.id, forProvider: provider)
+        let next = manager.rotateToNextKey(forProvider: provider, reason: "exhausted")
+        #expect(next == nil)
+        // The stale/disabled key should NOT be returned by activeAPIKey either,
+        // because it's disabled; but since k1 is still enabled and was the only
+        // option, activeAPIKey will still return k1 even though it's marked failed.
+        let active = manager.activeAPIKey(forProvider: provider)
+        #expect(active?.id == k1.id)
+    }
+
+    @Test func activeKeyReturnsNilWhenAllDisabled() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        let k2 = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)!
+        _ = manager.updateAPIKey(id: k1.id, disabled: true, forProvider: provider)
+        _ = manager.updateAPIKey(id: k2.id, disabled: true, forProvider: provider)
+
+        #expect(manager.activeAPIKey(forProvider: provider) == nil)
+    }
+
+    // MARK: - Legacy migration + backward compatibility
+
+    @Test func legacyKeyIsMigratedOnFirstRead() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        // Seed a legacy single key via the old single-key API, bypassing the
+        // multi-key store.
+        _ = manager.saveAPIKey("legacy-key", forProvider: provider)
+
+        let keys = manager.getAPIKeys(forProvider: provider)
+        #expect(keys.count == 1)
+        #expect(keys.first?.label == "Primary")
+        #expect(keys.first?.key == "legacy-key")
+    }
+
+    @Test func getAPIKeyReturnsActiveKeyForLegacyCallers() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        _ = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)!
+
+        _ = manager.setActiveKey(id: k1.id, forProvider: provider)
+        #expect(manager.getAPIKey(forProvider: provider) == "sk-1")
+
+        _ = manager.rotateToNextKey(forProvider: provider, reason: "rotate")
+        #expect(manager.getAPIKey(forProvider: provider) == "sk-2")
+    }
+
+    // MARK: - Failure classification
+
+    @Test func classifyHTTP401IsKeyLevel() {
+        let result = APIKeyFailureClass.classifyHTTP(statusCode: 401, message: "Unauthorized")
+        switch result {
+        case .keyLevel: break // expected
+        case .transient: Issue.record("401 should be key-level")
+        }
+    }
+
+    @Test func classifyHTTP429IsKeyLevel() {
+        let result = APIKeyFailureClass.classifyHTTP(statusCode: 429, message: "Too many requests")
+        switch result {
+        case .keyLevel: break
+        case .transient: Issue.record("429 should be key-level")
+        }
+    }
+
+    @Test func classifyHTTP500IsTransient() {
+        let result = APIKeyFailureClass.classifyHTTP(statusCode: 500, message: "server")
+        switch result {
+        case .transient: break
+        case .keyLevel: Issue.record("500 should be transient")
+        }
+    }
+
+    @Test func classifyElevenLabsQuotaExceededIsKeyLevel() {
+        let result = APIKeyFailureClass.classifyElevenLabsWSError("quota_exceeded: monthly limit reached")
+        switch result {
+        case .keyLevel: break
+        case .transient: Issue.record("quota_exceeded should be key-level")
+        }
+    }
+
+    @Test func classifyElevenLabsGenericErrorIsTransient() {
+        let result = APIKeyFailureClass.classifyElevenLabsWSError("network disruption")
+        switch result {
+        case .transient: break
+        case .keyLevel: Issue.record("generic network error should be transient")
+        }
+    }
+
+    @Test func classifyElevenLabsAuthErrorCaseInsensitive() {
+        let result = APIKeyFailureClass.classifyElevenLabsWSError("AUTH_ERROR: bad token")
+        switch result {
+        case .keyLevel: break
+        case .transient: Issue.record("auth_error matching must be case-insensitive")
+        }
+    }
+
+    // MARK: - Counts
+
+    @Test func apiKeyCountsReflectsEnabledAndDisabled() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        _ = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)
+        _ = manager.addAPIKey("sk-3", label: "Three", forProvider: provider)
+        _ = manager.updateAPIKey(id: k1.id, disabled: true, forProvider: provider)
+
+        let counts = manager.apiKeyCounts(forProvider: provider)
+        #expect(counts.total == 3)
+        #expect(counts.enabled == 2)
+    }
+
+    @Test func markKeyFailedPersistsReasonWithoutRotating() {
+        let provider = makeProviderKey()
+        defer { cleanup(provider) }
+        let manager = APIKeyManager.shared
+
+        let k1 = manager.addAPIKey("sk-1", label: "One", forProvider: provider)!
+        _ = manager.addAPIKey("sk-2", label: "Two", forProvider: provider)
+        _ = manager.setActiveKey(id: k1.id, forProvider: provider)
+
+        _ = manager.markKeyFailed(id: k1.id, reason: "429", forProvider: provider)
+
+        let updated = manager.getAPIKeys(forProvider: provider).first(where: { $0.id == k1.id })!
+        #expect(updated.lastFailureReason == "429")
+        // Active key should NOT have changed — markKeyFailed doesn't rotate.
+        #expect(manager.activeAPIKey(forProvider: provider)?.id == k1.id)
+    }
+}


### PR DESCRIPTION
## Summary

Hey Pax — long-time VoiceInk user here. I switched from Parakeet V3 to **ElevenLabs Scribe V2 Realtime** a few months ago and the accuracy bump is incredible. The one friction point is the free-tier model: I run **3 ElevenLabs accounts (3 keys × 10,000 credits/month)** and have to manually swap the key in VoiceInk roughly once a week when one runs out.

This PR fixes that by adding **multiple API keys per provider with automatic rotation** on auth/quota errors. Wired through both ElevenLabs flows (Scribe V2 Realtime streaming + Scribe v1 batch), with a clean management UI inside the existing model card.

I originally wrote this as a feature request, then realized I could just build it. Hope it's useful enough to land — happy to iterate on anything you want changed.

— **Gunit Bindal** ([@GunitBindal](https://github.com/GunitBindal))

---

## What's new (user-facing)

- **Multiple ElevenLabs API keys**: Configure as many as you want, each with a friendly label (\"Account 1\", \"Work key\", etc.).
- **Auto-rotation on key-level failures**: HTTP 401/402/403/429, ElevenLabs WS \`auth_error\`, \`quota_exceeded\`, \`rate_limited\`, \`resource_exhausted\`. Network failures and 5xx do **not** trigger rotation (so a flaky wifi blip doesn't burn through every key).
- **Mid-session quota handling**: If the active key hits quota mid-recording, the session fails cleanly with a \`.keyQuotaExceeded\` error explaining what happened, the key gets marked exhausted, and the **next recording automatically uses the next enabled key** — no manual switching.
- **Per-key controls**: enable/disable toggle, manual rotate, last-failure tooltip, remove, set-active.
- **Other providers untouched**: only the ElevenLabs card shows the multi-key UI; everything else is identical to before.

## What's new (architecture)

- New \`APIKeyEntry\` struct + extension on \`APIKeyManager\` for multi-key storage. Keys persist as a JSON-encoded array in **Keychain** (same security level as the existing single-key store), under a new versioned identifier (\`<provider>APIKeys_v1\`). Active rotation index lives in UserDefaults per provider.
- **Backward compatible**: the legacy single-key Keychain entry is kept in sync with the active multi-key entry on every save/rotation, so every existing call site that reads via \`getAPIKey(forProvider:)\` (which is many — \`AIService\`, \`AIEnhancementService\`, all the other batch providers, custom model code, etc.) keeps working with **zero changes**.
- **Transparent migration**: first time \`getAPIKeys(forProvider:)\` is called for a provider that only has a legacy single key, it auto-migrates into a one-entry \`[\"Primary\"]\` array. No data loss — the legacy entry stays intact until the user explicitly removes the last key.
- **Generic storage, opt-in UI**: \`APIKeyManager\` rotation works for any provider; only the ElevenLabs model card opts into the multi-key UI in this PR. Adding it to other providers later is a one-line \`supportsMultiKey\` flip plus wiring the rotation helper into their service code.

## Files changed

| File | Change |
|---|---|
| \`VoiceInk/Services/APIKeyRotation.swift\` | **New** — \`APIKeyEntry\`, \`APIKeyFailureClass\`, \`APIKeyManager\` rotation extension |
| \`VoiceInk/Transcription/Streaming/ElevenLabsStreamingProvider.swift\` | Connect-time retry loop over all enabled keys; mid-session quota errors mark active key + advance index |
| \`VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift\` | New \`.allKeysExhausted\` and \`.keyQuotaExceeded\` error cases |
| \`VoiceInk/Transcription/Batch/CloudTranscriptionService.swift\` | New \`transcribeElevenLabsWithRotation\` helper + \`.allKeysExhausted\` error case |
| \`VoiceInk/Views/AI Models/MultiAPIKeyConfigurationView.swift\` | **New** — multi-key management UI |
| \`VoiceInk/Views/AI Models/CloudModelCardRowView.swift\` | Branch on \`supportsMultiKey\` to render the new view; \"Configured (N keys)\" badge; \"Manage Keys\" / \"Remove All Keys\" menu |
| \`VoiceInkTests/APIKeyRotationTests.swift\` | **New** — 16 unit tests |

Net diff: **+1425 / −72** across 7 files. The change to existing files is small — most lines are the new files.

## Failure classification (the rotation contract)

| Failure | Source | Class | Behavior |
|---|---|---|---|
| HTTP 401 / 402 / 403 / 429 | LLMkit \`httpError\` | key-level | rotate to next key |
| WS \`auth_error\`, \`quota_exceeded\`, \`rate_limited\`, \`resource_exhausted\`, \`unauthorized\`, \`invalid_api_key\` | ElevenLabs WS event | key-level | rotate to next key |
| HTTP 5xx | LLMkit \`httpError\` | transient | fail immediately, no rotation |
| LLMkit \`networkError\` | URLSession failure | transient | fail immediately, no rotation |
| LLMkit \`timeout\` | LLMkit | transient | fail immediately, no rotation |
| \`decodingError\`, \`invalidURL\`, \`encodingError\`, \`noResultReturned\` | LLMkit | transient | fail immediately, no rotation |
| Any non-LLMkit error | runtime | transient | fail immediately, no rotation |

This is the most important part of the design: **a network blip should never cause us to mark all of the user's keys as failed**.

## Edge cases handled

- All keys disabled → \`activeAPIKey\` returns nil, \`getAPIKey(forProvider:)\` returns nil too, existing \`missingAPIKey\` path fires
- All keys exhausted with key-level errors → distinct \`.allKeysExhausted(lastReason:)\` error so the UI can show a useful message instead of a generic \"unauthorized\"
- Removing the active key → active index re-clamps to a valid surviving key
- Removing the last key → both multi-key store and legacy Keychain entry are cleared
- Duplicate key add → silently rejected with a friendly UI message
- Single enabled key, rest disabled → \`rotateToNextKey\` returns nil cleanly (won't infinite-loop)
- Mid-session quota error → key marked failed, active index advanced for the next session, current session fails with \`.keyQuotaExceeded(label, reason)\`
- LOCAL_BUILD path → KeychainService falls back to UserDefaults, multi-key store still works

## Manual test plan

Since \`xcodebuild\` requires Xcode (only Command Line Tools available in my CI environment), I haven't compiled locally — but the unit tests cover all the rotation logic and the UI follows the existing card patterns. Suggested manual verification:

- [ ] Existing single-key ElevenLabs setup migrates to multi-key on first open of the model card
- [ ] Add 2 keys, force key #1 to be invalid, start streaming → should auto-rotate to key #2 and connect
- [ ] Add 2 keys, disconnect wifi, start streaming → should fail immediately with connection error (no rotation)
- [ ] Add 2 keys, exhaust key #1's quota mid-session → session fails with the \"hit a quota error mid-session\" message; next recording uses key #2
- [ ] Remove all keys → card returns to \"Setup Required\" state
- [ ] Other providers (Groq / Deepgram / Mistral / etc.) still show the single-key UI unchanged

## Why this matters

Free-tier rotation is the obvious use case but it also helps any user who:
- Has a personal + work key and wants to round-robin
- Wants resilience when a single key gets rate-limited under heavy daily use
- Wants to evaluate paid vs free tiers without manually swapping

Thanks for VoiceInk — easily the best Mac dictation tool I've used. Let me know if you'd like me to extend this to other providers in a follow-up PR.

— Gunit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for multiple ElevenLabs API keys with automatic rotation on auth/quota errors. Works for both Scribe V2 Realtime and Scribe v1 batch, with a simple key management UI; existing single-key flows keep working.

- **New Features**
  - Configure multiple ElevenLabs keys with labels; manage in the model card.
  - Auto-rotate on key-level failures (HTTP 401/402/403/429, WS auth/quota/rate-limited); no rotation on network/5xx.
  - Mid-session quota/auth surfaces .keyQuotaExceeded; next session uses the next enabled key.
  - New .allKeysExhausted errors for clear UX when every key fails.
  - 16 unit tests cover rotation, migration, and failure classification.

- **Migration**
  - Existing single key auto-migrates to a one-entry [Primary] list; no user action needed.
  - Keys stored as a JSON array in Keychain under <provider>APIKeys_v1; active index in UserDefaults; legacy single-key entry stays in sync for backward compatibility.
  - Other providers remain single-key and unchanged.

<sup>Written for commit f5257db190641808a727ef5788ead0c85c3057c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

