### PR TITLE
Fix MediaRemoteAdapter CPU spike by using patched fork

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -695,7 +695,7 @@
 		};
 		E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ejbills/mediaremote-adapter";
+			repositoryURL = "https://github.com/Beingpax/mediaremote-adapter";
 			requirement = {
 				branch = master;
 				kind = branch;

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -58,10 +58,10 @@
     {
       "identity" : "mediaremote-adapter",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ejbills/mediaremote-adapter",
+      "location" : "https://github.com/Beingpax/mediaremote-adapter",
       "state" : {
         "branch" : "master",
-        "revision" : "b8ce5d15898299d4d314413a3c4e3a1f3f678fa2"
+        "revision" : "b97fa53f0654c8e33519e8a601b0bead3abd310a"
       }
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches `mediaremote-adapter` to a patched fork to resolve a CPU spike seen with the upstream package. Updates SwiftPM config to point to the fork and its pinned revision.

- **Dependencies**
  - Point `mediaremote-adapter` to `https://github.com/Beingpax/mediaremote-adapter` (branch `master`).
  - Update `Package.resolved` to revision `b97fa53f0654c8e33519e8a601b0bead3abd310a`.

<sup>Written for commit 36332171c23d3ec1509d401fea82ea7d529e6bf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

