### PR TITLE
Fix Power Mode config persisting when switching to unconfigured apps

### DIFF
--- a/VoiceInk/PowerMode/ActiveWindowService.swift
+++ b/VoiceInk/PowerMode/ActiveWindowService.swift
@@ -64,6 +64,11 @@ class ActiveWindowService: ObservableObject {
                 PowerModeManager.shared.setActiveConfiguration(config)
             }
             await PowerModeSessionManager.shared.beginSession(with: config)
+        } else {
+            await PowerModeSessionManager.shared.endSession()
+            await MainActor.run {
+                PowerModeManager.shared.setActiveConfiguration(nil)
+            }
         }
     }
 } 


### PR DESCRIPTION
## Summary
- When a Power Mode is activated for a specific app (e.g., WhatsApp), the configuration stays "stuck" after switching to an app without any Power Mode configured
- Root cause: `ActiveWindowService.applyConfiguration()` only sets the active config when a match is found, but never clears it when no match exists
- Fix: add an `else` branch to end the session and clear the active configuration when no matching Power Mode is found

## Related Issues
- #155 - Default model changes to the selected Power Model of the latest Power Mode
- #313 - Power mode turns on AI enhancement (and keeps it on)

## Changes
- `VoiceInk/PowerMode/ActiveWindowService.swift`: Added `else` block to call `endSession()` and `setActiveConfiguration(nil)` when no Power Mode matches the current app

## Test plan
- [x] Configure a Power Mode for a specific app (e.g., WhatsApp)
- [x] Record in that app → Power Mode activates correctly
- [x] Switch to an app without Power Mode and record → Power Mode deactivates, original settings restored
- [x] Verified `endSession()` is safe when no session exists (guard + return)
- [x] Verified `setActiveConfiguration(nil)` handles nil correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Power Mode staying active when switching to apps without a configured mode. If no matching app is found, we now end the session and clear the active configuration to restore defaults.

- **Bug Fixes**
  - In `ActiveWindowService.applyConfiguration()`, add an `else` branch to call `PowerModeSessionManager.endSession()` and `PowerModeManager.setActiveConfiguration(nil)`.

<sup>Written for commit 8ef66f8cd68c40e42823323984966fd276e1c253. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

