### PR TITLE
Add ActiveScreenResolver for recorder and panel placement + Apple Intellegence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ playground.xcworkspace
 build/
 .local-build/
 
+# Superpowers brainstorming/spec artifacts (local only)
+docs/superpowers/
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/VoiceInk/Notifications/AnnouncementManager.swift
+++ b/VoiceInk/Notifications/AnnouncementManager.swift
@@ -74,7 +74,7 @@ final class AnnouncementManager {
 
     @MainActor
     private func position(_ panel: NSPanel) {
-        let screen = NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens[0]
+        let screen = ActiveScreenResolver.currentActiveScreen()
         let visibleFrame = screen.visibleFrame
         // Match MiniRecorder: bottom padding 24, centered horizontally
         let bottomPadding: CGFloat = 24

--- a/VoiceInk/Notifications/NotificationManager.swift
+++ b/VoiceInk/Notifications/NotificationManager.swift
@@ -82,7 +82,7 @@ class NotificationManager {
 
     @MainActor
     private func positionWindow(_ window: NSWindow) {
-        let activeScreen = NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens[0]
+        let activeScreen = ActiveScreenResolver.currentActiveScreen()
         let screenRect = activeScreen.visibleFrame
         let notificationRect = window.frame
         

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -244,6 +244,19 @@ class AIEnhancementService: ObservableObject {
             }
         }
 
+        if aiService.selectedProvider == .appleIntelligence {
+            do {
+                let result = try await aiService.enhanceWithAppleIntelligence(text: formattedText, systemPrompt: systemMessage)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch {
+                if let aiError = error as? AppleIntelligenceError {
+                    throw EnhancementError.customError(aiError.errorDescription ?? "Apple Intelligence enhancement failed.")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
         try await waitForRateLimit()
 
         do {

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -15,6 +15,7 @@ enum AIProvider: String, CaseIterable {
     case speechmatics = "Speechmatics"
     case ollama = "Ollama"
     case localCLI = "Local CLI"
+    case appleIntelligence = "Apple Intelligence"
     case custom = "Custom"
     
     
@@ -45,6 +46,8 @@ enum AIProvider: String, CaseIterable {
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         case .localCLI:
+            return ""
+        case .appleIntelligence:
             return ""
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderBaseURL") ?? ""
@@ -77,6 +80,8 @@ enum AIProvider: String, CaseIterable {
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
         case .localCLI:
             return "local-cli"
+        case .appleIntelligence:
+            return "apple-on-device"
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderModel") ?? ""
         case .openRouter:
@@ -149,6 +154,8 @@ enum AIProvider: String, CaseIterable {
             return []
         case .localCLI:
             return []
+        case .appleIntelligence:
+            return []
         case .custom:
             return []
         case .openRouter:
@@ -158,7 +165,7 @@ enum AIProvider: String, CaseIterable {
     
     var requiresAPIKey: Bool {
         switch self {
-        case .ollama, .localCLI:
+        case .ollama, .localCLI, .appleIntelligence:
             return false
         default:
             return true
@@ -192,7 +199,15 @@ class AIService: ObservableObject {
                 }
             } else {
                 self.apiKey = ""
-                self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
+                switch selectedProvider {
+                case .localCLI:
+                    self.isAPIKeyValid = localCLIService.isConfigured
+                case .appleIntelligence:
+                    appleIntelligenceService.refreshAvailability()
+                    self.isAPIKeyValid = appleIntelligenceService.isAvailable
+                default:
+                    self.isAPIKeyValid = true
+                }
                 if selectedProvider == .ollama {
                     Task {
                         await ollamaService.checkConnection()
@@ -208,6 +223,7 @@ class AIService: ObservableObject {
     private let userDefaults = UserDefaults.standard
     private lazy var ollamaService = OllamaService()
     private lazy var localCLIService = LocalCLIService()
+    private lazy var appleIntelligenceService = AppleIntelligenceService()
     
     @Published private var openRouterModels: [String] = []
     
@@ -217,6 +233,8 @@ class AIService: ObservableObject {
                 return ollamaService.isConnected
             } else if provider == .localCLI {
                 return localCLIService.isConfigured
+            } else if provider == .appleIntelligence {
+                return appleIntelligenceService.isAvailable
             } else if provider.requiresAPIKey {
                 return APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue)
             }
@@ -276,7 +294,14 @@ class AIService: ObservableObject {
                 self.isAPIKeyValid = true
             }
         } else {
-            self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
+            switch selectedProvider {
+            case .localCLI:
+                self.isAPIKeyValid = localCLIService.isConfigured
+            case .appleIntelligence:
+                self.isAPIKeyValid = appleIntelligenceService.isAvailable
+            default:
+                self.isAPIKeyValid = true
+            }
         }
 
         loadSavedModelSelections()
@@ -443,6 +468,31 @@ class AIService: ObservableObject {
 
     func enhanceWithLocalCLI(systemPrompt: String, userPrompt: String) async throws -> String {
         try await localCLIService.enhance(systemPrompt: systemPrompt, userPrompt: userPrompt)
+    }
+
+    func enhanceWithAppleIntelligence(text: String, systemPrompt: String) async throws -> String {
+        try await appleIntelligenceService.enhance(text, systemPrompt: systemPrompt)
+    }
+
+    var appleIntelligenceIsAvailable: Bool {
+        appleIntelligenceService.isAvailable
+    }
+
+    var appleIntelligenceUnavailabilityReason: String? {
+        appleIntelligenceService.unavailabilityReason
+    }
+
+    func refreshAppleIntelligenceAvailability() {
+        let wasAvailable = appleIntelligenceService.isAvailable
+        appleIntelligenceService.refreshAvailability()
+        if selectedProvider == .appleIntelligence {
+            isAPIKeyValid = appleIntelligenceService.isAvailable
+            if wasAvailable && !appleIntelligenceService.isAvailable {
+                NotificationCenter.default.post(name: .aiProviderKeyChanged, object: nil)
+            }
+        }
+        objectWillChange.send()
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
     }
 
     private func refreshLocalCLIConfigurationState() {

--- a/VoiceInk/Services/AIEnhancement/AppleIntelligenceService.swift
+++ b/VoiceInk/Services/AIEnhancement/AppleIntelligenceService.swift
@@ -1,0 +1,84 @@
+import Foundation
+import os
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+class AppleIntelligenceService: ObservableObject {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "AppleIntelligenceService")
+
+    @Published private(set) var isAvailable: Bool = false
+    @Published private(set) var unavailabilityReason: String?
+
+    init() {
+        refreshAvailability()
+    }
+
+    func refreshAvailability() {
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            switch SystemLanguageModel.default.availability {
+            case .available:
+                isAvailable = true
+                unavailabilityReason = nil
+            case .unavailable(.appleIntelligenceNotEnabled):
+                isAvailable = false
+                unavailabilityReason = "Apple Intelligence is not enabled. Turn it on in System Settings › Apple Intelligence & Siri."
+            case .unavailable(.deviceNotEligible):
+                isAvailable = false
+                unavailabilityReason = "This Mac doesn't support Apple Intelligence."
+            case .unavailable(.modelNotReady):
+                isAvailable = false
+                unavailabilityReason = "Apple Intelligence is still downloading the on-device model. Try again in a few minutes."
+            @unknown default:
+                isAvailable = false
+                unavailabilityReason = "Apple Intelligence is unavailable."
+            }
+            return
+        }
+        #endif
+        isAvailable = false
+        unavailabilityReason = "Apple Intelligence requires macOS 26 or later on an Apple silicon Mac."
+    }
+
+    func enhance(_ text: String, systemPrompt: String) async throws -> String {
+        #if canImport(FoundationModels)
+        guard #available(macOS 26.0, *) else {
+            throw AppleIntelligenceError.unavailable("Requires macOS 26 or later.")
+        }
+
+        guard isAvailable else {
+            throw AppleIntelligenceError.unavailable(unavailabilityReason ?? "Apple Intelligence is not available.")
+        }
+
+        let session = LanguageModelSession {
+            systemPrompt
+        }
+
+        do {
+            let response = try await session.respond(to: text)
+            return response.content
+        } catch {
+            logger.error("Apple Intelligence enhancement failed: \(error.localizedDescription, privacy: .public)")
+            throw AppleIntelligenceError.generationFailed(error.localizedDescription)
+        }
+        #else
+        throw AppleIntelligenceError.unavailable("This build of VoiceInk was compiled without Apple Intelligence support (requires Xcode 26+).")
+        #endif
+    }
+}
+
+enum AppleIntelligenceError: Error, LocalizedError {
+    case unavailable(String)
+    case generationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let reason):
+            return reason
+        case .generationFailed(let details):
+            return "Apple Intelligence failed: \(details)"
+        }
+    }
+}

--- a/VoiceInk/Services/ActiveScreenResolver.swift
+++ b/VoiceInk/Services/ActiveScreenResolver.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import os
 
 enum ActiveScreenResolver {
@@ -7,11 +8,18 @@ enum ActiveScreenResolver {
         category: "ActiveScreenResolver"
     )
 
+    private static let ownBundleIdentifier = "com.prakashjoshipax.VoiceInk"
+
     /// Returns the screen the user is most likely working on.
     /// Resolution order: frontmost app's focused window (AX) →
     /// cursor location → NSScreen.main → NSScreen.screens[0].
     /// Never returns nil — callers get a usable screen in every case.
     static func currentActiveScreen() -> NSScreen {
+        if let screen = screenFromFrontmostAppFocusedWindow() {
+            logger.debug("resolved=ax screen=\(screen.localizedName, privacy: .public)")
+            return screen
+        }
+
         if let screen = screenUnderMouse() {
             logger.debug("resolved=cursor screen=\(screen.localizedName, privacy: .public)")
             return screen
@@ -26,6 +34,49 @@ enum ActiveScreenResolver {
         logger.debug("resolved=fallback screen=\(screen.localizedName, privacy: .public)")
         return screen
     }
+
+    // MARK: - AX branch
+
+    private static func screenFromFrontmostAppFocusedWindow() -> NSScreen? {
+        guard let frontmost = NSWorkspace.shared.frontmostApplication else { return nil }
+        // Don't target our own windows (Settings, About, onboarding).
+        if frontmost.bundleIdentifier == ownBundleIdentifier { return nil }
+
+        let appElement = AXUIElementCreateApplication(frontmost.processIdentifier)
+
+        var windowRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) == .success,
+              let windowValue = windowRef else { return nil }
+        let window = windowValue as! AXUIElement
+
+        guard let frame = axWindowFrame(window) else { return nil }
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        return NSScreen.screens.first { $0.frame.contains(center) }
+    }
+
+    /// Reads a window's frame via AX and converts to AppKit coordinates.
+    /// AX uses top-left origin with y growing downward; AppKit uses
+    /// bottom-left origin with y growing upward. The flip reference is the
+    /// primary screen's maxY (that's the origin AX reports against).
+    private static func axWindowFrame(_ window: AXUIElement) -> CGRect? {
+        var positionRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionRef) == .success,
+              AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRef) == .success,
+              let positionValue = positionRef,
+              let sizeValue = sizeRef else { return nil }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else { return nil }
+
+        let primaryMaxY = NSScreen.screens[0].frame.maxY
+        let flippedY = primaryMaxY - position.y - size.height
+        return CGRect(x: position.x, y: flippedY, width: size.width, height: size.height)
+    }
+
+    // MARK: - Cursor branch
 
     private static func screenUnderMouse() -> NSScreen? {
         let point = NSEvent.mouseLocation

--- a/VoiceInk/Services/ActiveScreenResolver.swift
+++ b/VoiceInk/Services/ActiveScreenResolver.swift
@@ -1,0 +1,34 @@
+import AppKit
+import os
+
+enum ActiveScreenResolver {
+    private static let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "ActiveScreenResolver"
+    )
+
+    /// Returns the screen the user is most likely working on.
+    /// Resolution order: frontmost app's focused window (AX) →
+    /// cursor location → NSScreen.main → NSScreen.screens[0].
+    /// Never returns nil — callers get a usable screen in every case.
+    static func currentActiveScreen() -> NSScreen {
+        if let screen = screenUnderMouse() {
+            logger.debug("resolved=cursor screen=\(screen.localizedName, privacy: .public)")
+            return screen
+        }
+
+        if let screen = NSScreen.main {
+            logger.debug("resolved=main screen=\(screen.localizedName, privacy: .public)")
+            return screen
+        }
+
+        let screen = NSScreen.screens[0]
+        logger.debug("resolved=fallback screen=\(screen.localizedName, privacy: .public)")
+        return screen
+    }
+
+    private static func screenUnderMouse() -> NSScreen? {
+        let point = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(point) }
+    }
+}

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -27,7 +27,16 @@ struct APIKeyManagementView: View {
                 .pickerStyle(.automatic)
                 .tint(.blue)
                 
-                if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama {
+                if aiService.selectedProvider == .appleIntelligence {
+                    Spacer()
+                    Circle()
+                        .fill(aiService.appleIntelligenceIsAvailable ? Color.green : Color.red)
+                        .frame(width: 8, height: 8)
+                    Text(aiService.appleIntelligenceIsAvailable ? "Available" : "Unavailable")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .help(aiService.appleIntelligenceIsAvailable ? "Apple Intelligence is ready." : (aiService.appleIntelligenceUnavailabilityReason ?? "Apple Intelligence is not available."))
+                } else if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama {
                     Spacer()
                     Circle()
                         .fill(Color.green)
@@ -63,6 +72,9 @@ struct APIKeyManagementView: View {
                 }
                 if aiService.selectedProvider == .localCLI {
                     syncLocalCLIStateFromService()
+                }
+                if aiService.selectedProvider == .appleIntelligence {
+                    aiService.refreshAppleIntelligenceAvailability()
                 }
             }
 
@@ -107,6 +119,7 @@ struct APIKeyManagementView: View {
                     
                 } else if !aiService.availableModels.isEmpty &&
                             aiService.selectedProvider != .ollama &&
+                            aiService.selectedProvider != .appleIntelligence &&
                             aiService.selectedProvider != .custom {
                     Picker("Model", selection: Binding(
                         get: { aiService.currentModel },
@@ -221,6 +234,44 @@ struct APIKeyManagementView: View {
                             .foregroundColor(.orange)
                     }
 
+                } else if aiService.selectedProvider == .appleIntelligence {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "apple.logo")
+                                .foregroundColor(.secondary)
+                            VStack(alignment: .leading, spacing: 4) {
+                                if aiService.appleIntelligenceIsAvailable {
+                                    Text("Apple Intelligence is ready. Enhancement runs fully on-device — no API key, no network.")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                } else {
+                                    Text(aiService.appleIntelligenceUnavailabilityReason ?? "Apple Intelligence is not available.")
+                                        .font(.caption)
+                                        .foregroundColor(.orange)
+                                }
+                            }
+                        }
+
+                        HStack {
+                            Button(action: {
+                                aiService.refreshAppleIntelligenceAvailability()
+                            }) {
+                                Label("Re-check", systemImage: "arrow.clockwise")
+                            }
+
+                            if !aiService.appleIntelligenceIsAvailable {
+                                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.intelligence") {
+                                    Link(destination: url) {
+                                        HStack {
+                                            Image(systemName: "gearshape")
+                                            Text("Open System Settings")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                 } else if aiService.selectedProvider == .custom {
                     TextField("API Endpoint URL", text: $aiService.customBaseURL, prompt: Text("e.g. https://api.openai.com/v1/chat/completions"))
                         .textFieldStyle(.roundedBorder)
@@ -327,6 +378,9 @@ struct APIKeyManagementView: View {
             }
             if aiService.selectedProvider == .localCLI {
                 syncLocalCLIStateFromService()
+            }
+            if aiService.selectedProvider == .appleIntelligence {
+                aiService.refreshAppleIntelligenceAvailability()
             }
         }
     }

--- a/VoiceInk/Views/Dictionary/DictionaryQuickAddPanel.swift
+++ b/VoiceInk/Views/Dictionary/DictionaryQuickAddPanel.swift
@@ -110,7 +110,7 @@ class DictionaryQuickAddPanel: NSPanel {
     }
 
     private static func centeredOrigin(for size: NSSize) -> NSPoint {
-        let screen = NSScreen.main ?? NSScreen.screens[0]
+        let screen = ActiveScreenResolver.currentActiveScreen()
         let x = screen.visibleFrame.midX - size.width / 2
         let y = screen.visibleFrame.midY - size.height / 2 + 60
         return NSPoint(x: x, y: y)

--- a/VoiceInk/Views/Recorder/MiniRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderPanel.swift
@@ -31,9 +31,7 @@ class MiniRecorderPanel: NSPanel {
     }
     
     static func calculateWindowMetrics() -> NSRect {
-        guard let screen = NSScreen.main else {
-            return NSRect(x: 0, y: 0, width: 300, height: 120)
-        }
+        let screen = ActiveScreenResolver.currentActiveScreen()
 
         // Fixed window size — large enough to accommodate live transcript content
         let width: CGFloat = 300

--- a/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
@@ -46,9 +46,7 @@ class NotchRecorderPanel: KeyablePanel {
     }
 
     static func calculateWindowMetrics() -> (frame: NSRect, notchWidth: CGFloat, notchHeight: CGFloat) {
-        guard let screen = NSScreen.main else {
-            return (NSRect(x: 0, y: 0, width: 280, height: 24), 280, 24)
-        }
+        let screen = ActiveScreenResolver.currentActiveScreen()
 
         let safeAreaInsets = screen.safeAreaInsets
         let notchHeight: CGFloat = safeAreaInsets.top > 0 ? safeAreaInsets.top : NSStatusBar.system.thickness

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -30,7 +30,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     // MARK: - Screen Geometry
 
     private var notchWidth: CGFloat {
-        guard let screen = NSScreen.main else { return 180 }
+        let screen = ActiveScreenResolver.currentActiveScreen()
         if let left = screen.auxiliaryTopLeftArea?.width,
            let right = screen.auxiliaryTopRightArea?.width {
             return screen.frame.width - left - right
@@ -39,7 +39,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     }
 
     private var notchHeight: CGFloat {
-        guard let screen = NSScreen.main else { return 37 }
+        let screen = ActiveScreenResolver.currentActiveScreen()
         if screen.safeAreaInsets.top > 0 { return screen.safeAreaInsets.top }
         return NSApplication.shared.mainMenu?.menuBarHeight ?? NSStatusBar.system.thickness
     }


### PR DESCRIPTION
## Summary
- Introduce `ActiveScreenResolver` with AX-based focused-window detection, cursor, and main-screen fallbacks
- Route mini recorder, notch recorder, dictionary quick-add panel, and notifications/announcements through the resolver for consistent multi-display placement
- Also includes Apple Intelligence as an on-device AI enhancement provider

## Test plan
- [x] Verify recorder/panel placement on single-display setup
- [x] Verify placement on multi-display setup with focused window on secondary screen
- [x] Verify fallback to cursor / main screen when no focused window is detected
- [x] Verify Apple Intelligence enhancement provider works on supported hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a centralized active screen resolver to place recorders, panels, and notifications on the screen the user is working on. Also adds Apple Intelligence as an on-device enhancement provider with availability checks and simple UI controls.

- **New Features**
  - Active screen resolution: AX focused-window detection with cursor and main-screen fallbacks; applied to mini recorder, notch recorder, dictionary quick-add panel, and notifications/announcements for correct multi-display placement.
  - Apple Intelligence provider: on-device enhancement (macOS 26+), no API key; availability status with reasons, re-check button, and System Settings deep link; auto-disables if availability regresses.

<sup>Written for commit 726899a5fde73f3f1d2eacde9d95f01aad8af17f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

