### PR TITLE
Fix paste failing on non-QWERTY keyboard layouts (Dvorak, Colemak, etc.)

### DIFF
--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -91,12 +91,12 @@ class CursorPaster {
             return
         }
         let currentID = sourceID(for: currentSource) ?? "unknown"
-        let switched = switchToQWERTYInputSource()
-        logger.notice("Pasting: inputSource=\(currentID, privacy: .public), switched=\(switched)")
+        let qwertySource = switchToQWERTYInputSource()
+        logger.notice("Pasting: inputSource=\(currentID, privacy: .public), switched=\(qwertySource != nil)")
 
         // If we switched input sources, wait 30 ms for the system to apply it
         // before posting the CGEvents. Use asyncAfter so the main thread is not blocked.
-        let eventDelay: TimeInterval = switched ? 0.03 : 0.0
+        let eventDelay: TimeInterval = qwertySource != nil ? 0.03 : 0.0
         DispatchQueue.main.asyncAfter(deadline: .now() + eventDelay) {
             let source = CGEventSource(stateID: .privateState)
 
@@ -116,28 +116,37 @@ class CursorPaster {
 
             logger.notice("CGEvents posted for Cmd+V")
 
-            if switched {
+            if let qwertySource {
                 // Restore the original input source after a short delay so the
-                // posted events are processed under ABC/US first.
+                // posted events are processed under ABC/US first. Only restore
+                // if the source is still the QWERTY one we switched to — if the
+                // user changed layouts in the meantime, leave their choice alone.
+                let qwertyID = sourceID(for: qwertySource)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    TISSelectInputSource(currentSource)
-                    logger.notice("Restored input source to \(currentID, privacy: .public)")
+                    if let nowSource = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+                       sourceID(for: nowSource) == qwertyID {
+                        TISSelectInputSource(currentSource)
+                        logger.notice("Restored input source to \(currentID, privacy: .public)")
+                    } else {
+                        logger.notice("Input source changed during paste — skipping restore")
+                    }
                 }
             }
         }
     }
 
-    /// Try to switch to ABC or US QWERTY. Returns true if a switch was made.
-    private static func switchToQWERTYInputSource() -> Bool {
-        guard let currentSourceRef = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return false }
+    /// Try to switch to ABC or US QWERTY. Returns the source switched to, or
+    /// nil if the active layout is already QWERTY-compatible.
+    private static func switchToQWERTYInputSource() -> TISInputSource? {
+        guard let currentSourceRef = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return nil }
         if let currentID = sourceID(for: currentSourceRef), isQWERTY(currentID) {
-            return false // already QWERTY, nothing to do
+            return nil // already QWERTY, nothing to do
         }
 
         let criteria = [kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource] as CFDictionary
         guard let list = TISCreateInputSourceList(criteria, false)?.takeRetainedValue() as? [TISInputSource] else {
             logger.error("Failed to list input sources")
-            return false
+            return nil
         }
 
         for targetID in ["com.apple.keylayout.ABC", "com.apple.keylayout.US"] {
@@ -145,7 +154,7 @@ class CursorPaster {
                 let status = TISSelectInputSource(match)
                 if status == noErr {
                     logger.notice("Switched input source to \(targetID, privacy: .public)")
-                    return true
+                    return match
                 } else {
                     logger.error("TISSelectInputSource failed with status \(status)")
                 }
@@ -153,7 +162,7 @@ class CursorPaster {
         }
 
         logger.error("No QWERTY input source found to switch to")
-        return false
+        return nil
     }
 
     private static func sourceID(for source: TISInputSource) -> String? {

--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import Carbon
 import os
 
 private let logger = Logger(subsystem: "com.VoiceInk", category: "CursorPaster")
@@ -74,30 +75,102 @@ class CursorPaster {
 
     // MARK: - CGEvent paste
 
-    // Posts Cmd+V via CGEvent without modifying the active input source.
+    /// Paste from the clipboard using CGEvent, temporarily switching to a
+    /// QWERTY-compatible input source when needed so that virtual key 0x09 is
+    /// reliably interpreted as "V" for Cmd+V regardless of active layout
+    /// (Dvorak, Colemak, etc.). QWERTY users are unaffected — the switch is
+    /// skipped when the current layout is already QWERTY-compatible.
     private static func pasteFromClipboard() {
         guard AXIsProcessTrusted() else {
             logger.error("Accessibility not trusted — cannot paste")
             return
         }
 
-        let source = CGEventSource(stateID: .privateState)
+        guard let currentSource = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
+            logger.error("TISCopyCurrentKeyboardInputSource returned nil")
+            return
+        }
+        let currentID = sourceID(for: currentSource) ?? "unknown"
+        let switched = switchToQWERTYInputSource()
+        logger.notice("Pasting: inputSource=\(currentID, privacy: .public), switched=\(switched)")
 
-        let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: 0x37, keyDown: true)
-        let vDown   = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
-        let vUp     = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
-        let cmdUp   = CGEvent(keyboardEventSource: source, virtualKey: 0x37, keyDown: false)
+        // If we switched input sources, wait 30 ms for the system to apply it
+        // before posting the CGEvents. Use asyncAfter so the main thread is not blocked.
+        let eventDelay: TimeInterval = switched ? 0.03 : 0.0
+        DispatchQueue.main.asyncAfter(deadline: .now() + eventDelay) {
+            let source = CGEventSource(stateID: .privateState)
 
-        cmdDown?.flags = .maskCommand
-        vDown?.flags   = .maskCommand
-        vUp?.flags     = .maskCommand
+            let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: 0x37, keyDown: true)
+            let vDown   = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
+            let vUp     = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
+            let cmdUp   = CGEvent(keyboardEventSource: source, virtualKey: 0x37, keyDown: false)
 
-        cmdDown?.post(tap: .cghidEventTap)
-        vDown?.post(tap: .cghidEventTap)
-        vUp?.post(tap: .cghidEventTap)
-        cmdUp?.post(tap: .cghidEventTap)
+            cmdDown?.flags = .maskCommand
+            vDown?.flags   = .maskCommand
+            vUp?.flags     = .maskCommand
 
-        logger.notice("CGEvents posted for Cmd+V")
+            cmdDown?.post(tap: .cghidEventTap)
+            vDown?.post(tap: .cghidEventTap)
+            vUp?.post(tap: .cghidEventTap)
+            cmdUp?.post(tap: .cghidEventTap)
+
+            logger.notice("CGEvents posted for Cmd+V")
+
+            if switched {
+                // Restore the original input source after a short delay so the
+                // posted events are processed under ABC/US first.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    TISSelectInputSource(currentSource)
+                    logger.notice("Restored input source to \(currentID, privacy: .public)")
+                }
+            }
+        }
+    }
+
+    /// Try to switch to ABC or US QWERTY. Returns true if a switch was made.
+    private static func switchToQWERTYInputSource() -> Bool {
+        guard let currentSourceRef = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return false }
+        if let currentID = sourceID(for: currentSourceRef), isQWERTY(currentID) {
+            return false // already QWERTY, nothing to do
+        }
+
+        let criteria = [kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource] as CFDictionary
+        guard let list = TISCreateInputSourceList(criteria, false)?.takeRetainedValue() as? [TISInputSource] else {
+            logger.error("Failed to list input sources")
+            return false
+        }
+
+        for targetID in ["com.apple.keylayout.ABC", "com.apple.keylayout.US"] {
+            if let match = list.first(where: { sourceID(for: $0) == targetID }) {
+                let status = TISSelectInputSource(match)
+                if status == noErr {
+                    logger.notice("Switched input source to \(targetID, privacy: .public)")
+                    return true
+                } else {
+                    logger.error("TISSelectInputSource failed with status \(status)")
+                }
+            }
+        }
+
+        logger.error("No QWERTY input source found to switch to")
+        return false
+    }
+
+    private static func sourceID(for source: TISInputSource) -> String? {
+        guard let raw = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else { return nil }
+        return Unmanaged<CFString>.fromOpaque(raw).takeUnretainedValue() as String
+    }
+
+    private static func isQWERTY(_ id: String) -> Bool {
+        let qwertyIDs: Set<String> = [
+            "com.apple.keylayout.ABC",
+            "com.apple.keylayout.US",
+            "com.apple.keylayout.USInternational-PC",
+            "com.apple.keylayout.British",
+            "com.apple.keylayout.Australian",
+            "com.apple.keylayout.Canadian",
+        ]
+        return qwertyIDs.contains(id)
     }
 
     // MARK: - Auto Send Keys


### PR DESCRIPTION
## Problem

Paste fails silently for users with non-QWERTY keyboard layouts (Dvorak, Colemak, and others). The dictated text is placed on the clipboard correctly, but the Cmd+V CGEvent never triggers a paste in the target app.

**Root cause:** `CGEvent` with virtual key `0x09` is layout-dependent. On QWERTY, `0x09` maps to the physical 'V' key, so Cmd+0x09 = Cmd+V. On Dvorak, that same virtual key maps to a different character — the system receives a key combination that is not Cmd+V, so nothing gets pasted.

## Why the AppleScript fallback doesn't solve it

The `useAppleScriptPaste` toggle uses `keystroke "v" using command down`. On Dvorak, System Events resolves `"v"` against the active keyboard layout when choosing which physical key to press — so it sends the wrong physical key, and paste still fails. The toggle does not help non-QWERTY users.

## Fix

Before posting the Cmd+V CGEvent, detect the current input source. If it's not QWERTY-compatible, temporarily switch to ABC/US (via Carbon TIS APIs), wait 30 ms for the system to apply the switch, post the events, then restore the original layout after 100 ms.

**QWERTY users are completely unaffected** — the source ID check short-circuits immediately and no switch is made.

This approach was previously merged in cbf7f60 but was reverted in 063e8ac. This PR restores it against the current codebase, which has changed significantly since that original commit.

## Behaviour

| Layout | Before | After |
|--------|--------|-------|
| QWERTY / ABC / US | ✅ works | ✅ works (no change) |
| Dvorak | ❌ silent failure | ✅ works |
| Colemak / other non-QWERTY | ❌ silent failure | ✅ works |

## Test plan

- [ ] Dictate with a QWERTY layout active — paste works as before
- [ ] Dictate with Dvorak active — paste now works
- [ ] Verify the input source returns to Dvorak after paste (check menu bar input source indicator)
- [ ] Verify "Use AppleScript Paste" toggle still works as an opt-in alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent paste failures on non-QWERTY layouts by temporarily switching to a QWERTY input source when sending Cmd+V, then restoring the user’s layout. QWERTY users see no change, and we avoid overwriting the layout if the user switches during paste.

- **Bug Fixes**
  - Detect the active input source via `Carbon TIS`. Skip switching if already QWERTY.
  - Switch to `com.apple.keylayout.ABC` or `com.apple.keylayout.US`, wait ~30 ms, post Cmd+V via `CGEvent`, then restore after ~100 ms only if the current source is still the QWERTY one we set.
  - Resolves paste on Dvorak, Colemak, and others. QWERTY remains unchanged.
  - Keeps the opt-in AppleScript paste path available.

<sup>Written for commit 718500e963f5e308136e6538b6419dd3c88cff8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

