### PR TITLE
Feature/streaming toggle support

### DIFF
--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/Beingpax/LLMkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c4ed80007e15e53a89e9bc464264d1194b8c0e3c"
+        "revision" : "ccf4b6290bbb2ad28e21c324997311f6757b3bc5"
       }
     },
     {

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "28852cee5e4183e1b418bd9dad35774163897010ecbcbd5413d67f0f6913b7c4",
+  "originHash" : "c2e2df8a2e09b563e3062683ce11c69b2712372c34c99d2bc78f0b526c730c55",
   "pins" : [
     {
       "identity" : "axswift",
@@ -52,7 +52,7 @@
       "location" : "https://github.com/Beingpax/LLMkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "ccf4b6290bbb2ad28e21c324997311f6757b3bc5"
+        "revision" : "91b228d3ff13febc6b61a58e5f3aa27e734d1c01"
       }
     },
     {

--- a/VoiceInk/AppDelegate.swift
+++ b/VoiceInk/AppDelegate.swift
@@ -6,6 +6,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     weak var menuBarManager: MenuBarManager?
     
     func applicationDidFinishLaunching(_ notification: Notification) {
+        StreamingKeysMigration.run()
         menuBarManager?.applyActivationPolicy()
     }
 

--- a/VoiceInk/AppDelegate.swift
+++ b/VoiceInk/AppDelegate.swift
@@ -6,7 +6,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     weak var menuBarManager: MenuBarManager?
     
     func applicationDidFinishLaunching(_ notification: Notification) {
-        StreamingKeysMigration.run()
         menuBarManager?.applyActivationPolicy()
     }
 

--- a/VoiceInk/Models/LanguageDictionary.swift
+++ b/VoiceInk/Models/LanguageDictionary.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+enum LanguageDictionary {
+
+    static func forProvider(isMultilingual: Bool, provider: ModelProvider = .local) -> [String: String] {
+        if !isMultilingual {
+            return ["en": "English"]
+        }
+
+        switch provider {
+        case .nativeApple:
+            let codes = ["ar", "de", "en", "es", "fr", "it", "ja", "ko", "pt", "yue", "zh"]
+            return all.filter { codes.contains($0.key) }
+
+        case .fluidAudio:
+            // Parakeet V3: 25 European languages (auto-detects internally)
+            let codes = [
+                "bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr",
+                "hr", "hu", "it", "lt", "lv", "mt", "nl", "pl", "pt", "ro",
+                "ru", "sk", "sl", "sv", "uk"
+            ]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .groq:
+            // Whisper Large v3 Turbo — same language set as local Whisper
+            return all
+
+        case .elevenLabs:
+            // Scribe v1 & v2: 99 languages
+            let codes = [
+                "af", "am", "ar", "as", "az", "be", "bg", "bn", "bs", "ca",
+                "cs", "cy", "da", "de", "el", "en", "es", "et", "eu", "fa",
+                "fi", "fil", "fr", "ga", "gl", "gu", "ha", "he", "hi", "hr",
+                "hu", "hy", "id", "ig", "is", "it", "ja", "jw", "ka", "kk",
+                "km", "kn", "ko", "ku", "ky", "lb", "ln", "lo", "lt", "lv",
+                "mi", "mk", "ml", "mn", "mr", "ms", "mt", "my", "ne", "nl",
+                "no", "or", "pa", "pl", "ps", "pt", "ro", "ru", "sd", "sk",
+                "sl", "sn", "so", "sr", "sv", "sw", "ta", "tg", "te", "th",
+                "tr", "uk", "ur", "uz", "vi", "wo", "xh", "yo", "yue", "zh", "zu"
+            ]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .deepgram:
+            // Nova-3: ~50 languages
+            let codes = [
+                "ar", "be", "bg", "bn", "bs", "ca", "cs", "da", "de", "el",
+                "en", "es", "et", "fa", "fi", "fr", "he", "hi", "hr", "hu",
+                "id", "it", "ja", "kn", "ko", "lt", "lv", "mk", "mr", "ms",
+                "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sr", "sv",
+                "ta", "te", "th", "tl", "tr", "uk", "ur", "vi", "zh"
+            ]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .mistral:
+            // Voxtral: 13 languages
+            let codes = ["ar", "de", "en", "es", "fr", "hi", "it", "ja", "ko", "nl", "pt", "ru", "zh"]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .gemini:
+            // Gemini 2.5 Pro/Flash: 97+ languages — broad enough to use full list
+            return all
+
+        case .xai:
+            // Grok STT: 25 languages
+            let codes = [
+                "ar", "cs", "da", "nl", "en", "fil", "fr", "de", "hi", "id",
+                "it", "ja", "ko", "mk", "ms", "fa", "pl", "pt", "ro", "ru",
+                "es", "sv", "th", "tr", "vi"
+            ]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .soniox:
+            // stt-async-v4: 60 languages (verified against OpenAPI schema)
+            let codes = [
+                "af", "sq", "ar", "az", "eu", "be", "bn", "bs", "bg", "ca",
+                "zh", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "gl",
+                "de", "el", "gu", "he", "hi", "hu", "id", "it", "ja", "kn",
+                "kk", "ko", "lv", "lt", "mk", "ms", "ml", "mr", "no", "fa",
+                "pl", "pt", "pa", "ro", "ru", "sr", "sk", "sl", "es", "sw",
+                "sv", "tl", "ta", "te", "th", "tr", "uk", "ur", "vi", "cy"
+            ]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .speechmatics:
+            // Enhanced accuracy model: 50+ languages
+            let codes = [
+                "ar", "ba", "eu", "be", "bn", "bg", "yue", "ca", "hr", "cs", "da",
+                "nl", "en", "et", "fi", "fr", "gl", "de", "el", "he", "hi",
+                "hu", "id", "it", "ja", "ko", "lv", "lt", "ms", "mt", "mr",
+                "mn", "no", "fa", "pl", "pt", "ro", "ru", "sk", "sl", "es",
+                "sw", "sv", "tl", "ta", "th", "tr", "uk", "ur", "vi", "cy",
+                "zh"
+            ]
+            var filtered = all.filter { codes.contains($0.key) }
+            filtered["auto"] = "Auto-detect"
+            return filtered
+
+        case .local, .custom:
+            // Local Whisper models support the full language list
+            return all
+        }
+    }
+
+    // Apple Native Speech languages in BCP-47 format
+    // Based on actual supported locales from SpeechTranscriber.supportedLocales
+    static let appleNative: [String: String] = [
+        "en-US": "English (United States)",
+        "en-GB": "English (United Kingdom)",
+        "en-CA": "English (Canada)",
+        "en-AU": "English (Australia)",
+        "en-IN": "English (India)",
+        "en-IE": "English (Ireland)",
+        "en-NZ": "English (New Zealand)",
+        "en-ZA": "English (South Africa)",
+        "en-SA": "English (Saudi Arabia)",
+        "en-AE": "English (UAE)",
+        "en-SG": "English (Singapore)",
+        "en-PH": "English (Philippines)",
+        "en-ID": "English (Indonesia)",
+        "es-ES": "Spanish (Spain)",
+        "es-MX": "Spanish (Mexico)",
+        "es-US": "Spanish (United States)",
+        "es-CO": "Spanish (Colombia)",
+        "es-CL": "Spanish (Chile)",
+        "es-419": "Spanish (Latin America)",
+        "fr-FR": "French (France)",
+        "fr-CA": "French (Canada)",
+        "fr-BE": "French (Belgium)",
+        "fr-CH": "French (Switzerland)",
+        "de-DE": "German (Germany)",
+        "de-AT": "German (Austria)",
+        "de-CH": "German (Switzerland)",
+        "zh-CN": "Chinese Simplified (China)",
+        "zh-TW": "Chinese Traditional (Taiwan)",
+        "zh-HK": "Chinese Traditional (Hong Kong)",
+        "ja-JP": "Japanese (Japan)",
+        "ko-KR": "Korean (South Korea)",
+        "yue-CN": "Cantonese (China)",
+        "pt-BR": "Portuguese (Brazil)",
+        "pt-PT": "Portuguese (Portugal)",
+        "it-IT": "Italian (Italy)",
+        "it-CH": "Italian (Switzerland)",
+        "ar-SA": "Arabic (Saudi Arabia)"
+    ]
+
+    static let all: [String: String] = [
+        "auto": "Auto-detect",
+        "af": "Afrikaans",
+        "am": "Amharic",
+        "ar": "Arabic",
+        "as": "Assamese",
+        "az": "Azerbaijani",
+        "ba": "Bashkir",
+        "be": "Belarusian",
+        "bg": "Bulgarian",
+        "bn": "Bengali",
+        "bo": "Tibetan",
+        "br": "Breton",
+        "bs": "Bosnian",
+        "ca": "Catalan",
+        "cs": "Czech",
+        "cy": "Welsh",
+        "da": "Danish",
+        "de": "German",
+        "el": "Greek",
+        "en": "English",
+        "es": "Spanish",
+        "et": "Estonian",
+        "eu": "Basque",
+        "fa": "Persian",
+        "fi": "Finnish",
+        "fil": "Filipino",
+        "fo": "Faroese",
+        "fr": "French",
+        "ga": "Irish",
+        "gl": "Galician",
+        "gu": "Gujarati",
+        "ha": "Hausa",
+        "haw": "Hawaiian",
+        "he": "Hebrew",
+        "hi": "Hindi",
+        "hr": "Croatian",
+        "ht": "Haitian Creole",
+        "hu": "Hungarian",
+        "hy": "Armenian",
+        "id": "Indonesian",
+        "ig": "Igbo",
+        "is": "Icelandic",
+        "it": "Italian",
+        "ja": "Japanese",
+        "jw": "Javanese",
+        "ka": "Georgian",
+        "kk": "Kazakh",
+        "km": "Khmer",
+        "kn": "Kannada",
+        "ko": "Korean",
+        "ku": "Kurdish",
+        "ky": "Kyrgyz",
+        "la": "Latin",
+        "lb": "Luxembourgish",
+        "ln": "Lingala",
+        "lo": "Lao",
+        "lt": "Lithuanian",
+        "lv": "Latvian",
+        "mg": "Malagasy",
+        "mi": "Maori",
+        "mk": "Macedonian",
+        "ml": "Malayalam",
+        "mn": "Mongolian",
+        "mr": "Marathi",
+        "ms": "Malay",
+        "mt": "Maltese",
+        "my": "Myanmar",
+        "ne": "Nepali",
+        "nl": "Dutch",
+        "nn": "Norwegian Nynorsk",
+        "no": "Norwegian",
+        "oc": "Occitan",
+        "or": "Odia",
+        "pa": "Punjabi",
+        "pl": "Polish",
+        "ps": "Pashto",
+        "pt": "Portuguese",
+        "ro": "Romanian",
+        "ru": "Russian",
+        "sa": "Sanskrit",
+        "sd": "Sindhi",
+        "si": "Sinhala",
+        "sk": "Slovak",
+        "sl": "Slovenian",
+        "sn": "Shona",
+        "so": "Somali",
+        "sq": "Albanian",
+        "sr": "Serbian",
+        "su": "Sundanese",
+        "sv": "Swedish",
+        "sw": "Swahili",
+        "ta": "Tamil",
+        "te": "Telugu",
+        "tg": "Tajik",
+        "th": "Thai",
+        "tk": "Turkmen",
+        "tl": "Tagalog",
+        "tr": "Turkish",
+        "tt": "Tatar",
+        "uk": "Ukrainian",
+        "ur": "Urdu",
+        "uz": "Uzbek",
+        "vi": "Vietnamese",
+        "wo": "Wolof",
+        "xh": "Xhosa",
+        "yi": "Yiddish",
+        "yo": "Yoruba",
+        "yue": "Cantonese",
+        "zh": "Chinese",
+        "zu": "Zulu"
+    ]
+}

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -124,7 +124,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.94,
             ramUsage: 0.8,
-            supportsStreaming: false,
+            supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .fluidAudio)
         ),
         FluidAudioModel(
@@ -135,7 +135,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.94,
             ramUsage: 0.8,
-            supportsStreaming: false,
+            supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .fluidAudio)
         ),
 
@@ -251,7 +251,7 @@ import Foundation
            speed: 0.99,
            accuracy: 0.98,
            isMultilingual: true,
-           supportsStreaming: false,
+           supportsStreaming: true,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .elevenLabs)
        ),
        CloudModel(
@@ -262,7 +262,7 @@ import Foundation
            speed: 0.99,
            accuracy: 0.96,
            isMultilingual: true,
-           supportsStreaming: false,
+           supportsStreaming: true,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .deepgram)
        ),
        CloudModel(
@@ -273,7 +273,7 @@ import Foundation
            speed: 0.99,
            accuracy: 0.96,
            isMultilingual: false,
-           supportsStreaming: false,
+           supportsStreaming: true,
            supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .deepgram)
        ),
         CloudModel(
@@ -294,10 +294,10 @@ import Foundation
             speed: 0.99,
             accuracy: 0.97,
             isMultilingual: true,
-            supportsStreaming: false,
+            supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
         ),
-        
+
         // Gemini Models
         CloudModel(
             name: "gemini-2.5-pro",
@@ -358,7 +358,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.97,
             isMultilingual: true,
-            supportsStreaming: false,
+            supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
         ),
 
@@ -371,7 +371,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.98,
             isMultilingual: true,
-            supportsStreaming: false,
+            supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .speechmatics)
         )
      ]

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -1,117 +1,7 @@
 import Foundation
- 
- enum PredefinedModels {
-    static func getLanguageDictionary(isMultilingual: Bool, provider: ModelProvider = .local) -> [String: String] {
-        if !isMultilingual {
-            return ["en": "English"]
-        } else {
-            // For Apple Native models, return only supported languages in simple format
-            if provider == .nativeApple {
-                let appleSupportedCodes = ["ar", "de", "en", "es", "fr", "it", "ja", "ko", "pt", "yue", "zh"]
-                return allLanguages.filter { appleSupportedCodes.contains($0.key) }
-            }
-            // For Speechmatics, return only supported languages
-            if provider == .speechmatics {
-                let speechmaticsSupportedCodes = [
-                    "ar", "ba", "eu", "be", "bn", "bg", "yue", "ca", "hr", "cs", "da",
-                    "nl", "en", "et", "fi", "fr", "gl", "de", "el", "he", "hi",
-                    "hu", "id", "it", "ja", "ko", "lv", "lt", "ms", "mt", "mr",
-                    "mn", "no", "fa", "pl", "pt", "ro", "ru", "sk", "sl", "es",
-                    "sw", "sv", "tl", "ta", "th", "tr", "uk", "ur", "vi", "cy",
-                    "zh"
-                ]
-                var filtered = allLanguages.filter { speechmaticsSupportedCodes.contains($0.key) }
-                filtered["auto"] = "Auto-detect"
-                return filtered
-            }
-            // For xAI, return only the 25 languages supported by Grok STT
-            if provider == .xai {
-                let xaiSupportedCodes = [
-                    "ar", "cs", "da", "nl", "en", "fr", "de", "hi", "id", "it",
-                    "ja", "ko", "mk", "ms", "fa", "pl", "pt", "ro", "ru", "es",
-                    "sv", "th", "tr", "vi"
-                ]
-                var filtered = allLanguages.filter { xaiSupportedCodes.contains($0.key) }
-                filtered["auto"] = "Auto-detect"
-                return filtered
-            }
-            // For Soniox, return only the 60 languages supported by stt-async-v4
-            if provider == .soniox {
-                let sonioxSupportedCodes = [
-                    "af", "sq", "ar", "az", "eu", "be", "bn", "bs", "bg", "ca",
-                    "zh", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "gl",
-                    "de", "el", "gu", "he", "hi", "hu", "id", "it", "ja", "kn",
-                    "kk", "ko", "lv", "lt", "mk", "ms", "ml", "mr", "no", "fa",
-                    "pl", "pt", "pa", "ro", "ru", "sr", "sk", "sl", "es", "sw",
-                    "sv", "tl", "ta", "te", "th", "tr", "uk", "ur", "vi", "cy"
-                ]
-                var filtered = allLanguages.filter { sonioxSupportedCodes.contains($0.key) }
-                filtered["auto"] = "Auto-detect"
-                return filtered
-            }
-            return allLanguages
-        }
-    }
-    
-    // Apple Native Speech specific languages with proper BCP-47 format
-    // Based on actual supported locales from SpeechTranscriber.supportedLocales
-    static let appleNativeLanguages = [
-        // English variants
-        "en-US": "English (United States)",
-        "en-GB": "English (United Kingdom)",
-        "en-CA": "English (Canada)",
-        "en-AU": "English (Australia)",
-        "en-IN": "English (India)",
-        "en-IE": "English (Ireland)",
-        "en-NZ": "English (New Zealand)",
-        "en-ZA": "English (South Africa)",
-        "en-SA": "English (Saudi Arabia)",
-        "en-AE": "English (UAE)",
-        "en-SG": "English (Singapore)",
-        "en-PH": "English (Philippines)",
-        "en-ID": "English (Indonesia)",
-        
-        // Spanish variants
-        "es-ES": "Spanish (Spain)",
-        "es-MX": "Spanish (Mexico)",
-        "es-US": "Spanish (United States)",
-        "es-CO": "Spanish (Colombia)",
-        "es-CL": "Spanish (Chile)",
-        "es-419": "Spanish (Latin America)",
-        
-        // French variants
-        "fr-FR": "French (France)",
-        "fr-CA": "French (Canada)",
-        "fr-BE": "French (Belgium)",
-        "fr-CH": "French (Switzerland)",
-        
-        // German variants
-        "de-DE": "German (Germany)",
-        "de-AT": "German (Austria)",
-        "de-CH": "German (Switzerland)",
-        
-        // Chinese variants
-        "zh-CN": "Chinese Simplified (China)",
-        "zh-TW": "Chinese Traditional (Taiwan)",
-        "zh-HK": "Chinese Traditional (Hong Kong)",
-        
-        // Other Asian languages
-        "ja-JP": "Japanese (Japan)",
-        "ko-KR": "Korean (South Korea)",
-        "yue-CN": "Cantonese (China)",
-        
-        // Portuguese variants
-        "pt-BR": "Portuguese (Brazil)",
-        "pt-PT": "Portuguese (Portugal)",
-        
-        // Italian variants
-        "it-IT": "Italian (Italy)",
-        "it-CH": "Italian (Switzerland)",
-        
-        // Arabic
-        "ar-SA": "Arabic (Saudi Arabia)"
-    ]
-    
+
+enum PredefinedModels {
+
     static var models: [any TranscriptionModel] {
         return predefinedModels + CustomModelManager.shared.customModels
     }
@@ -123,7 +13,7 @@ import Foundation
             displayName: "Apple Speech",
             description: "Uses the native Apple Speech framework for transcription. Requires macOS 26",
             isMultilingualModel: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .nativeApple)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .nativeApple)
         ),
         
         // Parakeet Models
@@ -136,7 +26,7 @@ import Foundation
             accuracy: 0.94,
             ramUsage: 0.8,
             supportsStreaming: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .fluidAudio)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: false, provider: .fluidAudio)
         ),
         FluidAudioModel(
             name: "parakeet-tdt-0.6b-v3",
@@ -147,7 +37,7 @@ import Foundation
             accuracy: 0.94,
             ramUsage: 0.8,
             supportsStreaming: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .fluidAudio)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .fluidAudio)
         ),
 
          // Local Models
@@ -155,7 +45,7 @@ import Foundation
              name: "ggml-tiny",
              displayName: "Tiny",
              size: "75 MB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .local),
              description: "Tiny model, fastest, least accurate",
              speed: 0.95,
              accuracy: 0.6,
@@ -165,7 +55,7 @@ import Foundation
              name: "ggml-tiny.en",
              displayName: "Tiny (English)",
              size: "75 MB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: false, provider: .local),
              description: "Tiny model optimized for English, fastest, least accurate",
              speed: 0.95,
              accuracy: 0.65,
@@ -175,7 +65,7 @@ import Foundation
              name: "ggml-base",
              displayName: "Base",
              size: "142 MB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .local),
              description: "Base model, good balance between speed and accuracy, supports multiple languages",
              speed: 0.85,
              accuracy: 0.72,
@@ -185,7 +75,7 @@ import Foundation
              name: "ggml-base.en",
              displayName: "Base (English)",
              size: "142 MB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: false, provider: .local),
              description: "Base model optimized for English, good balance between speed and accuracy",
              speed: 0.85,
              accuracy: 0.75,
@@ -195,7 +85,7 @@ import Foundation
              name: "ggml-large-v2",
              displayName: "Large v2",
              size: "2.9 GB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .local),
              description: "Large model v2, slower than Medium but more accurate",
              speed: 0.3,
              accuracy: 0.96,
@@ -205,7 +95,7 @@ import Foundation
              name: "ggml-large-v3",
              displayName: "Large v3",
              size: "2.9 GB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .local),
              description: "Large model v3, very slow but most accurate",
              speed: 0.3,
              accuracy: 0.98,
@@ -215,7 +105,7 @@ import Foundation
              name: "ggml-large-v3-turbo",
              displayName: "Large v3 Turbo",
              size: "1.5 GB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .local),
              description:
              "Large model v3 Turbo, faster than v3 with similar accuracy",
              speed: 0.75,
@@ -226,7 +116,7 @@ import Foundation
              name: "ggml-large-v3-turbo-q5_0",
              displayName: "Large v3 Turbo (Quantized)",
              size: "547 MB",
-             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .local),
+             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .local),
              description: "Quantized version of Large v3 Turbo, faster with slightly lower accuracy",
              speed: 0.75,
              accuracy: 0.95,
@@ -242,7 +132,7 @@ import Foundation
             speed: 0.65,
             accuracy: 0.95,
             isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .groq)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .groq)
         ),
         CloudModel(
            name: "scribe_v1",
@@ -252,7 +142,7 @@ import Foundation
            speed: 0.7,
            accuracy: 0.98,
            isMultilingual: true,
-           supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .elevenLabs)
+           supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .elevenLabs)
        ),
        CloudModel(
            name: "scribe_v2",
@@ -263,7 +153,7 @@ import Foundation
            accuracy: 0.98,
            isMultilingual: true,
            supportsStreaming: true,
-           supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .elevenLabs)
+           supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .elevenLabs)
        ),
        CloudModel(
            name: "nova-3",
@@ -274,7 +164,7 @@ import Foundation
            accuracy: 0.96,
            isMultilingual: true,
            supportsStreaming: true,
-           supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .deepgram)
+           supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .deepgram)
        ),
        CloudModel(
            name: "nova-3-medical",
@@ -285,7 +175,7 @@ import Foundation
            accuracy: 0.96,
            isMultilingual: false,
            supportsStreaming: true,
-           supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .deepgram)
+           supportedLanguages: LanguageDictionary.forProvider(isMultilingual: false, provider: .deepgram)
        ),
         CloudModel(
             name: "voxtral-mini-latest",
@@ -296,7 +186,7 @@ import Foundation
             accuracy: 0.98,
             isMultilingual: true,
             supportsStreaming: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .mistral)
         ),
         CloudModel(
             name: "grok-stt",
@@ -307,7 +197,7 @@ import Foundation
             accuracy: 0.98,
             isMultilingual: true,
             supportsStreaming: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .xai)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .xai)
         ),
 
         // Gemini Models
@@ -319,7 +209,7 @@ import Foundation
             speed: 0.7,
             accuracy: 0.97,
             isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .gemini)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
         ),
         CloudModel(
             name: "gemini-2.5-flash",
@@ -329,7 +219,7 @@ import Foundation
             speed: 0.9,
             accuracy: 0.95,
             isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .gemini)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
         ),
         CloudModel(
             name: "gemini-3.1-pro-preview",
@@ -339,7 +229,7 @@ import Foundation
             speed: 0.75,
             accuracy: 0.97,
             isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .gemini)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
         ),
         CloudModel(
             name: "gemini-3-flash-preview",
@@ -349,7 +239,7 @@ import Foundation
             speed: 0.92,
             accuracy: 0.95,
             isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .gemini)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
         )
         ,
         CloudModel(
@@ -361,7 +251,7 @@ import Foundation
             accuracy: 0.98,
             isMultilingual: true,
             supportsStreaming: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .soniox)
         ),
 
         // Speechmatics Models
@@ -374,111 +264,7 @@ import Foundation
             accuracy: 0.98,
             isMultilingual: true,
             supportsStreaming: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .speechmatics)
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .speechmatics)
         )
-     ]
- 
-     static let allLanguages = [
-         "auto": "Auto-detect",
-         "af": "Afrikaans",
-         "am": "Amharic",
-         "ar": "Arabic",
-         "as": "Assamese",
-         "az": "Azerbaijani",
-         "ba": "Bashkir",
-         "be": "Belarusian",
-         "bg": "Bulgarian",
-         "bn": "Bengali",
-         "bo": "Tibetan",
-         "br": "Breton",
-         "bs": "Bosnian",
-         "ca": "Catalan",
-         "cs": "Czech",
-         "cy": "Welsh",
-         "da": "Danish",
-         "de": "German",
-         "el": "Greek",
-         "en": "English",
-         "es": "Spanish",
-         "et": "Estonian",
-         "eu": "Basque",
-         "fa": "Persian",
-         "fi": "Finnish",
-         "fo": "Faroese",
-         "fr": "French",
-         "gl": "Galician",
-         "gu": "Gujarati",
-         "ha": "Hausa",
-         "haw": "Hawaiian",
-         "he": "Hebrew",
-         "hi": "Hindi",
-         "hr": "Croatian",
-         "ht": "Haitian Creole",
-         "hu": "Hungarian",
-         "hy": "Armenian",
-         "id": "Indonesian",
-         "is": "Icelandic",
-         "it": "Italian",
-         "ja": "Japanese",
-         "jw": "Javanese",
-         "ka": "Georgian",
-         "kk": "Kazakh",
-         "km": "Khmer",
-         "kn": "Kannada",
-         "ko": "Korean",
-         "la": "Latin",
-         "lb": "Luxembourgish",
-         "ln": "Lingala",
-         "lo": "Lao",
-         "lt": "Lithuanian",
-         "lv": "Latvian",
-         "mg": "Malagasy",
-         "mi": "Maori",
-         "mk": "Macedonian",
-         "ml": "Malayalam",
-         "mn": "Mongolian",
-         "mr": "Marathi",
-         "ms": "Malay",
-         "mt": "Maltese",
-         "my": "Myanmar",
-         "ne": "Nepali",
-         "nl": "Dutch",
-         "nn": "Norwegian Nynorsk",
-         "no": "Norwegian",
-         "oc": "Occitan",
-         "pa": "Punjabi",
-         "pl": "Polish",
-         "ps": "Pashto",
-         "pt": "Portuguese",
-         "ro": "Romanian",
-         "ru": "Russian",
-         "sa": "Sanskrit",
-         "sd": "Sindhi",
-         "si": "Sinhala",
-         "sk": "Slovak",
-         "sl": "Slovenian",
-         "sn": "Shona",
-         "so": "Somali",
-         "sq": "Albanian",
-         "sr": "Serbian",
-         "su": "Sundanese",
-         "sv": "Swedish",
-         "sw": "Swahili",
-         "ta": "Tamil",
-         "te": "Telugu",
-         "tg": "Tajik",
-         "th": "Thai",
-         "tk": "Turkmen",
-         "tl": "Tagalog",
-         "tr": "Turkish",
-         "tt": "Tatar",
-         "uk": "Ukrainian",
-         "ur": "Urdu",
-         "uz": "Uzbek",
-         "vi": "Vietnamese",
-         "yi": "Yiddish",
-         "yo": "Yoruba",
-         "yue": "Cantonese",
-         "zh": "Chinese",
      ]
  }

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -124,6 +124,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.94,
             ramUsage: 0.8,
+            supportsStreaming: false,
             supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .fluidAudio)
         ),
         FluidAudioModel(
@@ -134,6 +135,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.94,
             ramUsage: 0.8,
+            supportsStreaming: false,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .fluidAudio)
         ),
 
@@ -249,6 +251,7 @@ import Foundation
            speed: 0.99,
            accuracy: 0.98,
            isMultilingual: true,
+           supportsStreaming: false,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .elevenLabs)
        ),
        CloudModel(
@@ -259,6 +262,7 @@ import Foundation
            speed: 0.99,
            accuracy: 0.96,
            isMultilingual: true,
+           supportsStreaming: false,
            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .deepgram)
        ),
        CloudModel(
@@ -269,6 +273,7 @@ import Foundation
            speed: 0.99,
            accuracy: 0.96,
            isMultilingual: false,
+           supportsStreaming: false,
            supportedLanguages: getLanguageDictionary(isMultilingual: false, provider: .deepgram)
        ),
         CloudModel(
@@ -289,6 +294,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.97,
             isMultilingual: true,
+            supportsStreaming: false,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
         ),
         
@@ -352,6 +358,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.97,
             isMultilingual: true,
+            supportsStreaming: false,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
         ),
 
@@ -364,6 +371,7 @@ import Foundation
             speed: 0.99,
             accuracy: 0.98,
             isMultilingual: true,
+            supportsStreaming: false,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .speechmatics)
         )
      ]

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -245,8 +245,8 @@ import Foundation
        ),
        CloudModel(
            name: "scribe_v2",
-           displayName: "Scribe V2 Realtime (ElevenLabs)",
-           description: "ElevenLabs' Scribe V2 Realtime model for the most accurate transcription",
+           displayName: "Scribe V2 (ElevenLabs)",
+           description: "ElevenLabs' Scribe V2 model for the most accurate transcription",
            provider: .elevenLabs,
            speed: 0.99,
            accuracy: 0.98,
@@ -256,8 +256,8 @@ import Foundation
        ),
        CloudModel(
            name: "nova-3",
-           displayName: "Nova 3 Realtime (Deepgram)",
-           description: "Deepgram's latest Nova 3 model for realtime transcription",
+           displayName: "Nova 3 (Deepgram)",
+           description: "Deepgram's latest Nova 3 model for fast, accurate transcription",
            provider: .deepgram,
            speed: 0.99,
            accuracy: 0.96,
@@ -267,7 +267,7 @@ import Foundation
        ),
        CloudModel(
            name: "nova-3-medical",
-           displayName: "Nova 3 Medical Realtime (Deepgram)",
+           displayName: "Nova 3 Medical (Deepgram)",
            description: "Specialized medical transcription model optimized for clinical environments",
            provider: .deepgram,
            speed: 0.99,
@@ -278,21 +278,11 @@ import Foundation
        ),
         CloudModel(
             name: "voxtral-mini-latest",
-            displayName: "Voxtral Transcribe 2 (Mistral)",
-            description: "Mistral's latest transcription model for fast and accurate transcription",
-            provider: .mistral,
-            speed: 0.8,
-            accuracy: 0.98,
-            isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
-        ),
-        CloudModel(
-            name: "voxtral-mini-transcribe-realtime-2602",
-            displayName: "Voxtral Realtime (Mistral)",
-            description: "Mistral's Voxtral Realtime model for streaming transcription",
+            displayName: "Voxtral (Mistral)",
+            description: "Mistral's Voxtral model for fast and accurate transcription",
             provider: .mistral,
             speed: 0.99,
-            accuracy: 0.97,
+            accuracy: 0.98,
             isMultilingual: true,
             supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
@@ -343,20 +333,10 @@ import Foundation
         CloudModel(
             name: "stt-async-v4",
             displayName: "Soniox V4",
-            description: "Soniox asynchronous transcription model v4 with human-parity accuracy",
-            provider: .soniox,
-            speed: 0.8,
-            accuracy: 0.98,
-            isMultilingual: true,
-            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
-        ),
-        CloudModel(
-            name: "stt-rt-v4",
-            displayName: "Soniox Realtime V4",
-            description: "Soniox real-time streaming model v4 for low-latency transcription",
+            description: "Soniox transcription model v4 with human-parity accuracy",
             provider: .soniox,
             speed: 0.99,
-            accuracy: 0.97,
+            accuracy: 0.98,
             isMultilingual: true,
             supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .soniox)
@@ -365,7 +345,7 @@ import Foundation
         // Speechmatics Models
         CloudModel(
             name: "speechmatics-enhanced",
-            displayName: "Speechmatics Realtime",
+            displayName: "Speechmatics",
             description: "Speechmatics enhanced accuracy transcription with real-time streaming and 50+ language support",
             provider: .speechmatics,
             speed: 0.99,

--- a/VoiceInk/Models/PredefinedModels.swift
+++ b/VoiceInk/Models/PredefinedModels.swift
@@ -24,6 +24,17 @@ import Foundation
                 filtered["auto"] = "Auto-detect"
                 return filtered
             }
+            // For xAI, return only the 25 languages supported by Grok STT
+            if provider == .xai {
+                let xaiSupportedCodes = [
+                    "ar", "cs", "da", "nl", "en", "fr", "de", "hi", "id", "it",
+                    "ja", "ko", "mk", "ms", "fa", "pl", "pt", "ro", "ru", "es",
+                    "sv", "th", "tr", "vi"
+                ]
+                var filtered = allLanguages.filter { xaiSupportedCodes.contains($0.key) }
+                filtered["auto"] = "Auto-detect"
+                return filtered
+            }
             // For Soniox, return only the 60 languages supported by stt-async-v4
             if provider == .soniox {
                 let sonioxSupportedCodes = [
@@ -286,6 +297,17 @@ import Foundation
             isMultilingual: true,
             supportsStreaming: true,
             supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .mistral)
+        ),
+        CloudModel(
+            name: "grok-stt",
+            displayName: "Grok (xAI)",
+            description: "xAI's Grok speech-to-text with real-time streaming and batch transcription",
+            provider: .xai,
+            speed: 0.99,
+            accuracy: 0.98,
+            isMultilingual: true,
+            supportsStreaming: true,
+            supportedLanguages: getLanguageDictionary(isMultilingual: true, provider: .xai)
         ),
 
         // Gemini Models

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -28,7 +28,6 @@ protocol TranscriptionModel: Identifiable, Hashable {
     var isMultilingualModel: Bool { get }
     var supportedLanguages: [String: String] { get }
 
-    // Streaming capability
     var supportsStreaming: Bool { get }
 }
 
@@ -71,6 +70,18 @@ struct FluidAudioModel: TranscriptionModel {
         supportedLanguages.count > 1
     }
     let supportedLanguages: [String: String]
+
+    init(name: String, displayName: String, description: String, size: String, speed: Double, accuracy: Double, ramUsage: Double, supportsStreaming: Bool = false, supportedLanguages: [String: String]) {
+        self.name = name
+        self.displayName = displayName
+        self.description = description
+        self.size = size
+        self.speed = speed
+        self.accuracy = accuracy
+        self.ramUsage = ramUsage
+        self.supportsStreaming = supportsStreaming
+        self.supportedLanguages = supportedLanguages
+    }
 }
 
 // A new struct for cloud models

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -137,7 +137,7 @@ struct CustomCloudModel: TranscriptionModel, Codable {
         self.apiEndpoint = apiEndpoint
         self.modelName = modelName
         self.isMultilingualModel = isMultilingual
-        self.supportedLanguages = supportedLanguages ?? PredefinedModels.getLanguageDictionary(isMultilingual: isMultilingual)
+        self.supportedLanguages = supportedLanguages ?? LanguageDictionary.forProvider(isMultilingual: isMultilingual)
     }
 
     /// Custom Codable to migrate legacy apiKey from JSON to Keychain.
@@ -215,6 +215,6 @@ struct ImportedLocalModel: TranscriptionModel {
         self.displayName = fileBaseName
         self.description = "Imported local model"
         self.isMultilingualModel = true
-        self.supportedLanguages = PredefinedModels.getLanguageDictionary(isMultilingual: true, provider: .local)
+        self.supportedLanguages = LanguageDictionary.forProvider(isMultilingual: true, provider: .local)
     }
 }

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -11,6 +11,7 @@ enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case gemini = "Gemini"
     case soniox = "Soniox"
     case speechmatics = "Speechmatics"
+    case xai = "xAI"
     case custom = "Custom"
     case nativeApple = "Native Apple"
     // Future providers can be added here

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -28,6 +28,8 @@ protocol TranscriptionModel: Identifiable, Hashable {
     var isMultilingualModel: Bool { get }
     var supportedLanguages: [String: String] { get }
 
+    // Streaming capability
+    var supportsStreaming: Bool { get }
 }
 
 extension TranscriptionModel {
@@ -38,6 +40,8 @@ extension TranscriptionModel {
     var language: String {
         isMultilingualModel ? "Multilingual" : "English-only"
     }
+
+    var supportsStreaming: Bool { false }
 }
 
 // A new struct for Apple's native models
@@ -62,6 +66,7 @@ struct FluidAudioModel: TranscriptionModel {
     let speed: Double
     let accuracy: Double
     let ramUsage: Double
+    let supportsStreaming: Bool
     var isMultilingualModel: Bool {
         supportedLanguages.count > 1
     }
@@ -78,9 +83,10 @@ struct CloudModel: TranscriptionModel {
     let speed: Double
     let accuracy: Double
     let isMultilingualModel: Bool
+    let supportsStreaming: Bool
     let supportedLanguages: [String: String]
 
-    init(id: UUID = UUID(), name: String, displayName: String, description: String, provider: ModelProvider, speed: Double, accuracy: Double, isMultilingual: Bool, supportedLanguages: [String: String]) {
+    init(id: UUID = UUID(), name: String, displayName: String, description: String, provider: ModelProvider, speed: Double, accuracy: Double, isMultilingual: Bool, supportsStreaming: Bool = false, supportedLanguages: [String: String]) {
         self.id = id
         self.name = name
         self.displayName = displayName
@@ -89,6 +95,7 @@ struct CloudModel: TranscriptionModel {
         self.speed = speed
         self.accuracy = accuracy
         self.isMultilingualModel = isMultilingual
+        self.supportsStreaming = supportsStreaming
         self.supportedLanguages = supportedLanguages
     }
 }

--- a/VoiceInk/Services/APIKeyManager.swift
+++ b/VoiceInk/Services/APIKeyManager.swift
@@ -21,6 +21,7 @@ final class APIKeyManager {
         "elevenlabs": "elevenLabsAPIKey",
         "soniox": "sonioxAPIKey",
         "speechmatics": "speechmaticsAPIKey",
+        "xai": "xaiAPIKey",
         "openai": "openAIAPIKey",
         "anthropic": "anthropicAPIKey",
         "openrouter": "openRouterAPIKey"
@@ -36,6 +37,7 @@ final class APIKeyManager {
         "ElevenLabsAPIKey": "elevenLabsAPIKey",
         "SonioxAPIKey": "sonioxAPIKey",
         "SpeechmaticsAPIKey": "speechmaticsAPIKey",
+        "XAIAPIKey": "xaiAPIKey",
         "OpenAIAPIKey": "openAIAPIKey",
         "AnthropicAPIKey": "anthropicAPIKey",
         "OpenRouterAPIKey": "openRouterAPIKey"
@@ -206,6 +208,8 @@ final class APIKeyManager {
             return "SonioxAPIKey"
         case "speechmatics":
             return "SpeechmaticsAPIKey"
+        case "xai":
+            return "XAIAPIKey"
         case "openai":
             return "OpenAIAPIKey"
         case "anthropic":

--- a/VoiceInk/Services/StreamingKeysMigration.swift
+++ b/VoiceInk/Services/StreamingKeysMigration.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// One-time migration from legacy per-provider streaming UserDefaults keys
+/// to the generic per-model key pattern ("streaming-enabled-{model.name}").
+///
+/// Safe to delete this file once all users have updated past this version.
+enum StreamingKeysMigration {
+    static func run() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: "streaming-keys-migrated") else { return }
+
+        let legacyMappings: [(old: String, new: [String])] = [
+            ("parakeet-streaming-enabled", [
+                "streaming-enabled-parakeet-tdt-0.6b-v2",
+                "streaming-enabled-parakeet-tdt-0.6b-v3",
+            ]),
+        ]
+
+        for mapping in legacyMappings {
+            if let value = defaults.object(forKey: mapping.old) as? Bool {
+                for newKey in mapping.new {
+                    defaults.set(value, forKey: newKey)
+                }
+                defaults.removeObject(forKey: mapping.old)
+            }
+        }
+
+        defaults.set(true, forKey: "streaming-keys-migrated")
+    }
+}

--- a/VoiceInk/Services/StreamingKeysMigration.swift
+++ b/VoiceInk/Services/StreamingKeysMigration.swift
@@ -1,28 +1,36 @@
 import Foundation
 
-/// One-time migration from legacy per-provider streaming UserDefaults keys
-/// to the generic per-model key pattern ("streaming-enabled-{model.name}").
-///
-/// Safe to delete this file once all users have updated past this version.
+// Safe to delete once all users have updated past this version.
 enum StreamingKeysMigration {
     static func run() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: "streaming-keys-migrated") else { return }
 
-        let legacyMappings: [(old: String, new: [String])] = [
+        let legacyStreamingMappings: [(old: String, new: [String])] = [
             ("parakeet-streaming-enabled", [
                 "streaming-enabled-parakeet-tdt-0.6b-v2",
                 "streaming-enabled-parakeet-tdt-0.6b-v3",
             ]),
         ]
 
-        for mapping in legacyMappings {
+        for mapping in legacyStreamingMappings {
             if let value = defaults.object(forKey: mapping.old) as? Bool {
                 for newKey in mapping.new {
                     defaults.set(value, forKey: newKey)
                 }
                 defaults.removeObject(forKey: mapping.old)
             }
+        }
+
+        // Remap CurrentTranscriptionModel if it points to a removed streaming-only model name.
+        let removedModelMappings: [String: String] = [
+            "stt-rt-v4": "stt-async-v4",
+            "voxtral-mini-transcribe-realtime-2602": "voxtral-mini-latest",
+        ]
+
+        if let savedModel = defaults.string(forKey: "CurrentTranscriptionModel"),
+           let replacement = removedModelMappings[savedModel] {
+            defaults.set(replacement, forKey: "CurrentTranscriptionModel")
         }
 
         defaults.set(true, forKey: "streaming-keys-migrated")

--- a/VoiceInk/Services/StreamingKeysMigration.swift
+++ b/VoiceInk/Services/StreamingKeysMigration.swift
@@ -33,6 +33,23 @@ enum StreamingKeysMigration {
             defaults.set(replacement, forKey: "CurrentTranscriptionModel")
         }
 
+        // Remap selectedTranscriptionModelName inside each stored PowerModeConfig.
+        // Uses JSONSerialization so the migration stays independent of the PowerModeConfig struct shape.
+        let powerModeKey = "powerModeConfigurationsV2"
+        if let data = defaults.data(forKey: powerModeKey),
+           var configs = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] {
+            var changed = false
+            for index in configs.indices {
+                guard let savedModel = configs[index]["selectedTranscriptionModelName"] as? String,
+                      let replacement = removedModelMappings[savedModel] else { continue }
+                configs[index]["selectedTranscriptionModelName"] = replacement
+                changed = true
+            }
+            if changed, let newData = try? JSONSerialization.data(withJSONObject: configs) {
+                defaults.set(newData, forKey: powerModeKey)
+            }
+        }
+
         defaults.set(true, forKey: "streaming-keys-migrated")
     }
 }

--- a/VoiceInk/Transcription/Batch/CloudTranscriptionService.swift
+++ b/VoiceInk/Transcription/Batch/CloudTranscriptionService.swift
@@ -121,6 +121,16 @@ class CloudTranscriptionService: TranscriptionService {
                     customVocabulary: customVocabulary
                 )
 
+            case .xai:
+                let apiKey = try requireAPIKey(forProvider: "xAI")
+                return try await XAIClient.transcribe(
+                    audioData: audioData,
+                    fileName: fileName,
+                    apiKey: apiKey,
+                    language: language,
+                    format: true
+                )
+
             case .custom:
                 guard let customModel = model as? CustomCloudModel else {
                     throw CloudTranscriptionError.unsupportedProvider

--- a/VoiceInk/Transcription/Core/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionModelManager.swift
@@ -62,6 +62,8 @@ class TranscriptionModelManager: ObservableObject {
                 return APIKeyManager.shared.hasAPIKey(forProvider: "Soniox")
             case .speechmatics:
                 return APIKeyManager.shared.hasAPIKey(forProvider: "Speechmatics")
+            case .xai:
+                return APIKeyManager.shared.hasAPIKey(forProvider: "xAI")
             case .custom:
                 return true
             }

--- a/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
@@ -38,10 +38,9 @@ class TranscriptionServiceRegistry {
     }
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        let effectiveModel = batchFallbackModel(for: model) ?? model
-        let service = service(for: effectiveModel.provider)
-        logger.debug("Transcribing with \(effectiveModel.displayName, privacy: .public) using \(String(describing: type(of: service)), privacy: .public)")
-        return try await service.transcribe(audioURL: audioURL, model: effectiveModel)
+        let service = service(for: model.provider)
+        logger.debug("Transcribing with \(model.displayName, privacy: .public) using \(String(describing: type(of: service)), privacy: .public)")
+        return try await service.transcribe(audioURL: audioURL, model: model)
     }
 
     /// Creates a streaming or file-based session depending on the model's capabilities.
@@ -53,22 +52,9 @@ class TranscriptionServiceRegistry {
                 onPartialTranscript: onPartialTranscript
             )
             let fallback = service(for: model.provider)
-            let fallbackModel = batchFallbackModel(for: model)
-            return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback, fallbackModel: fallbackModel)
+            return StreamingTranscriptionSession(streamingService: streamingService, fallbackService: fallback)
         } else {
             return FileTranscriptionSession(service: service(for: model.provider))
-        }
-    }
-
-    // Maps streaming-only models to a batch-compatible equivalent for fallback.
-    private func batchFallbackModel(for model: any TranscriptionModel) -> (any TranscriptionModel)? {
-        switch (model.provider, model.name) {
-        case (.mistral, "voxtral-mini-transcribe-realtime-2602"):
-            return PredefinedModels.models.first { $0.name == "voxtral-mini-latest" }
-        case (.soniox, "stt-rt-v4"):
-            return PredefinedModels.models.first { $0.name == "stt-async-v4" }
-        default:
-            return nil
         }
     }
 

--- a/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionServiceRegistry.swift
@@ -74,22 +74,8 @@ class TranscriptionServiceRegistry {
 
     /// Whether the given model supports streaming transcription
     private func supportsStreaming(model: any TranscriptionModel) -> Bool {
-        switch model.provider {
-        case .elevenLabs:
-            return model.name == "scribe_v2"
-        case .deepgram:
-            return model.name == "nova-3" || model.name == "nova-3-medical"
-        case .mistral:
-            return model.name == "voxtral-mini-transcribe-realtime-2602"
-        case .soniox:
-            return model.name == "stt-rt-v4"
-        case .speechmatics:
-            return model.name == "speechmatics-enhanced"
-        case .fluidAudio:
-            return UserDefaults.standard.object(forKey: "parakeet-streaming-enabled") as? Bool ?? true
-        default:
-            return false
-        }
+        guard model.supportsStreaming else { return false }
+        return UserDefaults.standard.object(forKey: "streaming-enabled-\(model.name)") as? Bool ?? true
     }
 
     func cleanup() async {

--- a/VoiceInk/Transcription/Core/TranscriptionSession.swift
+++ b/VoiceInk/Transcription/Core/TranscriptionSession.swift
@@ -50,16 +50,13 @@ final class FileTranscriptionSession: TranscriptionSession {
 final class StreamingTranscriptionSession: TranscriptionSession {
     private let streamingService: StreamingTranscriptionService
     private let fallbackService: TranscriptionService
-    // Batch-compatible override for streaming-only models rejected by the provider's REST API.
-    private let fallbackModel: (any TranscriptionModel)?
     private var model: (any TranscriptionModel)?
     private var streamingFailed = false
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "StreamingTranscriptionSession")
 
-    init(streamingService: StreamingTranscriptionService, fallbackService: TranscriptionService, fallbackModel: (any TranscriptionModel)? = nil) {
+    init(streamingService: StreamingTranscriptionService, fallbackService: TranscriptionService) {
         self.streamingService = streamingService
         self.fallbackService = fallbackService
-        self.fallbackModel = fallbackModel
     }
 
     func prepare(model: any TranscriptionModel) async throws -> ((Data) -> Void)? {
@@ -108,10 +105,8 @@ final class StreamingTranscriptionSession: TranscriptionSession {
             streamingService.cancel()
         }
 
-        // Use fallbackModel if set — streaming-only models are rejected by the batch REST API.
-        let modelForFallback = fallbackModel ?? model
-        logger.notice("Using batch fallback for \(model.displayName, privacy: .public) with model \(modelForFallback.displayName, privacy: .public)")
-        return try await fallbackService.transcribe(audioURL: audioURL, model: modelForFallback)
+        logger.notice("Using batch fallback for \(model.displayName, privacy: .public)")
+        return try await fallbackService.transcribe(audioURL: audioURL, model: model)
     }
 
     func cancel() {

--- a/VoiceInk/Transcription/Streaming/SonioxStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/SonioxStreamingProvider.swift
@@ -36,7 +36,7 @@ final class SonioxStreamingProvider: StreamingTranscriptionProvider {
         startEventForwarding()
 
         do {
-            try await client.connect(apiKey: apiKey, model: model.name, language: language, customVocabulary: vocabulary)
+            try await client.connect(apiKey: apiKey, model: "stt-rt-v4", language: language, customVocabulary: vocabulary)
         } catch {
             // Clean up forwarding task on connection failure
             forwardingTask?.cancel()

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -178,6 +178,8 @@ class StreamingTranscriptionService {
             return SonioxStreamingProvider(modelContext: modelContext)
         case .speechmatics:
             return SpeechmaticsStreamingProvider(modelContext: modelContext)
+        case .xai:
+            return XAIStreamingProvider()
         case .fluidAudio:
             guard let fluidAudioService else {
                 fatalError("FluidAudioTranscriptionService required for FluidAudio streaming. Ensure it is passed to StreamingTranscriptionService.")
@@ -229,8 +231,11 @@ class StreamingTranscriptionService {
                         if !trimmed.isEmpty {
                             self.committedSegments.append(trimmed)
                         }
-
-                        // Signal for any committed response (including empty) during committing phase.
+                        // Refresh the live preview so it keeps showing the full running transcript
+                        // after a commit (instead of resetting to empty until the next partial).
+                        if self.state == .streaming {
+                            self.onPartialTranscript?(self.committedSegments.joined(separator: " "))
+                        }
                         if self.state == .committing {
                             self.commitSignal?.yield()
                         }
@@ -238,7 +243,9 @@ class StreamingTranscriptionService {
                 case .partial(let text):
                     await MainActor.run {
                         if self.state == .streaming {
-                            self.onPartialTranscript?(text)
+                            let prefix = self.committedSegments.joined(separator: " ")
+                            let display = prefix.isEmpty ? text : prefix + " " + text
+                            self.onPartialTranscript?(display)
                         }
                     }
                 case .sessionStarted:

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -244,7 +244,15 @@ class StreamingTranscriptionService {
                     await MainActor.run {
                         if self.state == .streaming {
                             let prefix = self.committedSegments.joined(separator: " ")
-                            let display = prefix.isEmpty ? text : prefix + " " + text
+                            let display: String
+                            if prefix.isEmpty {
+                                display = text
+                            } else if text.hasPrefix(prefix) || text.hasPrefix(prefix + " ") {
+                                // Provider already sends cumulative partials (e.g. FluidAudio fullText).
+                                display = text
+                            } else {
+                                display = prefix + " " + text
+                            }
                             self.onPartialTranscript?(display)
                         }
                     }

--- a/VoiceInk/Transcription/Streaming/XAIStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/XAIStreamingProvider.swift
@@ -1,0 +1,97 @@
+import Foundation
+import LLMkit
+
+/// xAI streaming provider wrapping `LLMkit.XAIStreamingClient`.
+final class XAIStreamingProvider: StreamingTranscriptionProvider {
+
+    private let client = LLMkit.XAIStreamingClient()
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var forwardingTask: Task<Void, Never>?
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init() {
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    deinit {
+        forwardingTask?.cancel()
+        eventsContinuation?.finish()
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "xAI"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        forwardingTask?.cancel()
+        startEventForwarding()
+
+        do {
+            try await client.connect(apiKey: apiKey, model: "", language: language)
+        } catch {
+            forwardingTask?.cancel()
+            forwardingTask = nil
+            throw mapError(error)
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        do {
+            try await client.sendAudioChunk(data)
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func commit() async throws {
+        do {
+            try await client.commit()
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func disconnect() async {
+        forwardingTask?.cancel()
+        forwardingTask = nil
+        await client.disconnect()
+        eventsContinuation?.finish()
+    }
+
+    // MARK: - Private
+
+    private func startEventForwarding() {
+        forwardingTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.client.transcriptionEvents {
+                switch event {
+                case .sessionStarted:
+                    self.eventsContinuation?.yield(.sessionStarted)
+                case .partial(let text):
+                    self.eventsContinuation?.yield(.partial(text: text))
+                case .committed(let text):
+                    self.eventsContinuation?.yield(.committed(text: text))
+                case .error(let message):
+                    self.eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(message)))
+                }
+            }
+        }
+    }
+
+    private func mapError(_ error: Error) -> Error {
+        guard let llmError = error as? LLMKitError else { return error }
+        switch llmError {
+        case .missingAPIKey:
+            return StreamingTranscriptionError.missingAPIKey
+        case .httpError(_, let message):
+            return StreamingTranscriptionError.serverError(message)
+        case .networkError(let detail):
+            return StreamingTranscriptionError.connectionFailed(detail)
+        default:
+            return StreamingTranscriptionError.serverError(llmError.localizedDescription ?? "Unknown error")
+        }
+    }
+}

--- a/VoiceInk/Transcription/Streaming/XAIStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/XAIStreamingProvider.swift
@@ -30,7 +30,7 @@ final class XAIStreamingProvider: StreamingTranscriptionProvider {
         startEventForwarding()
 
         do {
-            try await client.connect(apiKey: apiKey, model: "", language: language)
+            try await client.connect(apiKey: apiKey, model: model.name, language: language)
         } catch {
             forwardingTask?.cancel()
             forwardingTask = nil

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -40,6 +40,8 @@ struct CloudModelCardView: View {
             return "Soniox"
         case .speechmatics:
             return "Speechmatics"
+        case .xai:
+            return "xAI"
         default:
             return model.provider.rawValue
         }
@@ -296,6 +298,8 @@ struct CloudModelCardView: View {
                 result = await SonioxClient.verifyAPIKey(key)
             case .speechmatics:
                 result = await SpeechmaticsClient.verifyAPIKey(key)
+            case .xai:
+                result = await XAIClient.verifyAPIKey(key)
             default:
                 await MainActor.run {
                     isVerifying = false

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -11,7 +11,15 @@ struct CloudModelCardView: View {
     @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
     @State private var isExpanded = false
     @State private var apiKey = ""
-    @State private var streamingEnabled = true
+    @State private var streamingEnabled: Bool
+
+    init(model: CloudModel, isCurrent: Bool, setDefaultAction: @escaping () -> Void) {
+        self.model = model
+        self.isCurrent = isCurrent
+        self.setDefaultAction = setDefaultAction
+        let key = "streaming-enabled-\(model.name)"
+        _streamingEnabled = State(initialValue: UserDefaults.standard.object(forKey: key) as? Bool ?? true)
+    }
     @State private var isVerifying = false
     @State private var verificationStatus: VerificationStatus = .none
     @State private var verificationError: String? = nil
@@ -74,7 +82,6 @@ struct CloudModelCardView: View {
         .background(CardBackground(isSelected: isCurrent, useAccentGradientWhenSelected: isCurrent))
         .onAppear {
             loadSavedAPIKey()
-            streamingEnabled = UserDefaults.standard.object(forKey: streamingDefaultsKey) as? Bool ?? true
         }
     }
     

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -11,6 +11,7 @@ struct CloudModelCardView: View {
     @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
     @State private var isExpanded = false
     @State private var apiKey = ""
+    @State private var streamingEnabled = true
     @State private var isVerifying = false
     @State private var verificationStatus: VerificationStatus = .none
     @State private var verificationError: String? = nil
@@ -71,6 +72,7 @@ struct CloudModelCardView: View {
         .background(CardBackground(isSelected: isCurrent, useAccentGradientWhenSelected: isCurrent))
         .onAppear {
             loadSavedAPIKey()
+            streamingEnabled = UserDefaults.standard.object(forKey: streamingDefaultsKey) as? Bool ?? true
         }
     }
     
@@ -198,6 +200,18 @@ struct CloudModelCardView: View {
             
             if isConfigured {
                 Menu {
+                    if model.supportsStreaming {
+                        Button {
+                            streamingEnabled.toggle()
+                            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
+                        } label: {
+                            Label(
+                                streamingEnabled ? "Disable Live Streaming" : "Enable Live Streaming",
+                                systemImage: streamingEnabled ? "waveform.slash" : "waveform"
+                            )
+                        }
+                    }
+
                     Button {
                         clearAPIKey()
                     } label: {
@@ -268,6 +282,10 @@ struct CloudModelCardView: View {
         }
     }
     
+    private var streamingDefaultsKey: String {
+        "streaming-enabled-\(model.name)"
+    }
+
     private func loadSavedAPIKey() {
         if let savedKey = APIKeyManager.shared.getAPIKey(forProvider: providerKey) {
             apiKey = savedKey

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -81,9 +81,13 @@ struct CloudModelCardView: View {
             Text(model.displayName)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
-            
+
             statusBadge
-            
+
+            if model.supportsStreaming && isConfigured {
+                streamingModeBadge
+            }
+
             Spacer()
         }
     }
@@ -115,6 +119,30 @@ struct CloudModelCardView: View {
         }
     }
     
+    private var streamingModeBadge: some View {
+        Button {
+            streamingEnabled.toggle()
+            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: streamingEnabled ? "waveform" : "doc.text")
+                    .font(.system(size: 8, weight: .semibold))
+                Text(streamingEnabled ? "Live" : "Batch")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule().fill(streamingEnabled
+                    ? Color.accentColor.opacity(0.15)
+                    : Color(.secondaryLabelColor).opacity(0.15))
+            )
+            .foregroundColor(streamingEnabled ? Color.accentColor : Color(.secondaryLabelColor))
+        }
+        .buttonStyle(.plain)
+        .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
+    }
+
     private var metadataSection: some View {
         HStack(spacing: 12) {
             // Provider
@@ -200,18 +228,6 @@ struct CloudModelCardView: View {
             
             if isConfigured {
                 Menu {
-                    if model.supportsStreaming {
-                        Button {
-                            streamingEnabled.toggle()
-                            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
-                        } label: {
-                            Label(
-                                streamingEnabled ? "Disable Live Streaming" : "Enable Live Streaming",
-                                systemImage: streamingEnabled ? "waveform.slash" : "waveform"
-                            )
-                        }
-                    }
-
                     Button {
                         clearAPIKey()
                     } label: {

--- a/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardRowView.swift
@@ -82,8 +82,6 @@ struct CloudModelCardView: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
 
-            statusBadge
-
             if model.supportsStreaming && isConfigured {
                 streamingModeBadge
             }
@@ -92,55 +90,16 @@ struct CloudModelCardView: View {
         }
     }
     
-    private var statusBadge: some View {
-        Group {
-            if isCurrent {
-                Text("Default")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.accentColor))
-                    .foregroundColor(.white)
-            } else if isConfigured {
-                Text("Configured")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color(.systemGreen).opacity(0.2)))
-                    .foregroundColor(Color(.systemGreen))
-            } else {
-                Text("Setup Required")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color(.systemOrange).opacity(0.2)))
-                    .foregroundColor(Color(.systemOrange))
-            }
-        }
-    }
-    
     private var streamingModeBadge: some View {
-        Button {
-            streamingEnabled.toggle()
-            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
-        } label: {
-            HStack(spacing: 3) {
-                Image(systemName: streamingEnabled ? "waveform" : "doc.text")
-                    .font(.system(size: 8, weight: .semibold))
-                Text(streamingEnabled ? "Live" : "Batch")
-                    .font(.system(size: 11, weight: .medium))
+        Toggle("Real-time", isOn: $streamingEnabled)
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(Color(.secondaryLabelColor))
+            .onChange(of: streamingEnabled) { _, newValue in
+                UserDefaults.standard.set(newValue, forKey: streamingDefaultsKey)
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(
-                Capsule().fill(streamingEnabled
-                    ? Color.accentColor.opacity(0.15)
-                    : Color(.secondaryLabelColor).opacity(0.15))
-            )
-            .foregroundColor(streamingEnabled ? Color.accentColor : Color(.secondaryLabelColor))
-        }
-        .buttonStyle(.plain)
-        .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
+            .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
     }
 
     private var metadataSection: some View {

--- a/VoiceInk/Views/AI Models/CustomModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/CustomModelCardRowView.swift
@@ -33,29 +33,7 @@ struct CustomModelCardView: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
             
-            statusBadge
-            
             Spacer()
-        }
-    }
-    
-    private var statusBadge: some View {
-        Group {
-            if isCurrent {
-                Text("Default")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.accentColor))
-                    .foregroundColor(.white)
-            } else {
-                Text("Custom")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.orange.opacity(0.2)))
-                    .foregroundColor(Color.orange)
-            }
         }
     }
     

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
@@ -50,8 +50,37 @@ struct FluidAudioModelCardRowView: View {
                 .foregroundColor(Color(.labelColor))
 
             statusBadge
+
+            if model.supportsStreaming && isDownloaded {
+                streamingModeBadge
+            }
+
             Spacer()
         }
+    }
+
+    private var streamingModeBadge: some View {
+        Button {
+            streamingEnabled.toggle()
+            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: streamingEnabled ? "waveform" : "doc.text")
+                    .font(.system(size: 8, weight: .semibold))
+                Text(streamingEnabled ? "Live" : "Batch")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule().fill(streamingEnabled
+                    ? Color.accentColor.opacity(0.15)
+                    : Color(.secondaryLabelColor).opacity(0.15))
+            )
+            .foregroundColor(streamingEnabled ? Color.accentColor : Color(.secondaryLabelColor))
+        }
+        .buttonStyle(.plain)
+        .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
     }
 
     private var statusBadge: some View {
@@ -166,14 +195,6 @@ struct FluidAudioModelCardRowView: View {
                         Label("Show in Finder", systemImage: "folder")
                     }
 
-                    if model.supportsStreaming {
-                        Button {
-                            streamingEnabled.toggle()
-                            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
-                        } label: {
-                            Label(streamingEnabled ? "Disable Live Streaming" : "Enable Live Streaming", systemImage: streamingEnabled ? "waveform.slash" : "waveform")
-                        }
-                    }
                 } label: {
                     Image(systemName: "ellipsis.circle")
                         .font(.system(size: 14))

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
@@ -6,7 +6,15 @@ struct FluidAudioModelCardRowView: View {
     let model: FluidAudioModel
     @ObservedObject var fluidAudioModelManager: FluidAudioModelManager
     @ObservedObject var transcriptionModelManager: TranscriptionModelManager
-    @State private var streamingEnabled = true
+    @State private var streamingEnabled: Bool
+
+    init(model: FluidAudioModel, fluidAudioModelManager: FluidAudioModelManager, transcriptionModelManager: TranscriptionModelManager) {
+        self.model = model
+        _fluidAudioModelManager = ObservedObject(wrappedValue: fluidAudioModelManager)
+        _transcriptionModelManager = ObservedObject(wrappedValue: transcriptionModelManager)
+        let key = "streaming-enabled-\(model.name)"
+        _streamingEnabled = State(initialValue: UserDefaults.standard.object(forKey: key) as? Bool ?? true)
+    }
 
     private var streamingDefaultsKey: String {
         "streaming-enabled-\(model.name)"
@@ -38,9 +46,6 @@ struct FluidAudioModelCardRowView: View {
         }
         .padding(16)
         .background(CardBackground(isSelected: isCurrent, useAccentGradientWhenSelected: isCurrent))
-        .onAppear {
-            streamingEnabled = UserDefaults.standard.object(forKey: streamingDefaultsKey) as? Bool ?? true
-        }
     }
 
     private var headerSection: some View {

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
@@ -6,7 +6,11 @@ struct FluidAudioModelCardRowView: View {
     let model: FluidAudioModel
     @ObservedObject var fluidAudioModelManager: FluidAudioModelManager
     @ObservedObject var transcriptionModelManager: TranscriptionModelManager
-    @AppStorage("parakeet-streaming-enabled") private var streamingEnabled = true
+    @State private var streamingEnabled = true
+
+    private var streamingDefaultsKey: String {
+        "streaming-enabled-\(model.name)"
+    }
 
     var isCurrent: Bool {
         transcriptionModelManager.currentTranscriptionModel?.name == model.name
@@ -34,6 +38,9 @@ struct FluidAudioModelCardRowView: View {
         }
         .padding(16)
         .background(CardBackground(isSelected: isCurrent, useAccentGradientWhenSelected: isCurrent))
+        .onAppear {
+            streamingEnabled = UserDefaults.standard.object(forKey: streamingDefaultsKey) as? Bool ?? true
+        }
     }
 
     private var headerSection: some View {
@@ -159,10 +166,13 @@ struct FluidAudioModelCardRowView: View {
                         Label("Show in Finder", systemImage: "folder")
                     }
 
-                    Button {
-                        streamingEnabled.toggle()
-                    } label: {
-                        Label(streamingEnabled ? "Disable Live Streaming" : "Enable Live Streaming", systemImage: streamingEnabled ? "waveform.slash" : "waveform")
+                    if model.supportsStreaming {
+                        Button {
+                            streamingEnabled.toggle()
+                            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
+                        } label: {
+                            Label(streamingEnabled ? "Disable Live Streaming" : "Enable Live Streaming", systemImage: streamingEnabled ? "waveform.slash" : "waveform")
+                        }
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardRowView.swift
@@ -49,57 +49,19 @@ struct FluidAudioModelCardRowView: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
 
-            statusBadge
-
             if model.supportsStreaming && isDownloaded {
-                streamingModeBadge
+                Toggle("Real-time", isOn: $streamingEnabled)
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(Color(.secondaryLabelColor))
+                    .onChange(of: streamingEnabled) { _, newValue in
+                        UserDefaults.standard.set(newValue, forKey: streamingDefaultsKey)
+                    }
+                    .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
             }
 
             Spacer()
-        }
-    }
-
-    private var streamingModeBadge: some View {
-        Button {
-            streamingEnabled.toggle()
-            UserDefaults.standard.set(streamingEnabled, forKey: streamingDefaultsKey)
-        } label: {
-            HStack(spacing: 3) {
-                Image(systemName: streamingEnabled ? "waveform" : "doc.text")
-                    .font(.system(size: 8, weight: .semibold))
-                Text(streamingEnabled ? "Live" : "Batch")
-                    .font(.system(size: 11, weight: .medium))
-            }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(
-                Capsule().fill(streamingEnabled
-                    ? Color.accentColor.opacity(0.15)
-                    : Color(.secondaryLabelColor).opacity(0.15))
-            )
-            .foregroundColor(streamingEnabled ? Color.accentColor : Color(.secondaryLabelColor))
-        }
-        .buttonStyle(.plain)
-        .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
-    }
-
-    private var statusBadge: some View {
-        Group {
-            if isCurrent {
-                Text("Default")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.accentColor))
-                    .foregroundColor(.white)
-            } else if isDownloaded {
-                Text("Downloaded")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color(.quaternaryLabelColor)))
-                    .foregroundColor(Color(.labelColor))
-            }
         }
     }
 

--- a/VoiceInk/Views/AI Models/LocalModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/LocalModelCardRowView.swift
@@ -42,29 +42,7 @@ struct LocalModelCardView: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
             
-            statusBadge
-            
             Spacer()
-        }
-    }
-    
-    private var statusBadge: some View {
-        Group {
-            if isCurrent {
-                Text("Default")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.accentColor))
-                    .foregroundColor(.white)
-            } else if isDownloaded {
-                Text("Downloaded")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color(.quaternaryLabelColor)))
-                    .foregroundColor(Color(.labelColor))
-            }
         }
     }
     
@@ -213,21 +191,6 @@ struct ImportedLocalModelCardView: View {
                     Text(model.displayName)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(Color(.labelColor))
-                    if isCurrent {
-                        Text("Default")
-                            .font(.system(size: 11, weight: .medium))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Capsule().fill(Color.accentColor))
-                            .foregroundColor(.white)
-                    } else if isDownloaded {
-                        Text("Imported")
-                            .font(.system(size: 11, weight: .medium))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Capsule().fill(Color(.quaternaryLabelColor)))
-                            .foregroundColor(Color(.labelColor))
-                    }
                     Spacer()
                 }
 

--- a/VoiceInk/Views/AI Models/ModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/ModelCardRowView.swift
@@ -58,7 +58,7 @@ struct ModelCardRowView: View {
                         setDefaultAction: setDefaultAction
                     )
                 }
-            case .groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox, .speechmatics:
+            case .groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox, .speechmatics, .xai:
                 if let cloudModel = model as? CloudModel {
                     CloudModelCardView(
                         model: cloudModel,

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -318,7 +318,7 @@ struct ModelManagementView: View {
         case .local:
             return transcriptionModelManager.allAvailableModels.filter { $0.provider == .local || $0.provider == .nativeApple || $0.provider == .fluidAudio }
         case .cloud:
-            let cloudProviders: [ModelProvider] = [.groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox, .speechmatics]
+            let cloudProviders: [ModelProvider] = [.groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox, .speechmatics, .xai]
             return transcriptionModelManager.allAvailableModels.filter { cloudProviders.contains($0.provider) }
         case .custom:
             return transcriptionModelManager.allAvailableModels.filter { $0.provider == .custom }

--- a/VoiceInk/Views/AI Models/NativeModelCardRowView.swift
+++ b/VoiceInk/Views/AI Models/NativeModelCardRowView.swift
@@ -30,29 +30,7 @@ struct NativeAppleModelCardView: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
             
-            statusBadge
-            
             Spacer()
-        }
-    }
-    
-    private var statusBadge: some View {
-        Group {
-            if isCurrent {
-                Text("Default")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.accentColor))
-                    .foregroundColor(.white)
-            } else {
-                Text("Built-in")
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.blue.opacity(0.2)))
-                    .foregroundColor(Color.blue)
-            }
         }
     }
     

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -7,6 +7,7 @@ struct ModelSettingsView: View {
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("AppendTrailingSpace") private var appendTrailingSpace = true
     @AppStorage("PrewarmModelOnWake") private var prewarmModelOnWake = true
+    @AppStorage("showLiveTextPreview") private var showLiveTextPreview = true
     @State private var customPrompt: String = ""
     @State private var isEditing: Bool = false
 
@@ -73,6 +74,14 @@ struct ModelSettingsView: View {
                     HStack(spacing: 4) {
                         Text("Prewarm model (Experimental)")
                         InfoTip("Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization.")
+                    }
+                }
+                .toggleStyle(.switch)
+
+                Toggle(isOn: $showLiveTextPreview) {
+                    HStack(spacing: 4) {
+                        Text("Show Live Text Preview")
+                        InfoTip("Displays the live transcript preview in the recorder while speaking. Only applies when using real-time streaming models.")
                     }
                 }
                 .toggleStyle(.switch)

--- a/VoiceInk/Views/Recorder/MiniRecorderView.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderView.swift
@@ -5,6 +5,7 @@ struct MiniRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     @ObservedObject var recorder: Recorder
     @EnvironmentObject var windowManager: MiniWindowManager
     @EnvironmentObject private var enhancementService: AIEnhancementService
+    @AppStorage("showLiveTextPreview") private var showLiveTextPreview = true
 
     @State private var activePopover: ActivePopoverState = .none
 
@@ -18,7 +19,9 @@ struct MiniRecorderView<S: RecorderStateProvider & ObservableObject>: View {
 
     // true when live transcript is streaming in during recording
     private var hasLiveTranscript: Bool {
-        stateProvider.recordingState == .recording && !stateProvider.partialTranscript.isEmpty
+        showLiveTextPreview
+            && stateProvider.recordingState == .recording
+            && !stateProvider.partialTranscript.isEmpty
     }
 
     private var controlBar: some View {

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -5,6 +5,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     @ObservedObject var recorder: Recorder
     @EnvironmentObject var windowManager: NotchWindowManager
     @EnvironmentObject private var enhancementService: AIEnhancementService
+    @AppStorage("showLiveTextPreview") private var showLiveTextPreview = true
     @ObservedObject private var powerModeManager = PowerModeManager.shared
     @State private var activePopover: ActivePopoverState = .none
 
@@ -19,7 +20,8 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     private var displayState: DisplayState {
         switch stateProvider.recordingState {
         case .recording:
-            return stateProvider.partialTranscript.isEmpty ? .active : .liveText
+            let shouldShowLive = showLiveTextPreview && !stateProvider.partialTranscript.isEmpty
+            return shouldShowLive ? .liveText : .active
         case .transcribing, .enhancing:
             return .active
         default:

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -128,7 +128,8 @@ struct VoiceInkApp: App {
         engine.recorderUIManager = recorderUIManager
 
         // 6. Initialize model state
-        // refreshAllAvailableModels must run before loadCurrentTranscriptionModel so imported models are present when restoring the saved selection.
+        // Migration and refreshAllAvailableModels must run before loadCurrentTranscriptionModel so renamed keys are remapped and imported models are present when restoring the saved selection.
+        StreamingKeysMigration.run()
         whisperModelManager.createModelsDirectoryIfNeeded()
         whisperModelManager.loadAvailableModels()
         transcriptionModelManager.refreshAllAvailableModels()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a per-model Real-time streaming toggle, unifies streaming across providers, and adds a Live Text Preview in the recorder. Also adds xAI Grok STT with streaming and batch support, plus a shared `LanguageDictionary` with accurate per-provider language lists.

- **New Features**
  - Real-time toggle on Cloud and FluidAudio model cards; saved per model as `streaming-enabled-<model.name>`.
  - Models declare `supportsStreaming`; the registry + toggle decide when to open streaming sessions.
  - “Show Live Text Preview” setting; recorder shows a cumulative running transcript during streaming and keeps it visible after commits.
  - Added xAI Grok STT: new cloud model with streaming and batch transcription, API key support, and a curated 25-language list.
  - Consolidated model list and names: removed “Realtime,” merged to “Soniox V4” (batch `stt-async-v4`, streaming provider uses `stt-rt-v4`) and “Voxtral (Mistral)” (batch `voxtral-mini-latest`, streaming provider uses its realtime model).
  - Removed status badge pills from model cards; show a small “Real-time” toggle when supported.
  - Extracted `LanguageDictionary` with precise per-provider language support (adds Apple BCP-47 variants and “Auto-detect” where applicable; local/`groq`/`gemini` use full lists).
  - Updated `LLMkit` to the latest revision to support xAI streaming.
  - Fixed streaming toggle flicker by initializing toggle state from `UserDefaults` in card initializers.

- **Migration**
  - `StreamingKeysMigration` moves `parakeet-streaming-enabled` to per-model keys and remaps removed model names (`stt-rt-v4` → `stt-async-v4`, `voxtral-mini-transcribe-realtime-2602` → `voxtral-mini-latest`), including inside saved Power Mode configs.
  - Runs before restoring the saved model to keep the user’s selection during upgrade.

<sup>Written for commit 929d40b799c81e2040e9deecfc13d6fd9c1fc9b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

