### PR TITLE
Refactor startRecording to callback-based API; delay audio mute until…

### DIFF
--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -95,63 +95,51 @@ class Recorder: NSObject, ObservableObject {
         }
     }
 
-    func startRecording(toOutputFile url: URL) async throws {
+    func startRecording(toOutputFile url: URL, completion: @escaping (Result<Void, Error>) -> Void) {
         logger.notice("startRecording called – deviceID=\(self.deviceManager.getCurrentDevice(), privacy: .public), file=\(url.lastPathComponent, privacy: .public)")
         deviceManager.isRecordingActive = true
-        
+
         let currentDeviceID = deviceManager.getCurrentDevice()
         let lastDeviceID = UserDefaults.standard.string(forKey: "lastUsedMicrophoneDeviceID")
-        
         if String(currentDeviceID) != lastDeviceID {
             if let deviceName = deviceManager.availableDevices.first(where: { $0.id == currentDeviceID })?.name {
-                await MainActor.run {
-                    NotificationManager.shared.showNotification(
-                        title: "Using: \(deviceName)",
-                        type: .info
-                    )
-                }
+                NotificationManager.shared.showNotification(title: "Using: \(deviceName)", type: .info)
             }
         }
         UserDefaults.standard.set(String(currentDeviceID), forKey: "lastUsedMicrophoneDeviceID")
-        
 
-        let deviceID = deviceManager.getCurrentDevice()
+        let deviceID = currentDeviceID
 
-        do {
-            let coreAudioRecorder = CoreAudioRecorder()
-            coreAudioRecorder.onAudioChunk = onAudioChunk
-            recorder = coreAudioRecorder
+        let coreAudioRecorder = CoreAudioRecorder()
+        coreAudioRecorder.onAudioChunk = onAudioChunk
+        recorder = coreAudioRecorder
 
-            audioRestorationTask?.cancel()
-            audioRestorationTask = nil
-            _ = await mediaController.muteSystemAudio()
+        audioRestorationTask?.cancel()
+        audioRestorationTask = nil
+        audioMeterUpdateTimer?.cancel()
 
-            // Offload initialization to background thread to avoid hotkey lag.
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                audioSetupQueue.async {
-                    do {
-                        try coreAudioRecorder.startRecording(toOutputFile: url, deviceID: deviceID)
-                        continuation.resume()
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
+        let capturedLogger = logger
+        // Offload initialization to background thread to avoid hotkey lag.
+        audioSetupQueue.async { [weak self] in
+            do {
+                try coreAudioRecorder.startRecording(toOutputFile: url, deviceID: deviceID)
+                capturedLogger.notice("startRecording: CoreAudioRecorder started successfully")
+                DispatchQueue.main.async { [weak self] in
+                    self?.startAudioMeterTimer()
                 }
+                Task { [weak self] in
+                    guard let self = self else { return }
+                    await self.playbackController.pauseMedia()
+                }
+                completion(.success(()))
+            } catch {
+                capturedLogger.error("Failed to start recording: \(error.localizedDescription, privacy: .public)")
+                DispatchQueue.main.async { [weak self] in
+                    self?.stopRecording()
+                    self?.deviceManager.isRecordingActive = false
+                }
+                completion(.failure(error))
             }
-            logger.notice("startRecording: CoreAudioRecorder started successfully")
-
-            Task { [weak self] in
-                guard let self = self else { return }
-                await self.playbackController.pauseMedia()
-            }
-
-            audioMeterUpdateTimer?.cancel()
-
-            startAudioMeterTimer()
-
-        } catch {
-            logger.error("Failed to create audio recorder: \(error.localizedDescription, privacy: .public)")
-            stopRecording()
-            throw RecorderError.couldNotStartRecording
         }
     }
 
@@ -159,7 +147,7 @@ class Recorder: NSObject, ObservableObject {
         logger.notice("stopRecording called")
         audioMeterUpdateTimer?.cancel()
         audioMeterUpdateTimer = nil
-        
+
         // Capture current recorder to stop it on the serial hardware queue
         let currentRecorder = self.recorder
         audioSetupQueue.async {

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -131,14 +131,16 @@ class Recorder: NSObject, ObservableObject {
                     guard let self = self else { return }
                     await self.playbackController.pauseMedia()
                 }
-                completion(.success(()))
+                DispatchQueue.main.async {
+                    completion(.success(()))
+                }
             } catch {
                 capturedLogger.error("Failed to start recording: \(error.localizedDescription, privacy: .public)")
                 DispatchQueue.main.async { [weak self] in
                     self?.stopRecording()
                     self?.deviceManager.isRecordingActive = false
+                    completion(.failure(error))
                 }
-                completion(.failure(error))
             }
         }
     }

--- a/VoiceInk/SoundManager.swift
+++ b/VoiceInk/SoundManager.swift
@@ -2,6 +2,14 @@ import Foundation
 import AVFoundation
 import SwiftUI
 
+private final class AudioPlayerCompletionDelegate: NSObject, AVAudioPlayerDelegate {
+    private let onFinished: () -> Void
+    init(_ onFinished: @escaping () -> Void) { self.onFinished = onFinished }
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        DispatchQueue.main.async { self.onFinished() }
+    }
+}
+
 @MainActor
 class SoundManager: ObservableObject {
     static let shared = SoundManager()
@@ -11,6 +19,7 @@ class SoundManager: ObservableObject {
     private var escSound: AVAudioPlayer?
     private var customStartSound: AVAudioPlayer?
     private var customStopSound: AVAudioPlayer?
+    private var startSoundDelegate: AudioPlayerCompletionDelegate?
 
     @AppStorage("isSoundFeedbackEnabled") private var isSoundFeedbackEnabled = true
 
@@ -83,14 +92,26 @@ class SoundManager: ObservableObject {
         }
     }
 
-    func playStartSound() {
-        guard isSoundFeedbackEnabled else { return }
-
-        if let custom = customStartSound {
-            custom.play()
+    func playStartSound(onFinished: (() -> Void)? = nil) {
+        guard isSoundFeedbackEnabled else {
+            onFinished?()
+            return
+        }
+        guard let player = customStartSound ?? startSound else {
+            onFinished?()
+            return
+        }
+        player.volume = 0.4
+        if let onFinished {
+            let delegate = AudioPlayerCompletionDelegate(onFinished)
+            startSoundDelegate = delegate
+            player.delegate = delegate
         } else {
-            startSound?.volume = 0.4
-            startSound?.play()
+            startSoundDelegate = nil
+            player.delegate = nil
+        }
+        DispatchQueue.global(qos: .userInteractive).async {
+            player.play()
         }
     }
 

--- a/VoiceInk/SoundManager.swift
+++ b/VoiceInk/SoundManager.swift
@@ -110,9 +110,7 @@ class SoundManager: ObservableObject {
             startSoundDelegate = nil
             player.delegate = nil
         }
-        DispatchQueue.global(qos: .userInteractive).async {
-            player.play()
-        }
+        player.play()
     }
 
     func playStopSound() {

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -27,12 +27,10 @@ class RecorderUIManager: ObservableObject {
 
     @Published var isMiniRecorderVisible = false {
         didSet {
-            Task { @MainActor in
-                if isMiniRecorderVisible {
-                    showRecorderPanel()
-                } else {
-                    hideRecorderPanel()
-                }
+            if isMiniRecorderVisible {
+                showRecorderPanel()
+            } else {
+                hideRecorderPanel()
             }
         }
     }
@@ -96,7 +94,9 @@ class RecorderUIManager: ObservableObject {
                 await cancelRecording()
             }
         } else {
-            SoundManager.shared.playStartSound()
+            SoundManager.shared.playStartSound {
+                Task { await MediaController.shared.muteSystemAudio() }
+            }
             await MainActor.run { isMiniRecorderVisible = true }
             await engine.toggleRecord(powerModeId: powerModeId)
         }

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -51,14 +51,6 @@ class TranscriptionPipeline {
             return
         }
 
-        Task {
-            let isSystemMuteEnabled = UserDefaults.standard.bool(forKey: "isSystemMuteEnabled")
-            if isSystemMuteEnabled {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-            }
-            SoundManager.shared.playStopSound()
-        }
-
         var finalPastedText: String?
         var promptDetectionResult: PromptDetectionService.PromptDetectionResult?
 
@@ -174,7 +166,8 @@ class TranscriptionPipeline {
                     """
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) {
+                SoundManager.shared.playStopSound()
                 let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
                 CursorPaster.pasteAtCursor(textToPaste + (appendSpace ? " " : ""))
 

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -88,12 +88,9 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
             if let recordedFile {
                 if !shouldCancelRecording {
-                    let audioAsset = AVURLAsset(url: recordedFile)
-                    let duration = (try? CMTimeGetSeconds(await audioAsset.load(.duration))) ?? 0.0
-
                     let transcription = Transcription(
                         text: "",
-                        duration: duration,
+                        duration: 0,
                         audioFileURL: recordedFile.absoluteString,
                         transcriptionStatus: .pending
                     )

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -127,88 +127,93 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
             requestRecordPermission { [self] granted in
                 if granted {
-                    Task {
-                        do {
-                            let fileName = "\(UUID().uuidString).wav"
-                            let permanentURL = self.recordingsDirectory.appendingPathComponent(fileName)
-                            self.recordedFile = permanentURL
+                    let fileName = "\(UUID().uuidString).wav"
+                    let permanentURL = self.recordingsDirectory.appendingPathComponent(fileName)
+                    self.recordedFile = permanentURL
 
-                            let pendingChunks = OSAllocatedUnfairLock(initialState: [Data]())
-                            self.recorder.onAudioChunk = { data in
-                                pendingChunks.withLock { $0.append(data) }
-                            }
+                    let pendingChunks = OSAllocatedUnfairLock(initialState: [Data]())
+                    self.recorder.onAudioChunk = { data in
+                        pendingChunks.withLock { $0.append(data) }
+                    }
 
-                            try await self.recorder.startRecording(toOutputFile: permanentURL)
+                    self.recordingState = .recording
+                    self.logger.notice("toggleRecord: state=recording, starting audio hardware")
 
-                            guard self.recorderUIManager?.isMiniRecorderVisible ?? false, !self.shouldCancelRecording else {
-                                self.recorder.stopRecording()
+                    self.recorder.startRecording(toOutputFile: permanentURL) { result in
+                        Task { @MainActor [self] in
+                            do {
+                                try result.get()
+                                self.logger.notice("toggleRecord: audio hardware started successfully")
+
+                                guard self.recorderUIManager?.isMiniRecorderVisible ?? false, !self.shouldCancelRecording else {
+                                    self.recorder.stopRecording()
+                                    self.recordedFile = nil
+                                    self.recordingState = .idle
+                                    return
+                                }
+
+                                await ActiveWindowService.shared.applyConfiguration(powerModeId: powerModeId)
+
+                                if self.recordingState == .recording,
+                                   let model = self.transcriptionModelManager.currentTranscriptionModel {
+                                    let session = self.serviceRegistry.createSession(
+                                        for: model,
+                                        onPartialTranscript: { [weak self] partial in
+                                            Task { @MainActor in
+                                                self?.partialTranscript = partial
+                                            }
+                                        }
+                                    )
+                                    self.currentSession = session
+                                    let realCallback = try await session.prepare(model: model)
+
+                                    if let realCallback {
+                                        self.recorder.onAudioChunk = realCallback
+                                        let buffered = pendingChunks.withLock { chunks -> [Data] in
+                                            let result = chunks
+                                            chunks.removeAll()
+                                            return result
+                                        }
+                                        for chunk in buffered { realCallback(chunk) }
+                                    } else {
+                                        self.recorder.onAudioChunk = nil
+                                        pendingChunks.withLock { $0.removeAll() }
+                                    }
+                                }
+
+                                Task.detached { [weak self] in
+                                    guard let self else { return }
+
+                                    if let model = await self.transcriptionModelManager.currentTranscriptionModel,
+                                       model.provider == .whisper {
+                                        if let localWhisperModel = await self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
+                                           await self.whisperModelManager.whisperContext == nil {
+                                            do {
+                                                try await self.whisperModelManager.loadModel(localWhisperModel)
+                                            } catch {
+                                                await self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
+                                            }
+                                        }
+                                    } else if let fluidAudioModel = await self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
+                                        try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
+                                    }
+
+                                    if let enhancementService = await self.enhancementService {
+                                        await MainActor.run {
+                                            enhancementService.captureClipboardContext()
+                                        }
+                                        await enhancementService.captureScreenContext()
+                                    }
+                                }
+
+                            } catch {
+                                self.logger.error("❌ Failed to start recording: \(error.localizedDescription, privacy: .public)")
+                                self.recordingState = .idle
                                 self.recordedFile = nil
-                                return
+                                await NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
+                                self.logger.notice("toggleRecord: calling dismissMiniRecorder from error handler")
+                                await self.recorderUIManager?.dismissMiniRecorder()
                             }
-
-                            self.recordingState = .recording
-                            self.logger.notice("toggleRecord: recording started successfully, state=recording")
-
-                            await ActiveWindowService.shared.applyConfiguration(powerModeId: powerModeId)
-
-                            if self.recordingState == .recording,
-                               let model = self.transcriptionModelManager.currentTranscriptionModel {
-                                let session = self.serviceRegistry.createSession(
-                                    for: model,
-                                    onPartialTranscript: { [weak self] partial in
-                                        Task { @MainActor in
-                                            self?.partialTranscript = partial
-                                        }
-                                    }
-                                )
-                                self.currentSession = session
-                                let realCallback = try await session.prepare(model: model)
-
-                                if let realCallback {
-                                    self.recorder.onAudioChunk = realCallback
-                                    let buffered = pendingChunks.withLock { chunks -> [Data] in
-                                        let result = chunks
-                                        chunks.removeAll()
-                                        return result
-                                    }
-                                    for chunk in buffered { realCallback(chunk) }
-                                } else {
-                                    self.recorder.onAudioChunk = nil
-                                    pendingChunks.withLock { $0.removeAll() }
-                                }
-                            }
-
-                            Task.detached { [weak self] in
-                                guard let self else { return }
-
-                                if let model = await self.transcriptionModelManager.currentTranscriptionModel,
-                                   model.provider == .whisper {
-                                    if let localWhisperModel = await self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
-                                       await self.whisperModelManager.whisperContext == nil {
-                                        do {
-                                            try await self.whisperModelManager.loadModel(localWhisperModel)
-                                        } catch {
-                                            await self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
-                                        }
-                                    }
-                                } else if let fluidAudioModel = await self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
-                                    try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
-                                }
-
-                                if let enhancementService = await self.enhancementService {
-                                    await MainActor.run {
-                                        enhancementService.captureClipboardContext()
-                                    }
-                                    await enhancementService.captureScreenContext()
-                                }
-                            }
-
-                        } catch {
-                            self.logger.error("❌ Failed to start recording: \(error.localizedDescription, privacy: .public)")
-                            await NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
-                            self.logger.notice("toggleRecord: calling dismissMiniRecorder from error handler")
-                            await self.recorderUIManager?.dismissMiniRecorder()
-                            self.recordedFile = nil
                         }
                     }
                 } else {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored recording start to a callback-based API and moved hardware init off the main thread. Delays system audio mute until the start sound finishes, syncs the stop sound with paste, and smooths UI threading.

- **Refactors**
  - `Recorder.startRecording` now takes a completion callback, initializes on `audioSetupQueue`, starts the meter on the main thread, pauses media on success, and cleans up on failure.
  - `SoundManager.playStartSound` accepts an optional `onFinished` callback, uses an `AVAudioPlayerDelegate` to signal completion, and always calls the callback even when sound is disabled or unavailable.
  - `RecorderUIManager` mutes system audio via the start-sound completion and removes unnecessary `Task` wrappers when toggling the mini recorder.
  - `VoiceInkEngine` follows the callback flow: buffers chunks until the session is ready, applies window config, loads models/context in background, and resets UI/state on errors.

- **Bug Fixes**
  - Ensured main-thread delivery for start-sound completion and meter start; retained the player delegate to avoid premature deallocation.
  - Canceled any existing meter timer before start and kept heavy audio setup off the main thread to reduce hotkey lag.
  - Synced stop sound with paste and reduced paste delay from 50ms to 15ms for tighter feedback.

<sup>Written for commit 2bd4333703eb10d28c34898bb1866420989a4949. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

