### PR TITLE
Add GHA build workflow for local fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone whisper.cpp
+        run: |
+          mkdir -p ~/VoiceInk-Dependencies
+          git clone https://github.com/ggerganov/whisper.cpp.git ~/VoiceInk-Dependencies/whisper.cpp
+          echo "WHISPER_SHA=$(git -C ~/VoiceInk-Dependencies/whisper.cpp rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Cache whisper.xcframework
+        uses: actions/cache@v4
+        with:
+          path: ~/VoiceInk-Dependencies/whisper.cpp/build-apple/whisper.xcframework
+          key: whisper-xcframework-${{ env.WHISPER_SHA }}
+
+      - name: Build
+        run: make local
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VoiceInk
+          path: .local-build/Build/Products/Debug/VoiceInk.app
+          retention-days: 14


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions workflow to build VoiceInk on macOS 15 for pushes and PRs to main. Caches the `whisper.xcframework` using the `whisper.cpp` HEAD SHA and uploads the app artifact.

- **New Features**
  - Triggers on push/PR to `main`.
  - Builds on macOS 15 with `make local`.
  - Caches whisper.xcframework keyed by `whisper.cpp` HEAD SHA to speed up runs.
  - Uploads `VoiceInk.app` as an artifact (retention: 14 days).

<sup>Written for commit faac5d4e048581a3f4070359a0a6eca7993c7c09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

