### PR TITLE
Add Language Modes with cycle shortcut

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -12,6 +12,7 @@ extension KeyboardShortcuts.Name {
     static let retryLastTranscription = Self("retryLastTranscription")
     static let openHistoryWindow = Self("openHistoryWindow")
     static let quickAddToDictionary = Self("quickAddToDictionary")
+    static let cycleLanguageMode = Self("cycleLanguageMode")
 }
 
 @MainActor
@@ -203,6 +204,13 @@ class HotkeyManager: ObservableObject {
             guard let self else { return }
             Task { @MainActor in
                 DictionaryQuickAddManager.shared.toggle(modelContainer: self.engine.modelContext.container)
+            }
+        }
+
+        LanguageModeManager.shared.configure(engine: engine, recorderUIManager: recorderUIManager)
+        KeyboardShortcuts.onKeyUp(for: .cycleLanguageMode) {
+            Task { @MainActor in
+                await LanguageModeManager.shared.cycleToNext()
             }
         }
 

--- a/VoiceInk/Models/LanguageMode.swift
+++ b/VoiceInk/Models/LanguageMode.swift
@@ -126,6 +126,19 @@ class LanguageModeManager: ObservableObject {
         saveModes()
     }
 
+    /// Replace all modes in one shot. Used by settings import to restore a backup.
+    func replaceAll(modes newModes: [LanguageMode], activeId: UUID?) {
+        modes = newModes
+        saveModes()
+        if let activeId = activeId, newModes.contains(where: { $0.id == activeId }) {
+            activeModeId = activeId
+            UserDefaults.standard.set(activeId.uuidString, forKey: activeIdKey)
+        } else {
+            activeModeId = nil
+            UserDefaults.standard.removeObject(forKey: activeIdKey)
+        }
+    }
+
     var activeMode: LanguageMode? {
         guard let id = activeModeId else { return nil }
         return modes.first { $0.id == id }
@@ -185,7 +198,15 @@ class LanguageModeManager: ObservableObject {
            let stateProvider = stateProvider,
            stateProvider.currentTranscriptionModel?.name != modelName,
            let selectedModel = stateProvider.allAvailableModels.first(where: { $0.name == modelName }) {
-            await switchModel(to: selectedModel, using: stateProvider)
+            if selectedModel.provider == .whisper,
+               !stateProvider.availableModels.contains(where: { $0.name == modelName }) {
+                NotificationManager.shared.showNotification(
+                    title: "Model '\(selectedModel.displayName)' is not downloaded",
+                    type: .error
+                )
+            } else {
+                await switchModel(to: selectedModel, using: stateProvider)
+            }
         }
 
         NotificationManager.shared.showNotification(

--- a/VoiceInk/Models/LanguageMode.swift
+++ b/VoiceInk/Models/LanguageMode.swift
@@ -1,0 +1,211 @@
+import Foundation
+import SwiftUI
+
+struct LanguageMode: Codable, Identifiable, Equatable {
+    var id: UUID
+    var transcriptionModelName: String?
+    var language: String
+
+    init(
+        id: UUID = UUID(),
+        transcriptionModelName: String? = nil,
+        language: String = "auto"
+    ) {
+        self.id = id
+        self.transcriptionModelName = transcriptionModelName
+        self.language = language
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, transcriptionModelName, language
+    }
+
+    var displayName: String {
+        if language == "auto" { return "Auto-detect" }
+        return LanguageDictionary.all[language] ?? language.uppercased()
+    }
+
+    var emoji: String {
+        Self.flag(forLanguage: language)
+    }
+
+    static func flag(forLanguage code: String) -> String {
+        // Use BCP-47 region if present (e.g. "en-GB" → 🇬🇧).
+        if let dash = code.firstIndex(of: "-") {
+            let region = String(code[code.index(after: dash)...]).uppercased()
+            if region.count == 2, let flag = regionFlag(region) { return flag }
+        }
+        return languageFlags[code.lowercased()] ?? "🌐"
+    }
+
+    private static func regionFlag(_ region: String) -> String? {
+        let base: UInt32 = 127397
+        var s = ""
+        for ch in region.unicodeScalars {
+            guard let scalar = UnicodeScalar(base + ch.value) else { return nil }
+            s.unicodeScalars.append(scalar)
+        }
+        return s.isEmpty ? nil : s
+    }
+
+    private static let languageFlags: [String: String] = [
+        "auto": "🌐",
+        "en": "🇬🇧", "de": "🇩🇪", "es": "🇪🇸", "fr": "🇫🇷", "it": "🇮🇹",
+        "pt": "🇵🇹", "nl": "🇳🇱", "pl": "🇵🇱", "ru": "🇷🇺", "ja": "🇯🇵",
+        "zh": "🇨🇳", "yue": "🇭🇰", "ko": "🇰🇷", "ar": "🇸🇦", "hi": "🇮🇳",
+        "tr": "🇹🇷", "sv": "🇸🇪", "da": "🇩🇰", "no": "🇳🇴", "fi": "🇫🇮",
+        "cs": "🇨🇿", "el": "🇬🇷", "he": "🇮🇱", "th": "🇹🇭", "vi": "🇻🇳",
+        "id": "🇮🇩", "uk": "🇺🇦", "ro": "🇷🇴", "hu": "🇭🇺", "bg": "🇧🇬",
+        "hr": "🇭🇷", "sk": "🇸🇰", "sl": "🇸🇮", "et": "🇪🇪", "lv": "🇱🇻",
+        "lt": "🇱🇹", "mt": "🇲🇹", "is": "🇮🇸", "ga": "🇮🇪", "cy": "🇬🇧",
+        "fa": "🇮🇷", "ur": "🇵🇰", "bn": "🇧🇩", "ta": "🇮🇳", "te": "🇮🇳",
+        "ml": "🇮🇳", "kn": "🇮🇳", "mr": "🇮🇳", "gu": "🇮🇳", "pa": "🇮🇳",
+        "sw": "🇰🇪", "af": "🇿🇦", "ms": "🇲🇾", "tl": "🇵🇭", "ca": "🇪🇸",
+        "eu": "🇪🇸", "gl": "🇪🇸"
+    ]
+}
+
+@MainActor
+class LanguageModeManager: ObservableObject {
+    static let shared = LanguageModeManager()
+
+    @Published var modes: [LanguageMode] = []
+    @Published var activeModeId: UUID?
+
+    private let modesKey = "languageModesV1"
+    private let activeIdKey = "activeLanguageModeId"
+
+    private weak var stateProvider: (any PowerModeStateProvider)?
+    private weak var engine: VoiceInkEngine?
+    private weak var recorderUIManager: RecorderUIManager?
+
+    private init() {
+        loadModes()
+        if let raw = UserDefaults.standard.string(forKey: activeIdKey) {
+            activeModeId = UUID(uuidString: raw)
+        }
+    }
+
+    func configure(engine: VoiceInkEngine, recorderUIManager: RecorderUIManager) {
+        self.engine = engine
+        self.stateProvider = engine
+        self.recorderUIManager = recorderUIManager
+    }
+
+    private func loadModes() {
+        guard let data = UserDefaults.standard.data(forKey: modesKey),
+              let decoded = try? JSONDecoder().decode([LanguageMode].self, from: data) else { return }
+        modes = decoded
+    }
+
+    func saveModes() {
+        if let data = try? JSONEncoder().encode(modes) {
+            UserDefaults.standard.set(data, forKey: modesKey)
+        }
+    }
+
+    func addMode(_ mode: LanguageMode) {
+        modes.append(mode)
+        saveModes()
+    }
+
+    func updateMode(_ mode: LanguageMode) {
+        guard let idx = modes.firstIndex(where: { $0.id == mode.id }) else { return }
+        modes[idx] = mode
+        saveModes()
+    }
+
+    func removeMode(id: UUID) {
+        modes.removeAll { $0.id == id }
+        if activeModeId == id { activeModeId = nil }
+        saveModes()
+    }
+
+    func moveModes(fromOffsets: IndexSet, toOffset: Int) {
+        modes.move(fromOffsets: fromOffsets, toOffset: toOffset)
+        saveModes()
+    }
+
+    var activeMode: LanguageMode? {
+        guard let id = activeModeId else { return nil }
+        return modes.first { $0.id == id }
+    }
+
+    /// Advance to the next mode in the list and apply it.
+    /// If a recording is in progress, stop it (the current take transcribes normally),
+    /// switch the mode, and start a new recording in the new language.
+    func cycleToNext() async {
+        guard !modes.isEmpty else {
+            NotificationManager.shared.showNotification(
+                title: "No Language Modes configured",
+                type: .warning
+            )
+            return
+        }
+
+        let nextIndex: Int
+        if let currentId = activeModeId,
+           let currentIdx = modes.firstIndex(where: { $0.id == currentId }) {
+            nextIndex = (currentIdx + 1) % modes.count
+        } else {
+            nextIndex = 0
+        }
+
+        let next = modes[nextIndex]
+
+        let wasRecording = (engine?.recordingState == .recording) && (recorderUIManager?.isMiniRecorderVisible == true)
+
+        if wasRecording, let recorderUIManager = recorderUIManager {
+            // Stop the current take. This awaits transcription + paste + dismiss.
+            await recorderUIManager.toggleMiniRecorder()
+        }
+
+        await apply(next)
+
+        if wasRecording, let recorderUIManager = recorderUIManager {
+            // Start a fresh recording in the new language.
+            await recorderUIManager.toggleMiniRecorder()
+        }
+    }
+
+    func setActive(id: UUID) async {
+        guard let mode = modes.first(where: { $0.id == id }) else { return }
+        await apply(mode)
+    }
+
+    private func apply(_ mode: LanguageMode) async {
+        activeModeId = mode.id
+        UserDefaults.standard.set(mode.id.uuidString, forKey: activeIdKey)
+
+        UserDefaults.standard.set(mode.language, forKey: "SelectedLanguage")
+        NotificationCenter.default.post(name: .languageDidChange, object: nil)
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+
+        if let modelName = mode.transcriptionModelName,
+           let stateProvider = stateProvider,
+           stateProvider.currentTranscriptionModel?.name != modelName,
+           let selectedModel = stateProvider.allAvailableModels.first(where: { $0.name == modelName }) {
+            await switchModel(to: selectedModel, using: stateProvider)
+        }
+
+        NotificationManager.shared.showNotification(
+            title: "Mode: \(mode.emoji) \(mode.displayName)",
+            type: .info,
+            duration: 1.5
+        )
+    }
+
+    private func switchModel(to newModel: any TranscriptionModel, using stateProvider: any PowerModeStateProvider) async {
+        stateProvider.setDefaultTranscriptionModel(newModel)
+
+        switch newModel.provider {
+        case .whisper:
+            await stateProvider.cleanupModelResources()
+            if let whisperModel = stateProvider.availableModels.first(where: { $0.name == newModel.name }) {
+                try? await stateProvider.loadModel(whisperModel)
+            }
+        default:
+            await stateProvider.cleanupModelResources()
+        }
+    }
+}

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -73,6 +73,16 @@ enum BackupImporter {
         if categories.contains(.customModels) {
             importCustomModels(backup.customCloudModels, transcriptionModelManager: transcriptionModelManager)
         }
+
+        if categories.contains(.languageModes) {
+            if let modes = backup.languageModes {
+                let activeId = backup.activeLanguageModeId.flatMap(UUID.init)
+                LanguageModeManager.shared.replaceAll(modes: modes, activeId: activeId)
+                print("Successfully imported \(modes.count) Language Modes.")
+            } else {
+                print("No Language Modes found in the imported file.")
+            }
+        }
     }
 
     @MainActor
@@ -108,6 +118,9 @@ enum BackupImporter {
         }
         if let enhancementShortcut = general.toggleEnhancementShortcut {
             KeyboardShortcuts.setShortcut(enhancementShortcut, for: .toggleEnhancement)
+        }
+        if let cycleShortcut = general.cycleLanguageModeShortcut {
+            KeyboardShortcuts.setShortcut(cycleShortcut, for: .cycleLanguageMode)
         }
 
         if let hotkeyRaw = general.selectedHotkey1RawValue,

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -7,6 +7,7 @@ enum BackupCategory: String, CaseIterable, Hashable {
     case powerMode
     case dictionary
     case customModels
+    case languageModes
 
     var title: String {
         switch self {
@@ -20,6 +21,8 @@ enum BackupCategory: String, CaseIterable, Hashable {
             return "Dictionary"
         case .customModels:
             return "Custom Model Definitions"
+        case .languageModes:
+            return "Language Modes"
         }
     }
 }
@@ -77,6 +80,7 @@ struct GeneralBackup: Codable {
     let openHistoryWindowShortcut: KeyboardShortcuts.Shortcut?
     let quickAddToDictionaryShortcut: KeyboardShortcuts.Shortcut?
     let toggleEnhancementShortcut: KeyboardShortcuts.Shortcut?
+    let cycleLanguageModeShortcut: KeyboardShortcuts.Shortcut?
     let selectedHotkey1RawValue: String?
     let selectedHotkey2RawValue: String?
     let hotkeyMode1RawValue: String?
@@ -122,12 +126,14 @@ struct BackupFile: Codable {
     let generalSettings: GeneralBackup?
     let customEmojis: [String]?
     let customCloudModels: [CustomModelBackup]?
+    let languageModes: [LanguageMode]?
+    let activeLanguageModeId: String?
 
     private enum CodingKeys: String, CodingKey {
-        case version, customPrompts, powerModeConfigs, powerModeShortcuts, vocabularyWords, wordReplacements, generalSettings, customEmojis, customCloudModels
+        case version, customPrompts, powerModeConfigs, powerModeShortcuts, vocabularyWords, wordReplacements, generalSettings, customEmojis, customCloudModels, languageModes, activeLanguageModeId
     }
 
-    init(version: String, customPrompts: [CustomPrompt], powerModeConfigs: [PowerModeConfig], powerModeShortcuts: [String: KeyboardShortcuts.Shortcut]?, vocabularyWords: [WordBackup]?, wordReplacements: [String: String]?, generalSettings: GeneralBackup?, customEmojis: [String]?, customCloudModels: [CustomModelBackup]?) {
+    init(version: String, customPrompts: [CustomPrompt], powerModeConfigs: [PowerModeConfig], powerModeShortcuts: [String: KeyboardShortcuts.Shortcut]?, vocabularyWords: [WordBackup]?, wordReplacements: [String: String]?, generalSettings: GeneralBackup?, customEmojis: [String]?, customCloudModels: [CustomModelBackup]?, languageModes: [LanguageMode]?, activeLanguageModeId: String?) {
         self.version = version
         self.customPrompts = customPrompts
         self.powerModeConfigs = powerModeConfigs
@@ -137,6 +143,8 @@ struct BackupFile: Codable {
         self.generalSettings = generalSettings
         self.customEmojis = customEmojis
         self.customCloudModels = customCloudModels
+        self.languageModes = languageModes
+        self.activeLanguageModeId = activeLanguageModeId
     }
 
     init(from decoder: Decoder) throws {
@@ -150,5 +158,7 @@ struct BackupFile: Codable {
         generalSettings = try container.decodeIfPresent(GeneralBackup.self, forKey: .generalSettings)
         customEmojis = try container.decodeIfPresent([String].self, forKey: .customEmojis)
         customCloudModels = try container.decodeIfPresent([CustomModelBackup].self, forKey: .customCloudModels)
+        languageModes = try container.decodeIfPresent([LanguageMode].self, forKey: .languageModes)
+        activeLanguageModeId = try container.decodeIfPresent(String.self, forKey: .activeLanguageModeId)
     }
 }

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -164,6 +164,7 @@ class ImportExportService {
             openHistoryWindowShortcut: KeyboardShortcuts.getShortcut(for: .openHistoryWindow),
             quickAddToDictionaryShortcut: KeyboardShortcuts.getShortcut(for: .quickAddToDictionary),
             toggleEnhancementShortcut: KeyboardShortcuts.getShortcut(for: .toggleEnhancement),
+            cycleLanguageModeShortcut: KeyboardShortcuts.getShortcut(for: .cycleLanguageMode),
             selectedHotkey1RawValue: hotkeyManager.selectedHotkey1.rawValue,
             selectedHotkey2RawValue: hotkeyManager.selectedHotkey2.rawValue,
             hotkeyMode1RawValue: hotkeyManager.hotkeyMode1.rawValue,
@@ -200,7 +201,9 @@ class ImportExportService {
             wordReplacements: exportedWordReplacements,
             generalSettings: generalSettingsToExport,
             customEmojis: emojiManager.customEmojis,
-            customCloudModels: customModels
+            customCloudModels: customModels,
+            languageModes: LanguageModeManager.shared.modes,
+            activeLanguageModeId: LanguageModeManager.shared.activeModeId?.uuidString
         )
 
         let encoder = JSONEncoder()

--- a/VoiceInk/Views/Recorder/MiniRecorderView.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderView.swift
@@ -47,6 +47,11 @@ struct MiniRecorderView<S: RecorderStateProvider & ObservableObject>: View {
                 buttonSize: 22,
                 padding: EdgeInsets()
             )
+
+            RecorderLanguageModeButton(
+                buttonSize: 22,
+                padding: EdgeInsets()
+            )
             .padding(.trailing, 12)
         }
         .frame(height: controlBarHeight)

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -123,6 +123,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
             HStack(spacing: 10) {
                 RecorderPromptButton(activePopover: $activePopover, buttonSize: 20, padding: EdgeInsets())
                 RecorderPowerModeButton(activePopover: $activePopover, buttonSize: 20, padding: EdgeInsets())
+                RecorderLanguageModeButton(buttonSize: 20, padding: EdgeInsets())
                 Spacer(minLength: 0)
             }
             .padding(.leading, displayState == .liveText ? 18 : 14)

--- a/VoiceInk/Views/Recorder/RecorderComponents.swift
+++ b/VoiceInk/Views/Recorder/RecorderComponents.swift
@@ -263,6 +263,29 @@ struct RecorderPowerModeButton: View {
     }
 }
 
+// MARK: - Language Mode Indicator
+
+struct RecorderLanguageModeButton: View {
+    @ObservedObject private var languageModeManager = LanguageModeManager.shared
+    let buttonSize: CGFloat
+    let padding: EdgeInsets
+
+    init(buttonSize: CGFloat = 28, padding: EdgeInsets = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 7)) {
+        self.buttonSize = buttonSize
+        self.padding = padding
+    }
+
+    var body: some View {
+        if let active = languageModeManager.activeMode {
+            Text(active.emoji)
+                .font(.system(size: 14))
+                .frame(width: buttonSize)
+                .padding(padding)
+                .help("Language: \(active.displayName)")
+        }
+    }
+}
+
 // MARK: - Live Transcript View
 
 struct LiveTranscriptView: View {

--- a/VoiceInk/Views/Settings/LanguageModesSettingsView.swift
+++ b/VoiceInk/Views/Settings/LanguageModesSettingsView.swift
@@ -23,16 +23,26 @@ struct LanguageModesSettingsView: View {
                         LanguageModeRow(
                             mode: bindingForMode(mode),
                             isActive: manager.activeModeId == mode.id,
-                            availableModels: transcriptionModelManager.allAvailableModels,
+                            availableModels: transcriptionModelManager.usableModels,
                             onDelete: { manager.removeMode(id: mode.id) }
                         )
                     }
                 }
 
                 Button {
+                    let currentModel = transcriptionModelManager.currentTranscriptionModel
+                    let supported = currentModel?.supportedLanguages.keys
+                    let language: String = {
+                        if let supported = supported {
+                            if supported.contains("en") { return "en" }
+                            if supported.contains("auto") { return "auto" }
+                            return supported.first ?? "en"
+                        }
+                        return "en"
+                    }()
                     let newMode = LanguageMode(
-                        transcriptionModelName: transcriptionModelManager.currentTranscriptionModel?.name,
-                        language: "en"
+                        transcriptionModelName: currentModel?.name,
+                        language: language
                     )
                     manager.addMode(newMode)
                 } label: {

--- a/VoiceInk/Views/Settings/LanguageModesSettingsView.swift
+++ b/VoiceInk/Views/Settings/LanguageModesSettingsView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import KeyboardShortcuts
+
+struct LanguageModesSettingsView: View {
+    @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
+    @ObservedObject private var manager = LanguageModeManager.shared
+    @State private var isExpanded = false
+
+    var body: some View {
+        Section {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                LabeledContent("Cycle Modes Shortcut") {
+                    KeyboardShortcuts.Recorder(for: .cycleLanguageMode)
+                        .controlSize(.small)
+                }
+
+                if manager.modes.isEmpty {
+                    Text("Add a mode below to start cycling between language/model combinations.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(manager.modes) { mode in
+                        LanguageModeRow(
+                            mode: bindingForMode(mode),
+                            isActive: manager.activeModeId == mode.id,
+                            availableModels: transcriptionModelManager.allAvailableModels,
+                            onDelete: { manager.removeMode(id: mode.id) }
+                        )
+                    }
+                }
+
+                Button {
+                    let newMode = LanguageMode(
+                        transcriptionModelName: transcriptionModelManager.currentTranscriptionModel?.name,
+                        language: "en"
+                    )
+                    manager.addMode(newMode)
+                } label: {
+                    Label("Add Mode", systemImage: "plus.circle")
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text("Language Modes")
+                    InfoTip("Define a list of model + language presets, then cycle through them with a single shortcut.")
+                }
+            }
+        } header: {
+            Text("Language Modes")
+        }
+    }
+
+    private func bindingForMode(_ mode: LanguageMode) -> Binding<LanguageMode> {
+        Binding(
+            get: {
+                manager.modes.first(where: { $0.id == mode.id }) ?? mode
+            },
+            set: { updated in
+                manager.updateMode(updated)
+            }
+        )
+    }
+}
+
+private struct LanguageModeRow: View {
+    @Binding var mode: LanguageMode
+    let isActive: Bool
+    let availableModels: [any TranscriptionModel]
+    let onDelete: () -> Void
+
+    private var selectedModel: (any TranscriptionModel)? {
+        guard let name = mode.transcriptionModelName else { return nil }
+        return availableModels.first { $0.name == name }
+    }
+
+    private var supportedLanguages: [(key: String, value: String)] {
+        let languages = selectedModel?.supportedLanguages ?? LanguageDictionary.all
+        return languages.sorted { lhs, rhs in
+            if lhs.key == "auto" { return true }
+            if rhs.key == "auto" { return false }
+            return lhs.value < rhs.value
+        }
+    }
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    if isActive {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.accentColor)
+                    }
+                    Text(mode.emoji)
+                    Text(mode.displayName)
+                        .fontWeight(.medium)
+                    Spacer()
+                    Button(role: .destructive) {
+                        onDelete()
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.borderless)
+                }
+
+                LabeledContent("Model") {
+                    Picker("", selection: Binding(
+                        get: { mode.transcriptionModelName ?? "" },
+                        set: { newValue in
+                            mode.transcriptionModelName = newValue.isEmpty ? nil : newValue
+                            if let model = availableModels.first(where: { $0.name == newValue }),
+                               !model.supportedLanguages.keys.contains(mode.language) {
+                                mode.language = model.supportedLanguages.keys.contains("auto") ? "auto" : (model.supportedLanguages.keys.first ?? "en")
+                            }
+                        }
+                    )) {
+                        Text("Keep Current").tag("")
+                        ForEach(availableModels, id: \.name) { model in
+                            Text(model.displayName).tag(model.name)
+                        }
+                    }
+                    .labelsHidden()
+                }
+
+                LabeledContent("Language") {
+                    Picker("", selection: $mode.language) {
+                        ForEach(supportedLanguages, id: \.key) { key, value in
+                            Text(value).tag(key)
+                        }
+                    }
+                    .labelsHidden()
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -191,6 +191,9 @@ struct SettingsView: View {
                 }
             }
 
+            // MARK: - Language Modes
+            LanguageModesSettingsView()
+
             // MARK: - Power Mode
             PowerModeSection()
 


### PR DESCRIPTION
## Summary
- Adds a **Language Modes** feature: a user-defined list of `(transcription model, language)` presets, configurable from Settings.
- Adds a **Cycle Modes** keyboard shortcut that advances to the next mode in the list.
- While recording, pressing the cycle shortcut stops the current take (which transcribes and pastes normally), switches the active mode, and starts a new recording in the new language — useful for users who dictate in multiple languages back-to-back.

## Why
Existing Power Modes can already encode a model + language, but they're activation-driven (per-app/URL) and each gets its own dedicated hotkey. There was no way to bind a single shortcut that toggles between language presets — the way macOS dictation lets you switch language mid-dictation. This adds that.

## What changed
- `VoiceInk/Models/LanguageMode.swift` — `LanguageMode` struct and `LanguageModeManager` singleton. Persists in `UserDefaults` under `languageModesV1`. Derives display name from `LanguageDictionary.all` and flag emoji from a static language→flag map (with BCP-47 region fallback).
- `VoiceInk/Views/Settings/LanguageModesSettingsView.swift` — new Settings section. One `KeyboardShortcuts.Recorder` for the cycle hotkey, plus a `GroupBox` per mode with model + language pickers and a delete button. Language picker is filtered to the chosen model's `supportedLanguages`.
- `VoiceInk/HotkeyManager.swift` — registers `KeyboardShortcuts.Name.cycleLanguageMode` and wires `LanguageModeManager.shared` to the engine + `RecorderUIManager`.
- `VoiceInk/Views/Settings/SettingsView.swift` — inserts the new section above Power Mode.

## Notes / tradeoffs
- The cycle-while-recording flow is **sequential**, not concurrent: the current take fully transcribes and pastes before the new recording starts. There's a brief pause (typically <1s for short takes on local Whisper, longer if also switching to a model that has to load). This is a pragmatic fit for VoiceInk's batch transcription pipeline; truly concurrent transcription would require running the pipeline as a detached task and serializing the Whisper context across overlapping takes.
- Reuses existing infrastructure: `PowerModeStateProvider` (engine) for model switching with cleanup + load, `NotificationManager` toast for mode-switch feedback, `LanguageDictionary.all` for display names.
- No data model changes to existing types — Power Mode is untouched.

## Test plan
- [x] Build with `make local`.
- [x] Empty state: open Settings → Language Modes, verify the empty-state copy and the Add Mode button.
- [x] Add three modes (English, German, Spanish), confirm each row renders flag + name correctly and the language picker filters by the chosen model.
- [x] Bind a Cycle Modes Shortcut.
- [x] When idle: press the shortcut, verify the toast shows the new mode and `SelectedLanguage` updates.
- [x] When recording: press the shortcut, verify the previous take transcribes/pastes in the previous language and a fresh recording starts in the new language. Toast appears over the recorder.
- [x] Cycling wraps around to the first mode after the last.
- [x] Deleting the active mode clears `activeModeId`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Language Modes: user-defined model + language presets with a single cycle shortcut and a recorder indicator. Pressing the shortcut while recording finishes the current take, switches mode, and starts a new recording in the new language.

- **New Features**
  - Settings → Language Modes: create presets and bind a Cycle Modes shortcut via `KeyboardShortcuts`; only show usable/downloaded models; new modes default to a supported language.
  - Cycling applies the next preset: updates language, switches model if needed, wraps around; shows an error toast if the saved model isn’t available.
  - Recorder UI: shows the active language flag next to Power Mode with a tooltip; hidden when no mode is active.
  - Backup/restore: export/import `languageModes`, `activeLanguageModeId`, and the cycle shortcut; restore modes and the active id atomically.

<sup>Written for commit e6d80c1867349b2415913a1db04393c1ad9f98c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

