### PR TITLE
Improve model download progress UI

### DIFF
--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
         "branch" : "main",
-        "revision" : "04747b3e77c824917c2b422a7210ab9de9d3b029"
+        "revision" : "eff1752ebfa97cf57377b261789d18df39240aad"
       }
     },
     {

--- a/VoiceInk/Models/TranscriptionModelRegistry.swift
+++ b/VoiceInk/Models/TranscriptionModelRegistry.swift
@@ -32,7 +32,7 @@ enum TranscriptionModelRegistry {
             FluidAudioModel(
                 name: "parakeet-tdt-0.6b-v3",
                 displayName: "Parakeet V3",
-                description: "NVIDIA's Parakeet V3 model with multilingual support across English and 25 European languages",
+                description: "Parakeet V3 with English and 25 European language support",
                 size: "494 MB",
                 speed: 0.99,
                 accuracy: 0.94,

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
@@ -11,6 +11,7 @@ struct FluidAudioDownloadStatus {
 @MainActor
 class FluidAudioModelManager: ObservableObject {
     @Published private var downloadStatuses: [String: FluidAudioDownloadStatus] = [:]
+    private var activeDownloadIDs: [String: UUID] = [:]
 
     var onModelDeleted: ((String) -> Void)?
     var onModelsChanged: (() -> Void)?
@@ -56,15 +57,21 @@ class FluidAudioModelManager: ObservableObject {
         }
 
         let modelName = model.name
+        let downloadID = UUID()
+        activeDownloadIDs[modelName] = downloadID
         downloadStatuses[modelName] = FluidAudioDownloadStatus(
             fractionCompleted: 0.0,
             message: "Preparing FluidAudio download..."
         )
+        defer {
+            clearDownloadStatus(for: modelName, downloadID: downloadID)
+            onModelsChanged?()
+        }
 
         let version = FluidAudioModelManager.asrVersion(for: modelName)
         let progressHandler: DownloadUtils.ProgressHandler = { [weak self] progress in
             Task { @MainActor [weak self] in
-                self?.updateDownloadProgress(progress, for: modelName)
+                self?.updateDownloadProgress(progress, for: modelName, downloadID: downloadID)
             }
         }
 
@@ -76,10 +83,6 @@ class FluidAudioModelManager: ObservableObject {
         } catch {
             logger.error("❌ FluidAudio download failed for \(modelName, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
-
-        downloadStatuses[modelName] = nil
-
-        onModelsChanged?()
     }
 
     // MARK: - Delete
@@ -119,7 +122,15 @@ class FluidAudioModelManager: ObservableObject {
         AsrModels.defaultCacheDirectory(for: version)
     }
 
-    private func updateDownloadProgress(_ progress: DownloadUtils.DownloadProgress, for modelName: String) {
+    private func clearDownloadStatus(for modelName: String, downloadID: UUID) {
+        guard activeDownloadIDs[modelName] == downloadID else { return }
+        activeDownloadIDs[modelName] = nil
+        downloadStatuses[modelName] = nil
+    }
+
+    private func updateDownloadProgress(_ progress: DownloadUtils.DownloadProgress, for modelName: String, downloadID: UUID) {
+        guard activeDownloadIDs[modelName] == downloadID else { return }
+
         downloadStatuses[modelName] = FluidAudioDownloadStatus(
             fractionCompleted: min(max(progress.fractionCompleted, 0.0), 1.0),
             message: FluidAudioModelManager.statusMessage(for: progress)

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
@@ -3,10 +3,14 @@ import FluidAudio
 import AppKit
 import os
 
+struct FluidAudioDownloadStatus {
+    let fractionCompleted: Double
+    let message: String
+}
+
 @MainActor
 class FluidAudioModelManager: ObservableObject {
-    @Published var parakeetDownloadStates: [String: Bool] = [:]
-    @Published var downloadProgress: [String: Double] = [:]
+    @Published private var downloadStatuses: [String: FluidAudioDownloadStatus] = [:]
 
     var onModelDeleted: ((String) -> Void)?
     var onModelsChanged: (() -> Void)?
@@ -14,7 +18,7 @@ class FluidAudioModelManager: ObservableObject {
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "FluidAudioModelManager")
 
     // Add new Fluid Audio models here when support is added.
-    static let modelVersionMap: [String: AsrModelVersion] = [
+    private static let modelVersionMap: [String: AsrModelVersion] = [
         "parakeet-tdt-0.6b-v2": .v2,
         "parakeet-tdt-0.6b-v3": .v3,
     ]
@@ -28,7 +32,8 @@ class FluidAudioModelManager: ObservableObject {
     // MARK: - Query helpers
 
     func isFluidAudioModelDownloaded(named modelName: String) -> Bool {
-        UserDefaults.standard.bool(forKey: parakeetDefaultsKey(for: modelName))
+        let version = FluidAudioModelManager.asrVersion(for: modelName)
+        return AsrModels.modelsExist(at: cacheDirectory(for: version), version: version)
     }
 
     func isFluidAudioModelDownloaded(_ model: FluidAudioModel) -> Bool {
@@ -36,44 +41,43 @@ class FluidAudioModelManager: ObservableObject {
     }
 
     func isFluidAudioModelDownloading(_ model: FluidAudioModel) -> Bool {
-        parakeetDownloadStates[model.name] ?? false
+        downloadStatuses[model.name] != nil
+    }
+
+    func downloadStatus(for model: FluidAudioModel) -> FluidAudioDownloadStatus? {
+        downloadStatuses[model.name]
     }
 
     // MARK: - Download
 
     func downloadFluidAudioModel(_ model: FluidAudioModel) async {
-        if isFluidAudioModelDownloaded(model) {
+        if isFluidAudioModelDownloaded(model) || isFluidAudioModelDownloading(model) {
             return
         }
 
         let modelName = model.name
-        parakeetDownloadStates[modelName] = true
-        downloadProgress[modelName] = 0.0
+        downloadStatuses[modelName] = FluidAudioDownloadStatus(
+            fractionCompleted: 0.0,
+            message: "Preparing FluidAudio download..."
+        )
 
-        let timer = Timer.scheduledTimer(withTimeInterval: 1.2, repeats: true) { timer in
-            Task { @MainActor in
-                if let currentProgress = self.downloadProgress[modelName], currentProgress < 0.9 {
-                    self.downloadProgress[modelName] = currentProgress + 0.005
-                }
+        let version = FluidAudioModelManager.asrVersion(for: modelName)
+        let progressHandler: DownloadUtils.ProgressHandler = { [weak self] progress in
+            Task { @MainActor [weak self] in
+                self?.updateDownloadProgress(progress, for: modelName)
             }
         }
 
-        let version = FluidAudioModelManager.asrVersion(for: modelName)
-
         do {
-            _ = try await AsrModels.downloadAndLoad(version: version)
-            _ = try await VadManager()
-
-            UserDefaults.standard.set(true, forKey: parakeetDefaultsKey(for: modelName))
-            downloadProgress[modelName] = 1.0
+            _ = try await AsrModels.downloadAndLoad(
+                version: version,
+                progressHandler: progressHandler
+            )
         } catch {
-            UserDefaults.standard.set(false, forKey: parakeetDefaultsKey(for: modelName))
             logger.error("❌ FluidAudio download failed for \(modelName, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
 
-        timer.invalidate()
-        parakeetDownloadStates[modelName] = false
-        downloadProgress[modelName] = nil
+        downloadStatuses[modelName] = nil
 
         onModelsChanged?()
     }
@@ -81,14 +85,12 @@ class FluidAudioModelManager: ObservableObject {
     // MARK: - Delete
 
     func deleteFluidAudioModel(_ model: FluidAudioModel) {
-        let version = FluidAudioModelManager.asrVersion(for: model.name)
-        let cacheDirectory = parakeetCacheDirectory(for: version)
+        let cacheDirectory = cacheDirectory(for: model)
 
         do {
             if FileManager.default.fileExists(atPath: cacheDirectory.path) {
                 try FileManager.default.removeItem(at: cacheDirectory)
             }
-            UserDefaults.standard.set(false, forKey: parakeetDefaultsKey(for: model.name))
         } catch {
             // Silently ignore removal errors
         }
@@ -100,7 +102,7 @@ class FluidAudioModelManager: ObservableObject {
     // MARK: - Finder
 
     func showFluidAudioModelInFinder(_ model: FluidAudioModel) {
-        let cacheDirectory = parakeetCacheDirectory(for: FluidAudioModelManager.asrVersion(for: model.name))
+        let cacheDirectory = cacheDirectory(for: model)
 
         if FileManager.default.fileExists(atPath: cacheDirectory.path) {
             NSWorkspace.shared.selectFile(cacheDirectory.path, inFileViewerRootedAtPath: "")
@@ -109,11 +111,39 @@ class FluidAudioModelManager: ObservableObject {
 
     // MARK: - Private helpers
 
-    private func parakeetDefaultsKey(for modelName: String) -> String {
-        "ParakeetModelDownloaded_\(modelName)"
+    private func cacheDirectory(for model: FluidAudioModel) -> URL {
+        cacheDirectory(for: FluidAudioModelManager.asrVersion(for: model.name))
     }
 
-    private func parakeetCacheDirectory(for version: AsrModelVersion) -> URL {
+    private func cacheDirectory(for version: AsrModelVersion) -> URL {
         AsrModels.defaultCacheDirectory(for: version)
+    }
+
+    private func updateDownloadProgress(_ progress: DownloadUtils.DownloadProgress, for modelName: String) {
+        downloadStatuses[modelName] = FluidAudioDownloadStatus(
+            fractionCompleted: min(max(progress.fractionCompleted, 0.0), 1.0),
+            message: FluidAudioModelManager.statusMessage(for: progress)
+        )
+    }
+
+    private static func statusMessage(for progress: DownloadUtils.DownloadProgress) -> String {
+        switch progress.phase {
+        case .listing:
+            return "Listing files from repository..."
+        case .downloading(let completedFiles, let totalFiles):
+            guard totalFiles > 0 else {
+                return "Checking cached models..."
+            }
+            return "Downloading models: \(completedFiles)/\(totalFiles) files"
+        case .compiling(let modelName):
+            guard !modelName.isEmpty else {
+                return "Finalizing models..."
+            }
+            return "Compiling \(displayName(forModelComponent: modelName))"
+        }
+    }
+
+    private static func displayName(forModelComponent modelName: String) -> String {
+        modelName.replacingOccurrences(of: ".mlmodelc", with: "")
     }
 }

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -47,7 +47,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
         }
 
         let task = Task {
-            try await AsrModels.loadFromCache(
+            try await AsrModels.downloadAndLoad(
                 configuration: nil,
                 version: version
             )

--- a/VoiceInk/Transcription/Whisper/WhisperModelManager.swift
+++ b/VoiceInk/Transcription/Whisper/WhisperModelManager.swift
@@ -402,6 +402,7 @@ extension WhisperModelManager: WhisperModelProvider {}
 struct DownloadProgressView: View {
     let modelName: String
     let downloadProgress: [String: Double]
+    var isOptimizing = false
 
     @Environment(\.colorScheme) private var colorScheme
 
@@ -418,10 +419,18 @@ struct DownloadProgressView: View {
     }
 
     private var totalProgress: Double {
-        supportsCoreML ? (mainProgress * 0.5) + (coreMLProgress * 0.5) : mainProgress
+        if isOptimizing {
+            return 1
+        }
+
+        return supportsCoreML ? (mainProgress * 0.5) + (coreMLProgress * 0.5) : mainProgress
     }
 
     private var downloadPhase: String {
+        if isOptimizing {
+            return "Optimizing model for your device"
+        }
+
         if supportsCoreML && downloadProgress[modelName + "_coreml"] != nil {
             return "Downloading Core ML Model for \(modelName)"
         }
@@ -430,7 +439,15 @@ struct DownloadProgressView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(downloadPhase)
+            HStack {
+                Text(downloadPhase)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text("\(Int(totalProgress * 100))%")
+                    .fontDesign(.monospaced)
+            }
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(Color(.secondaryLabelColor))
 
@@ -446,13 +463,6 @@ struct DownloadProgressView: View {
                 }
             }
             .frame(height: 6)
-
-            HStack {
-                Spacer()
-                Text("\(Int(totalProgress * 100))%")
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundColor(Color(.secondaryLabelColor))
-            }
         }
         .padding(.vertical, 4)
         .animation(.smooth, value: totalProgress)

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardView.swift
@@ -101,12 +101,26 @@ struct FluidAudioModelCardView: View {
 
     private var progressSection: some View {
         Group {
-            if isDownloading {
-                let progress = fluidAudioModelManager.downloadProgress[model.name] ?? 0.0
-                ProgressView(value: progress)
-                    .progressViewStyle(LinearProgressViewStyle())
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 8)
+            if let status = fluidAudioModelManager.downloadStatus(for: model) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(status.message)
+                            .lineLimit(1)
+
+                        Spacer()
+
+                        Text("\(Int(status.fractionCompleted * 100))%")
+                            .fontDesign(.monospaced)
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(Color(.secondaryLabelColor))
+
+                    ProgressView(value: status.fractionCompleted)
+                        .progressViewStyle(LinearProgressViewStyle())
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 8)
+                .animation(.smooth, value: status.fractionCompleted)
             }
         }
     }

--- a/VoiceInk/Views/AI Models/WhisperModelCardView.swift
+++ b/VoiceInk/Views/AI Models/WhisperModelCardView.swift
@@ -94,10 +94,11 @@ struct WhisperModelCardView: View {
     
     private var progressSection: some View {
         Group {
-            if isDownloading {
+            if isDownloading || isWarming {
                 DownloadProgressView(
                     modelName: model.name,
-                    downloadProgress: downloadProgress
+                    downloadProgress: downloadProgress,
+                    isOptimizing: isWarming && !isDownloading
                 )
                 .padding(.top, 8)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -112,22 +113,12 @@ struct WhisperModelCardView: View {
                     .font(.system(size: 12))
                     .foregroundColor(Color(.secondaryLabelColor))
             } else if isDownloaded {
-                if isWarming {
-                    HStack(spacing: 6) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Optimizing model for your device...")
-                            .font(.system(size: 12))
-                            .foregroundColor(Color(.secondaryLabelColor))
-                    }
-                } else {
-                    Button(action: setDefaultAction) {
-                        Text("Set as Default")
-                            .font(.system(size: 12))
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                Button(action: setDefaultAction) {
+                    Text("Set as Default")
+                        .font(.system(size: 12))
                 }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             } else {
                 Button(action: downloadAction) {
                     HStack(spacing: 4) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show real-time, phase-aware download progress for `FluidAudio` and Whisper with clear messages and percentages. Removes fake progress, auto-downloads models, and ignores stale callbacks to keep the UI accurate.

- **New Features**
  - `FluidAudio`: wired progress handler from `AsrModels.downloadAndLoad`; phases: listing, downloading (x/y), compiling component names.
  - `FluidAudio` & Whisper: show percent next to the status message with smooth updates.
  - Whisper: progress view supports an “Optimizing model for your device” state during warmup.

- **Refactors**
  - Removed timer-based fake progress and `UserDefaults` flags; use `AsrModels.modelsExist` and a new `downloadStatuses` map.
  - Added per-download UUID tracking to ignore stale `FluidAudio` progress callbacks and clear status safely.
  - `FluidAudioTranscriptionService` now uses `AsrModels.downloadAndLoad` to fetch or load models automatically.
  - Consolidated cache helpers and Finder/delete flows; updated `FluidAudio` SwiftPM to the latest `main` and refined Parakeet V3 description.

<sup>Written for commit 3a7593e4b1d9762925c9f1ba85992c363557adaa. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/674?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

