### PR TITLE
Add transcript formatting cleanup options

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -23,6 +23,8 @@ enum AppDefaults {
             "IsTextFormattingEnabled": true,
             "IsVADEnabled": true,
             "RemoveFillerWords": true,
+            "RemovePunctuation": false,
+            "LowercaseTranscription": false,
             "SelectedLanguage": "en",
             "AppendTrailingSpace": true,
             "RecorderType": "mini",

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -31,6 +31,9 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var selectedPrompt: String?
     var selectedTranscriptionModelName: String?
     var selectedLanguage: String?
+    var isTextFormattingEnabled: Bool = false
+    var removePunctuation: Bool = false
+    var lowercaseTranscription: Bool = false
     var useScreenCapture: Bool
     var selectedAIProvider: String?
     var selectedAIModel: String?
@@ -40,7 +43,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var hotkeyShortcut: String? = nil
         
     enum CodingKeys: String, CodingKey {
-        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault, hotkeyShortcut
+        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, removePunctuation, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault, hotkeyShortcut
         case selectedWhisperModel
         case selectedTranscriptionModelName
     }
@@ -48,6 +51,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     init(id: UUID = UUID(), name: String, emoji: String, appConfigs: [AppConfig]? = nil,
          urlConfigs: [URLConfig]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, selectedLanguage: String? = nil, useScreenCapture: Bool = false,
+         isTextFormattingEnabled: Bool = false, removePunctuation: Bool = false, lowercaseTranscription: Bool = false,
          selectedAIProvider: String? = nil, selectedAIModel: String? = nil, autoSendKey: AutoSendKey = .none, isEnabled: Bool = true, isDefault: Bool = false, hotkeyShortcut: String? = nil) {
         self.id = id
         self.name = name
@@ -62,6 +66,9 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         self.selectedAIModel = selectedAIModel
         self.selectedTranscriptionModelName = selectedTranscriptionModelName ?? UserDefaults.standard.string(forKey: "CurrentTranscriptionModel")
         self.selectedLanguage = selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
+        self.isTextFormattingEnabled = isTextFormattingEnabled
+        self.removePunctuation = removePunctuation
+        self.lowercaseTranscription = lowercaseTranscription
         self.isEnabled = isEnabled
         self.isDefault = isDefault
         self.hotkeyShortcut = hotkeyShortcut
@@ -77,6 +84,9 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         isAIEnhancementEnabled = try container.decode(Bool.self, forKey: .isAIEnhancementEnabled)
         selectedPrompt = try container.decodeIfPresent(String.self, forKey: .selectedPrompt)
         selectedLanguage = try container.decodeIfPresent(String.self, forKey: .selectedLanguage)
+        isTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isTextFormattingEnabled) ?? false
+        removePunctuation = try container.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+        lowercaseTranscription = try container.decodeIfPresent(Bool.self, forKey: .lowercaseTranscription) ?? false
         useScreenCapture = try container.decode(Bool.self, forKey: .useScreenCapture)
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
         selectedAIModel = try container.decodeIfPresent(String.self, forKey: .selectedAIModel)
@@ -112,6 +122,9 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         try container.encode(isAIEnhancementEnabled, forKey: .isAIEnhancementEnabled)
         try container.encodeIfPresent(selectedPrompt, forKey: .selectedPrompt)
         try container.encodeIfPresent(selectedLanguage, forKey: .selectedLanguage)
+        try container.encode(isTextFormattingEnabled, forKey: .isTextFormattingEnabled)
+        try container.encode(removePunctuation, forKey: .removePunctuation)
+        try container.encode(lowercaseTranscription, forKey: .lowercaseTranscription)
         try container.encode(useScreenCapture, forKey: .useScreenCapture)
         try container.encodeIfPresent(selectedAIProvider, forKey: .selectedAIProvider)
         try container.encodeIfPresent(selectedAIModel, forKey: .selectedAIModel)

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -18,6 +18,9 @@ struct ConfigurationView: View {
     @State private var selectedPromptId: UUID?
     @State private var selectedTranscriptionModelName: String?
     @State private var selectedLanguage: String?
+    @State private var isTextFormattingEnabled = false
+    @State private var removePunctuation = false
+    @State private var lowercaseTranscription = false
     @State private var installedApps: [(url: URL, name: String, bundleId: String, icon: NSImage)] = []
     @State private var searchText = ""
     @State private var validationErrors: [PowerModeValidationError] = []
@@ -32,6 +35,7 @@ struct ConfigurationView: View {
     @State private var isDefault = false
     @State private var isShowingDeleteConfirmation = false
     @State private var powerModeConfigId: UUID = UUID()
+    @State private var isTranscriptFormattingExpanded = false
 
     private var effectiveModelName: String? {
         selectedTranscriptionModelName ?? transcriptionModelManager.currentTranscriptionModel?.name
@@ -67,6 +71,9 @@ struct ConfigurationView: View {
             _selectedPromptId = State(initialValue: nil)
             _selectedTranscriptionModelName = State(initialValue: nil)
             _selectedLanguage = State(initialValue: nil)
+            _isTextFormattingEnabled = State(initialValue: false)
+            _removePunctuation = State(initialValue: false)
+            _lowercaseTranscription = State(initialValue: false)
             _configName = State(initialValue: "")
             _selectedEmoji = State(initialValue: "✏️")
             _useScreenCapture = State(initialValue: false)
@@ -75,6 +82,7 @@ struct ConfigurationView: View {
             // Use UserDefaults directly since EnvironmentObjects aren't available in init
             _selectedAIProvider = State(initialValue: UserDefaults.standard.string(forKey: "selectedAIProvider"))
             _selectedAIModel = State(initialValue: nil)
+            _isTranscriptFormattingExpanded = State(initialValue: false)
         case .edit(let config):
             // Fetch latest version in case config was modified elsewhere
             let latestConfig = powerModeManager.getConfiguration(with: config.id) ?? config
@@ -83,6 +91,9 @@ struct ConfigurationView: View {
             _selectedPromptId = State(initialValue: latestConfig.selectedPrompt.flatMap { UUID(uuidString: $0) })
             _selectedTranscriptionModelName = State(initialValue: latestConfig.selectedTranscriptionModelName)
             _selectedLanguage = State(initialValue: latestConfig.selectedLanguage)
+            _isTextFormattingEnabled = State(initialValue: latestConfig.isTextFormattingEnabled)
+            _removePunctuation = State(initialValue: latestConfig.removePunctuation)
+            _lowercaseTranscription = State(initialValue: latestConfig.lowercaseTranscription)
             _configName = State(initialValue: latestConfig.name)
             _selectedEmoji = State(initialValue: latestConfig.emoji)
             _selectedAppConfigs = State(initialValue: latestConfig.appConfigs ?? [])
@@ -92,6 +103,7 @@ struct ConfigurationView: View {
             _isDefault = State(initialValue: latestConfig.isDefault)
             _selectedAIProvider = State(initialValue: latestConfig.selectedAIProvider)
             _selectedAIModel = State(initialValue: latestConfig.selectedAIModel)
+            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.removePunctuation || latestConfig.lowercaseTranscription)
         }
     }
 
@@ -318,6 +330,48 @@ struct ConfigurationView: View {
                                     selectedLanguage = "en"
                                 }
                             }
+                    }
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            isTranscriptFormattingExpanded.toggle()
+                        }
+                    } label: {
+                        HStack {
+                            Text("Transcript Formatting")
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundColor(.secondary)
+                                .rotationEffect(.degrees(isTranscriptFormattingExpanded ? 90 : 0))
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+
+                    if isTranscriptFormattingExpanded {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Toggle(isOn: $isTextFormattingEnabled) {
+                                HStack(spacing: 4) {
+                                    Text("Paragraph breaks")
+                                    InfoTip("Apply intelligent text formatting to break large block of text into paragraphs.")
+                                }
+                            }
+
+                            Toggle(isOn: $removePunctuation) {
+                                HStack(spacing: 4) {
+                                    Text("Remove punctuation")
+                                    InfoTip("Remove punctuation marks from transcription output.")
+                                }
+                            }
+
+                            Toggle(isOn: $lowercaseTranscription) {
+                                HStack(spacing: 4) {
+                                    Text("Lowercase output")
+                                    InfoTip("Convert transcription output to lowercase.")
+                                }
+                            }
+                        }
+                        .padding(.top, 4)
                     }
                 }
 
@@ -556,6 +610,9 @@ struct ConfigurationView: View {
                 selectedTranscriptionModelName: selectedTranscriptionModelName,
                 selectedLanguage: selectedLanguage,
                 useScreenCapture: useScreenCapture,
+                isTextFormattingEnabled: isTextFormattingEnabled,
+                removePunctuation: removePunctuation,
+                lowercaseTranscription: lowercaseTranscription,
                 selectedAIProvider: selectedAIProvider,
                 selectedAIModel: selectedAIModel,
                 autoSendKey: autoSendKey,
@@ -570,6 +627,9 @@ struct ConfigurationView: View {
             updatedConfig.selectedPrompt = selectedPromptId?.uuidString
             updatedConfig.selectedTranscriptionModelName = selectedTranscriptionModelName
             updatedConfig.selectedLanguage = selectedLanguage
+            updatedConfig.isTextFormattingEnabled = isTextFormattingEnabled
+            updatedConfig.removePunctuation = removePunctuation
+            updatedConfig.lowercaseTranscription = lowercaseTranscription
             updatedConfig.appConfigs = selectedAppConfigs.isEmpty ? nil : selectedAppConfigs
             updatedConfig.urlConfigs = websiteConfigs.isEmpty ? nil : websiteConfigs
             updatedConfig.useScreenCapture = useScreenCapture

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -9,6 +9,9 @@ struct ApplicationState: Codable {
     var selectedAIModel: String?
     var selectedLanguage: String?
     var transcriptionModelName: String?
+    var isTextFormattingEnabled: Bool?
+    var removePunctuation: Bool?
+    var lowercaseTranscription: Bool?
 }
 
 struct PowerModeSession: Codable {
@@ -51,7 +54,10 @@ class PowerModeSessionManager {
                 selectedAIProvider: enhancementService.getAIService()?.selectedProvider.rawValue,
                 selectedAIModel: enhancementService.getAIService()?.currentModel,
                 selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
-                transcriptionModelName: stateProvider.currentTranscriptionModel?.name
+                transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
+                isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
+                removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
+                lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
             )
 
             let newSession = PowerModeSession(
@@ -100,7 +106,10 @@ class PowerModeSessionManager {
             selectedAIProvider: enhancementService.getAIService()?.selectedProvider.rawValue,
             selectedAIModel: enhancementService.getAIService()?.currentModel,
             selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
-            transcriptionModelName: stateProvider.currentTranscriptionModel?.name
+            transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
+            isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
+            removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
+            lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
         )
 
         session.originalState = updatedState
@@ -134,6 +143,10 @@ class PowerModeSessionManager {
                 UserDefaults.standard.set(language, forKey: "SelectedLanguage")
                 NotificationCenter.default.post(name: .languageDidChange, object: nil)
             }
+
+            UserDefaults.standard.set(config.isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
+            UserDefaults.standard.set(config.removePunctuation, forKey: "RemovePunctuation")
+            UserDefaults.standard.set(config.lowercaseTranscription, forKey: "LowercaseTranscription")
         }
 
         if let modelName = config.selectedTranscriptionModelName,
@@ -168,6 +181,16 @@ class PowerModeSessionManager {
             if let language = state.selectedLanguage {
                 UserDefaults.standard.set(language, forKey: "SelectedLanguage")
                 NotificationCenter.default.post(name: .languageDidChange, object: nil)
+            }
+
+            if let isTextFormattingEnabled = state.isTextFormattingEnabled {
+                UserDefaults.standard.set(isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
+            }
+            if let removePunctuation = state.removePunctuation {
+                UserDefaults.standard.set(removePunctuation, forKey: "RemovePunctuation")
+            }
+            if let lowercaseTranscription = state.lowercaseTranscription {
+                UserDefaults.standard.set(lowercaseTranscription, forKey: "LowercaseTranscription")
             }
         }
 

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -169,6 +169,7 @@ class AudioTranscriptionManager: ObservableObject {
             }
 
             text = WordReplacementService.shared.applyReplacements(to: text, using: modelContext)
+            let cleanedText = TranscriptionOutputFilter.applyUserCleanupPreferences(text)
             try Task.checkCancellation()
 
             // Handle enhancement if enabled
@@ -181,7 +182,7 @@ class AudioTranscriptionManager: ObservableObject {
                 do {
                     let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(text)
                     transcription = Transcription(
-                        text: text,
+                        text: cleanedText,
                         duration: duration,
                         enhancedText: enhancedText,
                         audioFileURL: permanentURL.absoluteString,
@@ -198,7 +199,7 @@ class AudioTranscriptionManager: ObservableObject {
                 } catch {
                     logger.error("Enhancement failed: \(error.localizedDescription, privacy: .public)")
                     transcription = Transcription(
-                        text: text,
+                        text: cleanedText,
                         duration: duration,
                         enhancedText: "Enhancement failed: \(error.localizedDescription)",
                         audioFileURL: permanentURL.absoluteString,
@@ -211,7 +212,7 @@ class AudioTranscriptionManager: ObservableObject {
                 }
             } else {
                 transcription = Transcription(
-                    text: text,
+                    text: cleanedText,
                     duration: duration,
                     audioFileURL: permanentURL.absoluteString,
                     transcriptionModelName: currentModel.displayName,

--- a/VoiceInk/Services/AudioFileTranscriptionService.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionService.swift
@@ -61,6 +61,7 @@ class AudioTranscriptionService: ObservableObject {
 
             text = WordReplacementService.shared.applyReplacements(to: text, using: modelContext)
             logger.notice("✅ Word replacements applied")
+            let cleanedText = TranscriptionOutputFilter.applyUserCleanupPreferences(text)
 
             let audioAsset = AVURLAsset(url: url)
             let duration = CMTimeGetSeconds(try await audioAsset.load(.duration))
@@ -82,7 +83,7 @@ class AudioTranscriptionService: ObservableObject {
             let permanentURLString = permanentURL.absoluteString
 
             // Apply prompt detection for trigger words
-            let originalText = text
+            let originalText = cleanedText
             var promptDetectionResult: PromptDetectionService.PromptDetectionResult? = nil
 
             if let enhancementService = enhancementService, enhancementService.isConfigured {

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -24,6 +24,8 @@ struct GeneralSettings: Codable {
     let isPauseMediaEnabled: Bool?
     let audioResumptionDelay: Double?
     let isTextFormattingEnabled: Bool?
+    let removePunctuation: Bool?
+    let lowercaseTranscription: Bool?
     let isExperimentalFeaturesEnabled: Bool?
     let restoreClipboardAfterPaste: Bool?
     let clipboardRestoreDelay: Double?
@@ -63,6 +65,8 @@ class ImportExportService {
     private let keyIsSoundFeedbackEnabled = "isSoundFeedbackEnabled"
     private let keyIsSystemMuteEnabled = "isSystemMuteEnabled"
     private let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
+    private let keyRemovePunctuation = "RemovePunctuation"
+    private let keyLowercaseTranscription = "LowercaseTranscription"
 
     private init() {
         if let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
@@ -117,6 +121,8 @@ class ImportExportService {
             isPauseMediaEnabled: playbackController.isPauseMediaEnabled,
             audioResumptionDelay: mediaController.audioResumptionDelay,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: keyIsTextFormattingEnabled),
+            removePunctuation: UserDefaults.standard.bool(forKey: keyRemovePunctuation),
+            lowercaseTranscription: UserDefaults.standard.bool(forKey: keyLowercaseTranscription),
             isExperimentalFeaturesEnabled: UserDefaults.standard.bool(forKey: "isExperimentalFeaturesEnabled"),
             restoreClipboardAfterPaste: UserDefaults.standard.bool(forKey: "restoreClipboardAfterPaste"),
             clipboardRestoreDelay: UserDefaults.standard.double(forKey: "clipboardRestoreDelay"),
@@ -332,6 +338,12 @@ class ImportExportService {
                         }
                         if let textFormattingEnabled = general.isTextFormattingEnabled {
                             UserDefaults.standard.set(textFormattingEnabled, forKey: self.keyIsTextFormattingEnabled)
+                        }
+                        if let removePunctuation = general.removePunctuation {
+                            UserDefaults.standard.set(removePunctuation, forKey: self.keyRemovePunctuation)
+                        }
+                        if let lowercaseTranscription = general.lowercaseTranscription {
+                            UserDefaults.standard.set(lowercaseTranscription, forKey: self.keyLowercaseTranscription)
                         }
                         if let restoreClipboard = general.restoreClipboardAfterPaste {
                             UserDefaults.standard.set(restoreClipboard, forKey: "restoreClipboardAfterPaste")

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -85,17 +85,19 @@ class TranscriptionPipeline {
 
             text = WordReplacementService.shared.applyReplacements(to: text, using: modelContext)
             logger.notice("📝 WordReplacement: \(text, privacy: .public)")
+            let cleanedText = TranscriptionOutputFilter.applyUserCleanupPreferences(text)
+            logger.notice("📝 User cleanup result: \(cleanedText, privacy: .public)")
 
             let audioAsset = AVURLAsset(url: audioURL)
             let actualDuration = (try? CMTimeGetSeconds(await audioAsset.load(.duration))) ?? 0.0
 
-            transcription.text = text
+            transcription.text = cleanedText
             transcription.duration = actualDuration
             transcription.transcriptionModelName = model.displayName
             transcription.transcriptionDuration = transcriptionDuration
             transcription.powerModeName = powerModeName
             transcription.powerModeEmoji = powerModeEmoji
-            finalPastedText = text
+            finalPastedText = cleanedText
 
             if let enhancementService, enhancementService.isConfigured {
                 let detectionResult = await promptDetectionService.analyzeText(text, with: enhancementService)

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -3,6 +3,9 @@ import os
 
 struct TranscriptionOutputFilter {
     private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionOutputFilter")
+    private static let removePunctuationKey = "RemovePunctuation"
+    private static let lowercaseTranscriptionKey = "LowercaseTranscription"
+    private static let apostropheLikeCharacters = CharacterSet(charactersIn: "'’‘ʼ＇")
     
     private static let hallucinationPatterns = [
         #"\[.*?\]"#,     // []
@@ -51,5 +54,51 @@ struct TranscriptionOutputFilter {
         }
 
         return filteredText
+    }
+
+    static func applyUserCleanupPreferences(_ text: String) -> String {
+        let shouldRemovePunctuation = UserDefaults.standard.bool(forKey: removePunctuationKey)
+        let shouldLowercase = UserDefaults.standard.bool(forKey: lowercaseTranscriptionKey)
+
+        guard shouldRemovePunctuation || shouldLowercase else {
+            return text
+        }
+
+        var cleanedText = text
+        if shouldRemovePunctuation {
+            cleanedText = removePunctuation(from: cleanedText)
+        }
+        if shouldLowercase {
+            cleanedText = cleanedText.lowercased()
+        }
+
+        return cleanedText
+    }
+
+    static func removePunctuation(from text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        let punctuationSeparators = CharacterSet.punctuationCharacters.subtracting(apostropheLikeCharacters)
+        let cleanedScalars = text.unicodeScalars.map { scalar -> String in
+            if apostropheLikeCharacters.contains(scalar) {
+                return ""
+            }
+
+            if punctuationSeparators.contains(scalar) {
+                return " "
+            }
+
+            return String(scalar)
+        }
+
+        return normalizeWhitespace(cleanedScalars.joined())
+    }
+
+    private static func normalizeWhitespace(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: #"[^\S\r\n]{2,}"#, with: " ", options: .regularExpression)
+            .replacingOccurrences(of: #"[ \t]+\n"#, with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: #"\n[ \t]+"#, with: "\n", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 } 

--- a/VoiceInk/Views/Components/FillerWordsSettingsView.swift
+++ b/VoiceInk/Views/Components/FillerWordsSettingsView.swift
@@ -59,6 +59,7 @@ struct FillerWordsSettingsView: View {
                     HStack(spacing: 8) {
                         TextField("Add filler word", text: $newWord)
                             .textFieldStyle(.roundedBorder)
+                            .accessibilityLabel("Add filler word")
                             .onSubmit { addWord() }
 
                         Button(action: addWord) {
@@ -68,7 +69,7 @@ struct FillerWordsSettingsView: View {
                                 .font(.system(size: 16, weight: .semibold))
                         }
                         .buttonStyle(.borderless)
-                        .help("Add filler word")
+                        .accessibilityLabel("Add filler word")
                         .disabled(newWord.trimmingCharacters(in: .whitespaces).isEmpty)
                     }
                     .padding(.vertical, 4)
@@ -84,9 +85,7 @@ struct FillerWordsSettingsView: View {
                             }
                         }
                     }
-
                 }
-                .padding(.leading, 4)
             }
         }
         .alert("Duplicate Word", isPresented: $showDuplicateAlert) {

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -4,6 +4,8 @@ struct ModelSettingsView: View {
     @ObservedObject var whisperPrompt: WhisperPrompt
     @AppStorage("SelectedLanguage") private var selectedLanguage: String = "en"
     @AppStorage("IsTextFormattingEnabled") private var isTextFormattingEnabled = true
+    @AppStorage("RemovePunctuation") private var removePunctuation = false
+    @AppStorage("LowercaseTranscription") private var lowercaseTranscription = false
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("AppendTrailingSpace") private var appendTrailingSpace = true
     @AppStorage("PrewarmModelOnWake") private var prewarmModelOnWake = true
@@ -49,15 +51,40 @@ struct ModelSettingsView: View {
             }
 
             Section {
-                Toggle(isOn: $appendTrailingSpace) {
-                    Text("Add Space After Paste")
+                Toggle(isOn: $isTextFormattingEnabled) {
+                    HStack(spacing: 4) {
+                        Text("Paragraph breaks")
+                        InfoTip("Apply intelligent text formatting to break large block of text into paragraphs.")
+                    }
                 }
                 .toggleStyle(.switch)
 
-                Toggle(isOn: $isTextFormattingEnabled) {
+                Toggle(isOn: $removePunctuation) {
                     HStack(spacing: 4) {
-                        Text("Automatic text formatting")
-                        InfoTip("Apply intelligent text formatting to break large block of text into paragraphs.")
+                        Text("Remove punctuation")
+                        InfoTip("Remove punctuation marks from transcription output.")
+                    }
+                }
+                .toggleStyle(.switch)
+
+                Toggle(isOn: $lowercaseTranscription) {
+                    HStack(spacing: 4) {
+                        Text("Lowercase output")
+                        InfoTip("Convert transcription output to lowercase.")
+                    }
+                }
+                .toggleStyle(.switch)
+
+                FillerWordsSettingsView()
+            } header: {
+                Text("Transcript Formatting")
+            }
+
+            Section {
+                Toggle(isOn: $appendTrailingSpace) {
+                    HStack(spacing: 4) {
+                        Text("Add Space After Paste")
+                        InfoTip("Add a trailing space after pasted transcription output.")
                     }
                 }
                 .toggleStyle(.switch)
@@ -86,11 +113,7 @@ struct ModelSettingsView: View {
                 }
                 .toggleStyle(.switch)
             } header: {
-                Text("Transcription")
-            }
-
-            Section {
-                FillerWordsSettingsView()
+                Text("Advanced")
             }
         }
         .formStyle(.grouped)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds optional transcript cleanup to remove punctuation and/or lowercase output, with per-mode overrides in Power Mode. Cleanup runs after word replacements and applies to saved and pasted text across all transcription flows.

- **New Features**
  - New toggles in Model Settings: Remove punctuation, Lowercase output (under “Transcript Formatting”), plus clearer “Paragraph breaks” label.
  - Power Mode: per-mode controls for Paragraph breaks, Remove punctuation, Lowercase output; session manager applies and restores these settings on start/end.
  - Cleanup via TranscriptionOutputFilter.applyUserCleanupPreferences with whitespace normalization; applied across `AudioFileTranscriptionManager`, `AudioFileTranscriptionService`, and `TranscriptionPipeline`.
  - Defaults added in `AppDefaults` and persisted through Import/Export (`removePunctuation`, `lowercaseTranscription`).
  - Minor accessibility improvements in filler words UI (text field and button labels).

<sup>Written for commit 4fe8031c94a9bf48d51e383af464c6239f836ad8. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/675?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

