### PR TITLE
Add cloud STT providers: Cartesia Ink Whisper and AssemblyAI

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -9,13 +9,13 @@
 /* Begin PBXBuildFile section */
 		E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = E11BBA4D2E5DC555000AB839 /* FluidAudio */; };
 		E1342C1F2EB4844800CED8A2 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = E1342C1E2EB4844800CED8A2 /* Atomics */; };
-		E15433AB2F86A73C0083437A /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E15433AA2F86A73C0083437A /* LLMkit */; };
 		E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E161D4A02F41ECB90086F83D /* CloudKit.framework */; };
 		E1A261122CC143AC00B233D1 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = E1A261112CC143AC00B233D1 /* KeyboardShortcuts */; };
 		E1ADD45A2CC5352A00303ECB /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD4592CC5352A00303ECB /* LaunchAtLogin */; };
 		E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD45E2CC544F100303ECB /* Sparkle */; };
 		E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; };
 		E1D7EF9A2E35E19B00640029 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		E1DD18DE2FA11D000020AF3B /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD18DD2FA11D000020AF3B /* LLMkit */; };
 		E1ECEC162E44591300DFFBA8 /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = E1ECEC152E44591300DFFBA8 /* Zip */; };
 		E1F1037B2EF85FC700A4FF94 /* SelectedTextKit in Frameworks */ = {isa = PBXBuildFile; productRef = E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */; };
 		E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; };
@@ -95,7 +95,7 @@
 				E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */,
 				E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */,
 				E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */,
-				E15433AB2F86A73C0083437A /* LLMkit in Frameworks */,
+				E1DD18DE2FA11D000020AF3B /* LLMkit in Frameworks */,
 				E1F1037B2EF85FC700A4FF94 /* SelectedTextKit in Frameworks */,
 				E1A261122CC143AC00B233D1 /* KeyboardShortcuts in Frameworks */,
 			);
@@ -179,7 +179,7 @@
 				E11BBA4D2E5DC555000AB839 /* FluidAudio */,
 				E1342C1E2EB4844800CED8A2 /* Atomics */,
 				E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */,
-				E15433AA2F86A73C0083437A /* LLMkit */,
+				E1DD18DD2FA11D000020AF3B /* LLMkit */,
 			);
 			productName = VoiceInk;
 			productReference = E11473B02CBE0F0A00318EE4 /* VoiceInk.app */;
@@ -272,7 +272,7 @@
 				E11BBA4C2E5DC555000AB839 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */,
 				E1F103792EF85FC700A4FF94 /* XCRemoteSwiftPackageReference "SelectedTextKit" */,
-				E15433A92F86A73C0083437A /* XCRemoteSwiftPackageReference "LLMkit" */,
+				E1DD18DC2FA11D000020AF3B /* XCLocalSwiftPackageReference "../LLMkit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -644,6 +644,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		E1DD18DC2FA11D000020AF3B /* XCLocalSwiftPackageReference "../LLMkit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../LLMkit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		E11BBA4C2E5DC555000AB839 /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -659,14 +666,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.3.0;
-			};
-		};
-		E15433A92F86A73C0083437A /* XCRemoteSwiftPackageReference "LLMkit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Beingpax/LLMkit.git";
-			requirement = {
-				branch = main;
-				kind = branch;
 			};
 		};
 		E1A261102CC143AC00B233D1 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
@@ -730,11 +729,6 @@
 			package = E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */;
 			productName = Atomics;
 		};
-		E15433AA2F86A73C0083437A /* LLMkit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E15433A92F86A73C0083437A /* XCRemoteSwiftPackageReference "LLMkit" */;
-			productName = LLMkit;
-		};
 		E1A261112CC143AC00B233D1 /* KeyboardShortcuts */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1A261102CC143AC00B233D1 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
@@ -754,6 +748,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
 			productName = MediaRemoteAdapter;
+		};
+		E1DD18DD2FA11D000020AF3B /* LLMkit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LLMkit;
 		};
 		E1ECEC152E44591300DFFBA8 /* Zip */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = E11BBA4D2E5DC555000AB839 /* FluidAudio */; };
 		E1342C1F2EB4844800CED8A2 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = E1342C1E2EB4844800CED8A2 /* Atomics */; };
 		E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E161D4A02F41ECB90086F83D /* CloudKit.framework */; };
 		E1A261122CC143AC00B233D1 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = E1A261112CC143AC00B233D1 /* KeyboardShortcuts */; };
@@ -15,8 +14,9 @@
 		E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD45E2CC544F100303ECB /* Sparkle */; };
 		E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; };
 		E1D7EF9A2E35E19B00640029 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		E1DD18DE2FA11D000020AF3B /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD18DD2FA11D000020AF3B /* LLMkit */; };
-		E1ECEC162E44591300DFFBA8 /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = E1ECEC152E44591300DFFBA8 /* Zip */; };
+		E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD1EE02FA1D7D30020AF3B /* Zip */; };
+		E1DD20DE2FA20AD90020AF3B /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD20DD2FA20AD90020AF3B /* FluidAudio */; };
+		E1DD20E12FA20AEE0020AF3B /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD20E02FA20AEE0020AF3B /* LLMkit */; };
 		E1F1037B2EF85FC700A4FF94 /* SelectedTextKit in Frameworks */ = {isa = PBXBuildFile; productRef = E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */; };
 		E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; };
 		E1F350122F1D10D600790A2C /* whisper.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -89,13 +89,13 @@
 			files = (
 				E1342C1F2EB4844800CED8A2 /* Atomics in Frameworks */,
 				E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */,
-				E1ECEC162E44591300DFFBA8 /* Zip in Frameworks */,
 				E1ADD45A2CC5352A00303ECB /* LaunchAtLogin in Frameworks */,
-				E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */,
 				E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */,
 				E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */,
 				E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */,
-				E1DD18DE2FA11D000020AF3B /* LLMkit in Frameworks */,
+				E1DD20DE2FA20AD90020AF3B /* FluidAudio in Frameworks */,
+				E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */,
+				E1DD20E12FA20AEE0020AF3B /* LLMkit in Frameworks */,
 				E1F1037B2EF85FC700A4FF94 /* SelectedTextKit in Frameworks */,
 				E1A261122CC143AC00B233D1 /* KeyboardShortcuts in Frameworks */,
 			);
@@ -175,11 +175,11 @@
 				E1ADD4592CC5352A00303ECB /* LaunchAtLogin */,
 				E1ADD45E2CC544F100303ECB /* Sparkle */,
 				E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */,
-				E1ECEC152E44591300DFFBA8 /* Zip */,
-				E11BBA4D2E5DC555000AB839 /* FluidAudio */,
 				E1342C1E2EB4844800CED8A2 /* Atomics */,
 				E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */,
-				E1DD18DD2FA11D000020AF3B /* LLMkit */,
+				E1DD1EE02FA1D7D30020AF3B /* Zip */,
+				E1DD20DD2FA20AD90020AF3B /* FluidAudio */,
+				E1DD20E02FA20AEE0020AF3B /* LLMkit */,
 			);
 			productName = VoiceInk;
 			productReference = E11473B02CBE0F0A00318EE4 /* VoiceInk.app */;
@@ -269,10 +269,10 @@
 				E1ADD45D2CC544F100303ECB /* XCRemoteSwiftPackageReference "Sparkle" */,
 				E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */,
 				E1ECEC142E44590200DFFBA8 /* XCRemoteSwiftPackageReference "Zip" */,
-				E11BBA4C2E5DC555000AB839 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */,
 				E1F103792EF85FC700A4FF94 /* XCRemoteSwiftPackageReference "SelectedTextKit" */,
-				E1DD18DC2FA11D000020AF3B /* XCLocalSwiftPackageReference "../LLMkit" */,
+				E1DD20DC2FA20AD90020AF3B /* XCRemoteSwiftPackageReference "FluidAudio" */,
+				E1DD20DF2FA20AEE0020AF3B /* XCRemoteSwiftPackageReference "LLMkit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -644,22 +644,7 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		E1DD18DC2FA11D000020AF3B /* XCLocalSwiftPackageReference "../LLMkit" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../LLMkit;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
-		E11BBA4C2E5DC555000AB839 /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/FluidInference/FluidAudio";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-atomics.git";
@@ -700,6 +685,22 @@
 				kind = branch;
 			};
 		};
+		E1DD20DC2FA20AD90020AF3B /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		E1DD20DF2FA20AEE0020AF3B /* XCRemoteSwiftPackageReference "LLMkit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Beingpax/LLMkit.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		E1ECEC142E44590200DFFBA8 /* XCRemoteSwiftPackageReference "Zip" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/marmelroy/Zip";
@@ -719,11 +720,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		E11BBA4D2E5DC555000AB839 /* FluidAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E11BBA4C2E5DC555000AB839 /* XCRemoteSwiftPackageReference "FluidAudio" */;
-			productName = FluidAudio;
-		};
 		E1342C1E2EB4844800CED8A2 /* Atomics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */;
@@ -749,14 +745,20 @@
 			package = E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
 			productName = MediaRemoteAdapter;
 		};
-		E1DD18DD2FA11D000020AF3B /* LLMkit */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = LLMkit;
-		};
-		E1ECEC152E44591300DFFBA8 /* Zip */ = {
+		E1DD1EE02FA1D7D30020AF3B /* Zip */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1ECEC142E44590200DFFBA8 /* XCRemoteSwiftPackageReference "Zip" */;
 			productName = Zip;
+		};
+		E1DD20DD2FA20AD90020AF3B /* FluidAudio */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1DD20DC2FA20AD90020AF3B /* XCRemoteSwiftPackageReference "FluidAudio" */;
+			productName = FluidAudio;
+		};
+		E1DD20E02FA20AEE0020AF3B /* LLMkit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1DD20DF2FA20AEE0020AF3B /* XCRemoteSwiftPackageReference "LLMkit" */;
+			productName = LLMkit;
 		};
 		E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eadadded1c8ce49b3caee497a94e9bc0256a4a1c5803c086708e0e7a1e607542",
+  "originHash" : "5dc68de35f4d6eec8fea143f61dfe738594a7599418f5987952d77992d7d1d37",
   "pins" : [
     {
       "identity" : "axswift",
@@ -13,10 +13,10 @@
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/FluidInference/FluidAudio",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "eff1752ebfa97cf57377b261789d18df39240aad"
+        "revision" : "e332c18b49af64aa9ccae20af7a02d91cef444e5"
       }
     },
     {
@@ -44,6 +44,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "a04ec1c363be3627734f6dad757d82f5d4fa8fcc"
+      }
+    },
+    {
+      "identity" : "llmkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Beingpax/LLMkit.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "2ccd37ec0025c5b7804959cc98cb18ba7b86d2af"
       }
     },
     {

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c2e2df8a2e09b563e3062683ce11c69b2712372c34c99d2bc78f0b526c730c55",
+  "originHash" : "eadadded1c8ce49b3caee497a94e9bc0256a4a1c5803c086708e0e7a1e607542",
   "pins" : [
     {
       "identity" : "axswift",
@@ -44,15 +44,6 @@
       "state" : {
         "branch" : "main",
         "revision" : "a04ec1c363be3627734f6dad757d82f5d4fa8fcc"
-      }
-    },
-    {
-      "identity" : "llmkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Beingpax/LLMkit.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "91b228d3ff13febc6b61a58e5f3aa27e734d1c01"
       }
     },
     {

--- a/VoiceInk/Models/LanguageDictionary.swift
+++ b/VoiceInk/Models/LanguageDictionary.swift
@@ -1,7 +1,70 @@
 import Foundation
 
-enum LanguageDictionary {
+enum TranscriptionLanguageSupport {
+    private static let assemblyAIRealtimeLanguageCodes = ["en", "es", "de", "fr", "pt", "it"]
 
+    private static let assemblyAIBatchLanguageCodes = [
+        "en", "en_au", "en_uk", "en_us", "es", "fr", "de", "it", "pt", "nl",
+        "hi", "ja", "zh", "fi", "ko", "pl", "ru", "tr", "uk", "vi", "af",
+        "sq", "am", "ar", "hy", "as", "az", "ba", "eu", "be", "bn", "bs",
+        "br", "bg", "my", "ca", "hr", "cs", "da", "et", "fo", "gl", "ka",
+        "el", "gu", "ht", "ha", "haw", "he", "hu", "is", "id", "jw", "kn",
+        "kk", "km", "lo", "la", "lv", "ln", "lt", "lb", "mk", "mg", "ms",
+        "ml", "mt", "mi", "mr", "mn", "ne", "no", "nn", "oc", "pa", "ps",
+        "fa", "ro", "sa", "sr", "sn", "sd", "si", "sk", "sl", "so", "su",
+        "sw", "sv", "de_ch", "tl", "tg", "ta", "tt", "te", "th", "bo",
+        "tk", "ur", "uz", "cy", "yi", "yo"
+    ]
+
+    static func languages(for model: any TranscriptionModel) -> [String: String] {
+        if model.provider == .assemblyAI {
+            return assemblyAILanguages(usesRealtime: assemblyAIUsesRealtime(for: model))
+        }
+
+        return model.supportedLanguages
+    }
+
+    static func validLanguageOrFallback(_ language: String?, for model: any TranscriptionModel) -> String {
+        let languages = languages(for: model)
+
+        if let language, languages[language] != nil {
+            return language
+        }
+
+        if languages["auto"] != nil {
+            return "auto"
+        }
+
+        if languages["en"] != nil {
+            return "en"
+        }
+
+        return languages.keys.sorted { lhs, rhs in
+            languages[lhs, default: lhs] < languages[rhs, default: rhs]
+        }.first ?? "en"
+    }
+
+    private static func assemblyAILanguages(usesRealtime: Bool) -> [String: String] {
+        let codes = usesRealtime ? assemblyAIRealtimeLanguageCodes : assemblyAIBatchLanguageCodes
+        var filtered = LanguageDictionary.all.filter { codes.contains($0.key) }
+        filtered["auto"] = "Auto-detect"
+        return filtered
+    }
+
+    private static func assemblyAIUsesRealtime(for model: any TranscriptionModel) -> Bool {
+        guard model.provider == .assemblyAI, model.supportsStreaming else {
+            return false
+        }
+
+        if let cloudProvider = CloudProviderRegistry.provider(for: model.provider), cloudProvider.isStreamingOnly {
+            return true
+        }
+
+        return UserDefaults.standard.object(forKey: "streaming-enabled-\(model.name)") as? Bool ?? true
+    }
+}
+
+enum LanguageDictionary {
     static func forProvider(isMultilingual: Bool, provider: ModelProvider = .whisper) -> [String: String] {
         if !isMultilingual {
             return ["en": "English"]
@@ -97,8 +160,12 @@ enum LanguageDictionary {
         "cy": "Welsh",
         "da": "Danish",
         "de": "German",
+        "de_ch": "Swiss German",
         "el": "Greek",
         "en": "English",
+        "en_au": "Australian English",
+        "en_uk": "British English",
+        "en_us": "US English",
         "es": "Spanish",
         "et": "Estonian",
         "eu": "Basque",

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -12,6 +12,7 @@ enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case soniox = "Soniox"
     case speechmatics = "Speechmatics"
     case xai = "xAI"
+    case cartesia = "Cartesia"
     case custom = "Custom"
     case nativeApple = "Native Apple"
 

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -11,6 +11,7 @@ enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case gemini = "Gemini"
     case soniox = "Soniox"
     case speechmatics = "Speechmatics"
+    case assemblyAI = "AssemblyAI"
     case xai = "xAI"
     case cartesia = "Cartesia"
     case custom = "Custom"

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -58,6 +58,17 @@ struct ConfigurationView: View {
         return model.provider == .fluidAudio || model.provider == .gemini
     }
 
+    private func availableLanguages(for model: any TranscriptionModel) -> [String: String] {
+        TranscriptionLanguageSupport.languages(for: model)
+    }
+
+    private func useCompatibleLanguage(for model: any TranscriptionModel) {
+        selectedLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(
+            selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage"),
+            for: model
+        )
+    }
+
     init(mode: ConfigurationMode, powerModeManager: PowerModeManager, onDismiss: @escaping () -> Void) {
         self.mode = mode
         self.powerModeManager = powerModeManager
@@ -287,11 +298,13 @@ struct ConfigurationView: View {
                             }
                         }
                         .onChange(of: selectedTranscriptionModelName) { _, newModelName in
-                            // Auto-set language to "auto" for models that only support auto-detection
                             if let modelName = newModelName ?? transcriptionModelManager.currentTranscriptionModel?.name,
-                               let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }),
-                               model.provider == .fluidAudio || model.provider == .gemini {
-                                selectedLanguage = "auto"
+                               let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }) {
+                                if model.provider == .fluidAudio || model.provider == .gemini {
+                                    selectedLanguage = "auto"
+                                } else {
+                                    useCompatibleLanguage(for: model)
+                                }
                             }
                         }
                     }
@@ -313,7 +326,7 @@ struct ConfigurationView: View {
                         )
 
                         Picker("Language", selection: languageBinding) {
-                            ForEach(modelInfo.supportedLanguages.sorted(by: {
+                            ForEach(availableLanguages(for: modelInfo).sorted(by: {
                                 if $0.key == "auto" { return true }
                                 if $1.key == "auto" { return false }
                                 return $0.value < $1.value
@@ -543,6 +556,13 @@ struct ConfigurationView: View {
 
                 if isAIEnhancementEnabled && selectedPromptId == nil {
                     selectedPromptId = enhancementService.allPrompts.first?.id
+                }
+
+                if let selectedModelName = effectiveModelName,
+                   let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName }),
+                   model.provider != .fluidAudio,
+                   model.provider != .gemini {
+                    useCompatibleLanguage(for: model)
                 }
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -139,11 +139,6 @@ class PowerModeSessionManager {
                 }
             }
 
-            if let language = config.selectedLanguage {
-                UserDefaults.standard.set(language, forKey: "SelectedLanguage")
-                NotificationCenter.default.post(name: .languageDidChange, object: nil)
-            }
-
             UserDefaults.standard.set(config.isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
             UserDefaults.standard.set(config.removePunctuation, forKey: "RemovePunctuation")
             UserDefaults.standard.set(config.lowercaseTranscription, forKey: "LowercaseTranscription")
@@ -153,6 +148,10 @@ class PowerModeSessionManager {
            let selectedModel = await stateProvider.allAvailableModels.first(where: { $0.name == modelName }),
            stateProvider.currentTranscriptionModel?.name != modelName {
             await handleModelChange(to: selectedModel)
+        }
+
+        if let language = config.selectedLanguage {
+            applyCompatibleLanguage(language, preferredModelName: config.selectedTranscriptionModelName)
         }
 
         await MainActor.run {
@@ -178,11 +177,6 @@ class PowerModeSessionManager {
                 }
             }
 
-            if let language = state.selectedLanguage {
-                UserDefaults.standard.set(language, forKey: "SelectedLanguage")
-                NotificationCenter.default.post(name: .languageDidChange, object: nil)
-            }
-
             if let isTextFormattingEnabled = state.isTextFormattingEnabled {
                 UserDefaults.standard.set(isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
             }
@@ -199,6 +193,27 @@ class PowerModeSessionManager {
            stateProvider.currentTranscriptionModel?.name != modelName {
             await handleModelChange(to: selectedModel)
         }
+
+        if let language = state.selectedLanguage {
+            applyCompatibleLanguage(language, preferredModelName: state.transcriptionModelName)
+        }
+    }
+
+    private func applyCompatibleLanguage(_ language: String, preferredModelName: String?) {
+        guard let model = model(named: preferredModelName) ?? stateProvider?.currentTranscriptionModel else {
+            UserDefaults.standard.set(language, forKey: "SelectedLanguage")
+            NotificationCenter.default.post(name: .languageDidChange, object: nil)
+            return
+        }
+
+        let compatibleLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(language, for: model)
+        UserDefaults.standard.set(compatibleLanguage, forKey: "SelectedLanguage")
+        NotificationCenter.default.post(name: .languageDidChange, object: nil)
+    }
+
+    private func model(named modelName: String?) -> (any TranscriptionModel)? {
+        guard let modelName else { return nil }
+        return stateProvider?.allAvailableModels.first { $0.name == modelName }
     }
 
     private func handleModelChange(to newModel: any TranscriptionModel) async {

--- a/VoiceInk/PowerMode/PowerModeViewComponents.swift
+++ b/VoiceInk/PowerMode/PowerModeViewComponents.swift
@@ -120,7 +120,7 @@ struct ConfigurationRow: View {
             
             if let modelName = config.selectedTranscriptionModelName,
                let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }),
-               let langName = model.supportedLanguages[langCode] {
+               let langName = TranscriptionLanguageSupport.languages(for: model)[langCode] {
                 return langName
             }
             return langCode.uppercased()

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -13,6 +13,7 @@ enum AIProvider: String, CaseIterable {
     case deepgram = "Deepgram"
     case soniox = "Soniox"
     case speechmatics = "Speechmatics"
+    case assemblyAI = "AssemblyAI"
     case ollama = "Ollama"
     case localCLI = "Local CLI"
     case custom = "Custom"
@@ -42,6 +43,8 @@ enum AIProvider: String, CaseIterable {
             return "https://api.soniox.com/v1"
         case .speechmatics:
             return "https://asr.api.speechmatics.com/v2"
+        case .assemblyAI:
+            return "https://api.assemblyai.com/v2/transcript"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         case .localCLI:
@@ -73,6 +76,8 @@ enum AIProvider: String, CaseIterable {
             return "stt-async-v4"
         case .speechmatics:
             return "speechmatics-enhanced"
+        case .assemblyAI:
+            return "universal-3-pro"
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
         case .localCLI:
@@ -144,6 +149,8 @@ enum AIProvider: String, CaseIterable {
             return ["stt-async-v4"]
         case .speechmatics:
             return ["speechmatics-enhanced"]
+        case .assemblyAI:
+            return ["universal-3-pro"]
         case .ollama:
             return []
         case .localCLI:
@@ -359,6 +366,8 @@ class AIService: ObservableObject {
                 result = await SonioxClient.verifyAPIKey(key)
             case .speechmatics:
                 result = await SpeechmaticsClient.verifyAPIKey(key)
+            case .assemblyAI:
+                result = await AssemblyAIClient.verifyAPIKey(key)
             case .openRouter:
                 result = await OpenRouterClient.verifyAPIKey(key, model: currentModel)
             case .gemini:
@@ -472,5 +481,4 @@ class AIService: ObservableObject {
         }
     }
 }
-
 

--- a/VoiceInk/Services/APIKeyManager.swift
+++ b/VoiceInk/Services/APIKeyManager.swift
@@ -18,6 +18,7 @@ final class APIKeyManager {
         "elevenlabs": "elevenLabsAPIKey",
         "soniox": "sonioxAPIKey",
         "speechmatics": "speechmaticsAPIKey",
+        "assemblyai": "assemblyAIAPIKey",
         "xai": "xaiAPIKey",
         "cartesia": "cartesiaAPIKey",
         "openai": "openAIAPIKey",

--- a/VoiceInk/Services/APIKeyManager.swift
+++ b/VoiceInk/Services/APIKeyManager.swift
@@ -19,6 +19,7 @@ final class APIKeyManager {
         "soniox": "sonioxAPIKey",
         "speechmatics": "speechmaticsAPIKey",
         "xai": "xaiAPIKey",
+        "cartesia": "cartesiaAPIKey",
         "openai": "openAIAPIKey",
         "anthropic": "anthropicAPIKey",
         "openrouter": "openRouterAPIKey"

--- a/VoiceInk/Transcription/Cloud/AssemblyAIProvider.swift
+++ b/VoiceInk/Transcription/Cloud/AssemblyAIProvider.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftData
+import LLMkit
+
+struct AssemblyAIProvider: CloudProvider {
+    let modelProvider: ModelProvider = .assemblyAI
+    let providerKey: String = "AssemblyAI"
+    let languageCodes: [String]? = ["en", "es", "de", "fr", "pt", "it"]
+    let includesAutoDetect: Bool = true
+
+    var models: [CloudModel] {[
+        CloudModel(
+            name: "universal-3-pro",
+            displayName: "Universal-3 Pro (AssemblyAI)",
+            description: "Highest-accuracy multilingual transcription with realtime support.",
+            provider: .assemblyAI,
+            speed: 0.94,
+            accuracy: 0.98,
+            isMultilingual: true,
+            supportsStreaming: true,
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .assemblyAI)
+        ),
+        CloudModel(
+            name: "universal-streaming",
+            displayName: "Universal-2 (AssemblyAI)",
+            description: "Balanced multilingual transcription with auto-detect.",
+            provider: .assemblyAI,
+            speed: 0.96,
+            accuracy: 0.92,
+            isMultilingual: true,
+            supportsStreaming: true,
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .assemblyAI)
+        )
+    ]}
+
+    func transcribe(audioData: Data, fileName: String, apiKey: String, model: String, language: String?, prompt: String?, customVocabulary: [String]) async throws -> String {
+        return try await AssemblyAIClient.transcribe(
+            audioData: audioData,
+            fileName: fileName,
+            apiKey: apiKey,
+            model: model,
+            language: language,
+            prompt: prompt,
+            customVocabulary: customVocabulary
+        )
+    }
+
+    func makeStreamingProvider(modelContext: ModelContext) -> (any StreamingTranscriptionProvider)? {
+        AssemblyAIStreamingProvider(modelContext: modelContext)
+    }
+
+    func verifyAPIKey(_ key: String) async -> (isValid: Bool, errorMessage: String?) {
+        return await AssemblyAIClient.verifyAPIKey(key)
+    }
+}

--- a/VoiceInk/Transcription/Cloud/CartesiaProvider.swift
+++ b/VoiceInk/Transcription/Cloud/CartesiaProvider.swift
@@ -17,7 +17,7 @@ struct CartesiaProvider: CloudProvider {
         "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
         "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl",
         "tr", "tt", "uk", "ur", "uz", "vi", "yi", "yo", "yue", "zh",
-        "zh", "zu"
+        "zu"
     ]
     let includesAutoDetect: Bool = false
 

--- a/VoiceInk/Transcription/Cloud/CartesiaProvider.swift
+++ b/VoiceInk/Transcription/Cloud/CartesiaProvider.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftData
+import LLMkit
+
+struct CartesiaProvider: CloudProvider {
+    let modelProvider: ModelProvider = .cartesia
+    let providerKey: String = "Cartesia"
+    let isStreamingOnly: Bool = true
+    let languageCodes: [String]? = [
+        "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo",
+        "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es",
+        "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw",
+        "he", "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja",
+        "jw", "ka", "kk", "km", "kn", "ko", "la", "lb", "ln", "lo",
+        "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt",
+        "my", "ne", "nl", "nn", "no", "oc", "pa", "pl", "ps", "pt",
+        "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
+        "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl",
+        "tr", "tt", "uk", "ur", "uz", "vi", "yi", "yo", "yue", "zh",
+        "zh", "zu"
+    ]
+    let includesAutoDetect: Bool = false
+
+    var models: [CloudModel] {[
+        CloudModel(
+            name: "ink-whisper",
+            displayName: "Ink Whisper (Cartesia)",
+            description: "Cartesia's fastest streaming STT model — engineered for real-time voice agents with 90+ language support",
+            provider: .cartesia,
+            speed: 0.99,
+            accuracy: 0.94,
+            isMultilingual: true,
+            supportsStreaming: true,
+            supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .cartesia)
+        )
+    ]}
+
+    func makeStreamingProvider(modelContext: ModelContext) -> (any StreamingTranscriptionProvider)? {
+        CartesiaStreamingProvider(modelContext: modelContext)
+    }
+
+    func verifyAPIKey(_ key: String) async -> (isValid: Bool, errorMessage: String?) {
+        return await CartesiaStreamingClient.verifyAPIKey(key)
+    }
+}

--- a/VoiceInk/Transcription/Cloud/CloudProvider.swift
+++ b/VoiceInk/Transcription/Cloud/CloudProvider.swift
@@ -7,10 +7,22 @@ protocol CloudProvider {
     var languageCodes: [String]? { get }
     var includesAutoDetect: Bool { get }
     var models: [CloudModel] { get }
+    /// True when the provider has no batch HTTP endpoint and requires streaming for all transcription.
+    var isStreamingOnly: Bool { get }
 
     func transcribe(audioData: Data, fileName: String, apiKey: String, model: String, language: String?, prompt: String?, customVocabulary: [String]) async throws -> String
     func makeStreamingProvider(modelContext: ModelContext) -> (any StreamingTranscriptionProvider)?
     func verifyAPIKey(_ key: String) async -> (isValid: Bool, errorMessage: String?)
+}
+
+extension CloudProvider {
+    var isStreamingOnly: Bool { false }
+
+    /// Streaming-only providers inherit this and get a clear error if batch is somehow attempted.
+    /// Providers that support batch transcription override this with their real implementation.
+    func transcribe(audioData: Data, fileName: String, apiKey: String, model: String, language: String?, prompt: String?, customVocabulary: [String]) async throws -> String {
+        throw CloudTranscriptionError.unsupportedProvider
+    }
 }
 
 enum CloudProviderRegistry {
@@ -22,7 +34,8 @@ enum CloudProviderRegistry {
         GeminiProvider(),
         SonioxProvider(),
         SpeechmaticsProvider(),
-        XAIProvider()
+        XAIProvider(),
+        CartesiaProvider()
     ]
 
     static func provider(for modelProvider: ModelProvider) -> (any CloudProvider)? {

--- a/VoiceInk/Transcription/Cloud/CloudProvider.swift
+++ b/VoiceInk/Transcription/Cloud/CloudProvider.swift
@@ -34,6 +34,7 @@ enum CloudProviderRegistry {
         GeminiProvider(),
         SonioxProvider(),
         SpeechmaticsProvider(),
+        AssemblyAIProvider(),
         XAIProvider(),
         CartesiaProvider()
     ]

--- a/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
@@ -61,6 +61,7 @@ class TranscriptionModelManager: ObservableObject {
         if let savedModelName = UserDefaults.standard.string(forKey: "CurrentTranscriptionModel"),
            let savedModel = allAvailableModels.first(where: { $0.name == savedModelName }) {
             currentTranscriptionModel = savedModel
+            ensureSelectedLanguageIsSupported(by: savedModel)
         }
     }
 
@@ -69,6 +70,7 @@ class TranscriptionModelManager: ObservableObject {
     func setDefaultTranscriptionModel(_ model: any TranscriptionModel) {
         self.currentTranscriptionModel = model
         UserDefaults.standard.set(model.name, forKey: "CurrentTranscriptionModel")
+        ensureSelectedLanguageIsSupported(by: model)
 
         if model.provider != .whisper {
             whisperModelManager?.loadedWhisperModel = nil
@@ -77,6 +79,16 @@ class TranscriptionModelManager: ObservableObject {
 
         NotificationCenter.default.post(name: .didChangeModel, object: nil, userInfo: ["modelName": model.name])
         NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+    }
+
+    private func ensureSelectedLanguageIsSupported(by model: any TranscriptionModel) {
+        let currentLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage")
+        let compatibleLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(currentLanguage, for: model)
+
+        if currentLanguage != compatibleLanguage {
+            UserDefaults.standard.set(compatibleLanguage, forKey: "SelectedLanguage")
+            NotificationCenter.default.post(name: .languageDidChange, object: nil)
+        }
     }
 
     // MARK: - Refresh all available models

--- a/VoiceInk/Transcription/Engine/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionServiceRegistry.swift
@@ -61,6 +61,10 @@ class TranscriptionServiceRegistry {
     /// Whether the given model supports streaming transcription
     private func supportsStreaming(model: any TranscriptionModel) -> Bool {
         guard model.supportsStreaming else { return false }
+        // Streaming-only providers (e.g. Cartesia) have no batch endpoint — always stream.
+        if let cloudProvider = CloudProviderRegistry.provider(for: model.provider), cloudProvider.isStreamingOnly {
+            return true
+        }
         return UserDefaults.standard.object(forKey: "streaming-enabled-\(model.name)") as? Bool ?? true
     }
 

--- a/VoiceInk/Transcription/Engine/TranscriptionSession.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionSession.swift
@@ -61,6 +61,7 @@ final class StreamingTranscriptionSession: TranscriptionSession {
 
     func prepare(model: any TranscriptionModel) async throws -> ((Data) -> Void)? {
         self.model = model
+        logger.notice("Streaming session prepare model=\(model.displayName, privacy: .public)")
 
         // Return callback immediately; WebSocket connects in background
         let service = streamingService
@@ -68,19 +69,16 @@ final class StreamingTranscriptionSession: TranscriptionSession {
             service?.sendAudioChunk(data)
         }
 
-        Task.detached { [weak self] in
+        Task { [weak self] in
             guard let self = self else { return }
             do {
+                let start = Date()
                 try await self.streamingService.startStreaming(model: model)
-                await MainActor.run {
-                    self.logger.notice("Streaming connected for \(model.displayName, privacy: .public)")
-                }
+                self.logger.notice("Streaming session connected model=\(model.displayName, privacy: .public) elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s")
             } catch {
                 let desc = error.localizedDescription
-                await MainActor.run {
-                    self.logger.error("❌ Failed to start streaming, will fall back to batch: \(desc, privacy: .public)")
-                    self.streamingFailed = true
-                }
+                self.logger.error("❌ Failed to start streaming, will fall back to batch: \(desc, privacy: .public)")
+                self.streamingFailed = true
             }
         }
 
@@ -94,8 +92,10 @@ final class StreamingTranscriptionSession: TranscriptionSession {
 
         if !streamingFailed {
             do {
+                let start = Date()
+                logger.notice("Streaming stop/transcribe started model=\(model.displayName, privacy: .public)")
                 let text = try await streamingService.stopAndGetFinalText()
-                logger.notice("Streaming transcript received")
+                logger.notice("Streaming transcript received elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s chars=\(text.count, privacy: .public)")
                 return text
             } catch {
                 logger.error("❌ Streaming failed, falling back to batch: \(error.localizedDescription, privacy: .public)")
@@ -105,8 +105,11 @@ final class StreamingTranscriptionSession: TranscriptionSession {
             streamingService.cancel()
         }
 
-        logger.notice("Using batch fallback for \(model.displayName, privacy: .public)")
-        return try await fallbackService.transcribe(audioURL: audioURL, model: model)
+        let fallbackStart = Date()
+        logger.notice("Using batch fallback for \(model.displayName, privacy: .public) file=\(audioURL.lastPathComponent, privacy: .public)")
+        let text = try await fallbackService.transcribe(audioURL: audioURL, model: model)
+        logger.notice("Batch fallback completed elapsed=\(Date().timeIntervalSince(fallbackStart), format: .fixed(precision: 3), privacy: .public)s chars=\(text.count, privacy: .public)")
+        return text
     }
 
     func cancel() {

--- a/VoiceInk/Transcription/Streaming/AssemblyAIStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/AssemblyAIStreamingProvider.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftData
+import LLMkit
+
+/// AssemblyAI streaming provider wrapping `LLMkit.AssemblyAIStreamingClient`.
+final class AssemblyAIStreamingProvider: StreamingTranscriptionProvider {
+
+    private let client = LLMkit.AssemblyAIStreamingClient()
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var forwardingTask: Task<Void, Never>?
+    private let modelContext: ModelContext
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    deinit {
+        forwardingTask?.cancel()
+        eventsContinuation?.finish()
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "AssemblyAI"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        forwardingTask?.cancel()
+        startEventForwarding()
+
+        do {
+            try await client.connect(
+                apiKey: apiKey,
+                model: model.name,
+                language: language,
+                prompt: transcriptionPrompt(),
+                customVocabulary: getCustomDictionaryTerms()
+            )
+        } catch {
+            forwardingTask?.cancel()
+            forwardingTask = nil
+            throw mapError(error)
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        do {
+            try await client.sendAudioChunk(data)
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func commit() async throws {
+        do {
+            try await client.commit()
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func disconnect() async {
+        forwardingTask?.cancel()
+        forwardingTask = nil
+        await client.disconnect()
+        eventsContinuation?.finish()
+    }
+
+    // MARK: - Private
+
+    private func startEventForwarding() {
+        forwardingTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.client.transcriptionEvents {
+                switch event {
+                case .sessionStarted:
+                    self.eventsContinuation?.yield(.sessionStarted)
+                case .partial(let text):
+                    self.eventsContinuation?.yield(.partial(text: text))
+                case .committed(let text):
+                    self.eventsContinuation?.yield(.committed(text: text))
+                case .error(let message):
+                    self.eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(message)))
+                }
+            }
+        }
+    }
+
+    private func transcriptionPrompt() -> String? {
+        let prompt = UserDefaults.standard.string(forKey: "TranscriptionPrompt") ?? ""
+        return prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : prompt
+    }
+
+    private func getCustomDictionaryTerms() -> [String] {
+        let descriptor = FetchDescriptor<VocabularyWord>(sortBy: [SortDescriptor(\.word)])
+        guard let vocabularyWords = try? modelContext.fetch(descriptor) else {
+            return []
+        }
+        var seen = Set<String>()
+        var unique: [String] = []
+        for word in vocabularyWords {
+            let trimmed = word.word.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let key = trimmed.lowercased()
+            if !seen.contains(key) {
+                seen.insert(key)
+                unique.append(trimmed)
+            }
+        }
+        return unique
+    }
+
+    private func mapError(_ error: Error) -> Error {
+        guard let llmError = error as? LLMKitError else { return error }
+        switch llmError {
+        case .missingAPIKey:
+            return StreamingTranscriptionError.missingAPIKey
+        case .httpError(_, let message):
+            return StreamingTranscriptionError.serverError(message)
+        case .networkError(let detail):
+            return StreamingTranscriptionError.connectionFailed(detail)
+        case .timeout:
+            return StreamingTranscriptionError.timeout
+        default:
+            return StreamingTranscriptionError.serverError(llmError.localizedDescription ?? "Unknown error")
+        }
+    }
+}

--- a/VoiceInk/Transcription/Streaming/CartesiaStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/CartesiaStreamingProvider.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SwiftData
+import LLMkit
+
+/// Cartesia Ink streaming provider wrapping `LLMkit.CartesiaStreamingClient`.
+final class CartesiaStreamingProvider: StreamingTranscriptionProvider {
+
+    private let client = LLMkit.CartesiaStreamingClient()
+    private var eventsContinuation: AsyncStream<StreamingTranscriptionEvent>.Continuation?
+    private var forwardingTask: Task<Void, Never>?
+    private let modelContext: ModelContext
+
+    private(set) var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent>
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        var continuation: AsyncStream<StreamingTranscriptionEvent>.Continuation!
+        transcriptionEvents = AsyncStream { continuation = $0 }
+        eventsContinuation = continuation
+    }
+
+    deinit {
+        forwardingTask?.cancel()
+        eventsContinuation?.finish()
+    }
+
+    func connect(model: any TranscriptionModel, language: String?) async throws {
+        guard let apiKey = APIKeyManager.shared.getAPIKey(forProvider: "Cartesia"), !apiKey.isEmpty else {
+            throw StreamingTranscriptionError.missingAPIKey
+        }
+
+        forwardingTask?.cancel()
+        startEventForwarding()
+
+        do {
+            try await client.connect(apiKey: apiKey, model: model.name, language: language, customVocabulary: [])
+        } catch {
+            forwardingTask?.cancel()
+            forwardingTask = nil
+            throw mapError(error)
+        }
+    }
+
+    func sendAudioChunk(_ data: Data) async throws {
+        do {
+            try await client.sendAudioChunk(data)
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func commit() async throws {
+        do {
+            try await client.commit()
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func disconnect() async {
+        forwardingTask?.cancel()
+        forwardingTask = nil
+        await client.disconnect()
+        eventsContinuation?.finish()
+    }
+
+    // MARK: - Private
+
+    private func startEventForwarding() {
+        forwardingTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.client.transcriptionEvents {
+                switch event {
+                case .sessionStarted:
+                    self.eventsContinuation?.yield(.sessionStarted)
+                case .partial(let text):
+                    self.eventsContinuation?.yield(.partial(text: text))
+                case .committed(let text):
+                    self.eventsContinuation?.yield(.committed(text: text))
+                case .error(let message):
+                    self.eventsContinuation?.yield(.error(StreamingTranscriptionError.serverError(message)))
+                }
+            }
+        }
+    }
+
+    private func mapError(_ error: Error) -> Error {
+        guard let llmError = error as? LLMKitError else { return error }
+        switch llmError {
+        case .missingAPIKey:
+            return StreamingTranscriptionError.missingAPIKey
+        case .httpError(_, let message):
+            return StreamingTranscriptionError.serverError(message)
+        case .networkError(let detail):
+            return StreamingTranscriptionError.connectionFailed(detail)
+        default:
+            return StreamingTranscriptionError.serverError(llmError.localizedDescription ?? "Unknown error")
+        }
+    }
+}

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -26,6 +26,43 @@ private final class AudioChunkSource: @unchecked Sendable {
     }
 }
 
+private final class StreamingMetrics: @unchecked Sendable {
+    private let lock = NSLock()
+    private var receivedChunks = 0
+    private var receivedBytes = 0
+    private var sentChunks = 0
+    private var sentBytes = 0
+
+    func reset() {
+        lock.lock()
+        receivedChunks = 0
+        receivedBytes = 0
+        sentChunks = 0
+        sentBytes = 0
+        lock.unlock()
+    }
+
+    func recordReceived(_ byteCount: Int) {
+        lock.lock()
+        receivedChunks += 1
+        receivedBytes += byteCount
+        lock.unlock()
+    }
+
+    func recordSent(_ byteCount: Int) {
+        lock.lock()
+        sentChunks += 1
+        sentBytes += byteCount
+        lock.unlock()
+    }
+
+    func snapshot() -> (receivedChunks: Int, receivedBytes: Int, sentChunks: Int, sentBytes: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (receivedChunks, receivedBytes, sentChunks, sentBytes)
+    }
+}
+
 /// Lifecycle states for a streaming transcription session.
 enum StreamingState {
     case idle
@@ -51,6 +88,10 @@ class StreamingTranscriptionService {
     private let modelContext: ModelContext
     private let fluidAudioService: FluidAudioTranscriptionService?
     private var onPartialTranscript: ((String) -> Void)?
+    private let metrics = StreamingMetrics()
+    private var stopStartedAt: Date?
+    private var firstPartialLogged = false
+    private var firstCommitLogged = false
 
     init(modelContext: ModelContext, fluidAudioService: FluidAudioTranscriptionService? = nil, onPartialTranscript: ((String) -> Void)? = nil) {
         self.modelContext = modelContext
@@ -74,13 +115,18 @@ class StreamingTranscriptionService {
 
     /// Start a streaming transcription session for the given model.
     func startStreaming(model: any TranscriptionModel) async throws {
+        let start = Date()
         state = .connecting
         committedSegments = []
+        metrics.reset()
+        firstPartialLogged = false
+        firstCommitLogged = false
 
         let provider = createProvider(for: model)
         self.provider = provider
 
         let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
+        logger.notice("Streaming start requested model=\(model.displayName, privacy: .public) language=\(selectedLanguage, privacy: .public)")
 
         try await provider.connect(model: model, language: selectedLanguage)
 
@@ -95,11 +141,12 @@ class StreamingTranscriptionService {
         startSendLoop()
         startEventConsumer()
 
-        logger.notice("Streaming started for model: \(model.displayName, privacy: .public)")
+        logger.notice("Streaming connected model=\(model.displayName, privacy: .public) elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s")
     }
 
     /// Buffers an audio chunk for sending. Safe to call from the audio callback thread.
     nonisolated func sendAudioChunk(_ data: Data) {
+        metrics.recordReceived(data.count)
         chunkSource.send(data)
     }
 
@@ -110,6 +157,9 @@ class StreamingTranscriptionService {
         }
 
         state = .committing
+        stopStartedAt = Date()
+        let beforeDrain = metrics.snapshot()
+        logger.notice("Streaming stop requested receivedChunks=\(beforeDrain.receivedChunks, privacy: .public) sentChunks=\(beforeDrain.sentChunks, privacy: .public) receivedBytes=\(beforeDrain.receivedBytes, privacy: .public) sentBytes=\(beforeDrain.sentBytes, privacy: .public)")
 
         // Finish the chunk source so the send loop drains remaining chunks and exits naturally.
         await drainRemainingChunks()
@@ -132,6 +182,9 @@ class StreamingTranscriptionService {
 
         // Wait for the server to acknowledge our commit (or timeout)
         let finalText = await waitForFinalCommit(signalStream: signalStream)
+        if let stopStartedAt {
+            logger.notice("Streaming stop completed elapsed=\(Date().timeIntervalSince(stopStartedAt), format: .fixed(precision: 3), privacy: .public)s finalChars=\(finalText.count, privacy: .public)")
+        }
 
         state = .done
         await cleanupStreaming()
@@ -184,11 +237,13 @@ class StreamingTranscriptionService {
     private func startSendLoop() {
         let source = chunkSource
         let provider = provider
+        let metrics = metrics
 
         sendTask = Task.detached { [weak self] in
             for await chunk in source.stream {
                 do {
                     try await provider?.sendAudioChunk(chunk)
+                    metrics.recordSent(chunk.count)
                 } catch {
                     let desc = error.localizedDescription
                     await MainActor.run {
@@ -201,9 +256,12 @@ class StreamingTranscriptionService {
 
     /// Finishes the chunk source and waits for the send loop to process all remaining buffered chunks.
     private func drainRemainingChunks() async {
+        let start = Date()
         chunkSource.finish()
         await sendTask?.value
         sendTask = nil
+        let snapshot = metrics.snapshot()
+        logger.notice("Streaming drain finished elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s receivedChunks=\(snapshot.receivedChunks, privacy: .public) sentChunks=\(snapshot.sentChunks, privacy: .public) receivedBytes=\(snapshot.receivedBytes, privacy: .public) sentBytes=\(snapshot.sentBytes, privacy: .public)")
     }
 
     /// Consumes transcription events throughout the session, accumulating committed segments.
@@ -218,6 +276,11 @@ class StreamingTranscriptionService {
                 case .committed(let text):
                     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                     await MainActor.run {
+                        if !self.firstCommitLogged {
+                            self.firstCommitLogged = true
+                            let elapsed = self.stopStartedAt.map { Date().timeIntervalSince($0) } ?? 0
+                            self.logger.notice("Streaming first committed event chars=\(trimmed.count, privacy: .public) stopElapsed=\(elapsed, format: .fixed(precision: 3), privacy: .public)s")
+                        }
                         if !trimmed.isEmpty {
                             self.committedSegments.append(trimmed)
                         }
@@ -232,6 +295,10 @@ class StreamingTranscriptionService {
                     }
                 case .partial(let text):
                     await MainActor.run {
+                        if !self.firstPartialLogged {
+                            self.firstPartialLogged = true
+                            self.logger.notice("Streaming first partial event chars=\(text.count, privacy: .public)")
+                        }
                         if self.state == .streaming {
                             let prefix = self.committedSegments.joined(separator: " ")
                             let display: String
@@ -277,6 +344,7 @@ class StreamingTranscriptionService {
             group.cancelAll()
             return result
         }
+        logger.notice("Streaming final wait finished received=\(receivedInTime, privacy: .public) segments=\(self.committedSegments.count, privacy: .public)")
 
         // Clean up the signal
         commitSignal?.finish()

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -20,7 +20,7 @@ struct APIKeyManagementView: View {
         Section("AI Provider Integration") {
             HStack {
                 Picker("Provider", selection: $aiService.selectedProvider) {
-                    ForEach(AIProvider.allCases.filter { $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox && $0 != .speechmatics }, id: \.self) { provider in
+                    ForEach(AIProvider.allCases.filter { $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox && $0 != .speechmatics && $0 != .assemblyAI }, id: \.self) { provider in
                         Text(provider.rawValue).tag(provider)
                     }
                 }
@@ -368,6 +368,7 @@ struct APIKeyManagementView: View {
         case .deepgram: return URL(string: "https://console.deepgram.com/api-keys")
         case .soniox: return URL(string: "https://console.soniox.com/")
         case .speechmatics: return URL(string: "https://portal.speechmatics.com/manage-access/")
+        case .assemblyAI: return URL(string: "https://www.assemblyai.com/dashboard/api-keys")
         case .openRouter: return URL(string: "https://openrouter.ai/keys")
         case .cerebras: return URL(string: "https://cloud.cerebras.ai/")
         default: return nil

--- a/VoiceInk/Views/AI Models/CloudModelCardView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardView.swift
@@ -80,16 +80,23 @@ struct CloudModelCardView: View {
         }
     }
     
+    private var isStreamingOnly: Bool {
+        CloudProviderRegistry.provider(for: model.provider)?.isStreamingOnly ?? false
+    }
+
     private var streamingModeBadge: some View {
-        Toggle("Real-time", isOn: $streamingEnabled)
+        Toggle("Real-time", isOn: isStreamingOnly ? .constant(true) : $streamingEnabled)
             .toggleStyle(.switch)
             .controlSize(.mini)
             .font(.system(size: 11, weight: .medium))
             .foregroundColor(Color(.secondaryLabelColor))
+            .disabled(isStreamingOnly)
             .onChange(of: streamingEnabled) { _, newValue in
-                UserDefaults.standard.set(newValue, forKey: streamingDefaultsKey)
+                if !isStreamingOnly {
+                    UserDefaults.standard.set(newValue, forKey: streamingDefaultsKey)
+                }
             }
-            .help(streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming")
+            .help(isStreamingOnly ? "This model only supports real-time streaming" : (streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming"))
     }
 
     private var metadataSection: some View {

--- a/VoiceInk/Views/AI Models/CloudModelCardView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardView.swift
@@ -9,6 +9,7 @@ struct CloudModelCardView: View {
     var setDefaultAction: () -> Void
 
     @EnvironmentObject private var transcriptionModelManager: TranscriptionModelManager
+    @AppStorage("SelectedLanguage") private var selectedLanguage: String = "en"
     @State private var isExpanded = false
     @State private var apiKey = ""
     @State private var streamingEnabled: Bool
@@ -94,9 +95,23 @@ struct CloudModelCardView: View {
             .onChange(of: streamingEnabled) { _, newValue in
                 if !isStreamingOnly {
                     UserDefaults.standard.set(newValue, forKey: streamingDefaultsKey)
+                    ensureCurrentModelLanguageIsStillValid()
+                    NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
                 }
             }
             .help(isStreamingOnly ? "This model only supports real-time streaming" : (streamingEnabled ? "Live streaming enabled — click to switch to batch" : "Batch mode — click to enable live streaming"))
+    }
+
+    private func ensureCurrentModelLanguageIsStillValid() {
+        guard transcriptionModelManager.currentTranscriptionModel?.name == model.name else {
+            return
+        }
+
+        let compatibleLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(selectedLanguage, for: model)
+        if selectedLanguage != compatibleLanguage {
+            selectedLanguage = compatibleLanguage
+            NotificationCenter.default.post(name: .languageDidChange, object: nil)
+        }
     }
 
     private var metadataSection: some View {

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -12,8 +12,11 @@ struct LanguageSelectionView: View {
     // Add display mode parameter with full as the default
     var displayMode: LanguageDisplayMode = .full
     @ObservedObject var whisperPrompt: WhisperPrompt
+    @State private var languageOptionsRefreshID = UUID()
 
     private func updateLanguage(_ language: String) {
+        guard selectedLanguage != language else { return }
+
         // Update UI state - the UserDefaults updating is now automatic with @AppStorage
         selectedLanguage = language
 
@@ -40,25 +43,40 @@ struct LanguageSelectionView: View {
         return provider == .fluidAudio || provider == .gemini
     }
 
-    // Function to get current model's supported languages
-    private func getCurrentModelLanguages() -> [String: String] {
+    private func availableLanguagesForCurrentModel() -> [String: String] {
         guard let currentModel = transcriptionModelManager.currentTranscriptionModel else {
             return ["en": "English"] // Default to English if no model found
         }
-        return currentModel.supportedLanguages
+        return TranscriptionLanguageSupport.languages(for: currentModel)
+    }
+
+    private func useCompatibleLanguageForCurrentModel() {
+        guard let currentModel = transcriptionModelManager.currentTranscriptionModel else { return }
+        updateLanguage(TranscriptionLanguageSupport.validLanguageOrFallback(selectedLanguage, for: currentModel))
     }
 
     // Get the display name of the current language
     private func currentLanguageDisplayName() -> String {
-        return getCurrentModelLanguages()[selectedLanguage] ?? "Unknown"
+        return availableLanguagesForCurrentModel()[selectedLanguage] ?? "Unknown"
     }
 
     var body: some View {
-        switch displayMode {
-        case .full:
-            fullView
-        case .menuItem:
-            menuItemView
+        Group {
+            switch displayMode {
+            case .full:
+                fullView
+            case .menuItem:
+                menuItemView
+            }
+        }
+        .id(languageOptionsRefreshID)
+        .onAppear(perform: useCompatibleLanguageForCurrentModel)
+        .onChange(of: transcriptionModelManager.currentTranscriptionModel?.name) { _, _ in
+            useCompatibleLanguageForCurrentModel()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .AppSettingsDidChange)) { _ in
+            languageOptionsRefreshID = UUID()
+            useCompatibleLanguageForCurrentModel()
         }
     }
 
@@ -95,7 +113,7 @@ struct LanguageSelectionView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Picker("Select Language", selection: $selectedLanguage) {
                             ForEach(
-                                currentModel.supportedLanguages.sorted(by: {
+                                availableLanguagesForCurrentModel().sorted(by: {
                                     if $0.key == "auto" { return true }
                                     if $1.key == "auto" { return false }
                                     return $0.value < $1.value
@@ -167,7 +185,7 @@ struct LanguageSelectionView: View {
             } else if isMultilingualModel() {
                 Menu {
                     ForEach(
-                        getCurrentModelLanguages().sorted(by: {
+                        availableLanguagesForCurrentModel().sorted(by: {
                             if $0.key == "auto" { return true }
                             if $1.key == "auto" { return false }
                             return $0.value < $1.value


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two cloud STT providers: Cartesia Ink Whisper (streaming-only) and AssemblyAI (batch + streaming), with adaptive language selection and safer fallbacks in Power Mode. Also switches `FluidAudio` and `LLMkit` to remote Swift packages.

- **New Features**
  - Cartesia Ink Whisper: streaming-only with 90+ languages; UI enforces real-time.
  - AssemblyAI: batch and streaming with “Universal-3 Pro” and “Universal-2”.
  - Adaptive language: mode-aware lists for AssemblyAI; centralized via TranscriptionLanguageSupport with safe auto-fallbacks.
  - API keys: storage and verification for `assemblyai` and `cartesia`; API Key UI includes both.
  - Streaming UX: chunk/byte metrics, first partial/commit logs, sturdier connect/commit flow, and cleaner batch fallback.

- **Bug Fixes**
  - Removed duplicate `zh` language code in the Cartesia provider list.

<sup>Written for commit e94801849357e16d587ae9e1c022c4faf20d3676. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/677?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



