### PR TITLE
Feature/recorder session stats

### DIFF
--- a/VoiceInk/Models/SessionMetric.swift
+++ b/VoiceInk/Models/SessionMetric.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SessionMetric {
+    var id: UUID
+    @Attribute(.unique) var transcriptionId: UUID
+    var timestamp: Date
+    var source: String
+    var wordCount: Int
+    var audioDuration: TimeInterval
+    var transcriptionModelName: String?
+    var transcriptionDuration: TimeInterval?
+    var speedFactor: Double?
+    var powerModeName: String?
+    var aiEnhancementModelName: String?
+    var enhancementDuration: TimeInterval?
+
+    init(
+        transcriptionId: UUID,
+        timestamp: Date = Date(),
+        source: String = "recorder",
+        wordCount: Int,
+        audioDuration: TimeInterval,
+        transcriptionModelName: String?,
+        transcriptionDuration: TimeInterval?,
+        speedFactor: Double?,
+        powerModeName: String?,
+        aiEnhancementModelName: String?,
+        enhancementDuration: TimeInterval?
+    ) {
+        self.id = UUID()
+        self.transcriptionId = transcriptionId
+        self.timestamp = timestamp
+        self.source = source
+        self.wordCount = wordCount
+        self.audioDuration = audioDuration
+        self.transcriptionModelName = transcriptionModelName
+        self.transcriptionDuration = transcriptionDuration
+        self.speedFactor = speedFactor
+        self.powerModeName = powerModeName
+        self.aiEnhancementModelName = aiEnhancementModelName
+        self.enhancementDuration = enhancementDuration
+    }
+}

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -15,6 +15,7 @@ extension Notification.Name {
     static let transcriptionCreated = Notification.Name("transcriptionCreated")
     static let transcriptionCompleted = Notification.Name("transcriptionCompleted")
     static let transcriptionDeleted = Notification.Name("transcriptionDeleted")
+    static let sessionMetricsDidChange = Notification.Name("sessionMetricsDidChange")
     static let enhancementToggleChanged = Notification.Name("enhancementToggleChanged")
     static let openFileForTranscription = Notification.Name("openFileForTranscription")
     static let audioDeviceSwitchRequired = Notification.Name("audioDeviceSwitchRequired")

--- a/VoiceInk/Services/SessionMetricMigrationService.swift
+++ b/VoiceInk/Services/SessionMetricMigrationService.swift
@@ -12,14 +12,15 @@ final class SessionMetricMigrationService {
 
     private init() {}
 
-    func runIfNeeded(modelContainer: ModelContainer) {
-        guard !UserDefaults.standard.bool(forKey: completionKey), !isRunning else { return }
+    @discardableResult
+    func runIfNeeded(modelContainer: ModelContainer) -> Task<Void, Never>? {
+        guard !UserDefaults.standard.bool(forKey: completionKey), !isRunning else { return nil }
         isRunning = true
 
         let logger = self.logger
         let completionKey = self.completionKey
 
-        Task.detached(priority: .utility) {
+        return Task.detached(priority: .utility) {
             let backgroundContext = ModelContext(modelContainer)
             var insertedCount = 0
 
@@ -71,9 +72,6 @@ final class SessionMetricMigrationService {
 
                 if insertedCount > 0 {
                     try backgroundContext.save()
-                    await MainActor.run {
-                        NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
-                    }
                 }
 
                 UserDefaults.standard.set(true, forKey: completionKey)
@@ -84,6 +82,7 @@ final class SessionMetricMigrationService {
 
             await MainActor.run {
                 SessionMetricMigrationService.shared.isRunning = false
+                NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
             }
         }
     }

--- a/VoiceInk/Services/SessionMetricMigrationService.swift
+++ b/VoiceInk/Services/SessionMetricMigrationService.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftData
+import OSLog
+
+@MainActor
+final class SessionMetricMigrationService {
+    static let shared = SessionMetricMigrationService()
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "SessionMetricMigrationService")
+    private let completionKey = "HasCompletedStatsMigration"
+    private(set) var isRunning = false
+
+    private init() {}
+
+    func runIfNeeded(modelContainer: ModelContainer) {
+        guard !UserDefaults.standard.bool(forKey: completionKey), !isRunning else { return }
+        isRunning = true
+
+        let logger = self.logger
+        let completionKey = self.completionKey
+
+        Task.detached(priority: .utility) {
+            let backgroundContext = ModelContext(modelContainer)
+            var insertedCount = 0
+
+            do {
+                // Build a Set of already-migrated IDs in one query instead of
+                // checking per-record — turns N queries into 1.
+                let existingIds = Set(
+                    try backgroundContext.fetch(FetchDescriptor<SessionMetric>())
+                        .map { $0.transcriptionId }
+                )
+
+                let descriptor = FetchDescriptor<Transcription>(
+                    predicate: #Predicate<Transcription> { $0.transcriptionStatus == "completed" }
+                )
+                let transcriptions = try backgroundContext.fetch(descriptor)
+
+                for transcription in transcriptions {
+                    guard !existingIds.contains(transcription.id) else { continue }
+
+                    let enhancementDuration = transcription.enhancementDuration.flatMap { $0 > 0 ? $0 : nil }
+                    let audioDuration = max(transcription.duration, 0)
+                    let transcriptionDuration = transcription.transcriptionDuration.flatMap { $0 > 0 ? $0 : nil }
+                    let speedFactor = transcriptionDuration.flatMap { d in
+                        audioDuration > 0 ? audioDuration / d : nil
+                    }
+                    let textForCounting: String = {
+                        if let enhanced = transcription.enhancedText,
+                           transcription.enhancementDuration != nil,
+                           !enhanced.isEmpty { return enhanced }
+                        return transcription.text
+                    }()
+
+                    let metric = SessionMetric(
+                        transcriptionId: transcription.id,
+                        timestamp: transcription.timestamp,
+                        source: "recorder",
+                        wordCount: WordCounter.count(in: textForCounting),
+                        audioDuration: audioDuration,
+                        transcriptionModelName: transcription.transcriptionModelName,
+                        transcriptionDuration: transcriptionDuration,
+                        speedFactor: speedFactor,
+                        powerModeName: transcription.powerModeName,
+                        aiEnhancementModelName: transcription.aiEnhancementModelName,
+                        enhancementDuration: enhancementDuration
+                    )
+                    backgroundContext.insert(metric)
+                    insertedCount += 1
+                }
+
+                if insertedCount > 0 {
+                    try backgroundContext.save()
+                    await MainActor.run {
+                        NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
+                    }
+                }
+
+                UserDefaults.standard.set(true, forKey: completionKey)
+                logger.notice("Completed stats migration with \(insertedCount, privacy: .public) session metric(s)")
+            } catch {
+                logger.error("Stats migration failed: \(error.localizedDescription, privacy: .public)")
+            }
+
+            await MainActor.run {
+                SessionMetricMigrationService.shared.isRunning = false
+            }
+        }
+    }
+}

--- a/VoiceInk/Services/SessionMetricRecorder.swift
+++ b/VoiceInk/Services/SessionMetricRecorder.swift
@@ -1,0 +1,69 @@
+import Foundation
+import SwiftData
+import OSLog
+
+enum SessionMetricRecorder {
+    private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "SessionMetricRecorder")
+    private static let source = "recorder"
+
+    @discardableResult
+    static func recordRecorderSession(
+        transcription: Transcription,
+        model: (any TranscriptionModel)?,
+        in modelContext: ModelContext,
+        timestamp: Date = Date()
+    ) throws -> Bool {
+        guard transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue else {
+            return false
+        }
+
+        let transcriptionId = transcription.id
+        let descriptor = FetchDescriptor<SessionMetric>(
+            predicate: #Predicate<SessionMetric> { metric in
+                metric.transcriptionId == transcriptionId
+            }
+        )
+
+        if try modelContext.fetchCount(descriptor) > 0 {
+            return false
+        }
+
+        let textForCounting = finalTextForCounting(from: transcription)
+        let wordCount = WordCounter.count(in: textForCounting)
+        let audioDuration = max(transcription.duration, 0)
+        let transcriptionDuration = transcription.transcriptionDuration.flatMap { $0 > 0 ? $0 : nil }
+        let speedFactor = transcriptionDuration.flatMap { duration in
+            audioDuration > 0 ? audioDuration / duration : nil
+        }
+
+        let enhancementDuration = transcription.enhancementDuration.flatMap { $0 > 0 ? $0 : nil }
+
+        let metric = SessionMetric(
+            transcriptionId: transcription.id,
+            timestamp: timestamp,
+            source: source,
+            wordCount: wordCount,
+            audioDuration: audioDuration,
+            transcriptionModelName: transcription.transcriptionModelName ?? model?.displayName,
+            transcriptionDuration: transcriptionDuration,
+            speedFactor: speedFactor,
+            powerModeName: transcription.powerModeName,
+            aiEnhancementModelName: transcription.aiEnhancementModelName,
+            enhancementDuration: enhancementDuration
+        )
+
+        modelContext.insert(metric)
+        logger.notice("Recorded session metric for transcription \(transcriptionId.uuidString, privacy: .public)")
+        return true
+    }
+
+    private static func finalTextForCounting(from transcription: Transcription) -> String {
+        if let enhancedText = transcription.enhancedText,
+           transcription.enhancementDuration != nil,
+           !enhancedText.isEmpty {
+            return enhancedText
+        }
+
+        return transcription.text
+    }
+}

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -169,10 +169,10 @@ class TranscriptionPipeline {
             if didInsertSessionMetric {
                 NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
             }
+            NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
         } catch {
             logger.error("Failed to save transcription: \(error.localizedDescription, privacy: .public)")
         }
-        NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
 
         if shouldCancel() { await onCleanup(); return }
 

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -53,6 +53,7 @@ class TranscriptionPipeline {
 
         var finalPastedText: String?
         var promptDetectionResult: PromptDetectionService.PromptDetectionResult?
+        var didInsertSessionMetric = false
 
         logger.notice("🔄 Starting transcription...")
 
@@ -144,6 +145,15 @@ class TranscriptionPipeline {
             }
 
             transcription.transcriptionStatus = TranscriptionStatus.completed.rawValue
+            do {
+                didInsertSessionMetric = try SessionMetricRecorder.recordRecorderSession(
+                    transcription: transcription,
+                    model: model,
+                    in: modelContext
+                )
+            } catch {
+                logger.error("Failed to record session metric: \(error.localizedDescription, privacy: .public)")
+            }
 
         } catch {
             let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
@@ -154,7 +164,14 @@ class TranscriptionPipeline {
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
         }
 
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+            if didInsertSessionMetric {
+                NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
+            }
+        } catch {
+            logger.error("Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+        }
         NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
 
         if shouldCancel() { await onCleanup(); return }

--- a/VoiceInk/Views/Metrics/MetricsContent.swift
+++ b/VoiceInk/Views/Metrics/MetricsContent.swift
@@ -12,6 +12,7 @@ struct MetricsContent: View {
     @State private var totalDuration: TimeInterval = 0
     @State private var isLoadingMetrics: Bool = true
     @State private var metricsTask: Task<Void, Never>?
+    @State private var isModelStatsPanelPresented = false
 
     var body: some View {
         Group {
@@ -49,19 +50,7 @@ struct MetricsContent: View {
         .task {
             await loadMetricsEfficiently()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .transcriptionCreated)) { _ in
-            metricsTask?.cancel()
-            metricsTask = Task {
-                await loadMetricsEfficiently()
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .transcriptionCompleted)) { _ in
-            metricsTask?.cancel()
-            metricsTask = Task {
-                await loadMetricsEfficiently()
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .sessionMetricsDidChange)) { _ in
             metricsTask?.cancel()
             metricsTask = Task {
                 await loadMetricsEfficiently()
@@ -70,6 +59,32 @@ struct MetricsContent: View {
         .onDisappear {
             metricsTask?.cancel()
         }
+        .overlay {
+            Color.black.opacity(isModelStatsPanelPresented ? 0.1 : 0)
+                .ignoresSafeArea()
+                .allowsHitTesting(isModelStatsPanelPresented)
+                .onTapGesture {
+                    withAnimation(.smooth(duration: 0.3)) { isModelStatsPanelPresented = false }
+                }
+                .animation(.smooth(duration: 0.3), value: isModelStatsPanelPresented)
+        }
+        .overlay(alignment: .trailing) {
+            if isModelStatsPanelPresented {
+                ModelPerformancePanel {
+                    withAnimation(.smooth(duration: 0.3)) { isModelStatsPanelPresented = false }
+                }
+                .frame(width: 400)
+                .frame(maxHeight: .infinity)
+                .background(Color(NSColor.windowBackgroundColor))
+                .overlay(alignment: .leading) {
+                    Rectangle().fill(Color(NSColor.separatorColor)).frame(width: 1)
+                }
+                .shadow(color: .black.opacity(0.08), radius: 8, x: -2, y: 0)
+                .ignoresSafeArea()
+                .transition(.move(edge: .trailing))
+            }
+        }
+        .animation(.smooth(duration: 0.3), value: isModelStatsPanelPresented)
     }
     
     private func loadMetricsEfficiently() async {
@@ -89,8 +104,7 @@ struct MetricsContent: View {
                 return
             }
 
-            let completedFilter = #Predicate<Transcription> { $0.transcriptionStatus == "completed" }
-            let count = try backgroundContext.fetchCount(FetchDescriptor<Transcription>(predicate: completedFilter))
+            let count = try backgroundContext.fetchCount(FetchDescriptor<SessionMetric>())
 
             guard !Task.isCancelled else {
                 await MainActor.run {
@@ -99,21 +113,19 @@ struct MetricsContent: View {
                 return
             }
 
-            var descriptor = FetchDescriptor<Transcription>(predicate: completedFilter)
-            descriptor.propertiesToFetch = [\.text, \.duration]
+            var descriptor = FetchDescriptor<SessionMetric>()
+            descriptor.propertiesToFetch = [\.wordCount, \.audioDuration]
 
             var words = 0
             var duration: TimeInterval = 0
 
-            try backgroundContext.enumerate(descriptor) { transcription in
-                words += transcription.text.split(whereSeparator: \.isWhitespace).count
-                duration += transcription.duration
+            try backgroundContext.enumerate(descriptor) { metric in
+                words += metric.wordCount
+                duration += metric.audioDuration
             }
 
             guard !Task.isCancelled else {
-                await MainActor.run {
-                    self.isLoadingMetrics = false
-                }
+                await MainActor.run { self.isLoadingMetrics = false }
                 return
             }
 
@@ -121,13 +133,15 @@ struct MetricsContent: View {
                 self.totalCount = count
                 self.totalWords = words
                 self.totalDuration = duration
-                self.isLoadingMetrics = false
+                // Stay in loading state if migration is still running and no data yet —
+                // sessionMetricsDidChange will trigger a reload when it finishes.
+                if count > 0 || !SessionMetricMigrationService.shared.isRunning {
+                    self.isLoadingMetrics = false
+                }
             }
         } catch {
             logger.error("Error loading metrics: \(error.localizedDescription, privacy: .public)")
-            await MainActor.run {
-                self.isLoadingMetrics = false
-            }
+            await MainActor.run { self.isLoadingMetrics = false }
         }
     }
 
@@ -136,7 +150,7 @@ struct MetricsContent: View {
             Image(systemName: "waveform")
                 .font(.system(size: 56, weight: .semibold))
                 .foregroundColor(.secondary)
-            Text("No Transcriptions Yet")
+            Text("No Recorder Sessions Yet")
                 .font(.title3.weight(.semibold))
             Text("Start your first recording to unlock value insights.")
                 .foregroundColor(.secondary)
@@ -230,9 +244,25 @@ struct MetricsContent: View {
             )
         }
     }
-    
+
     private var footerActionsView: some View {
-        CopySystemInfoButton()
+        HStack(spacing: 12) {
+            Button(action: {
+                withAnimation(.smooth(duration: 0.3)) { isModelStatsPanelPresented = true }
+            }) {
+                HStack(spacing: 8) {
+                    Image(systemName: "gauge")
+                    Text("Model Performance")
+                }
+                .font(.system(size: 13, weight: .medium))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(.thinMaterial))
+            }
+            .buttonStyle(.plain)
+            .help("View transcription and enhancement model performance")
+            CopySystemInfoButton()
+        }
     }
     
     private var formattedTimeSaved: String {
@@ -284,12 +314,6 @@ struct MetricsContent: View {
         Int(Double(totalWords) * 5.0)
     }
     
-    private var dateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter
-    }
 }
 
 private enum Formatters {

--- a/VoiceInk/Views/Metrics/ModelPerformancePanel.swift
+++ b/VoiceInk/Views/Metrics/ModelPerformancePanel.swift
@@ -181,7 +181,7 @@ private struct ModelPerformancePanelContent: View {
                 Text(String(format: "%.1fx", stat.speedFactor))
                     .font(.system(size: 24, weight: .bold, design: .rounded))
                     .foregroundColor(.mint)
-                Text("Faster than Real-time")
+                Text(stat.speedFactor >= 1.0 ? "Faster than Real-time" : "Slower than Real-time")
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
             }

--- a/VoiceInk/Views/Metrics/ModelPerformancePanel.swift
+++ b/VoiceInk/Views/Metrics/ModelPerformancePanel.swift
@@ -1,0 +1,341 @@
+import SwiftUI
+import SwiftData
+
+// MARK: - Time filter
+
+enum TimeFilter: String, CaseIterable, Identifiable {
+    case last7Days  = "Last 7 Days"
+    case last30Days = "Last 30 Days"
+    case thisYear   = "This Year"
+    case allTime    = "All Time"
+
+    var id: String { rawValue }
+
+    var predicate: Predicate<SessionMetric>? {
+        let now = Date()
+        switch self {
+        case .allTime:
+            return nil
+        case .last7Days:
+            let start = now.addingTimeInterval(-7 * 24 * 3600)
+            return #Predicate<SessionMetric> { $0.timestamp >= start }
+        case .last30Days:
+            let start = now.addingTimeInterval(-30 * 24 * 3600)
+            return #Predicate<SessionMetric> { $0.timestamp >= start }
+        case .thisYear:
+            guard let start = Calendar.current.dateInterval(of: .year, for: now)?.start else { return nil }
+            return #Predicate<SessionMetric> { $0.timestamp >= start }
+        }
+    }
+}
+
+// MARK: - Panel shell (owns filter state)
+
+struct ModelPerformancePanel: View {
+    @AppStorage("modelPerfPanelFilter") private var filterRaw: String = TimeFilter.last7Days.rawValue
+    let onClose: () -> Void
+
+    private var filter: TimeFilter { TimeFilter(rawValue: filterRaw) ?? .last7Days }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .background(Color(NSColor.windowBackgroundColor))
+                .overlay(Divider().opacity(0.5), alignment: .bottom)
+                .zIndex(1)
+
+            ModelPerformancePanelContent(filter: filter)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("Model Performance")
+                .font(.headline.weight(.semibold))
+            Spacer()
+            Picker("", selection: Binding(get: { filter }, set: { filterRaw = $0.rawValue })) {
+                ForEach(TimeFilter.allCases) { f in
+                    Text(f.rawValue).tag(f)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .fixedSize()
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.1))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Content (owns @Query, reacts to filter)
+
+private struct ModelPerformancePanelContent: View {
+    @Query private var metrics: [SessionMetric]
+
+    init(filter: TimeFilter) {
+        if let predicate = filter.predicate {
+            _metrics = Query(filter: predicate)
+        } else {
+            _metrics = Query()
+        }
+    }
+
+    private var modelStats: [ModelPerformanceStat] {
+        var accumulators: [String: ModelPerformanceAccumulator] = [:]
+        for metric in metrics {
+            guard let name = metric.transcriptionModelName,
+                  let processingDuration = metric.transcriptionDuration,
+                  processingDuration > 0 else { continue }
+            accumulators[name, default: ModelPerformanceAccumulator()].add(
+                audioDuration: metric.audioDuration,
+                processingDuration: processingDuration
+            )
+        }
+        return accumulators.map { name, acc in acc.stat(named: name) }
+            .sorted { $0.avgProcessingTime < $1.avgProcessingTime }
+    }
+
+    private var enhancementStats: [EnhancementStat] {
+        var accumulators: [String: EnhancementAccumulator] = [:]
+        for metric in metrics {
+            guard let name = metric.aiEnhancementModelName,
+                  let duration = metric.enhancementDuration,
+                  duration > 0 else { continue }
+            accumulators[name, default: EnhancementAccumulator()].add(duration: duration)
+        }
+        return accumulators.map { name, acc in acc.stat(named: name) }
+            .sorted { $0.avgDuration < $1.avgDuration }
+    }
+
+    private let gridColumns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    var body: some View {
+        if modelStats.isEmpty && enhancementStats.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    if !modelStats.isEmpty {
+                        modelsSection
+                    }
+                    if !enhancementStats.isEmpty {
+                        enhancementSection
+                    }
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.system(size: 32, weight: .light))
+                .foregroundColor(.secondary)
+            Text("No data for this period")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Models grid
+
+    private var modelsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("Transcription Models")
+            LazyVGrid(columns: gridColumns, spacing: 12) {
+                ForEach(modelStats) { stat in
+                    modelTile(stat)
+                }
+            }
+        }
+    }
+
+    private func modelTile(_ stat: ModelPerformanceStat) -> some View {
+        VStack(spacing: 10) {
+            VStack(spacing: 2) {
+                Text(stat.name)
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                Text("\(stat.sessionCount) sessions")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+
+            VStack(spacing: 3) {
+                Text(String(format: "%.1fx", stat.speedFactor))
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundColor(.mint)
+                Text("Faster than Real-time")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+
+            Divider().padding(.horizontal, 8)
+
+            HStack(spacing: 0) {
+                VStack(spacing: 2) {
+                    Text(formatDuration(stat.avgAudioDuration))
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundColor(.indigo)
+                    Text("Avg. Audio")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+
+                Rectangle()
+                    .fill(Color(NSColor.separatorColor))
+                    .frame(width: 1, height: 24)
+
+                VStack(spacing: 2) {
+                    Text(String(format: "%.2fs", stat.avgProcessingTime))
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundColor(.teal)
+                    Text("Avg. Processing")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(14)
+        .background(MetricCardBackground(color: .mint))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Enhancement Models
+
+    private var enhancementSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("Enhancement Models")
+            LazyVGrid(columns: gridColumns, spacing: 12) {
+                ForEach(enhancementStats) { stat in
+                    enhancementTile(stat)
+                }
+            }
+        }
+    }
+
+    private func enhancementTile(_ stat: EnhancementStat) -> some View {
+        VStack(spacing: 10) {
+            VStack(spacing: 2) {
+                Text(stat.name)
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                Text("\(stat.sessionCount) sessions")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+
+            VStack(spacing: 3) {
+                Text(String(format: "%.2fs", stat.avgDuration))
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundColor(.indigo)
+                Text("Avg. Enhancement Time")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(14)
+        .background(MetricCardBackground(color: .indigo))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(.secondary)
+            .textCase(.uppercase)
+            .tracking(0.5)
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: duration) ?? "0s"
+    }
+}
+
+// MARK: - Data models
+
+struct ModelPerformanceStat: Identifiable {
+    var id: String { name }
+    let name: String
+    let sessionCount: Int
+    let totalProcessingTime: TimeInterval
+    let avgProcessingTime: TimeInterval
+    let avgAudioDuration: TimeInterval
+    let speedFactor: Double
+}
+
+struct ModelPerformanceAccumulator {
+    var sessionCount = 0
+    var totalProcessingTime: TimeInterval = 0
+    var totalAudioDuration: TimeInterval = 0
+
+    mutating func add(audioDuration: TimeInterval, processingDuration: TimeInterval) {
+        sessionCount += 1
+        totalProcessingTime += processingDuration
+        totalAudioDuration += audioDuration
+    }
+
+    func stat(named name: String) -> ModelPerformanceStat {
+        let safeCount = max(sessionCount, 1)
+        let speedFactor = totalProcessingTime > 0 ? totalAudioDuration / totalProcessingTime : 0
+        return ModelPerformanceStat(
+            name: name,
+            sessionCount: sessionCount,
+            totalProcessingTime: totalProcessingTime,
+            avgProcessingTime: totalProcessingTime / Double(safeCount),
+            avgAudioDuration: totalAudioDuration / Double(safeCount),
+            speedFactor: speedFactor
+        )
+    }
+}
+
+struct EnhancementStat: Identifiable {
+    var id: String { name }
+    let name: String
+    let sessionCount: Int
+    let avgDuration: TimeInterval
+}
+
+struct EnhancementAccumulator {
+    var sessionCount = 0
+    var totalDuration: TimeInterval = 0
+
+    mutating func add(duration: TimeInterval) {
+        sessionCount += 1
+        totalDuration += duration
+    }
+
+    func stat(named name: String) -> EnhancementStat {
+        let safeCount = max(sessionCount, 1)
+        return EnhancementStat(
+            name: name,
+            sessionCount: sessionCount,
+            avgDuration: totalDuration / Double(safeCount)
+        )
+    }
+}

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -170,11 +170,11 @@ struct VoiceInkApp: App {
 
         AppShortcuts.updateAppShortcutParameters()
 
-        // Migrate stats before transcript cleanup can remove historical recorder sessions.
-        SessionMetricMigrationService.shared.runIfNeeded(modelContainer: container)
-
-        // Start cleanup service for the app's lifetime, not tied to window lifecycle
-        TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: container.mainContext)
+        let migrationTask = SessionMetricMigrationService.shared.runIfNeeded(modelContainer: container)
+        Task {
+            await migrationTask?.value
+            TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: container.mainContext)
+        }
     }
 
     // MARK: - Container Creation Helpers

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -50,6 +50,7 @@ struct VoiceInkApp: App {
         let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "Initialization")
         let schema = Schema([
             Transcription.self,
+            SessionMetric.self,
             VocabularyWord.self,
             WordReplacement.self
         ])
@@ -169,6 +170,9 @@ struct VoiceInkApp: App {
 
         AppShortcuts.updateAppShortcutParameters()
 
+        // Migrate stats before transcript cleanup can remove historical recorder sessions.
+        SessionMetricMigrationService.shared.runIfNeeded(modelContainer: container)
+
         // Start cleanup service for the app's lifetime, not tied to window lifecycle
         TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: container.mainContext)
     }
@@ -187,6 +191,7 @@ struct VoiceInkApp: App {
             // Define storage locations
             let defaultStoreURL = appSupportURL.appendingPathComponent("default.store")
             let dictionaryStoreURL = appSupportURL.appendingPathComponent("dictionary.store")
+            let statsStoreURL = appSupportURL.appendingPathComponent("stats.store")
 
             // Transcript configuration
             let transcriptSchema = Schema([Transcription.self])
@@ -211,10 +216,19 @@ struct VoiceInkApp: App {
                 cloudKitDatabase: dictionaryCloudKit
             )
 
+            // Recorder session metrics configuration
+            let statsSchema = Schema([SessionMetric.self])
+            let statsConfig = ModelConfiguration(
+                "stats",
+                schema: statsSchema,
+                url: statsStoreURL,
+                cloudKitDatabase: .none
+            )
+
             // Initialize container
             return try ModelContainer(
                 for: schema,
-                configurations: transcriptConfig, dictionaryConfig
+                configurations: transcriptConfig, dictionaryConfig, statsConfig
             )
         } catch {
             logger.error("❌ Failed to create persistent ModelContainer: \(error.localizedDescription, privacy: .public)")
@@ -240,7 +254,14 @@ struct VoiceInkApp: App {
                 isStoredInMemoryOnly: true
             )
 
-            return try ModelContainer(for: schema, configurations: transcriptConfig, dictionaryConfig)
+            let statsSchema = Schema([SessionMetric.self])
+            let statsConfig = ModelConfiguration(
+                "stats",
+                schema: statsSchema,
+                isStoredInMemoryOnly: true
+            )
+
+            return try ModelContainer(for: schema, configurations: transcriptConfig, dictionaryConfig, statsConfig)
         } catch {
             logger.error("❌ Failed to create in-memory ModelContainer: \(error.localizedDescription, privacy: .public)")
             return nil

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -171,9 +171,10 @@ struct VoiceInkApp: App {
         AppShortcuts.updateAppShortcutParameters()
 
         let migrationTask = SessionMetricMigrationService.shared.runIfNeeded(modelContainer: container)
+        let mainContext = container.mainContext
         Task {
             await migrationTask?.value
-            TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: container.mainContext)
+            TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: mainContext)
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add recorder session metrics with a separate stats store and a model performance panel. Metrics now read from `SessionMetric`, update via `sessionMetricsDidChange`, and stay consistent during migration.

- **New Features**
  - Added `SessionMetric` to persist recorder stats (word count, audio duration, model names, durations, speed factor, power mode).
  - Added `SessionMetricRecorder`; `TranscriptionPipeline` records on completion and posts `sessionMetricsDidChange` after save.
  - Metrics view now aggregates from `SessionMetric` and includes a sliding "Model Performance" panel with time filters and tiles for transcription/enhancement models.
  - Introduced a separate SwiftData config/store for stats (`stats.store`) so metrics survive transcript cleanup.
  - Fixed speed label when a model is slower than real-time.

- **Migration**
  - One-time background migration (`SessionMetricMigrationService`) backfills completed transcriptions with a single ID prefetch and batched save (~4000+ records in ~2s).
  - Metrics screen stays loading while migration runs and posts `sessionMetricsDidChange` when done.

<sup>Written for commit caf94aed04490a3b2b588602b52c8cfc49d53b20. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/678?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

