### PR TITLE
Fix paste timing 

### DIFF
--- a/VoiceInk/CursorPaster.swift
+++ b/VoiceInk/CursorPaster.swift
@@ -6,45 +6,72 @@ import os
 private let logger = Logger(subsystem: "com.VoiceInk", category: "CursorPaster")
 
 class CursorPaster {
+    private typealias ClipboardSnapshot = [(NSPasteboard.PasteboardType, Data)]
 
     static func pasteAtCursor(_ text: String) {
+        Task {
+            await MainActor.run {
+                startPasteAtCursor(text)
+            }.value
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    static func startPasteAtCursor(_ text: String) -> Task<Void, Never> {
         let pasteboard = NSPasteboard.general
         let shouldRestoreClipboard = UserDefaults.standard.bool(forKey: "restoreClipboardAfterPaste")
+        let savedContents = shouldRestoreClipboard ? snapshotClipboard(from: pasteboard) : []
 
-        var savedContents: [(NSPasteboard.PasteboardType, Data)] = []
+        _ = ClipboardManager.setClipboard(text, transient: shouldRestoreClipboard)
 
-        if shouldRestoreClipboard {
-            let currentItems = pasteboard.pasteboardItems ?? []
+        return Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            postPasteCommand()
 
-            for item in currentItems {
-                for type in item.types {
-                    if let data = item.data(forType: type) {
-                        savedContents.append((type, data))
-                    }
+            if shouldRestoreClipboard {
+                scheduleClipboardRestore(savedContents, on: pasteboard)
+            }
+        }
+    }
+
+    @MainActor
+    static func pasteAtCursorAndWaitUntilPosted(_ text: String) async {
+        await startPasteAtCursor(text).value
+    }
+
+    private static func snapshotClipboard(from pasteboard: NSPasteboard) -> ClipboardSnapshot {
+        var savedContents: ClipboardSnapshot = []
+        let currentItems = pasteboard.pasteboardItems ?? []
+
+        for item in currentItems {
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    savedContents.append((type, data))
                 }
             }
         }
 
-        ClipboardManager.setClipboard(text, transient: shouldRestoreClipboard)
+        return savedContents
+    }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            if UserDefaults.standard.bool(forKey: "useAppleScriptPaste") {
-                pasteUsingAppleScript()
-            } else {
-                pasteFromClipboard()
-            }
+    private static func postPasteCommand() {
+        if UserDefaults.standard.bool(forKey: "useAppleScriptPaste") {
+            pasteUsingAppleScript()
+        } else {
+            pasteFromClipboard()
         }
+    }
 
-        if shouldRestoreClipboard {
-            let restoreDelay = UserDefaults.standard.double(forKey: "clipboardRestoreDelay")
-            let delay = max(restoreDelay, 0.25)
+    private static func scheduleClipboardRestore(_ savedContents: ClipboardSnapshot, on pasteboard: NSPasteboard) {
+        let restoreDelay = UserDefaults.standard.double(forKey: "clipboardRestoreDelay")
+        let delay = max(restoreDelay, 0.25)
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                if !savedContents.isEmpty {
-                    pasteboard.clearContents()
-                    for (type, data) in savedContents {
-                        pasteboard.setData(data, forType: type)
-                    }
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            if !savedContents.isEmpty {
+                pasteboard.clearContents()
+                for (type, data) in savedContents {
+                    pasteboard.setData(data, forType: type)
                 }
             }
         }

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -4,7 +4,7 @@ import SwiftData
 import os
 
 /// Handles the full post-recording pipeline:
-/// transcribe → filter → format → word-replace → prompt-detect → AI enhance → save → paste → dismiss
+/// transcribe → filter → format → word-replace → prompt-detect → AI enhance → start paste + dismiss → save
 @MainActor
 class TranscriptionPipeline {
     private let modelContext: ModelContext
@@ -35,7 +35,7 @@ class TranscriptionPipeline {
     ///   - onStateChange: Called when the pipeline moves to a new recording state (e.g. `.enhancing`).
     ///   - shouldCancel: Returns true if the user requested cancellation.
     ///   - onCleanup: Called when cancellation is detected to release model resources.
-    ///   - onDismiss: Called at the end to dismiss the recorder panel.
+    ///   - onDismiss: Called as soon as paste is initiated to dismiss the recorder panel.
     func run(
         transcription: Transcription,
         audioURL: URL,
@@ -145,16 +145,6 @@ class TranscriptionPipeline {
             }
 
             transcription.transcriptionStatus = TranscriptionStatus.completed.rawValue
-            do {
-                didInsertSessionMetric = try SessionMetricRecorder.recordRecorderSession(
-                    transcription: transcription,
-                    model: model,
-                    in: modelContext
-                )
-            } catch {
-                logger.error("Failed to record session metric: \(error.localizedDescription, privacy: .public)")
-            }
-
         } catch {
             let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             let recoverySuggestion = (error as? LocalizedError)?.recoverySuggestion ?? ""
@@ -164,18 +154,45 @@ class TranscriptionPipeline {
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
         }
 
-        do {
-            try modelContext.save()
-            if didInsertSessionMetric {
-                NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
+        func saveTranscriptionAndPostCompletion() {
+            if transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue {
+                do {
+                    didInsertSessionMetric = try SessionMetricRecorder.recordRecorderSession(
+                        transcription: transcription,
+                        model: model,
+                        in: modelContext
+                    )
+                } catch {
+                    logger.error("Failed to record session metric: \(error.localizedDescription, privacy: .public)")
+                }
             }
-            NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
-        } catch {
-            logger.error("Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+
+            do {
+                try modelContext.save()
+                if didInsertSessionMetric {
+                    NotificationCenter.default.post(name: .sessionMetricsDidChange, object: nil)
+                }
+                NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
+            } catch {
+                logger.error("Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+            }
         }
 
-        if shouldCancel() { await onCleanup(); return }
+        func restorePromptDetectionSettingsIfNeeded() async {
+            if let result = promptDetectionResult,
+               let enhancementService,
+               result.shouldEnableAI {
+                await promptDetectionService.restoreOriginalSettings(result, to: enhancementService)
+            }
+        }
 
+        if shouldCancel() {
+            await onCleanup()
+            saveTranscriptionAndPostCompletion()
+            return
+        }
+
+        let dismissTask: Task<Void, Never>?
         if var textToPaste = finalPastedText,
            transcription.transcriptionStatus == TranscriptionStatus.completed.rawValue {
             if case .trialExpired = licenseViewModel.licenseState {
@@ -185,26 +202,31 @@ class TranscriptionPipeline {
                     """
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) {
-                SoundManager.shared.playStopSound()
-                let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
-                CursorPaster.pasteAtCursor(textToPaste + (appendSpace ? " " : ""))
+            let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
+            let pastedText = textToPaste + (appendSpace ? " " : "")
+            let pastePostTask = CursorPaster.startPasteAtCursor(pastedText)
+            SoundManager.shared.playStopSound()
+            let autoSendKey = PowerModeManager.shared.currentActiveConfiguration?.autoSendKey
+            await restorePromptDetectionSettingsIfNeeded()
+            dismissTask = Task { @MainActor in
+                await onDismiss()
+            }
+            await pastePostTask.value
 
-                let powerMode = PowerModeManager.shared
-                if let activeConfig = powerMode.currentActiveConfiguration, activeConfig.autoSendKey.isEnabled {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        CursorPaster.performAutoSend(activeConfig.autoSendKey)
-                    }
+            if let autoSendKey, autoSendKey.isEnabled {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    CursorPaster.performAutoSend(autoSendKey)
                 }
             }
+        } else {
+            await restorePromptDetectionSettingsIfNeeded()
+            await onDismiss()
+            dismissTask = nil
         }
 
-        if let result = promptDetectionResult,
-           let enhancementService,
-           result.shouldEnableAI {
-            await promptDetectionService.restoreOriginalSettings(result, to: enhancementService)
-        }
+        saveTranscriptionAndPostCompletion()
 
-        await onDismiss()
+        await dismissTask?.value
     }
 }

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -55,14 +55,15 @@ struct VoiceInkApp: App {
             WordReplacement.self
         ])
         var initializationFailed = false
+        let resolvedContainer: ModelContainer
 
         // Attempt 1: Try persistent storage
         if let persistentContainer = Self.createPersistentContainer(schema: schema, logger: logger) {
-            container = persistentContainer
+            resolvedContainer = persistentContainer
         }
         // Attempt 2: Try in-memory storage
         else if let memoryContainer = Self.createInMemoryContainer(schema: schema, logger: logger) {
-            container = memoryContainer
+            resolvedContainer = memoryContainer
 
             logger.warning("Using in-memory storage as fallback. Data will not persist between sessions.")
 
@@ -83,11 +84,12 @@ struct VoiceInkApp: App {
 
             // Create minimal in-memory container to satisfy initialization
             let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-            container = (try? ModelContainer(for: schema, configurations: [config])) ?? {
+            resolvedContainer = (try? ModelContainer(for: schema, configurations: [config])) ?? {
                 preconditionFailure("Unable to create ModelContainer. SwiftData is unavailable.")
             }()
         }
 
+        container = resolvedContainer
         containerInitializationFailed = initializationFailed
 
         // Initialize services with proper sharing of instances
@@ -97,7 +99,7 @@ struct VoiceInkApp: App {
         let updaterViewModel = UpdaterViewModel()
         _updaterViewModel = StateObject(wrappedValue: updaterViewModel)
 
-        let enhancementService = AIEnhancementService(aiService: aiService, modelContext: container.mainContext)
+        let enhancementService = AIEnhancementService(aiService: aiService, modelContext: resolvedContainer.mainContext)
         _enhancementService = StateObject(wrappedValue: enhancementService)
 
         // 1. Create modelsDirectory URL
@@ -118,7 +120,7 @@ struct VoiceInkApp: App {
 
         // 4. Create engine
         let engine = VoiceInkEngine(
-            modelContext: container.mainContext,
+            modelContext: resolvedContainer.mainContext,
             whisperModelManager: whisperModelManager,
             transcriptionModelManager: transcriptionModelManager,
             enhancementService: enhancementService
@@ -148,7 +150,7 @@ struct VoiceInkApp: App {
 
         let menuBarManager = MenuBarManager()
         _menuBarManager = StateObject(wrappedValue: menuBarManager)
-        menuBarManager.configure(modelContainer: container, engine: engine)
+        menuBarManager.configure(modelContainer: resolvedContainer, engine: engine)
 
         let activeWindowService = ActiveWindowService.shared
         activeWindowService.configure(with: enhancementService)
@@ -157,7 +159,7 @@ struct VoiceInkApp: App {
         let prewarmService = ModelPrewarmService(
             transcriptionModelManager: transcriptionModelManager,
             whisperModelManager: whisperModelManager,
-            modelContext: container.mainContext
+            modelContext: resolvedContainer.mainContext
         )
         _prewarmService = StateObject(wrappedValue: prewarmService)
 
@@ -170,8 +172,8 @@ struct VoiceInkApp: App {
 
         AppShortcuts.updateAppShortcutParameters()
 
-        let migrationTask = SessionMetricMigrationService.shared.runIfNeeded(modelContainer: container)
-        let mainContext = container.mainContext
+        let migrationTask = SessionMetricMigrationService.shared.runIfNeeded(modelContainer: resolvedContainer)
+        let mainContext = resolvedContainer.mainContext
         Task {
             await migrationTask?.value
             TranscriptionAutoCleanupService.shared.startMonitoring(modelContext: mainContext)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes delayed/missed pastes by starting the paste on the main thread and waiting for it to post before dismissing the panel. Also resolves auto-send and teardown races, and cleans up app initialization to use the correct model container.

- **Bug Fixes**
  - Start paste via `CursorPaster.startPasteAtCursor` with a 50ms delay on the main thread; await posting before dismissal and auto-send. Clipboard snapshot/restore is now reliable with a minimum 250ms restore delay.
  - In the pipeline, trigger paste and stop sound first, await paste completion, then schedule auto-send (500ms) and dismiss promptly. Handles cancel paths and posts completion notifications consistently.

- **Refactors**
  - Extracted clipboard snapshot/restore and paste dispatch into helpers; added `pasteAtCursorAndWaitUntilPosted` for precise sequencing.
  - Use a single `resolvedContainer` to initialize all services and contexts, preventing early or mismatched `ModelContext` usage.

<sup>Written for commit 6a21b5784ad1de6ef211e580bf48f0a1073d32b3. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/679?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

