### PR TITLE
Fix recording startup race and mute timing

### DIFF
--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -17,6 +17,7 @@ class Recorder: NSObject, ObservableObject {
     private let audioMeterQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.audiometer", qos: .userInteractive)
     /// Dedicated serial queue for hardware setup.
     private let audioSetupQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.audioSetup", qos: .userInitiated)
+    private var audioMuteTask: Task<Void, Never>?
     private var audioRestorationTask: Task<Void, Never>?
     private let smoothedValuesLock = NSLock()
     private var smoothedAverage: Float = 0
@@ -95,7 +96,16 @@ class Recorder: NSObject, ObservableObject {
         }
     }
 
-    func startRecording(toOutputFile url: URL, completion: @escaping (Result<Void, Error>) -> Void) {
+    func scheduleSystemMute(afterDelayNanoseconds delay: UInt64 = 250_000_000) {
+        audioMuteTask?.cancel()
+        audioMuteTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            guard !Task.isCancelled, let self else { return }
+            _ = await self.mediaController.muteSystemAudio()
+        }
+    }
+
+    func startRecording(toOutputFile url: URL) async throws {
         logger.notice("startRecording called – deviceID=\(self.deviceManager.getCurrentDevice(), privacy: .public), file=\(url.lastPathComponent, privacy: .public)")
         deviceManager.isRecordingActive = true
 
@@ -110,43 +120,44 @@ class Recorder: NSObject, ObservableObject {
 
         let deviceID = currentDeviceID
 
-        let coreAudioRecorder = CoreAudioRecorder()
-        coreAudioRecorder.onAudioChunk = onAudioChunk
-        recorder = coreAudioRecorder
-
         audioRestorationTask?.cancel()
         audioRestorationTask = nil
         audioMeterUpdateTimer?.cancel()
 
-        let capturedLogger = logger
-        // Offload initialization to background thread to avoid hotkey lag.
-        audioSetupQueue.async { [weak self] in
-            do {
-                try coreAudioRecorder.startRecording(toOutputFile: url, deviceID: deviceID)
-                capturedLogger.notice("startRecording: CoreAudioRecorder started successfully")
-                DispatchQueue.main.async { [weak self] in
-                    self?.startAudioMeterTimer()
-                }
-                Task { [weak self] in
-                    guard let self = self else { return }
-                    await self.playbackController.pauseMedia()
-                }
-                DispatchQueue.main.async {
-                    completion(.success(()))
-                }
-            } catch {
-                capturedLogger.error("Failed to start recording: \(error.localizedDescription, privacy: .public)")
-                DispatchQueue.main.async { [weak self] in
-                    self?.stopRecording()
-                    self?.deviceManager.isRecordingActive = false
-                    completion(.failure(error))
+        let coreAudioRecorder = CoreAudioRecorder()
+        coreAudioRecorder.onAudioChunk = onAudioChunk
+        recorder = coreAudioRecorder
+
+        do {
+            // Offload initialization to background thread to avoid hotkey lag.
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                audioSetupQueue.async {
+                    do {
+                        try coreAudioRecorder.startRecording(toOutputFile: url, deviceID: deviceID)
+                        continuation.resume()
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
+            logger.notice("startRecording: CoreAudioRecorder started successfully")
+
+            startAudioMeterTimer()
+            Task { [weak self] in
+                guard let self else { return }
+                await self.playbackController.pauseMedia()
+            }
+        } catch {
+            logger.error("Failed to start recording: \(error.localizedDescription, privacy: .public)")
+            stopRecording()
+            throw RecorderError.couldNotStartRecording
         }
     }
 
     func stopRecording() {
         logger.notice("stopRecording called")
+        audioMuteTask?.cancel()
+        audioMuteTask = nil
         audioMeterUpdateTimer?.cancel()
         audioMeterUpdateTimer = nil
 

--- a/VoiceInk/SoundManager.swift
+++ b/VoiceInk/SoundManager.swift
@@ -2,14 +2,6 @@ import Foundation
 import AVFoundation
 import SwiftUI
 
-private final class AudioPlayerCompletionDelegate: NSObject, AVAudioPlayerDelegate {
-    private let onFinished: () -> Void
-    init(_ onFinished: @escaping () -> Void) { self.onFinished = onFinished }
-    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        DispatchQueue.main.async { self.onFinished() }
-    }
-}
-
 @MainActor
 class SoundManager: ObservableObject {
     static let shared = SoundManager()
@@ -19,7 +11,6 @@ class SoundManager: ObservableObject {
     private var escSound: AVAudioPlayer?
     private var customStartSound: AVAudioPlayer?
     private var customStopSound: AVAudioPlayer?
-    private var startSoundDelegate: AudioPlayerCompletionDelegate?
 
     @AppStorage("isSoundFeedbackEnabled") private var isSoundFeedbackEnabled = true
 
@@ -92,25 +83,15 @@ class SoundManager: ObservableObject {
         }
     }
 
-    func playStartSound(onFinished: (() -> Void)? = nil) {
-        guard isSoundFeedbackEnabled else {
-            onFinished?()
-            return
-        }
-        guard let player = customStartSound ?? startSound else {
-            onFinished?()
-            return
-        }
-        player.volume = 0.4
-        if let onFinished {
-            let delegate = AudioPlayerCompletionDelegate(onFinished)
-            startSoundDelegate = delegate
-            player.delegate = delegate
+    func playStartSound() {
+        guard isSoundFeedbackEnabled else { return }
+
+        if let custom = customStartSound {
+            custom.play()
         } else {
-            startSoundDelegate = nil
-            player.delegate = nil
+            startSound?.volume = 0.4
+            startSound?.play()
         }
-        player.play()
     }
 
     func playStopSound() {

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -94,9 +94,7 @@ class RecorderUIManager: ObservableObject {
                 await cancelRecording()
             }
         } else {
-            SoundManager.shared.playStartSound {
-                Task { await MediaController.shared.muteSystemAudio() }
-            }
+            SoundManager.shared.playStartSound()
             await MainActor.run { isMiniRecorderVisible = true }
             await engine.toggleRecord(powerModeId: powerModeId)
         }
@@ -111,7 +109,7 @@ class RecorderUIManager: ObservableObject {
             return
         }
 
-        let wasRecording = engine.recordingState == .recording
+        let wasRecording = engine.recordingState == .recording || engine.recordingState == .starting
 
         await MainActor.run {
             engine.recordingState = .busy

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -11,6 +11,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
     @Published var shouldCancelRecording = false
     var partialTranscript: String = ""
     var currentSession: TranscriptionSession?
+    private var activeRecordingStartID: UUID?
 
     let recorder = Recorder()
     var recordedFile: URL? = nil
@@ -81,7 +82,18 @@ class VoiceInkEngine: NSObject, ObservableObject {
     func toggleRecord(powerModeId: UUID? = nil) async {
         logger.notice("toggleRecord called – state=\(String(describing: self.recordingState), privacy: .public)")
 
+        if recordingState == .starting {
+            logger.notice("toggleRecord: cancelling in-flight recording start")
+            shouldCancelRecording = true
+            activeRecordingStartID = nil
+            recorder.stopRecording()
+            recordedFile = nil
+            recordingState = .idle
+            return
+        }
+
         if recordingState == .recording {
+            activeRecordingStartID = nil
             partialTranscript = ""
             recordingState = .transcribing
             await recorder.stopRecording()
@@ -124,93 +136,103 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
             requestRecordPermission { [self] granted in
                 if granted {
-                    let fileName = "\(UUID().uuidString).wav"
-                    let permanentURL = self.recordingsDirectory.appendingPathComponent(fileName)
-                    self.recordedFile = permanentURL
+                    Task { @MainActor [self] in
+                        let startID = UUID()
+                        self.activeRecordingStartID = startID
 
-                    let pendingChunks = OSAllocatedUnfairLock(initialState: [Data]())
-                    self.recorder.onAudioChunk = { data in
-                        pendingChunks.withLock { $0.append(data) }
-                    }
+                        do {
+                            let fileName = "\(UUID().uuidString).wav"
+                            let permanentURL = self.recordingsDirectory.appendingPathComponent(fileName)
+                            self.recordedFile = permanentURL
 
-                    self.recordingState = .recording
-                    self.logger.notice("toggleRecord: state=recording, starting audio hardware")
+                            let pendingChunks = OSAllocatedUnfairLock(initialState: [Data]())
+                            self.recorder.onAudioChunk = { data in
+                                pendingChunks.withLock { $0.append(data) }
+                            }
 
-                    self.recorder.startRecording(toOutputFile: permanentURL) { result in
-                        Task { @MainActor [self] in
-                            do {
-                                try result.get()
-                                self.logger.notice("toggleRecord: audio hardware started successfully")
+                            self.recordingState = .starting
+                            self.logger.notice("toggleRecord: state=starting, starting audio hardware")
+                            self.recorder.scheduleSystemMute()
 
-                                guard self.recorderUIManager?.isMiniRecorderVisible ?? false, !self.shouldCancelRecording else {
+                            try await self.recorder.startRecording(toOutputFile: permanentURL)
+
+                            guard self.activeRecordingStartID == startID,
+                                  self.recorderUIManager?.isMiniRecorderVisible ?? false,
+                                  !self.shouldCancelRecording else {
+                                if self.activeRecordingStartID == startID {
                                     self.recorder.stopRecording()
                                     self.recordedFile = nil
                                     self.recordingState = .idle
-                                    return
+                                    self.activeRecordingStartID = nil
                                 }
-
-                                await ActiveWindowService.shared.applyConfiguration(powerModeId: powerModeId)
-
-                                if self.recordingState == .recording,
-                                   let model = self.transcriptionModelManager.currentTranscriptionModel {
-                                    let session = self.serviceRegistry.createSession(
-                                        for: model,
-                                        onPartialTranscript: { [weak self] partial in
-                                            Task { @MainActor in
-                                                self?.partialTranscript = partial
-                                            }
-                                        }
-                                    )
-                                    self.currentSession = session
-                                    let realCallback = try await session.prepare(model: model)
-
-                                    if let realCallback {
-                                        self.recorder.onAudioChunk = realCallback
-                                        let buffered = pendingChunks.withLock { chunks -> [Data] in
-                                            let result = chunks
-                                            chunks.removeAll()
-                                            return result
-                                        }
-                                        for chunk in buffered { realCallback(chunk) }
-                                    } else {
-                                        self.recorder.onAudioChunk = nil
-                                        pendingChunks.withLock { $0.removeAll() }
-                                    }
-                                }
-
-                                Task.detached { [weak self] in
-                                    guard let self else { return }
-
-                                    if let model = await self.transcriptionModelManager.currentTranscriptionModel,
-                                       model.provider == .whisper {
-                                        if let localWhisperModel = await self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
-                                           await self.whisperModelManager.whisperContext == nil {
-                                            do {
-                                                try await self.whisperModelManager.loadModel(localWhisperModel)
-                                            } catch {
-                                                await self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
-                                            }
-                                        }
-                                    } else if let fluidAudioModel = await self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
-                                        try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
-                                    }
-
-                                    if let enhancementService = await self.enhancementService {
-                                        await MainActor.run {
-                                            enhancementService.captureClipboardContext()
-                                        }
-                                        await enhancementService.captureScreenContext()
-                                    }
-                                }
-
-                            } catch {
-                                self.logger.error("❌ Failed to start recording: \(error.localizedDescription, privacy: .public)")
-                                self.recordingState = .idle
-                                self.recordedFile = nil
-                                await NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
-                                self.logger.notice("toggleRecord: calling dismissMiniRecorder from error handler")
-                                await self.recorderUIManager?.dismissMiniRecorder()
+                                return
                             }
+
+                            self.recordingState = .recording
+                            self.logger.notice("toggleRecord: recording started successfully, state=recording")
+
+                            await ActiveWindowService.shared.applyConfiguration(powerModeId: powerModeId)
+
+                            if self.recordingState == .recording,
+                               let model = self.transcriptionModelManager.currentTranscriptionModel {
+                                let session = self.serviceRegistry.createSession(
+                                    for: model,
+                                    onPartialTranscript: { [weak self] partial in
+                                        Task { @MainActor in
+                                            self?.partialTranscript = partial
+                                        }
+                                    }
+                                )
+                                self.currentSession = session
+                                let realCallback = try await session.prepare(model: model)
+
+                                if let realCallback {
+                                    self.recorder.onAudioChunk = realCallback
+                                    let buffered = pendingChunks.withLock { chunks -> [Data] in
+                                        let result = chunks
+                                        chunks.removeAll()
+                                        return result
+                                    }
+                                    for chunk in buffered { realCallback(chunk) }
+                                } else {
+                                    self.recorder.onAudioChunk = nil
+                                    pendingChunks.withLock { $0.removeAll() }
+                                }
+                            }
+
+                            Task.detached { [weak self] in
+                                guard let self else { return }
+
+                                if let model = await self.transcriptionModelManager.currentTranscriptionModel,
+                                   model.provider == .whisper {
+                                    if let localWhisperModel = await self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
+                                       await self.whisperModelManager.whisperContext == nil {
+                                        do {
+                                            try await self.whisperModelManager.loadModel(localWhisperModel)
+                                        } catch {
+                                            await self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
+                                        }
+                                    }
+                                } else if let fluidAudioModel = await self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
+                                    try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
+                                }
+
+                                if let enhancementService = await self.enhancementService {
+                                    await MainActor.run {
+                                        enhancementService.captureClipboardContext()
+                                    }
+                                    await enhancementService.captureScreenContext()
+                                }
+                            }
+
+                        } catch {
+                            self.logger.error("❌ Failed to start recording: \(error.localizedDescription, privacy: .public)")
+                            self.recordingState = .idle
+                            self.recordedFile = nil
+                            self.activeRecordingStartID = nil
+                            await NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
+                            self.logger.notice("toggleRecord: calling dismissMiniRecorder from error handler")
+                            await self.recorderUIManager?.dismissMiniRecorder()
                         }
                     }
                 } else {
@@ -259,6 +281,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
     func cleanupResources() async {
         logger.notice("cleanupResources: releasing model resources")
+        activeRecordingStartID = nil
         await whisperModelManager.cleanupResources()
         await serviceRegistry.cleanup()
         logger.notice("cleanupResources: completed")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the recording start race and aligns system mute with the start sound so the chime plays cleanly and the first speech isn’t missed. Rapid toggles are now handled reliably without getting stuck.

- **Bug Fixes**
  - Prevented start/stop race by adding a `.starting` state and `activeRecordingStartID`; a second toggle cancels an in-flight start.
  - Centralized mute timing: `Recorder.scheduleSystemMute` mutes ~250ms after start and is canceled on stop. Removed UI-triggered mute.
  - `Recorder.startRecording` is now `async throws`; hardware init runs on `audioSetupQueue` via a continuation, with proper cleanup on failure.
  - `RecorderUIManager` treats `.starting` as active for stop logic to avoid stuck states.

- **Refactors**
  - Simplified `SoundManager.playStartSound` (no delegate/callback).
  - Kept early buffering of audio chunks until the transcription session is ready.
  - Reset `activeRecordingStartID` during engine cleanup.

<sup>Written for commit 6249a02cd0032e0bc428d7740ff568d68a6eba7b. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/680?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

