### PR TITLE
Fix native Apple Speech asset handling

### DIFF
--- a/VoiceInk/Models/LanguageDictionary.swift
+++ b/VoiceInk/Models/LanguageDictionary.swift
@@ -31,6 +31,12 @@ enum TranscriptionLanguageSupport {
             return language
         }
 
+        if model.provider == .nativeApple {
+            if languages["en-US"] != nil {
+                return "en-US"
+            }
+        }
+
         if languages["auto"] != nil {
             return "auto"
         }
@@ -81,8 +87,7 @@ enum LanguageDictionary {
 
         switch provider {
         case .nativeApple:
-            let codes = ["ar", "de", "en", "es", "fr", "it", "ja", "ko", "pt", "yue", "zh"]
-            return all.filter { codes.contains($0.key) }
+            return appleNative
 
         case .fluidAudio:
             let codes = [
@@ -99,46 +104,39 @@ enum LanguageDictionary {
         }
     }
 
-    // Apple Native Speech languages in BCP-47 format
-    // Based on actual supported locales from SpeechTranscriber.supportedLocales
+    // Apple Native Speech languages in BCP-47 format.
+    // Queried from SpeechTranscriber.supportedLocales on macOS 26.4.
     static let appleNative: [String: String] = [
-        "en-US": "English (United States)",
-        "en-GB": "English (United Kingdom)",
-        "en-CA": "English (Canada)",
-        "en-AU": "English (Australia)",
-        "en-IN": "English (India)",
-        "en-IE": "English (Ireland)",
-        "en-NZ": "English (New Zealand)",
-        "en-ZA": "English (South Africa)",
-        "en-SA": "English (Saudi Arabia)",
-        "en-AE": "English (UAE)",
-        "en-SG": "English (Singapore)",
-        "en-PH": "English (Philippines)",
-        "en-ID": "English (Indonesia)",
-        "es-ES": "Spanish (Spain)",
-        "es-MX": "Spanish (Mexico)",
-        "es-US": "Spanish (United States)",
-        "es-CO": "Spanish (Colombia)",
-        "es-CL": "Spanish (Chile)",
-        "es-419": "Spanish (Latin America)",
-        "fr-FR": "French (France)",
-        "fr-CA": "French (Canada)",
-        "fr-BE": "French (Belgium)",
-        "fr-CH": "French (Switzerland)",
         "de-DE": "German (Germany)",
         "de-AT": "German (Austria)",
         "de-CH": "German (Switzerland)",
-        "zh-CN": "Chinese Simplified (China)",
-        "zh-TW": "Chinese Traditional (Taiwan)",
-        "zh-HK": "Chinese Traditional (Hong Kong)",
+        "en-AU": "English (Australia)",
+        "en-CA": "English (Canada)",
+        "en-GB": "English (United Kingdom)",
+        "en-IE": "English (Ireland)",
+        "en-IN": "English (India)",
+        "en-NZ": "English (New Zealand)",
+        "en-SG": "English (Singapore)",
+        "en-US": "English (United States)",
+        "en-ZA": "English (South Africa)",
+        "es-CL": "Spanish (Chile)",
+        "es-ES": "Spanish (Spain)",
+        "es-MX": "Spanish (Mexico)",
+        "es-US": "Spanish (United States)",
+        "fr-BE": "French (Belgium)",
+        "fr-CA": "French (Canada)",
+        "fr-CH": "French (Switzerland)",
+        "fr-FR": "French (France)",
+        "it-CH": "Italian (Switzerland)",
+        "it-IT": "Italian (Italy)",
         "ja-JP": "Japanese (Japan)",
         "ko-KR": "Korean (South Korea)",
-        "yue-CN": "Cantonese (China)",
         "pt-BR": "Portuguese (Brazil)",
         "pt-PT": "Portuguese (Portugal)",
-        "it-IT": "Italian (Italy)",
-        "it-CH": "Italian (Switzerland)",
-        "ar-SA": "Arabic (Saudi Arabia)"
+        "yue-CN": "Cantonese (China mainland)",
+        "zh-CN": "Chinese (China mainland)",
+        "zh-HK": "Chinese (Hong Kong)",
+        "zh-TW": "Chinese (Taiwan)"
     ]
 
     static let all: [String: String] = [

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -149,12 +149,12 @@ class Recorder: NSObject, ObservableObject {
             }
         } catch {
             logger.error("Failed to start recording: \(error.localizedDescription, privacy: .public)")
-            stopRecording()
+            await stopRecording()
             throw RecorderError.couldNotStartRecording
         }
     }
 
-    func stopRecording() {
+    func stopRecording() async {
         logger.notice("stopRecording called")
         audioMuteTask?.cancel()
         audioMuteTask = nil
@@ -163,11 +163,15 @@ class Recorder: NSObject, ObservableObject {
 
         // Capture current recorder to stop it on the serial hardware queue
         let currentRecorder = self.recorder
-        audioSetupQueue.async {
-            currentRecorder?.stopRecording()
-        }
         recorder = nil
         onAudioChunk = nil
+
+        await withCheckedContinuation { continuation in
+            audioSetupQueue.async {
+                currentRecorder?.stopRecording()
+                continuation.resume()
+            }
+        }
 
         smoothedValuesLock.lock()
         smoothedAverage = 0
@@ -187,7 +191,7 @@ class Recorder: NSObject, ObservableObject {
         logger.error("❌ Recording error occurred: \(error.localizedDescription, privacy: .public)")
 
         // Stop the recording
-        stopRecording()
+        await stopRecording()
 
         // Notify the user about the recording failure
         await MainActor.run {

--- a/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
@@ -55,11 +55,26 @@ class TranscriptionModelManager: ObservableObject {
         }
     }
 
+    func isAvailableOnCurrentOS(_ model: any TranscriptionModel) -> Bool {
+        switch model.provider {
+        case .nativeApple:
+            if #available(macOS 26, *) { return true } else { return false }
+        default:
+            return true
+        }
+    }
+
     // MARK: - Model loading from UserDefaults
 
     func loadCurrentTranscriptionModel() {
         if let savedModelName = UserDefaults.standard.string(forKey: "CurrentTranscriptionModel"),
            let savedModel = allAvailableModels.first(where: { $0.name == savedModelName }) {
+            guard isAvailableOnCurrentOS(savedModel) else {
+                UserDefaults.standard.removeObject(forKey: "CurrentTranscriptionModel")
+                currentTranscriptionModel = nil
+                return
+            }
+
             currentTranscriptionModel = savedModel
             ensureSelectedLanguageIsSupported(by: savedModel)
         }
@@ -68,6 +83,14 @@ class TranscriptionModelManager: ObservableObject {
     // MARK: - Set default model
 
     func setDefaultTranscriptionModel(_ model: any TranscriptionModel) {
+        guard isAvailableOnCurrentOS(model) else {
+            NotificationManager.shared.showNotification(
+                title: "\(model.displayName) requires macOS 26 or later",
+                type: .error
+            )
+            return
+        }
+
         self.currentTranscriptionModel = model
         UserDefaults.standard.set(model.name, forKey: "CurrentTranscriptionModel")
         ensureSelectedLanguageIsSupported(by: model)

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -55,8 +55,6 @@ class TranscriptionPipeline {
         var promptDetectionResult: PromptDetectionService.PromptDetectionResult?
         var didInsertSessionMetric = false
 
-        logger.notice("🔄 Starting transcription...")
-
         do {
             let transcriptionStart = Date()
             var text: String
@@ -65,9 +63,7 @@ class TranscriptionPipeline {
             } else {
                 text = try await serviceRegistry.transcribe(audioURL: audioURL, model: model)
             }
-            logger.notice("📝 Transcript: \(text, privacy: .public)")
             text = TranscriptionOutputFilter.filter(text)
-            logger.notice("📝 Output filter result: \(text, privacy: .public)")
             let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
             let powerModeManager = PowerModeManager.shared
@@ -81,13 +77,10 @@ class TranscriptionPipeline {
 
             if UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled") {
                 text = WhisperTextFormatter.format(text)
-                logger.notice("📝 Formatted transcript: \(text, privacy: .public)")
             }
 
             text = WordReplacementService.shared.applyReplacements(to: text, using: modelContext)
-            logger.notice("📝 WordReplacement: \(text, privacy: .public)")
             let cleanedText = TranscriptionOutputFilter.applyUserCleanupPreferences(text)
-            logger.notice("📝 User cleanup result: \(cleanedText, privacy: .public)")
 
             let audioAsset = AVURLAsset(url: audioURL)
             let actualDuration = (try? CMTimeGetSeconds(await audioAsset.load(.duration))) ?? 0.0
@@ -122,7 +115,6 @@ class TranscriptionPipeline {
 
                 do {
                     let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(textForAI)
-                    logger.notice("📝 AI enhancement: \(enhancedText, privacy: .public)")
                     transcription.enhancedText = enhancedText
                     transcription.aiEnhancementModelName = enhancementService.getAIService()?.currentModel
                     transcription.promptName = promptName
@@ -147,10 +139,19 @@ class TranscriptionPipeline {
             transcription.transcriptionStatus = TranscriptionStatus.completed.rawValue
         } catch {
             let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            let recoverySuggestion = (error as? LocalizedError)?.recoverySuggestion ?? ""
-            let fullErrorText = recoverySuggestion.isEmpty ? errorDescription : "\(errorDescription) \(recoverySuggestion)"
 
-            transcription.text = "Transcription Failed: \(fullErrorText)"
+            if let nativeAppleError = error as? NativeAppleTranscriptionService.ServiceError,
+               case .assetDownloadRequired = nativeAppleError {
+                await MainActor.run {
+                    NotificationManager.shared.showNotification(
+                        title: errorDescription,
+                        type: .error,
+                        duration: 5.0
+                    )
+                }
+            }
+
+            transcription.text = "Transcription Failed: \(errorDescription)"
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
         }
 

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -86,7 +86,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
             logger.notice("toggleRecord: cancelling in-flight recording start")
             shouldCancelRecording = true
             activeRecordingStartID = nil
-            recorder.stopRecording()
+            await recorder.stopRecording()
             recordedFile = nil
             recordingState = .idle
             return
@@ -160,7 +160,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                   self.recorderUIManager?.isMiniRecorderVisible ?? false,
                                   !self.shouldCancelRecording else {
                                 if self.activeRecordingStartID == startID {
-                                    self.recorder.stopRecording()
+                                    await self.recorder.stopRecording()
                                     self.recordedFile = nil
                                     self.recordingState = .idle
                                     self.activeRecordingStartID = nil

--- a/VoiceInk/Transcription/Native/NativeAppleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Native/NativeAppleTranscriptionService.swift
@@ -10,31 +10,14 @@ import Speech
 /// Falls back with an unsupported-provider error on earlier OS versions so the application can gracefully degrade.
 class NativeAppleTranscriptionService: TranscriptionService {
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "NativeAppleTranscriptionService")
-    
-    /// Maps simple language codes to Apple's BCP-47 locale format
-    private func mapToAppleLocale(_ simpleCode: String) -> String {
-        let mapping = [
-            "en": "en-US",
-            "es": "es-ES", 
-            "fr": "fr-FR",
-            "de": "de-DE",
-            "ar": "ar-SA",
-            "it": "it-IT",
-            "ja": "ja-JP",
-            "ko": "ko-KR",
-            "pt": "pt-BR",
-            "yue": "yue-CN",
-            "zh": "zh-CN"
-        ]
-        return mapping[simpleCode] ?? "en-US"
-    }
-    
+
     enum ServiceError: Error, LocalizedError {
         case unsupportedOS
         case transcriptionFailed
         case localeNotSupported
         case invalidModel
-        case assetAllocationFailed
+        case assetDownloadRequired(String)
+        case resultStreamTimedOut
         
         var errorDescription: String? {
             switch self {
@@ -46,10 +29,18 @@ class NativeAppleTranscriptionService: TranscriptionService {
                 return "The selected language is not supported by SpeechAnalyzer."
             case .invalidModel:
                 return "Invalid model type provided for Native Apple transcription."
-            case .assetAllocationFailed:
-                return "Failed to allocate assets for the selected locale."
+            case .assetDownloadRequired(let displayName):
+                return "Download required for \(displayName)."
+            case .resultStreamTimedOut:
+                return "Apple Speech did not finish returning transcription results."
             }
         }
+    }
+
+    private func languageDisplayName(for localeIdentifier: String) -> String {
+        LanguageDictionary.appleNative[localeIdentifier]
+            ?? Locale.current.localizedString(forIdentifier: localeIdentifier)
+            ?? localeIdentifier
     }
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
@@ -65,54 +56,32 @@ class NativeAppleTranscriptionService: TranscriptionService {
         // Feature gated: SpeechAnalyzer/SpeechTranscriber are future APIs.
         // Enable by defining ENABLE_NATIVE_SPEECH_ANALYZER in build settings once building against macOS 26+ SDKs.
         #if canImport(Speech) && ENABLE_NATIVE_SPEECH_ANALYZER
-        logger.notice("Starting Apple native transcription with SpeechAnalyzer.")
-        
         let audioFile = try AVAudioFile(forReading: audioURL)
+        let audioDuration = Double(audioFile.length) / audioFile.processingFormat.sampleRate
         
-        // Get the user's selected language in simple format and convert to BCP-47 format
-        let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
-        let appleLocale = mapToAppleLocale(selectedLanguage)
-        let locale = Locale(identifier: appleLocale)
+        // Apple Speech stores and consumes actual BCP-47 locale identifiers directly.
+        let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en-US"
+        let locale = Locale(identifier: selectedLanguage)
 
-        // Check for locale support and asset installation status using proper BCP-47 format
         let supportedLocales = await SpeechTranscriber.supportedLocales
         let installedLocales = await SpeechTranscriber.installedLocales
-        let isLocaleSupported = supportedLocales.map({ $0.identifier(.bcp47) }).contains(locale.identifier(.bcp47))
-        let isLocaleInstalled = installedLocales.map({ $0.identifier(.bcp47) }).contains(locale.identifier(.bcp47))
-
-        // Create the detailed log message
-        let supportedIdentifiers = supportedLocales.map { $0.identifier(.bcp47) }.sorted().joined(separator: ", ")
-        let installedIdentifiers = installedLocales.map { $0.identifier(.bcp47) }.sorted().joined(separator: ", ")
-        let availableForDownload = Set(supportedLocales).subtracting(Set(installedLocales)).map { $0.identifier(.bcp47) }.sorted().joined(separator: ", ")
+        let supportedIdentifiers = Set(supportedLocales.map { $0.identifier(.bcp47) })
+        let installedIdentifiers = Set(installedLocales.map { $0.identifier(.bcp47) })
+        let isLocaleSupported = supportedIdentifiers.contains(locale.identifier(.bcp47))
+        let isLocaleInstalled = installedIdentifiers.contains(locale.identifier(.bcp47))
         
-        var statusMessage: String
-        if isLocaleInstalled {
-            statusMessage = "✅ Installed"
-        } else if isLocaleSupported {
-            statusMessage = "❌ Not Installed (Available for download)"
-        } else {
-            statusMessage = "❌ Not Supported"
-        }
-        
-        let logMessage = """
-        
-        --- Native Speech Transcription ---
-        Selected Language: '\(selectedLanguage)' → Apple Locale: '\(locale.identifier(.bcp47))'
-        Status: \(statusMessage)
-        ------------------------------------
-        Supported Locales: [\(supportedIdentifiers)]
-        Installed Locales: [\(installedIdentifiers)]
-        Available for Download: [\(availableForDownload)]
-        ------------------------------------
-        """
-        logger.notice("\(logMessage, privacy: .public)")
+        let selectedLocaleIdentifier = locale.identifier(.bcp47)
+        let displayName = languageDisplayName(for: selectedLocaleIdentifier)
 
         guard isLocaleSupported else {
             logger.error("Transcription failed: Locale '\(locale.identifier(.bcp47), privacy: .public)' is not supported by SpeechTranscriber.")
             throw ServiceError.localeNotSupported
         }
-        
-        // Asset reservations are managed automatically by the system.
+
+        guard isLocaleInstalled else {
+            logger.error("Transcription failed: Assets for '\(selectedLocaleIdentifier, privacy: .public)' are not downloaded.")
+            throw ServiceError.assetDownloadRequired(displayName)
+        }
         
         let transcriber = SpeechTranscriber(
             locale: locale,
@@ -121,49 +90,110 @@ class NativeAppleTranscriptionService: TranscriptionService {
             attributeOptions: []
         )
         
-        // Ensure model assets are available, triggering a system download prompt if necessary.
-        try await ensureModelIsAvailable(for: transcriber, locale: locale)
+        await ensureModelIsReserved(for: locale, transcriber: transcriber)
         
-        let analyzer = SpeechAnalyzer(modules: [transcriber])
-        
-        try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
-        
-        var transcript: AttributedString = ""
-        for try await result in transcriber.results {
-            transcript += result.text
+        let modules: [any SpeechModule] = [transcriber]
+        let analyzer = SpeechAnalyzer(modules: modules)
+        let resultTask = Task<String, Error> {
+            var transcript = ""
+            for try await result in transcriber.results {
+                transcript += String(result.text.characters)
+            }
+            return transcript
+        }
+
+        do {
+            let lastSampleTime = try await analyzer.analyzeSequence(from: audioFile)
+
+            if let lastSampleTime {
+                try await analyzer.finalizeAndFinish(through: lastSampleTime)
+            } else {
+                resultTask.cancel()
+                await analyzer.cancelAndFinishNow()
+                logger.error("Transcription failed: Apple Speech received no audio samples for '\(selectedLocaleIdentifier, privacy: .public)'.")
+                throw ServiceError.transcriptionFailed
+            }
+        } catch {
+            resultTask.cancel()
+            await analyzer.cancelAndFinishNow()
+            throw error
         }
         
-        var finalTranscription = String(transcript.characters).trimmingCharacters(in: .whitespacesAndNewlines)
+        let resultTimeout = max(20.0, audioDuration * 4.0 + 10.0)
+        let finalTranscription: String
+        do {
+            finalTranscription = try await waitForResultStream(
+                resultTask,
+                timeout: resultTimeout
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            resultTask.cancel()
+            await analyzer.cancelAndFinishNow()
+            throw error
+        }
 
-        logger.notice("Native transcription successful. Length: \(finalTranscription.count, privacy: .public) characters.")
         return finalTranscription
         #else
-        logger.notice("Native Apple transcription is disabled in this build (future Speech APIs not enabled).")
         throw ServiceError.unsupportedOS
         #endif
     }
     
     
     
-    // Forward-compatibility: Use Any here because SpeechTranscriber is only available in future macOS SDKs.
-    // This avoids referencing an unavailable SDK symbol while keeping the method shape for later adoption.
     @available(macOS 26, *)
-    private func ensureModelIsAvailable(for transcriber: SpeechTranscriber, locale: Locale) async throws {
+    private func ensureModelIsReserved(for locale: Locale, transcriber: SpeechTranscriber) async {
         #if canImport(Speech) && ENABLE_NATIVE_SPEECH_ANALYZER
-        let installedLocales = await SpeechTranscriber.installedLocales
-        let isInstalled = installedLocales.map({ $0.identifier(.bcp47) }).contains(locale.identifier(.bcp47))
+        let localeIdentifier = locale.identifier(.bcp47)
+        let reservedLocales = await AssetInventory.reservedLocales
+        guard !reservedLocales.contains(where: { $0.identifier(.bcp47) == localeIdentifier }) else {
+            return
+        }
 
-        if !isInstalled {
-            logger.notice("Assets for '\(locale.identifier(.bcp47), privacy: .public)' not installed. Requesting system download.")
-            
-            if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-                try await request.downloadAndInstall()
-                logger.notice("Asset download for '\(locale.identifier(.bcp47), privacy: .public)' complete.")
-            } else {
-                logger.error("Asset download for '\(locale.identifier(.bcp47), privacy: .public)' failed: Could not create installation request.")
-                // Note: We don't throw an error here, as transcription might still work with a base model.
+        for reservedLocale in reservedLocales {
+            await AssetInventory.release(reservedLocale: reservedLocale)
+        }
+
+        do {
+            let reserved = try await AssetInventory.reserve(locale: locale)
+
+            guard reserved else {
+                let finalStatus = await AssetInventory.status(forModules: [transcriber])
+                logger.warning("Apple Speech asset reservation returned false for '\(localeIdentifier, privacy: .public)'. Continuing because the locale is already downloaded. Status: \(String(describing: finalStatus), privacy: .public).")
+                return
             }
+        } catch {
+            let finalStatus = await AssetInventory.status(forModules: [transcriber])
+            logger.warning("Apple Speech asset reservation failed for '\(localeIdentifier, privacy: .public)': \(error.localizedDescription, privacy: .public). Continuing because the locale is already downloaded. Status: \(String(describing: finalStatus), privacy: .public).")
         }
         #endif
+    }
+
+    private func waitForResultStream(
+        _ resultTask: Task<String, Error>,
+        timeout: TimeInterval
+    ) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await resultTask.value
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw ServiceError.resultStreamTimedOut
+            }
+
+            do {
+                guard let result = try await group.next() else {
+                    throw ServiceError.transcriptionFailed
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                logger.error("Apple Speech result wait failed: \(error.localizedDescription, privacy: .public).")
+                throw error
+            }
+        }
     }
 } 

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -1,8 +1,6 @@
 import Foundation
-import os
 
 struct TranscriptionOutputFilter {
-    private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionOutputFilter")
     private static let removePunctuationKey = "RemovePunctuation"
     private static let lowercaseTranscriptionKey = "LowercaseTranscription"
     private static let apostropheLikeCharacters = CharacterSet(charactersIn: "'’‘ʼ＇")
@@ -45,13 +43,6 @@ struct TranscriptionOutputFilter {
         // Clean whitespace
         filteredText = filteredText.replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
         filteredText = filteredText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Log results
-        if filteredText != text {
-            logger.notice("📝 Output filter result: \(filteredText, privacy: .public)")
-        } else {
-            logger.notice("📝 Output filter result (unchanged): \(filteredText, privacy: .public)")
-        }
 
         return filteredText
     }

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -12,7 +12,6 @@ struct LanguageSelectionView: View {
     // Add display mode parameter with full as the default
     var displayMode: LanguageDisplayMode = .full
     @ObservedObject var whisperPrompt: WhisperPrompt
-    @State private var languageOptionsRefreshID = UUID()
 
     private func updateLanguage(_ language: String) {
         guard selectedLanguage != language else { return }
@@ -43,6 +42,10 @@ struct LanguageSelectionView: View {
         return provider == .fluidAudio || provider == .gemini
     }
 
+    private func isNativeAppleModelSelected() -> Bool {
+        transcriptionModelManager.currentTranscriptionModel?.provider == .nativeApple
+    }
+
     private func availableLanguagesForCurrentModel() -> [String: String] {
         guard let currentModel = transcriptionModelManager.currentTranscriptionModel else {
             return ["en": "English"] // Default to English if no model found
@@ -60,6 +63,21 @@ struct LanguageSelectionView: View {
         return availableLanguagesForCurrentModel()[selectedLanguage] ?? "Unknown"
     }
 
+    private var selectedLanguageBinding: Binding<String> {
+        Binding(
+            get: { selectedLanguage },
+            set: { updateLanguage($0) }
+        )
+    }
+
+    private var nativeAppleAssetControl: some View {
+        NativeAppleLanguageAssetControl(
+            localeIdentifier: selectedLanguage,
+            isVisible: true
+        )
+        .layoutPriority(1)
+    }
+
     var body: some View {
         Group {
             switch displayMode {
@@ -69,13 +87,13 @@ struct LanguageSelectionView: View {
                 menuItemView
             }
         }
-        .id(languageOptionsRefreshID)
-        .onAppear(perform: useCompatibleLanguageForCurrentModel)
+        .onAppear {
+            useCompatibleLanguageForCurrentModel()
+        }
         .onChange(of: transcriptionModelManager.currentTranscriptionModel?.name) { _, _ in
             useCompatibleLanguageForCurrentModel()
         }
         .onReceive(NotificationCenter.default.publisher(for: .AppSettingsDidChange)) { _ in
-            languageOptionsRefreshID = UUID()
             useCompatibleLanguageForCurrentModel()
         }
     }
@@ -111,20 +129,24 @@ struct LanguageSelectionView: View {
                     .disabled(true)
                 } else if isMultilingualModel() {
                     VStack(alignment: .leading, spacing: 8) {
-                        Picker("Select Language", selection: $selectedLanguage) {
-                            ForEach(
-                                availableLanguagesForCurrentModel().sorted(by: {
-                                    if $0.key == "auto" { return true }
-                                    if $1.key == "auto" { return false }
-                                    return $0.value < $1.value
-                                }), id: \.key
-                            ) { key, value in
-                                Text(value).tag(key)
+                        HStack(spacing: 8) {
+                            Picker("Select Language", selection: selectedLanguageBinding) {
+                                ForEach(
+                                    availableLanguagesForCurrentModel().sorted(by: {
+                                        if $0.key == "auto" { return true }
+                                        if $1.key == "auto" { return false }
+                                        return $0.value < $1.value
+                                    }), id: \.key
+                                ) { key, value in
+                                    Text(value).tag(key)
+                                }
                             }
-                        }
-                        .pickerStyle(MenuPickerStyle())
-                        .onChange(of: selectedLanguage) { oldValue, newValue in
-                            updateLanguage(newValue)
+                            .pickerStyle(MenuPickerStyle())
+                            .frame(maxWidth: isNativeAppleModelSelected() ? 280 : .infinity, alignment: .leading)
+
+                            if isNativeAppleModelSelected() {
+                                nativeAppleAssetControl
+                            }
                         }
 
                         Text("Current model: \(currentModel.displayName)")
@@ -183,30 +205,36 @@ struct LanguageSelectionView: View {
                 }
                 .disabled(true)
             } else if isMultilingualModel() {
-                Menu {
-                    ForEach(
-                        availableLanguagesForCurrentModel().sorted(by: {
-                            if $0.key == "auto" { return true }
-                            if $1.key == "auto" { return false }
-                            return $0.value < $1.value
-                        }), id: \.key
-                    ) { key, value in
-                        Button {
-                            updateLanguage(key)
-                        } label: {
-                            HStack {
-                                Text(value)
-                                if selectedLanguage == key {
-                                    Image(systemName: "checkmark")
+                HStack(spacing: 8) {
+                    Menu {
+                        ForEach(
+                            availableLanguagesForCurrentModel().sorted(by: {
+                                if $0.key == "auto" { return true }
+                                if $1.key == "auto" { return false }
+                                return $0.value < $1.value
+                            }), id: \.key
+                        ) { key, value in
+                            Button {
+                                updateLanguage(key)
+                            } label: {
+                                HStack {
+                                    Text(value)
+                                    if selectedLanguage == key {
+                                        Image(systemName: "checkmark")
+                                    }
                                 }
                             }
                         }
+                    } label: {
+                        HStack {
+                            Text("Language: \(currentLanguageDisplayName())")
+                            Image(systemName: "chevron.up.chevron.down")
+                                .font(.system(size: 10))
+                        }
                     }
-                } label: {
-                    HStack {
-                        Text("Language: \(currentLanguageDisplayName())")
-                        Image(systemName: "chevron.up.chevron.down")
-                            .font(.system(size: 10))
+
+                    if isNativeAppleModelSelected() {
+                        nativeAppleAssetControl
                     }
                 }
             } else {

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -316,7 +316,10 @@ struct ModelManagementView: View {
                 return index1 < index2
             }
         case .local:
-            return transcriptionModelManager.allAvailableModels.filter { $0.provider == .whisper || $0.provider == .nativeApple || $0.provider == .fluidAudio }
+            return transcriptionModelManager.allAvailableModels.filter {
+                ($0.provider == .whisper || $0.provider == .nativeApple || $0.provider == .fluidAudio)
+                    && transcriptionModelManager.isAvailableOnCurrentOS($0)
+            }
         case .cloud:
             return transcriptionModelManager.allAvailableModels.filter { CloudProviderRegistry.provider(for: $0.provider) != nil }
         case .custom:

--- a/VoiceInk/Views/AI Models/NativeAppleLanguageAssetControl.swift
+++ b/VoiceInk/Views/AI Models/NativeAppleLanguageAssetControl.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+import os
+
+#if canImport(Speech)
+import Speech
+#endif
+
+private enum NativeAppleSpeechAssetState: Equatable {
+    case checking
+    case downloaded
+    case needsDownload
+    case downloading
+    case notSupported
+    case assetManagementUnavailable
+    case failed(String)
+}
+
+struct NativeAppleLanguageAssetControl: View {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "NativeAppleLanguageAssetControl")
+
+    let localeIdentifier: String
+    let isVisible: Bool
+
+    @State private var state: NativeAppleSpeechAssetState = .checking
+    @State private var refreshTask: Task<Void, Never>?
+
+    private var refreshKey: String {
+        "\(isVisible)-\(localeIdentifier)"
+    }
+
+    var body: some View {
+        Group {
+            if isVisible {
+                content
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .onChange(of: refreshKey, initial: true) { _, _ in
+            refreshAssetState()
+        }
+        .onDisappear {
+            refreshTask?.cancel()
+            refreshTask = nil
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .checking:
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 28, height: 24)
+                .help("Checking Apple Speech language download status.")
+        case .downloaded:
+            EmptyView()
+        case .needsDownload:
+            Button(action: downloadAsset) {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .controlSize(.small)
+            .frame(width: 28, height: 24)
+            .help("Download this Apple Speech language before transcribing.")
+            .accessibilityLabel("Download Apple Speech language")
+        case .downloading:
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 28, height: 24)
+                .help("Downloading Apple Speech language.")
+        case .notSupported:
+            Image(systemName: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(width: 28, height: 24)
+                .help("This language is not supported by Apple Speech.")
+        case .assetManagementUnavailable:
+            Image(systemName: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(width: 28, height: 24)
+                .help("Apple Speech asset management is not available on this system.")
+        case .failed(let message):
+            Button(action: downloadAsset) {
+                Image(systemName: "arrow.clockwise.circle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .controlSize(.small)
+            .frame(width: 28, height: 24)
+            .help("Retry downloading this Apple Speech language. \(message)")
+            .accessibilityLabel("Retry Apple Speech language download")
+        }
+    }
+
+    private func refreshAssetState() {
+        guard isVisible else {
+            refreshTask?.cancel()
+            refreshTask = nil
+            return
+        }
+
+        let localeIdentifier = localeIdentifier
+        state = .checking
+        refreshTask?.cancel()
+        refreshTask = Task {
+            let resolvedState = await assetState(for: localeIdentifier)
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            state = resolvedState
+        }
+    }
+
+    private func downloadAsset() {
+        let localeIdentifier = localeIdentifier
+        state = .downloading
+        refreshTask?.cancel()
+
+        refreshTask = Task {
+            let resolvedState = await installAsset(for: localeIdentifier)
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            state = resolvedState
+        }
+    }
+
+    private func assetState(for localeIdentifier: String) async -> NativeAppleSpeechAssetState {
+        guard #available(macOS 26, *) else {
+            return .assetManagementUnavailable
+        }
+
+        #if canImport(Speech) && ENABLE_NATIVE_SPEECH_ANALYZER
+        let locale = Locale(identifier: localeIdentifier)
+        let selectedIdentifier = locale.identifier(.bcp47)
+        let supportedIdentifiers = await Set(SpeechTranscriber.supportedLocales.map { $0.identifier(.bcp47) })
+
+        guard supportedIdentifiers.contains(selectedIdentifier) else {
+            return .notSupported
+        }
+
+        let installedIdentifiers = await Set(SpeechTranscriber.installedLocales.map { $0.identifier(.bcp47) })
+        return installedIdentifiers.contains(selectedIdentifier) ? .downloaded : .needsDownload
+        #else
+        return .assetManagementUnavailable
+        #endif
+    }
+
+    private func installAsset(for localeIdentifier: String) async -> NativeAppleSpeechAssetState {
+        guard #available(macOS 26, *) else {
+            logger.error("Apple Speech asset download unavailable for '\(localeIdentifier, privacy: .public)': requires macOS 26 or later.")
+            return .assetManagementUnavailable
+        }
+
+        #if canImport(Speech) && ENABLE_NATIVE_SPEECH_ANALYZER
+        do {
+            let locale = Locale(identifier: localeIdentifier)
+            let normalizedIdentifier = locale.identifier(.bcp47)
+            let transcriber = SpeechTranscriber(
+                locale: locale,
+                transcriptionOptions: [],
+                reportingOptions: [],
+                attributeOptions: []
+            )
+
+            let reservedLocales = await AssetInventory.reservedLocales
+            for reservedLocale in reservedLocales {
+                await AssetInventory.release(reservedLocale: reservedLocale)
+            }
+
+            let reserved = try await AssetInventory.reserve(locale: locale)
+
+            guard reserved else {
+                logger.error("Apple Speech asset reservation returned false for '\(normalizedIdentifier, privacy: .public)'.")
+                return .failed("Could not reserve Apple Speech assets for \(normalizedIdentifier).")
+            }
+
+            guard let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) else {
+                return await assetState(for: localeIdentifier)
+            }
+
+            try await request.downloadAndInstall()
+            return await assetState(for: localeIdentifier)
+        } catch {
+            logger.error("Apple Speech asset download failed for '\(localeIdentifier, privacy: .public)': \(error.localizedDescription, privacy: .public).")
+            return .failed(error.localizedDescription)
+        }
+        #else
+        logger.error("Apple Speech asset download unavailable for '\(localeIdentifier, privacy: .public)': ENABLE_NATIVE_SPEECH_ANALYZER is not active.")
+        return .assetManagementUnavailable
+        #endif
+    }
+}

--- a/VoiceInk/Views/AI Models/NativeAppleLanguageAssetControl.swift
+++ b/VoiceInk/Views/AI Models/NativeAppleLanguageAssetControl.swift
@@ -176,9 +176,13 @@ struct NativeAppleLanguageAssetControl: View {
 
             let reserved = try await AssetInventory.reserve(locale: locale)
 
-            guard reserved else {
-                logger.error("Apple Speech asset reservation returned false for '\(normalizedIdentifier, privacy: .public)'.")
-                return .failed("Could not reserve Apple Speech assets for \(normalizedIdentifier).")
+            if !reserved {
+                let currentState = await assetState(for: localeIdentifier)
+                if currentState != .needsDownload {
+                    return currentState
+                }
+
+                logger.warning("Apple Speech asset reservation returned false for '\(normalizedIdentifier, privacy: .public)'. Continuing to request installation after confirming the asset still needs download.")
             }
 
             guard let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) else {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes native Apple Speech by using real BCP‑47 locales with installed-asset checks and a small UI to check/download languages, while hard-gating the model to macOS 26+. Also improves recorder shutdown and reduces noisy logs.

- **New Features**
  - Added `NativeAppleLanguageAssetControl` beside the language picker for Apple Speech; shows status and downloads assets via `AssetInventory`.
  - Updated the native Apple language list to actual BCP‑47 locales in `LanguageDictionary.appleNative` with clear display names.

- **Bug Fixes**
  - Transcription now uses the selected BCP‑47 locale with `SpeechTranscriber`, verifies support/install status, and shows a “Download required” user notification when missing.
  - Reserves/releases Apple Speech assets via `AssetInventory`, treats false reservations as non‑fatal, waits for result stream with a timeout, and cancels cleanly on errors to avoid hangs.
  - Gates the native Apple model to macOS 26+; hides/blocks selection on older macOS, removes incompatible saved selections with a notification, and defaults to `en-US` when needed.
  - Made recorder `stopRecording()` async and awaited in the engine to prevent races; reduced excessive logging in the pipeline and filters.

<sup>Written for commit 61f5f8fcddfa7dc06f5c0e532779e8723d651514. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/681?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

