### PR TITLE
Add adjustable audio ducking during recording (closes #683)

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -15,6 +15,7 @@ enum AppDefaults {
             // Audio & Media
             "isSystemMuteEnabled": true,
             "audioResumptionDelay": 0.0,
+            "audioDuckingPercent": 100,
             "isPauseMediaEnabled": false,
             "isSoundFeedbackEnabled": true,
             CustomSoundManager.SoundType.start.builtInSoundKey: CustomSoundManager.SoundType.start.defaultBuiltInSound.rawValue,

--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -38,10 +38,12 @@ final class MediaController: ObservableObject {
         unmuteTask = nil
         muteGeneration += 1
 
-        // Start each cycle with a clean mode. The successful path below sets
-        // it; on failure or no-op (0%) it stays .none so a later stop won't
-        // restore a stale saved volume from a previous recording.
-        activeDuckingMode = .none
+        // If the previous cycle was cancelled before its restore ran, system
+        // audio is still in a ducked/muted state. Apply that restore now so
+        // the new cycle starts from the user's actual volume — and so a
+        // later stop won't try to restore a stale saved value if the new
+        // cycle ends up being a no-op (0% or failure).
+        applyPendingRestoreImmediately()
 
         let percent = max(0, min(100, audioDuckingPercent))
 
@@ -88,6 +90,24 @@ final class MediaController: ObservableObject {
 
         activeDuckingMode = .volume(savedVolume: currentVolume)
         return true
+    }
+
+    private func applyPendingRestoreImmediately() {
+        let shouldUnmute = didMuteAudio && !wasAudioMutedBeforeRecording
+
+        switch activeDuckingMode {
+        case .mute:
+            if shouldUnmute {
+                _ = setSystemMuted(false)
+            }
+        case .volume(let savedVolume):
+            _ = setSystemVolume(savedVolume)
+        case .none:
+            break
+        }
+
+        didMuteAudio = false
+        activeDuckingMode = .none
     }
 
     func unmuteSystemAudio() async {

--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -38,6 +38,11 @@ final class MediaController: ObservableObject {
         unmuteTask = nil
         muteGeneration += 1
 
+        // Start each cycle with a clean mode. The successful path below sets
+        // it; on failure or no-op (0%) it stays .none so a later stop won't
+        // restore a stale saved volume from a previous recording.
+        activeDuckingMode = .none
+
         let percent = max(0, min(100, audioDuckingPercent))
 
         // Full mute path preserves the original behavior and the macOS

--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -60,6 +60,14 @@ final class MediaController: ObservableObject {
     }
 
     private func applyFullMute() async -> Bool {
+        // A prior .volume restore is still unresolved. Switching to .mute
+        // here would overwrite the saved volume, so a later stop would
+        // unmute but never restore the user's volume — the device would
+        // stay at the ducked level. Bail so the prior mode survives.
+        if case .volume = activeDuckingMode {
+            return false
+        }
+
         let currentlyMuted = isSystemAudioMuted()
 
         if currentlyMuted {
@@ -85,13 +93,17 @@ final class MediaController: ObservableObject {
         // failed and applyPendingRestoreImmediately kept the state), reuse
         // it as the baseline. Reading current volume here would anchor on
         // the still-ducked level and drift the user's true volume on stop.
+        // If the unresolved mode is .mute instead, refuse to overwrite —
+        // a stop with mode=.volume would never unmute the device.
         let baselineVolume: Float
-        if case .volume(let prevSaved) = activeDuckingMode {
+        switch activeDuckingMode {
+        case .volume(let prevSaved):
             baselineVolume = prevSaved
-        } else if let current = getSystemVolume() {
-            baselineVolume = current
-        } else {
+        case .mute:
             return false
+        case .none:
+            guard let current = getSystemVolume() else { return false }
+            baselineVolume = current
         }
 
         let factor = Float(100 - percent) / 100.0

--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -81,14 +81,25 @@ final class MediaController: ObservableObject {
     }
 
     private func applyVolumeDucking(percent: Int) -> Bool {
-        guard let currentVolume = getSystemVolume() else { return false }
+        // If a prior cycle's saved volume is still pending (its restore
+        // failed and applyPendingRestoreImmediately kept the state), reuse
+        // it as the baseline. Reading current volume here would anchor on
+        // the still-ducked level and drift the user's true volume on stop.
+        let baselineVolume: Float
+        if case .volume(let prevSaved) = activeDuckingMode {
+            baselineVolume = prevSaved
+        } else if let current = getSystemVolume() {
+            baselineVolume = current
+        } else {
+            return false
+        }
 
         let factor = Float(100 - percent) / 100.0
-        let targetVolume = max(0.0, min(1.0, currentVolume * factor))
+        let targetVolume = max(0.0, min(1.0, baselineVolume * factor))
 
         guard setSystemVolume(targetVolume) else { return false }
 
-        activeDuckingMode = .volume(savedVolume: currentVolume)
+        activeDuckingMode = .volume(savedVolume: baselineVolume)
         return true
     }
 
@@ -98,10 +109,16 @@ final class MediaController: ObservableObject {
         switch activeDuckingMode {
         case .mute:
             if shouldUnmute {
-                _ = setSystemMuted(false)
+                // Keep state (mode + didMuteAudio) on failure so the next
+                // unmuteSystemAudio or applyPendingRestoreImmediately can
+                // retry the restore instead of forgetting we own the mute.
+                guard setSystemMuted(false) else { return }
             }
         case .volume(let savedVolume):
-            _ = setSystemVolume(savedVolume)
+            // Same here: if the restore fails, leave .volume(savedVolume)
+            // in place so applyVolumeDucking can carry the baseline forward
+            // and a later cycle still has a path back to the user's volume.
+            guard setSystemVolume(savedVolume) else { return }
         case .none:
             break
         }

--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -5,8 +5,15 @@ final class MediaController: ObservableObject {
 
     static let shared = MediaController()
 
+    private enum DuckingMode {
+        case none
+        case mute
+        case volume(savedVolume: Float)
+    }
+
     private var didMuteAudio = false
     private var wasAudioMutedBeforeRecording = false
+    private var activeDuckingMode: DuckingMode = .none
     private var unmuteTask: Task<Void, Never>?
     private var muteGeneration: Int = 0
 
@@ -18,6 +25,10 @@ final class MediaController: ObservableObject {
         didSet { UserDefaults.standard.set(audioResumptionDelay, forKey: "audioResumptionDelay") }
     }
 
+    @Published var audioDuckingPercent: Int = UserDefaults.standard.integer(forKey: "audioDuckingPercent") {
+        didSet { UserDefaults.standard.set(audioDuckingPercent, forKey: "audioDuckingPercent") }
+    }
+
     private init() {}
 
     func muteSystemAudio() async -> Bool {
@@ -27,30 +38,58 @@ final class MediaController: ObservableObject {
         unmuteTask = nil
         muteGeneration += 1
 
+        let percent = max(0, min(100, audioDuckingPercent))
+
+        // Full mute path preserves the original behavior and the macOS
+        // volume-slider state. Use volume scalar only for partial ducking.
+        if percent >= 100 {
+            return await applyFullMute()
+        } else if percent > 0 {
+            return applyVolumeDucking(percent: percent)
+        } else {
+            // 0% reduction means "do nothing".
+            return false
+        }
+    }
+
+    private func applyFullMute() async -> Bool {
         let currentlyMuted = isSystemAudioMuted()
 
         if currentlyMuted {
             if didMuteAudio {
-                // We muted it previously, stay responsible for unmuting
                 wasAudioMutedBeforeRecording = false
             } else {
-                // User muted it, don't unmute when done
                 wasAudioMutedBeforeRecording = true
                 didMuteAudio = false
             }
+            activeDuckingMode = .mute
             return true
         }
 
         wasAudioMutedBeforeRecording = false
         let success = setSystemMuted(true)
         didMuteAudio = success
+        activeDuckingMode = success ? .mute : .none
         return success
+    }
+
+    private func applyVolumeDucking(percent: Int) -> Bool {
+        guard let currentVolume = getSystemVolume() else { return false }
+
+        let factor = Float(100 - percent) / 100.0
+        let targetVolume = max(0.0, min(1.0, currentVolume * factor))
+
+        guard setSystemVolume(targetVolume) else { return false }
+
+        activeDuckingMode = .volume(savedVolume: currentVolume)
+        return true
     }
 
     func unmuteSystemAudio() async {
         guard isSystemMuteEnabled else { return }
 
         let delay = audioResumptionDelay
+        let mode = activeDuckingMode
         let shouldUnmute = didMuteAudio && !wasAudioMutedBeforeRecording
         let myGeneration = muteGeneration
 
@@ -63,11 +102,19 @@ final class MediaController: ObservableObject {
             guard !Task.isCancelled else { return }
             guard self.muteGeneration == myGeneration else { return }
 
-            if shouldUnmute {
-                _ = self.setSystemMuted(false)
+            switch mode {
+            case .mute:
+                if shouldUnmute {
+                    _ = self.setSystemMuted(false)
+                }
+            case .volume(let savedVolume):
+                _ = self.setSystemVolume(savedVolume)
+            case .none:
+                break
             }
 
             self.didMuteAudio = false
+            self.activeDuckingMode = .none
         }
 
         unmuteTask = task
@@ -139,6 +186,53 @@ final class MediaController: ObservableObject {
         if status != noErr || !isSettable.boolValue { return false }
 
         status = AudioObjectSetPropertyData(deviceID, &address, 0, nil, propertySize, &muteValue)
+        return status == noErr
+    }
+
+    private func getSystemVolume() -> Float? {
+        guard let deviceID = getDefaultOutputDevice() else { return nil }
+
+        var volume: Float = 0
+        var propertySize = UInt32(MemoryLayout<Float>.size)
+
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        if !AudioObjectHasProperty(deviceID, &address) {
+            // Some devices expose volume only on the master channel.
+            address.mElement = 0
+            if !AudioObjectHasProperty(deviceID, &address) { return nil }
+        }
+
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &propertySize, &volume)
+        return status == noErr ? volume : nil
+    }
+
+    private func setSystemVolume(_ volume: Float) -> Bool {
+        guard let deviceID = getDefaultOutputDevice() else { return false }
+
+        var newValue = max(0.0, min(1.0, volume))
+        let propertySize = UInt32(MemoryLayout<Float>.size)
+
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        if !AudioObjectHasProperty(deviceID, &address) {
+            address.mElement = 0
+            if !AudioObjectHasProperty(deviceID, &address) { return false }
+        }
+
+        var isSettable: DarwinBoolean = false
+        var status = AudioObjectIsPropertySettable(deviceID, &address, &isSettable)
+        if status != noErr || !isSettable.boolValue { return false }
+
+        status = AudioObjectSetPropertyData(deviceID, &address, 0, nil, propertySize, &newValue)
         return status == noErr
     }
 }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -166,13 +166,34 @@ struct SettingsView: View {
                     isEnabled: $mediaController.isSystemMuteEnabled,
                     label: "Mute Audio While Recording"
                 ) {
-                    Picker("Resume Delay", selection: $mediaController.audioResumptionDelay) {
-                        Text("0s").tag(0.0)
-                        Text("1s").tag(1.0)
-                        Text("2s").tag(2.0)
-                        Text("3s").tag(3.0)
-                        Text("4s").tag(4.0)
-                        Text("5s").tag(5.0)
+                    VStack(alignment: .leading, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("Ducking Amount")
+                                InfoTip("How much to lower system audio while recording. 100% fully mutes (default); lower values keep audio audible at a reduced volume — useful when listening to music or video.")
+                                Spacer()
+                                Text("\(mediaController.audioDuckingPercent)%")
+                                    .foregroundColor(.secondary)
+                                    .monospacedDigit()
+                            }
+                            Slider(
+                                value: Binding(
+                                    get: { Double(mediaController.audioDuckingPercent) },
+                                    set: { mediaController.audioDuckingPercent = Int($0) }
+                                ),
+                                in: 0...100,
+                                step: 5
+                            )
+                        }
+
+                        Picker("Resume Delay", selection: $mediaController.audioResumptionDelay) {
+                            Text("0s").tag(0.0)
+                            Text("1s").tag(1.0)
+                            Text("2s").tag(2.0)
+                            Text("3s").tag(3.0)
+                            Text("4s").tag(4.0)
+                            Text("5s").tag(5.0)
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

Implements the feature requested in #683: a slider for adjustable volume reduction (ducking) during recording, instead of only binary mute/unmute. Users who listen to background music or video while dictating can now keep audio audible at a reduced level rather than silencing it completely.

## Behavior

- New setting **Ducking Amount** (0–100%, step 5) lives inside the existing **Mute Audio While Recording** expandable row.
- **Default is 100%**, which preserves the previous full-mute behavior — no migration needed for existing users.
- **100%** uses the original `kAudioDevicePropertyMute` path, so the macOS volume slider keeps its visual position (just shows the muted icon), and existing user-mute detection still applies.
- **<100%** captures the current output volume, reduces it via `kAudioDevicePropertyVolumeScalar` to `currentVolume × (100 − percent) / 100`, and restores the original volume on stop (respecting the existing `audioResumptionDelay`).
- **0%** is treated as a no-op while the toggle is on.

## Implementation

- `MediaController.swift`: added `audioDuckingPercent` (UserDefaults-backed), a `DuckingMode` enum to track which path was used (mute vs. volume scalar) for correct restore, and `getSystemVolume()` / `setSystemVolume()` helpers mirroring the existing CoreAudio mute helpers.
- `SettingsView.swift`: added a `Slider` + percentage label + `InfoTip` inside the existing Mute row.
- `AppDefaults.swift`: registered `audioDuckingPercent: 100` so existing users continue to get full mute.

The `unmuteSystemAudio()` cancellation/generation logic is preserved; volume restore is gated by the same `muteGeneration` check so quickly-retriggered recordings don't race.

## Test plan

- [x] `make local` — builds cleanly with no new warnings
- [x] Manual: 100% (default) — system audio fully mutes during recording, restores after (no regression vs. main)
- [x] Manual: 50% — music continues at reduced volume during recording, restores to original level after stop
- [x] Manual: 0% — no audio change while toggle is on
- [x] Manual: with `audioResumptionDelay > 0`, volume restore is correctly delayed

<img width="706" height="282" alt="image" src="https://github.com/user-attachments/assets/9ab1e0db-bded-4cec-a75a-03aa5b77d0f1" />