### PR TITLE
Add selective backup import categories

### DIFF
--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -3,6 +3,17 @@ import KeyboardShortcuts
 import LaunchAtLogin
 import SwiftData
 
+enum BackupImportError: LocalizedError {
+    case saveFailed(String, Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .saveFailed(let item, let error):
+            return "Failed to save imported \(item): \(error.localizedDescription)"
+        }
+    }
+}
+
 enum BackupImporter {
     private static let keyIsAudioCleanupEnabled = "IsAudioCleanupEnabled"
     private static let keyIsTranscriptionCleanupEnabled = "IsTranscriptionCleanupEnabled"
@@ -14,7 +25,11 @@ enum BackupImporter {
     private static let keyLowercaseTranscription = "LowercaseTranscription"
 
     @MainActor
-    static func apply(_ backup: BackupFile, categories: Set<BackupCategory>, enhancementService: AIEnhancementService, hotkeyManager: HotkeyManager, menuBarManager: MenuBarManager, mediaController: MediaController, playbackController: PlaybackController, soundManager: SoundManager, recorderUIManager: RecorderUIManager, modelContext: ModelContext, transcriptionModelManager: TranscriptionModelManager) {
+    static func apply(_ backup: BackupFile, categories: Set<BackupCategory>, enhancementService: AIEnhancementService, hotkeyManager: HotkeyManager, menuBarManager: MenuBarManager, mediaController: MediaController, playbackController: PlaybackController, soundManager: SoundManager, recorderUIManager: RecorderUIManager, modelContext: ModelContext, transcriptionModelManager: TranscriptionModelManager) throws {
+        if categories.contains(.dictionary) {
+            try importDictionary(from: backup, modelContext: modelContext)
+        }
+
         if categories.contains(.general) {
             importGeneral(
                 backup.generalSettings,
@@ -53,10 +68,6 @@ enum BackupImporter {
                 }
             }
             print("Successfully imported \(backup.powerModeConfigs.count) Power Mode configurations.")
-        }
-
-        if categories.contains(.dictionary) {
-            importDictionary(from: backup, modelContext: modelContext)
         }
 
         if categories.contains(.customModels) {
@@ -185,28 +196,34 @@ enum BackupImporter {
     }
 
     @MainActor
-    private static func importDictionary(from backup: BackupFile, modelContext: ModelContext) {
+    private static func importDictionary(from backup: BackupFile, modelContext: ModelContext) throws {
+        var insertedWords = 0
+        var insertedReplacements = 0
+        var skippedInvalidReplacements = 0
+
         if let words = backup.vocabularyWords {
             let descriptor = FetchDescriptor<VocabularyWord>()
-            let existingWords = (try? modelContext.fetch(descriptor)) ?? []
+            let existingWords = try modelContext.fetch(descriptor)
             var existingWordsSet = Set(existingWords.map { $0.word.lowercased() })
 
             for item in words {
-                let lowercasedWord = item.word.lowercased()
+                let word = item.word.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !word.isEmpty else { continue }
+
+                let lowercasedWord = word.lowercased()
                 if !existingWordsSet.contains(lowercasedWord) {
-                    modelContext.insert(VocabularyWord(word: item.word))
+                    modelContext.insert(VocabularyWord(word: word))
                     existingWordsSet.insert(lowercasedWord)
+                    insertedWords += 1
                 }
             }
-            try? modelContext.save()
-            print("Successfully imported vocabulary words to SwiftData.")
         } else {
             print("No vocabulary words found in the imported file. Existing items remain unchanged.")
         }
 
         if let replacements = backup.wordReplacements {
             let descriptor = FetchDescriptor<WordReplacement>()
-            let existingReplacements = (try? modelContext.fetch(descriptor)) ?? []
+            let existingReplacements = try modelContext.fetch(descriptor)
 
             var existingKeys = Set<String>()
             for existing in existingReplacements {
@@ -214,18 +231,43 @@ enum BackupImporter {
             }
 
             for (original, replacement) in replacements {
-                let importTokens = tokens(from: original)
+                let trimmedOriginal = original.trimmingCharacters(in: .whitespacesAndNewlines)
+                let trimmedReplacement = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+                let importTokens = tokens(from: trimmedOriginal)
+                guard !importTokens.isEmpty, !trimmedReplacement.isEmpty else {
+                    skippedInvalidReplacements += 1
+                    continue
+                }
+
                 let hasConflict = importTokens.contains { existingKeys.contains($0) }
 
                 if !hasConflict {
-                    modelContext.insert(WordReplacement(originalText: original, replacementText: replacement))
+                    modelContext.insert(WordReplacement(originalText: trimmedOriginal, replacementText: trimmedReplacement))
                     existingKeys.formUnion(importTokens)
+                    insertedReplacements += 1
                 }
             }
-            try? modelContext.save()
-            print("Successfully imported word replacements to SwiftData.")
         } else {
             print("No word replacements found in the imported file. Existing replacements remain unchanged.")
+        }
+
+        guard insertedWords > 0 || insertedReplacements > 0 else {
+            print("No new dictionary entries were imported.")
+            if skippedInvalidReplacements > 0 {
+                print("Skipped \(skippedInvalidReplacements) invalid word replacements from the imported file.")
+            }
+            return
+        }
+
+        do {
+            try modelContext.save()
+            print("Successfully imported \(insertedWords) vocabulary words and \(insertedReplacements) word replacements to SwiftData.")
+            if skippedInvalidReplacements > 0 {
+                print("Skipped \(skippedInvalidReplacements) invalid word replacements from the imported file.")
+            }
+        } catch {
+            modelContext.rollback()
+            throw BackupImportError.saveFailed("dictionary entries", error)
         }
     }
 

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -1,0 +1,252 @@
+import Foundation
+import KeyboardShortcuts
+import LaunchAtLogin
+import SwiftData
+
+enum BackupImporter {
+    private static let keyIsAudioCleanupEnabled = "IsAudioCleanupEnabled"
+    private static let keyIsTranscriptionCleanupEnabled = "IsTranscriptionCleanupEnabled"
+    private static let keyTranscriptionRetentionMinutes = "TranscriptionRetentionMinutes"
+    private static let keyAudioRetentionPeriod = "AudioRetentionPeriod"
+
+    private static let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
+    private static let keyRemovePunctuation = "RemovePunctuation"
+    private static let keyLowercaseTranscription = "LowercaseTranscription"
+
+    @MainActor
+    static func apply(_ backup: BackupFile, categories: Set<BackupCategory>, enhancementService: AIEnhancementService, hotkeyManager: HotkeyManager, menuBarManager: MenuBarManager, mediaController: MediaController, playbackController: PlaybackController, soundManager: SoundManager, recorderUIManager: RecorderUIManager, modelContext: ModelContext, transcriptionModelManager: TranscriptionModelManager) {
+        if categories.contains(.general) {
+            importGeneral(
+                backup.generalSettings,
+                hotkeyManager: hotkeyManager,
+                menuBarManager: menuBarManager,
+                mediaController: mediaController,
+                playbackController: playbackController,
+                soundManager: soundManager,
+                recorderUIManager: recorderUIManager
+            )
+        }
+
+        if categories.contains(.prompts) {
+            let predefinedPrompts = enhancementService.customPrompts.filter { $0.isPredefined }
+            enhancementService.customPrompts = predefinedPrompts + backup.customPrompts
+            print("Successfully imported \(backup.customPrompts.count) custom prompts.")
+        }
+
+        if categories.contains(.powerMode) {
+            let powerModeManager = PowerModeManager.shared
+            powerModeManager.configurations = backup.powerModeConfigs
+
+            if let shortcuts = backup.powerModeShortcuts {
+                for (idString, shortcut) in shortcuts {
+                    guard let id = UUID(uuidString: idString) else { continue }
+                    KeyboardShortcuts.setShortcut(shortcut, for: .powerMode(id: id))
+                }
+            }
+
+            powerModeManager.saveConfigurations()
+
+            if let customEmojis = backup.customEmojis {
+                let emojiManager = EmojiManager.shared
+                for emoji in customEmojis {
+                    _ = emojiManager.addCustomEmoji(emoji)
+                }
+            }
+            print("Successfully imported \(backup.powerModeConfigs.count) Power Mode configurations.")
+        }
+
+        if categories.contains(.dictionary) {
+            importDictionary(from: backup, modelContext: modelContext)
+        }
+
+        if categories.contains(.customModels) {
+            importCustomModels(backup.customCloudModels, transcriptionModelManager: transcriptionModelManager)
+        }
+    }
+
+    @MainActor
+    private static func importGeneral(_ general: GeneralBackup?, hotkeyManager: HotkeyManager, menuBarManager: MenuBarManager, mediaController: MediaController, playbackController: PlaybackController, soundManager: SoundManager, recorderUIManager: RecorderUIManager) {
+        guard let general else {
+            print("No general settings found in the imported file.")
+            return
+        }
+
+        if let shortcut = general.toggleMiniRecorderShortcut {
+            KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder)
+        }
+        if let shortcut2 = general.toggleMiniRecorderShortcut2 {
+            KeyboardShortcuts.setShortcut(shortcut2, for: .toggleMiniRecorder2)
+        }
+        if let pasteShortcut = general.pasteLastTranscriptionShortcut {
+            KeyboardShortcuts.setShortcut(pasteShortcut, for: .pasteLastTranscription)
+        }
+        if let pasteEnhancementShortcut = general.pasteLastEnhancementShortcut {
+            KeyboardShortcuts.setShortcut(pasteEnhancementShortcut, for: .pasteLastEnhancement)
+        }
+        if let retryShortcut = general.retryLastTranscriptionShortcut {
+            KeyboardShortcuts.setShortcut(retryShortcut, for: .retryLastTranscription)
+        }
+        if let cancelShortcut = general.cancelRecorderShortcut {
+            KeyboardShortcuts.setShortcut(cancelShortcut, for: .cancelRecorder)
+        }
+        if let historyShortcut = general.openHistoryWindowShortcut {
+            KeyboardShortcuts.setShortcut(historyShortcut, for: .openHistoryWindow)
+        }
+        if let dictionaryShortcut = general.quickAddToDictionaryShortcut {
+            KeyboardShortcuts.setShortcut(dictionaryShortcut, for: .quickAddToDictionary)
+        }
+        if let enhancementShortcut = general.toggleEnhancementShortcut {
+            KeyboardShortcuts.setShortcut(enhancementShortcut, for: .toggleEnhancement)
+        }
+
+        if let hotkeyRaw = general.selectedHotkey1RawValue,
+           let hotkey = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw) {
+            hotkeyManager.selectedHotkey1 = hotkey
+        }
+        if let hotkeyRaw2 = general.selectedHotkey2RawValue,
+           let hotkey2 = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw2) {
+            hotkeyManager.selectedHotkey2 = hotkey2
+        }
+        if let hotkeyModeRaw = general.hotkeyMode1RawValue,
+           let mode = HotkeyManager.HotkeyMode(rawValue: hotkeyModeRaw) {
+            hotkeyManager.hotkeyMode1 = mode
+        }
+        if let hotkeyModeRaw2 = general.hotkeyMode2RawValue,
+           let mode2 = HotkeyManager.HotkeyMode(rawValue: hotkeyModeRaw2) {
+            hotkeyManager.hotkeyMode2 = mode2
+        }
+        if let middleClickEnabled = general.isMiddleClickToggleEnabled {
+            hotkeyManager.isMiddleClickToggleEnabled = middleClickEnabled
+        }
+        if let middleClickDelay = general.middleClickActivationDelay {
+            hotkeyManager.middleClickActivationDelay = middleClickDelay
+        }
+        if let launch = general.launchAtLoginEnabled {
+            LaunchAtLogin.isEnabled = launch
+        }
+        if let menuOnly = general.isMenuBarOnly {
+            menuBarManager.isMenuBarOnly = menuOnly
+        }
+        if let recType = general.recorderType {
+            recorderUIManager.recorderType = recType
+        }
+
+        if let transcriptionCleanup = general.isTranscriptionCleanupEnabled {
+            UserDefaults.standard.set(transcriptionCleanup, forKey: keyIsTranscriptionCleanupEnabled)
+        }
+        if let transcriptionMinutes = general.transcriptionRetentionMinutes {
+            UserDefaults.standard.set(transcriptionMinutes, forKey: keyTranscriptionRetentionMinutes)
+        }
+        if let audioCleanup = general.isAudioCleanupEnabled {
+            UserDefaults.standard.set(audioCleanup, forKey: keyIsAudioCleanupEnabled)
+        }
+        if let audioRetention = general.audioRetentionPeriod {
+            UserDefaults.standard.set(audioRetention, forKey: keyAudioRetentionPeriod)
+        }
+
+        if let soundFeedback = general.isSoundFeedbackEnabled {
+            soundManager.isEnabled = soundFeedback
+        }
+        if let muteSystem = general.isSystemMuteEnabled {
+            mediaController.isSystemMuteEnabled = muteSystem
+        }
+        if let pauseMedia = general.isPauseMediaEnabled {
+            playbackController.isPauseMediaEnabled = pauseMedia
+        }
+        if let audioDelay = general.audioResumptionDelay {
+            mediaController.audioResumptionDelay = audioDelay
+        }
+        if let experimentalEnabled = general.isExperimentalFeaturesEnabled {
+            UserDefaults.standard.set(experimentalEnabled, forKey: "isExperimentalFeaturesEnabled")
+            if experimentalEnabled == false {
+                playbackController.isPauseMediaEnabled = false
+            }
+        }
+        if let textFormattingEnabled = general.isTextFormattingEnabled {
+            UserDefaults.standard.set(textFormattingEnabled, forKey: keyIsTextFormattingEnabled)
+        }
+        if let removePunctuation = general.removePunctuation {
+            UserDefaults.standard.set(removePunctuation, forKey: keyRemovePunctuation)
+        }
+        if let lowercaseTranscription = general.lowercaseTranscription {
+            UserDefaults.standard.set(lowercaseTranscription, forKey: keyLowercaseTranscription)
+        }
+        if let restoreClipboard = general.restoreClipboardAfterPaste {
+            UserDefaults.standard.set(restoreClipboard, forKey: "restoreClipboardAfterPaste")
+        }
+        if let clipboardDelay = general.clipboardRestoreDelay {
+            UserDefaults.standard.set(clipboardDelay, forKey: "clipboardRestoreDelay")
+        }
+        if let appleScriptPaste = general.useAppleScriptPaste {
+            UserDefaults.standard.set(appleScriptPaste, forKey: "useAppleScriptPaste")
+        }
+
+        print("Successfully imported general settings.")
+    }
+
+    @MainActor
+    private static func importDictionary(from backup: BackupFile, modelContext: ModelContext) {
+        if let words = backup.vocabularyWords {
+            let descriptor = FetchDescriptor<VocabularyWord>()
+            let existingWords = (try? modelContext.fetch(descriptor)) ?? []
+            var existingWordsSet = Set(existingWords.map { $0.word.lowercased() })
+
+            for item in words {
+                let lowercasedWord = item.word.lowercased()
+                if !existingWordsSet.contains(lowercasedWord) {
+                    modelContext.insert(VocabularyWord(word: item.word))
+                    existingWordsSet.insert(lowercasedWord)
+                }
+            }
+            try? modelContext.save()
+            print("Successfully imported vocabulary words to SwiftData.")
+        } else {
+            print("No vocabulary words found in the imported file. Existing items remain unchanged.")
+        }
+
+        if let replacements = backup.wordReplacements {
+            let descriptor = FetchDescriptor<WordReplacement>()
+            let existingReplacements = (try? modelContext.fetch(descriptor)) ?? []
+
+            var existingKeys = Set<String>()
+            for existing in existingReplacements {
+                existingKeys.formUnion(tokens(from: existing.originalText))
+            }
+
+            for (original, replacement) in replacements {
+                let importTokens = tokens(from: original)
+                let hasConflict = importTokens.contains { existingKeys.contains($0) }
+
+                if !hasConflict {
+                    modelContext.insert(WordReplacement(originalText: original, replacementText: replacement))
+                    existingKeys.formUnion(importTokens)
+                }
+            }
+            try? modelContext.save()
+            print("Successfully imported word replacements to SwiftData.")
+        } else {
+            print("No word replacements found in the imported file. Existing replacements remain unchanged.")
+        }
+    }
+
+    @MainActor
+    private static func importCustomModels(_ models: [CustomModelBackup]?, transcriptionModelManager: TranscriptionModelManager) {
+        guard let models else {
+            print("No custom models found in the imported file.")
+            return
+        }
+
+        let customModelManager = CustomCloudModelManager.shared
+        customModelManager.customModels = models.map { $0.makeModel() }
+        customModelManager.saveCustomModels()
+        transcriptionModelManager.refreshAllAvailableModels()
+        print("Successfully imported \(models.count) custom model definitions.")
+    }
+
+    private static func tokens(from text: String) -> [String] {
+        text
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -1,0 +1,121 @@
+import Foundation
+import KeyboardShortcuts
+
+enum BackupCategory: String, CaseIterable, Hashable {
+    case general
+    case prompts
+    case powerMode
+    case dictionary
+    case customModels
+
+    var title: String {
+        switch self {
+        case .general:
+            return "General Settings"
+        case .prompts:
+            return "Custom Prompts"
+        case .powerMode:
+            return "Power Mode"
+        case .dictionary:
+            return "Dictionary"
+        case .customModels:
+            return "Custom Model Definitions"
+        }
+    }
+}
+
+struct CustomModelBackup: Codable {
+    let id: UUID
+    let name: String
+    let displayName: String
+    let description: String
+    let apiEndpoint: String
+    let modelName: String
+    let isMultilingualModel: Bool
+    let supportedLanguages: [String: String]
+    let apiKey: String?
+
+    init(model: CustomCloudModel) {
+        self.id = model.id
+        self.name = model.name
+        self.displayName = model.displayName
+        self.description = model.description
+        self.apiEndpoint = model.apiEndpoint
+        self.modelName = model.modelName
+        self.isMultilingualModel = model.isMultilingualModel
+        self.supportedLanguages = model.supportedLanguages
+        self.apiKey = nil
+    }
+
+    func makeModel() -> CustomCloudModel {
+        let model = CustomCloudModel(
+            id: id,
+            name: name,
+            displayName: displayName,
+            description: description,
+            apiEndpoint: apiEndpoint,
+            modelName: modelName,
+            isMultilingual: isMultilingualModel,
+            supportedLanguages: supportedLanguages
+        )
+
+        if let apiKey, !apiKey.isEmpty {
+            APIKeyManager.shared.saveCustomModelAPIKey(apiKey, forModelId: id)
+        }
+
+        return model
+    }
+}
+
+struct GeneralBackup: Codable {
+    let toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?
+    let toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
+    let pasteLastTranscriptionShortcut: KeyboardShortcuts.Shortcut?
+    let pasteLastEnhancementShortcut: KeyboardShortcuts.Shortcut?
+    let retryLastTranscriptionShortcut: KeyboardShortcuts.Shortcut?
+    let cancelRecorderShortcut: KeyboardShortcuts.Shortcut?
+    let openHistoryWindowShortcut: KeyboardShortcuts.Shortcut?
+    let quickAddToDictionaryShortcut: KeyboardShortcuts.Shortcut?
+    let toggleEnhancementShortcut: KeyboardShortcuts.Shortcut?
+    let selectedHotkey1RawValue: String?
+    let selectedHotkey2RawValue: String?
+    let hotkeyMode1RawValue: String?
+    let hotkeyMode2RawValue: String?
+    let isMiddleClickToggleEnabled: Bool?
+    let middleClickActivationDelay: Int?
+    let launchAtLoginEnabled: Bool?
+    let isMenuBarOnly: Bool?
+    let recorderType: String?
+    let isTranscriptionCleanupEnabled: Bool?
+    let transcriptionRetentionMinutes: Int?
+    let isAudioCleanupEnabled: Bool?
+    let audioRetentionPeriod: Int?
+
+    let isSoundFeedbackEnabled: Bool?
+    let isSystemMuteEnabled: Bool?
+    let isPauseMediaEnabled: Bool?
+    let audioResumptionDelay: Double?
+    let isTextFormattingEnabled: Bool?
+    let removePunctuation: Bool?
+    let lowercaseTranscription: Bool?
+    let isExperimentalFeaturesEnabled: Bool?
+    let restoreClipboardAfterPaste: Bool?
+    let clipboardRestoreDelay: Double?
+    let useAppleScriptPaste: Bool?
+}
+
+struct WordBackup: Codable {
+    let word: String
+}
+
+struct BackupFile: Codable {
+    let version: String
+    let customPrompts: [CustomPrompt]
+    let powerModeConfigs: [PowerModeConfig]
+    let powerModeShortcuts: [String: KeyboardShortcuts.Shortcut]?
+    let vocabularyWords: [WordBackup]?
+    let wordReplacements: [String: String]?
+    let generalSettings: GeneralBackup?
+    let customEmojis: [String]?
+    let customCloudModels: [CustomModelBackup]?
+}

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -53,8 +53,8 @@ struct CustomModelBackup: Codable {
             name: name,
             displayName: displayName,
             description: description,
-            apiEndpoint: apiEndpoint,
-            modelName: modelName,
+            apiEndpoint: apiEndpoint.trimmingCharacters(in: .whitespacesAndNewlines),
+            modelName: modelName.trimmingCharacters(in: .whitespacesAndNewlines),
             isMultilingual: isMultilingualModel,
             supportedLanguages: supportedLanguages
         )
@@ -106,6 +106,10 @@ struct GeneralBackup: Codable {
 
 struct WordBackup: Codable {
     let word: String
+
+    init(word: String) {
+        self.word = word
+    }
 }
 
 struct BackupFile: Codable {
@@ -118,4 +122,33 @@ struct BackupFile: Codable {
     let generalSettings: GeneralBackup?
     let customEmojis: [String]?
     let customCloudModels: [CustomModelBackup]?
+
+    private enum CodingKeys: String, CodingKey {
+        case version, customPrompts, powerModeConfigs, powerModeShortcuts, vocabularyWords, wordReplacements, generalSettings, customEmojis, customCloudModels
+    }
+
+    init(version: String, customPrompts: [CustomPrompt], powerModeConfigs: [PowerModeConfig], powerModeShortcuts: [String: KeyboardShortcuts.Shortcut]?, vocabularyWords: [WordBackup]?, wordReplacements: [String: String]?, generalSettings: GeneralBackup?, customEmojis: [String]?, customCloudModels: [CustomModelBackup]?) {
+        self.version = version
+        self.customPrompts = customPrompts
+        self.powerModeConfigs = powerModeConfigs
+        self.powerModeShortcuts = powerModeShortcuts
+        self.vocabularyWords = vocabularyWords
+        self.wordReplacements = wordReplacements
+        self.generalSettings = generalSettings
+        self.customEmojis = customEmojis
+        self.customCloudModels = customCloudModels
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(String.self, forKey: .version) ?? "0.0.0"
+        customPrompts = try container.decodeIfPresent([CustomPrompt].self, forKey: .customPrompts) ?? []
+        powerModeConfigs = try container.decodeIfPresent([PowerModeConfig].self, forKey: .powerModeConfigs) ?? []
+        powerModeShortcuts = try container.decodeIfPresent([String: KeyboardShortcuts.Shortcut].self, forKey: .powerModeShortcuts)
+        vocabularyWords = try container.decodeIfPresent([WordBackup].self, forKey: .vocabularyWords)
+        wordReplacements = try container.decodeIfPresent([String: String].self, forKey: .wordReplacements)
+        generalSettings = try container.decodeIfPresent(GeneralBackup.self, forKey: .generalSettings)
+        customEmojis = try container.decodeIfPresent([String].self, forKey: .customEmojis)
+        customCloudModels = try container.decodeIfPresent([CustomModelBackup].self, forKey: .customCloudModels)
+    }
 }

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -273,7 +273,7 @@ class ImportExportService {
                 return
             }
 
-            BackupImporter.apply(
+            try BackupImporter.apply(
                 backup,
                 categories: selectedCategories,
                 enhancementService: enhancementService,

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -5,65 +5,112 @@ import KeyboardShortcuts
 import LaunchAtLogin
 import SwiftData
 
-struct GeneralSettings: Codable {
-    let toggleMiniRecorderShortcut: KeyboardShortcuts.Shortcut?
-    let toggleMiniRecorderShortcut2: KeyboardShortcuts.Shortcut?
-    let retryLastTranscriptionShortcut: KeyboardShortcuts.Shortcut?
-    let selectedHotkey1RawValue: String?
-    let selectedHotkey2RawValue: String?
-    let launchAtLoginEnabled: Bool?
-    let isMenuBarOnly: Bool?
-    let recorderType: String?
-    let isTranscriptionCleanupEnabled: Bool?
-    let transcriptionRetentionMinutes: Int?
-    let isAudioCleanupEnabled: Bool?
-    let audioRetentionPeriod: Int?
+private final class BackupOptions: NSObject {
+    let view: NSView
 
-    let isSoundFeedbackEnabled: Bool?
-    let isSystemMuteEnabled: Bool?
-    let isPauseMediaEnabled: Bool?
-    let audioResumptionDelay: Double?
-    let isTextFormattingEnabled: Bool?
-    let removePunctuation: Bool?
-    let lowercaseTranscription: Bool?
-    let isExperimentalFeaturesEnabled: Bool?
-    let restoreClipboardAfterPaste: Bool?
-    let clipboardRestoreDelay: Double?
-    let useAppleScriptPaste: Bool?
-}
+    private let allButton: NSButton
+    private let individualButton: NSButton
+    private let categoryButtons: [BackupCategory: NSButton]
 
-// Simple codable struct for vocabulary words (for export/import only)
-struct VocabularyWordData: Codable {
-    let word: String
-}
+    override init() {
+        self.view = NSView(frame: NSRect(x: 0, y: 0, width: 360, height: 188))
+        self.allButton = NSButton(radioButtonWithTitle: "All", target: nil, action: nil)
+        self.individualButton = NSButton(radioButtonWithTitle: "Individual categories", target: nil, action: nil)
 
-struct VoiceInkExportedSettings: Codable {
-    let version: String
-    let customPrompts: [CustomPrompt]
-    let powerModeConfigs: [PowerModeConfig]
-    let vocabularyWords: [VocabularyWordData]?
-    let wordReplacements: [String: String]?
-    let generalSettings: GeneralSettings?
-    let customEmojis: [String]?
-    let customCloudModels: [CustomCloudModel]?
+        var buttons: [BackupCategory: NSButton] = [:]
+        for category in BackupCategory.allCases {
+            let button = NSButton(checkboxWithTitle: category.title, target: nil, action: nil)
+            button.state = .on
+            button.isEnabled = false
+            buttons[category] = button
+        }
+        self.categoryButtons = buttons
+
+        super.init()
+
+        allButton.state = .on
+        individualButton.state = .off
+        allButton.target = self
+        allButton.action = #selector(modeChanged(_:))
+        individualButton.target = self
+        individualButton.action = #selector(modeChanged(_:))
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let categoryStack = NSStackView()
+        categoryStack.orientation = .vertical
+        categoryStack.alignment = .leading
+        categoryStack.spacing = 6
+        categoryStack.translatesAutoresizingMaskIntoConstraints = false
+
+        for category in BackupCategory.allCases {
+            guard let button = categoryButtons[category] else { continue }
+            button.target = self
+            button.action = #selector(categoryChanged(_:))
+            categoryStack.addArrangedSubview(button)
+        }
+
+        view.addSubview(stack)
+        view.addSubview(categoryStack)
+        stack.addArrangedSubview(allButton)
+        stack.addArrangedSubview(individualButton)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: 4),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            categoryStack.topAnchor.constraint(equalTo: individualButton.bottomAnchor, constant: 6),
+            categoryStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 18),
+            categoryStack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            categoryStack.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
+        ])
+    }
+
+    var selectedCategories: Set<BackupCategory> {
+        if allButton.state == .on {
+            return Set(BackupCategory.allCases)
+        }
+
+        return Set(categoryButtons.compactMap { category, button in
+            button.state == .on ? category : nil
+        })
+    }
+
+    @objc private func modeChanged(_ sender: NSButton) {
+        let useAll = sender == allButton
+        allButton.state = useAll ? .on : .off
+        individualButton.state = useAll ? .off : .on
+        setCategoryButtonsEnabled(!useAll)
+    }
+
+    @objc private func categoryChanged(_ sender: NSButton) {
+        guard individualButton.state != .on else { return }
+        allButton.state = .off
+        individualButton.state = .on
+        setCategoryButtonsEnabled(true)
+    }
+
+    private func setCategoryButtonsEnabled(_ isEnabled: Bool) {
+        for button in categoryButtons.values {
+            button.isEnabled = isEnabled
+        }
+    }
 }
 
 class ImportExportService {
     static let shared = ImportExportService()
     private let currentSettingsVersion: String
-    private let dictionaryItemsKey = "CustomVocabularyItems"
-    private let wordReplacementsKey = "wordReplacements"
 
-
-    private let keyIsMenuBarOnly = "IsMenuBarOnly"
-    private let keyRecorderType = "RecorderType"
     private let keyIsAudioCleanupEnabled = "IsAudioCleanupEnabled"
     private let keyIsTranscriptionCleanupEnabled = "IsTranscriptionCleanupEnabled"
     private let keyTranscriptionRetentionMinutes = "TranscriptionRetentionMinutes"
     private let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
-    private let keyIsSoundFeedbackEnabled = "isSoundFeedbackEnabled"
-    private let keyIsSystemMuteEnabled = "isSystemMuteEnabled"
     private let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
     private let keyRemovePunctuation = "RemovePunctuation"
     private let keyLowercaseTranscription = "LowercaseTranscription"
@@ -84,15 +131,20 @@ class ImportExportService {
         let exportablePrompts = enhancementService.customPrompts.filter { !$0.isPredefined }
 
         let powerConfigs = powerModeManager.configurations
+        let powerModeShortcuts = Dictionary(uniqueKeysWithValues: powerConfigs.compactMap { config -> (String, KeyboardShortcuts.Shortcut)? in
+            guard config.hotkeyShortcut != nil else { return nil }
+            guard let shortcut = KeyboardShortcuts.getShortcut(for: .powerMode(id: config.id)) else { return nil }
+            return (config.id.uuidString, shortcut)
+        })
 
         // Export custom models
-        let customModels = CustomCloudModelManager.shared.customModels
+        let customModels = CustomCloudModelManager.shared.customModels.map { CustomModelBackup(model: $0) }
 
         // Fetch vocabulary words from SwiftData
-        var exportedDictionaryItems: [VocabularyWordData]? = nil
+        var exportedDictionaryItems: [WordBackup]? = nil
         let vocabularyDescriptor = FetchDescriptor<VocabularyWord>()
         if let items = try? modelContext.fetch(vocabularyDescriptor), !items.isEmpty {
-            exportedDictionaryItems = items.map { VocabularyWordData(word: $0.word) }
+            exportedDictionaryItems = items.map { WordBackup(word: $0.word) }
         }
 
         // Fetch word replacements from SwiftData
@@ -102,12 +154,22 @@ class ImportExportService {
             exportedWordReplacements = Dictionary(replacements.map { ($0.originalText, $0.replacementText) }, uniquingKeysWith: { _, last in last })
         }
 
-        let generalSettingsToExport = GeneralSettings(
+        let generalSettingsToExport = GeneralBackup(
             toggleMiniRecorderShortcut: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder),
             toggleMiniRecorderShortcut2: KeyboardShortcuts.getShortcut(for: .toggleMiniRecorder2),
+            pasteLastTranscriptionShortcut: KeyboardShortcuts.getShortcut(for: .pasteLastTranscription),
+            pasteLastEnhancementShortcut: KeyboardShortcuts.getShortcut(for: .pasteLastEnhancement),
             retryLastTranscriptionShortcut: KeyboardShortcuts.getShortcut(for: .retryLastTranscription),
+            cancelRecorderShortcut: KeyboardShortcuts.getShortcut(for: .cancelRecorder),
+            openHistoryWindowShortcut: KeyboardShortcuts.getShortcut(for: .openHistoryWindow),
+            quickAddToDictionaryShortcut: KeyboardShortcuts.getShortcut(for: .quickAddToDictionary),
+            toggleEnhancementShortcut: KeyboardShortcuts.getShortcut(for: .toggleEnhancement),
             selectedHotkey1RawValue: hotkeyManager.selectedHotkey1.rawValue,
             selectedHotkey2RawValue: hotkeyManager.selectedHotkey2.rawValue,
+            hotkeyMode1RawValue: hotkeyManager.hotkeyMode1.rawValue,
+            hotkeyMode2RawValue: hotkeyManager.hotkeyMode2.rawValue,
+            isMiddleClickToggleEnabled: hotkeyManager.isMiddleClickToggleEnabled,
+            middleClickActivationDelay: hotkeyManager.middleClickActivationDelay,
             launchAtLoginEnabled: LaunchAtLogin.isEnabled,
             isMenuBarOnly: menuBarManager.isMenuBarOnly,
             recorderType: recorderUIManager.recorderType,
@@ -129,10 +191,11 @@ class ImportExportService {
             useAppleScriptPaste: UserDefaults.standard.bool(forKey: "useAppleScriptPaste")
         )
 
-        let exportedSettings = VoiceInkExportedSettings(
+        let exportedSettings = BackupFile(
             version: currentSettingsVersion,
             customPrompts: exportablePrompts,
             powerModeConfigs: powerConfigs,
+            powerModeShortcuts: powerModeShortcuts.isEmpty ? nil : powerModeShortcuts,
             vocabularyWords: exportedDictionaryItems,
             wordReplacements: exportedWordReplacements,
             generalSettings: generalSettingsToExport,
@@ -179,192 +242,91 @@ class ImportExportService {
         openPanel.canChooseDirectories = false
         openPanel.allowsMultipleSelection = false
         openPanel.title = "Import VoiceInk Settings"
-        openPanel.message = "Choose a settings file to import. This will overwrite ALL settings (prompts, power modes, dictionary, general app settings)."
+        openPanel.message = "Choose a settings backup, then select what you want to import."
 
-        DispatchQueue.main.async {
-            if openPanel.runModal() == .OK {
-                guard let url = openPanel.url else {
-                    self.showAlert(title: "Import Error", message: "Could not get the file URL from the open panel.")
-                    return
-                }
-
-                do {
-                    let jsonData = try Data(contentsOf: url)
-                    let decoder = JSONDecoder()
-                    let importedSettings = try decoder.decode(VoiceInkExportedSettings.self, from: jsonData)
-                    
-                    if importedSettings.version != self.currentSettingsVersion {
-                        self.showAlert(title: "Version Mismatch", message: "The imported settings file (version \(importedSettings.version)) is from a different version than your application (version \(self.currentSettingsVersion)). Proceeding with import, but be aware of potential incompatibilities.")
-                    }
-
-                    let predefinedPrompts = enhancementService.customPrompts.filter { $0.isPredefined }
-                    enhancementService.customPrompts = predefinedPrompts + importedSettings.customPrompts
-                    
-                    let powerModeManager = PowerModeManager.shared
-                    powerModeManager.configurations = importedSettings.powerModeConfigs
-                    powerModeManager.saveConfigurations()
-
-                    // Import Custom Models
-                    if let modelsToImport = importedSettings.customCloudModels {
-                        let customModelManager = CustomCloudModelManager.shared
-                        customModelManager.customModels = modelsToImport
-                        customModelManager.saveCustomModels() // Ensure they are persisted
-                        transcriptionModelManager.refreshAllAvailableModels() // Refresh the UI
-                        print("Successfully imported \(modelsToImport.count) custom models.")
-                    } else {
-                        print("No custom models found in the imported file.")
-                    }
-
-                    if let customEmojis = importedSettings.customEmojis {
-                        let emojiManager = EmojiManager.shared
-                        for emoji in customEmojis {
-                            _ = emojiManager.addCustomEmoji(emoji)
-                        }
-                    }
-
-                    // Import vocabulary words to SwiftData
-                    if let itemsToImport = importedSettings.vocabularyWords {
-                        let vocabularyDescriptor = FetchDescriptor<VocabularyWord>()
-                        let existingWords = (try? modelContext.fetch(vocabularyDescriptor)) ?? []
-                        let existingWordsSet = Set(existingWords.map { $0.word.lowercased() })
-
-                        for item in itemsToImport {
-                            if !existingWordsSet.contains(item.word.lowercased()) {
-                                let newWord = VocabularyWord(word: item.word)
-                                modelContext.insert(newWord)
-                            }
-                        }
-                        try? modelContext.save()
-                        print("Successfully imported vocabulary words to SwiftData.")
-                    } else {
-                        print("No vocabulary words found in the imported file. Existing items remain unchanged.")
-                    }
-
-                    // Import word replacements to SwiftData
-                    if let replacementsToImport = importedSettings.wordReplacements {
-                        let replacementsDescriptor = FetchDescriptor<WordReplacement>()
-                        let existingReplacements = (try? modelContext.fetch(replacementsDescriptor)) ?? []
-
-                        // Build a set of existing replacement keys for duplicate checking
-                        var existingKeysSet = Set<String>()
-                        for existing in existingReplacements {
-                            let tokens = existing.originalText
-                                .split(separator: ",")
-                                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-                                .filter { !$0.isEmpty }
-                            existingKeysSet.formUnion(tokens)
-                        }
-
-                        for (original, replacement) in replacementsToImport {
-                            let importTokens = original
-                                .split(separator: ",")
-                                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-                                .filter { !$0.isEmpty }
-
-                            // Check if any token already exists
-                            let hasConflict = importTokens.contains { existingKeysSet.contains($0) }
-
-                            if !hasConflict {
-                                let newReplacement = WordReplacement(originalText: original, replacementText: replacement)
-                                modelContext.insert(newReplacement)
-                                // Add these tokens to the set to prevent duplicates within the import
-                                existingKeysSet.formUnion(importTokens)
-                            }
-                        }
-                        try? modelContext.save()
-                        print("Successfully imported word replacements to SwiftData.")
-                    } else {
-                        print("No word replacements found in the imported file. Existing replacements remain unchanged.")
-                    }
-
-                    if let general = importedSettings.generalSettings {
-                        if let shortcut = general.toggleMiniRecorderShortcut {
-                            KeyboardShortcuts.setShortcut(shortcut, for: .toggleMiniRecorder)
-                        }
-                        if let shortcut2 = general.toggleMiniRecorderShortcut2 {
-                            KeyboardShortcuts.setShortcut(shortcut2, for: .toggleMiniRecorder2)
-                        }
-                        if let retryShortcut = general.retryLastTranscriptionShortcut {
-                            KeyboardShortcuts.setShortcut(retryShortcut, for: .retryLastTranscription)
-                        }
-                        if let hotkeyRaw = general.selectedHotkey1RawValue,
-                           let hotkey = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw) {
-                            hotkeyManager.selectedHotkey1 = hotkey
-                        }
-                        if let hotkeyRaw2 = general.selectedHotkey2RawValue,
-                           let hotkey2 = HotkeyManager.HotkeyOption(rawValue: hotkeyRaw2) {
-                            hotkeyManager.selectedHotkey2 = hotkey2
-                        }
-                        if let launch = general.launchAtLoginEnabled {
-                            LaunchAtLogin.isEnabled = launch
-                        }
-                        if let menuOnly = general.isMenuBarOnly {
-                            menuBarManager.isMenuBarOnly = menuOnly
-                        }
-                        if let recType = general.recorderType {
-                            recorderUIManager.recorderType = recType
-                        }
-
-                        if let transcriptionCleanup = general.isTranscriptionCleanupEnabled {
-                            UserDefaults.standard.set(transcriptionCleanup, forKey: self.keyIsTranscriptionCleanupEnabled)
-                        }
-                        if let transcriptionMinutes = general.transcriptionRetentionMinutes {
-                            UserDefaults.standard.set(transcriptionMinutes, forKey: self.keyTranscriptionRetentionMinutes)
-                        }
-                        if let audioCleanup = general.isAudioCleanupEnabled {
-                            UserDefaults.standard.set(audioCleanup, forKey: self.keyIsAudioCleanupEnabled)
-                        }
-                        if let audioRetention = general.audioRetentionPeriod {
-                            UserDefaults.standard.set(audioRetention, forKey: self.keyAudioRetentionPeriod)
-                        }
-
-                        if let soundFeedback = general.isSoundFeedbackEnabled {
-                            soundManager.isEnabled = soundFeedback
-                        }
-                        if let muteSystem = general.isSystemMuteEnabled {
-                            mediaController.isSystemMuteEnabled = muteSystem
-                        }
-                        if let pauseMedia = general.isPauseMediaEnabled {
-                            playbackController.isPauseMediaEnabled = pauseMedia
-                        }
-                        if let audioDelay = general.audioResumptionDelay {
-                            mediaController.audioResumptionDelay = audioDelay
-                        }
-                        if let experimentalEnabled = general.isExperimentalFeaturesEnabled {
-                            UserDefaults.standard.set(experimentalEnabled, forKey: "isExperimentalFeaturesEnabled")
-                            if experimentalEnabled == false {
-                                playbackController.isPauseMediaEnabled = false
-                            }
-                        }
-                        if let textFormattingEnabled = general.isTextFormattingEnabled {
-                            UserDefaults.standard.set(textFormattingEnabled, forKey: self.keyIsTextFormattingEnabled)
-                        }
-                        if let removePunctuation = general.removePunctuation {
-                            UserDefaults.standard.set(removePunctuation, forKey: self.keyRemovePunctuation)
-                        }
-                        if let lowercaseTranscription = general.lowercaseTranscription {
-                            UserDefaults.standard.set(lowercaseTranscription, forKey: self.keyLowercaseTranscription)
-                        }
-                        if let restoreClipboard = general.restoreClipboardAfterPaste {
-                            UserDefaults.standard.set(restoreClipboard, forKey: "restoreClipboardAfterPaste")
-                        }
-                        if let clipboardDelay = general.clipboardRestoreDelay {
-                            UserDefaults.standard.set(clipboardDelay, forKey: "clipboardRestoreDelay")
-                        }
-                        if let appleScriptPaste = general.useAppleScriptPaste {
-                            UserDefaults.standard.set(appleScriptPaste, forKey: "useAppleScriptPaste")
-                        }
-                    }
-
-                    self.showRestartAlert(message: "Settings imported successfully from \(url.lastPathComponent). All settings (including general app settings) have been applied.")
-
-                } catch {
-                    self.showAlert(title: "Import Error", message: "Error importing settings: \(error.localizedDescription). The file might be corrupted or not in the correct format.")
-                }
-            } else {
-                self.showAlert(title: "Import Canceled", message: "The settings import operation was canceled.")
-            }
+        guard openPanel.runModal() == .OK else {
+            showAlert(title: "Import Canceled", message: "The settings import operation was canceled.")
+            return
         }
+
+        guard let url = openPanel.url else {
+            showAlert(title: "Import Error", message: "Could not get the file URL from the open panel.")
+            return
+        }
+
+        do {
+            let jsonData = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            let backup = try decoder.decode(BackupFile.self, from: jsonData)
+
+            if backup.version != currentSettingsVersion {
+                showAlert(title: "Version Mismatch", message: "The imported settings file (version \(backup.version)) is from a different version than your application (version \(currentSettingsVersion)). Proceeding with import, but be aware of potential incompatibilities.")
+            }
+
+            guard let selectedCategories = presentImportSelectionDialog() else {
+                showAlert(title: "Import Canceled", message: "No settings were imported.")
+                return
+            }
+
+            guard !selectedCategories.isEmpty else {
+                showAlert(title: "Import Error", message: "Select at least one category to import.")
+                return
+            }
+
+            BackupImporter.apply(
+                backup,
+                categories: selectedCategories,
+                enhancementService: enhancementService,
+                hotkeyManager: hotkeyManager,
+                menuBarManager: menuBarManager,
+                mediaController: mediaController,
+                playbackController: playbackController,
+                soundManager: soundManager,
+                recorderUIManager: recorderUIManager,
+                modelContext: modelContext,
+                transcriptionModelManager: transcriptionModelManager
+            )
+
+            showImportSuccessAlert(
+                message: "Settings imported successfully from \(url.lastPathComponent).\n\nImported: \(categorySummary(for: selectedCategories)).",
+                needsAPIKeyReminder: needsAPIKeyReminder(for: selectedCategories)
+            )
+        } catch {
+            showAlert(title: "Import Error", message: "Error importing settings: \(error.localizedDescription). The file might be corrupted or not in the correct format.")
+        }
+    }
+
+    private func presentImportSelectionDialog() -> Set<BackupCategory>? {
+        let accessory = BackupOptions()
+        let alert = NSAlert()
+        alert.messageText = "Import Settings"
+        alert.informativeText = "Choose what to import from this backup."
+        alert.alertStyle = .informational
+        alert.accessoryView = accessory.view
+        alert.addButton(withTitle: "Import")
+        alert.addButton(withTitle: "Cancel")
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else {
+            return nil
+        }
+
+        return accessory.selectedCategories
+    }
+
+    private func categorySummary(for categories: Set<BackupCategory>) -> String {
+        if categories == Set(BackupCategory.allCases) {
+            return "All settings"
+        }
+
+        return BackupCategory.allCases
+            .filter { categories.contains($0) }
+            .map(\.title)
+            .joined(separator: ", ")
+    }
+
+    private func needsAPIKeyReminder(for categories: Set<BackupCategory>) -> Bool {
+        !categories.isDisjoint(with: [.prompts, .powerMode, .customModels])
     }
 
     private func showAlert(title: String, message: String) {
@@ -378,17 +340,24 @@ class ImportExportService {
         }
     }
 
-    private func showRestartAlert(message: String) {
+    private func showImportSuccessAlert(message: String, needsAPIKeyReminder: Bool) {
         DispatchQueue.main.async {
             let alert = NSAlert()
             alert.messageText = "Import Successful"
-            alert.informativeText = message + "\n\nIMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the Enhancement section.\n\nIt is recommended to restart VoiceInk for all changes to take full effect."
+            var informativeText = message
+            if needsAPIKeyReminder {
+                informativeText += "\n\nIMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the Enhancement section."
+            }
+            informativeText += "\n\nIt is recommended to restart VoiceInk for all changes to take full effect."
+            alert.informativeText = informativeText
             alert.alertStyle = .informational
             alert.addButton(withTitle: "OK")
-            alert.addButton(withTitle: "Configure API Keys")
+            if needsAPIKeyReminder {
+                alert.addButton(withTitle: "Configure API Keys")
+            }
             
             let response = alert.runModal()
-            if response == .alertSecondButtonReturn {
+            if needsAPIKeyReminder && response == .alertSecondButtonReturn {
                 NotificationCenter.default.post(
                     name: .navigateToDestination,
                     object: nil,

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -285,7 +285,7 @@ struct SettingsView: View {
             } header: {
                 Text("Backup")
             } footer: {
-                Text("Export or import all your settings, prompts, power modes, dictionary, and custom models.")
+                Text("Export all settings, or choose specific categories when importing a backup.")
             }
 
             // MARK: - Diagnostics
@@ -496,4 +496,3 @@ extension Text {
             .fixedSize(horizontal: false, vertical: true)
     }
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds selective backup import by category with a simple picker, so users can import only what they need. Refactors import/export into typed models and a new `BackupImporter` with better validation and transactional saves.

- **New Features**
  - Import dialog lets you pick All or specific categories: General Settings, Custom Prompts, Power Mode, Dictionary, Custom Model Definitions.
  - Imports Power Mode configs and per-mode shortcuts; merges imported prompts with predefined; restores custom emojis.
  - Dictionary import de-duplicates words, skips invalid replacements, and avoids conflicting replacement keys.
  - Success alert lists imported categories and, when relevant, offers a quick link to configure API keys.

- **Refactors**
  - Introduced `BackupTypes` (typed backup models) and `BackupImporter` (category-specific import logic with rollback on save failure).
  - Export now includes more general shortcuts/modes and per-mode shortcuts; custom models exported as `CustomModelBackup` (no API keys).
  - Simplified `ImportExportService` with an accessory options UI, selection validation, and clearer messaging; updated Settings footer copy.

<sup>Written for commit 2227ef455c0a49c10b39e2ea32618af0a21c8991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

