### PR TITLE
Add Soniox region selection

### DIFF
--- a/VoiceInk/Transcription/Cloud/SonioxProvider.swift
+++ b/VoiceInk/Transcription/Cloud/SonioxProvider.swift
@@ -36,7 +36,8 @@ struct SonioxProvider: CloudProvider {
             apiKey: apiKey,
             model: model,
             language: language,
-            customVocabulary: customVocabulary
+            customVocabulary: customVocabulary,
+            baseURL: SonioxRegion.current.restBaseURL
         )
     }
 
@@ -45,6 +46,54 @@ struct SonioxProvider: CloudProvider {
     }
 
     func verifyAPIKey(_ key: String) async -> (isValid: Bool, errorMessage: String?) {
-        return await SonioxClient.verifyAPIKey(key)
+        return await SonioxClient.verifyAPIKey(key, baseURL: SonioxRegion.current.restBaseURL)
+    }
+}
+
+enum SonioxRegion: String, CaseIterable, Identifiable {
+    case us
+    case eu
+    case jp
+
+    static let defaultsKey = "SonioxRegion"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .us:
+            return "United States"
+        case .eu:
+            return "European Union"
+        case .jp:
+            return "Japan"
+        }
+    }
+
+    var restBaseURL: URL {
+        switch self {
+        case .us:
+            return URL(string: "https://api.soniox.com/v1")!
+        case .eu:
+            return URL(string: "https://api.eu.soniox.com/v1")!
+        case .jp:
+            return URL(string: "https://api.jp.soniox.com/v1")!
+        }
+    }
+
+    var realtimeWebSocketURL: URL {
+        switch self {
+        case .us:
+            return URL(string: "wss://stt-rt.soniox.com/transcribe-websocket")!
+        case .eu:
+            return URL(string: "wss://stt-rt.eu.soniox.com/transcribe-websocket")!
+        case .jp:
+            return URL(string: "wss://stt-rt.jp.soniox.com/transcribe-websocket")!
+        }
+    }
+
+    static var current: SonioxRegion {
+        let rawValue = UserDefaults.standard.string(forKey: defaultsKey) ?? SonioxRegion.us.rawValue
+        return SonioxRegion(rawValue: rawValue) ?? .us
     }
 }

--- a/VoiceInk/Transcription/Streaming/SonioxStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/SonioxStreamingProvider.swift
@@ -36,7 +36,13 @@ final class SonioxStreamingProvider: StreamingTranscriptionProvider {
         startEventForwarding()
 
         do {
-            try await client.connect(apiKey: apiKey, model: "stt-rt-v4", language: language, customVocabulary: vocabulary)
+            try await client.connect(
+                apiKey: apiKey,
+                model: "stt-rt-v4",
+                language: language,
+                customVocabulary: vocabulary,
+                webSocketURL: SonioxRegion.current.realtimeWebSocketURL
+            )
         } catch {
             // Clean up forwarding task on connection failure
             forwardingTask?.cancel()
@@ -117,7 +123,7 @@ final class SonioxStreamingProvider: StreamingTranscriptionProvider {
         case .networkError(let detail):
             return StreamingTranscriptionError.connectionFailed(detail)
         default:
-            return StreamingTranscriptionError.serverError(llmError.localizedDescription ?? "Unknown error")
+            return StreamingTranscriptionError.serverError(llmError.errorDescription ?? "Unknown error")
         }
     }
 }

--- a/VoiceInk/Views/AI Models/CloudModelCardView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardView.swift
@@ -175,9 +175,7 @@ struct CloudModelCardView: View {
                 .controlSize(.small)
             } else {
                 Button(action: {
-                    withAnimation(.interpolatingSpring(stiffness: 170, damping: 20)) {
-                        isExpanded.toggle()
-                    }
+                    toggleConfiguration()
                 }) {
                     HStack(spacing: 4) {
                         Text("Configure")
@@ -199,6 +197,14 @@ struct CloudModelCardView: View {
             
             if isConfigured {
                 Menu {
+                    if hasProviderConfiguration {
+                        Button {
+                            toggleConfiguration()
+                        } label: {
+                            Label(isExpanded ? "Hide Configuration" : "Configure", systemImage: "gearshape")
+                        }
+                    }
+
                     Button {
                         clearAPIKey()
                     } label: {
@@ -217,6 +223,11 @@ struct CloudModelCardView: View {
     
     private var configurationSection: some View {
         VStack(alignment: .leading, spacing: 12) {
+            if hasProviderConfiguration {
+                CloudProviderConfigurationSection(provider: model.provider)
+                Divider()
+            }
+
             Text("API Key Configuration")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
@@ -271,6 +282,16 @@ struct CloudModelCardView: View {
     
     private var streamingDefaultsKey: String {
         "streaming-enabled-\(model.name)"
+    }
+
+    private var hasProviderConfiguration: Bool {
+        CloudProviderConfigurationSection.hasConfiguration(for: model.provider)
+    }
+
+    private func toggleConfiguration() {
+        withAnimation(.interpolatingSpring(stiffness: 170, damping: 20)) {
+            isExpanded.toggle()
+        }
     }
 
     private func loadSavedAPIKey() {

--- a/VoiceInk/Views/AI Models/CloudProviderConfigurationSection.swift
+++ b/VoiceInk/Views/AI Models/CloudProviderConfigurationSection.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct CloudProviderConfigurationSection: View {
+    let provider: ModelProvider
+
+    static func hasConfiguration(for provider: ModelProvider) -> Bool {
+        switch provider {
+        case .soniox:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var body: some View {
+        switch provider {
+        case .soniox:
+            SonioxRegionPickerView()
+        default:
+            EmptyView()
+        }
+    }
+}
+
+private struct SonioxRegionPickerView: View {
+    @AppStorage(SonioxRegion.defaultsKey) private var regionRawValue = SonioxRegion.us.rawValue
+
+    private var selectedRegion: SonioxRegion {
+        SonioxRegion(rawValue: regionRawValue) ?? .us
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Soniox Region", selection: $regionRawValue) {
+                ForEach(SonioxRegion.allCases) { region in
+                    Text(region.displayName).tag(region.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+            .onChange(of: regionRawValue) { _, _ in
+                NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+            }
+
+            Text(selectedRegion.restBaseURL.absoluteString)
+                .font(.caption)
+                .foregroundColor(Color(.secondaryLabelColor))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Soniox US, EU, and Japan region selection in cloud model configuration
- Route Soniox REST and realtime streaming calls through the selected region endpoints
- Keep Soniox protocol details in LLMKit via Beingpax/LLMkit#6

Fixes #693

## Verification
- xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Soniox region selection (US, EU, Japan) to cloud model settings and route all REST and realtime traffic to the selected region. Defaults to US and applies to API verification and streaming connections.

- New Features
  - Region picker for Soniox with persistent selection (US/EU/JP).
  - REST calls use region `restBaseURL`; API key verification updated to use it.
  - Realtime streaming connects via region `realtimeWebSocketURL`.
  - Provider configuration section added to `CloudModelCardView` with a quick toggle.

<sup>Written for commit d051555c8560aed523e0cfc5ee9fc32177fda713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

