### PR TITLE
Add delayedHold HotkeyMode (Hold to Start) — recording starts only after 0.5s press

### DIFF
--- a/VoiceInk/HotkeyManager.swift
+++ b/VoiceInk/HotkeyManager.swift
@@ -95,12 +95,14 @@ class HotkeyManager: ObservableObject {
         case toggle = "toggle"
         case pushToTalk = "pushToTalk"
         case hybrid = "hybrid"
+        case delayedHold = "delayedHold"
 
         var displayName: String {
             switch self {
             case .toggle: return "Toggle"
             case .pushToTalk: return "Push to Talk"
             case .hybrid: return "Hybrid"
+            case .delayedHold: return "Hold to Start"
             }
         }
     }
@@ -408,6 +410,22 @@ class HotkeyManager: ObservableObject {
                     logger.notice("processKeyPress: starting recording (push-to-talk key down)")
                     await recorderUIManager.toggleMiniRecorder()
                 }
+
+            case .delayedHold:
+                let pressStartTime = eventTime
+                Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(Self.hybridPressThreshold * 1_000_000_000))
+                    await MainActor.run {
+                        guard let self = self else { return }
+                        if self.currentKeyState
+                            && self.keyPressEventTime == pressStartTime
+                            && !self.recorderUIManager.isMiniRecorderVisible
+                            && self.canProcessHotkeyAction {
+                            self.logger.notice("processKeyPress: starting recording (delayed-hold threshold reached)")
+                            Task { await self.recorderUIManager.toggleMiniRecorder() }
+                        }
+                    }
+                }
             }
         } else {
             switch mode {
@@ -429,6 +447,16 @@ class HotkeyManager: ObservableObject {
                     await recorderUIManager.toggleMiniRecorder()
                 } else {
                     isHandsFreeMode = true
+                }
+
+            case .delayedHold:
+                if recorderUIManager.isMiniRecorderVisible && engine.recordingState == .recording {
+                    guard canProcessHotkeyAction else {
+                        keyPressEventTime = nil
+                        return
+                    }
+                    logger.notice("processKeyPress: stopping recording (delayed-hold key up)")
+                    await recorderUIManager.toggleMiniRecorder()
                 }
             }
 
@@ -469,6 +497,22 @@ class HotkeyManager: ObservableObject {
                 logger.notice("handleCustomShortcutKeyDown: starting recording (push-to-talk key down)")
                 await recorderUIManager.toggleMiniRecorder()
             }
+
+        case .delayedHold:
+            let pressStartTime = eventTime
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(Self.hybridPressThreshold * 1_000_000_000))
+                await MainActor.run {
+                    guard let self = self else { return }
+                    if self.shortcutCurrentKeyState
+                        && self.shortcutKeyPressEventTime == pressStartTime
+                        && !self.recorderUIManager.isMiniRecorderVisible
+                        && self.canProcessHotkeyAction {
+                        self.logger.notice("handleCustomShortcutKeyDown: starting recording (delayed-hold threshold reached)")
+                        Task { await self.recorderUIManager.toggleMiniRecorder() }
+                    }
+                }
+            }
         }
     }
 
@@ -495,6 +539,16 @@ class HotkeyManager: ObservableObject {
                 await recorderUIManager.toggleMiniRecorder()
             } else {
                 isShortcutHandsFreeMode = true
+            }
+
+        case .delayedHold:
+            if recorderUIManager.isMiniRecorderVisible && engine.recordingState == .recording {
+                guard canProcessHotkeyAction else {
+                    shortcutKeyPressEventTime = nil
+                    return
+                }
+                logger.notice("handleCustomShortcutKeyUp: stopping recording (delayed-hold key up)")
+                await recorderUIManager.toggleMiniRecorder()
             }
         }
 


### PR DESCRIPTION
## Summary
Adds a new `delayedHold` HotkeyMode (display name **Hold to Start**) that ignores short taps (< 500ms) and only starts recording when the hotkey is held for at least 500ms. Recording stops on key-release (push-to-talk style).

## Motivation
Users mapping PTT to modifier keys like Left Control experience conflicts with common shortcuts (Cmd+V, Cmd+C, Cmd+A). All three existing modes start recording on key-down, so accidental triggers are frequent for anyone with one hand on the modifier row. This mode keeps the ergonomic single-modifier hotkey while filtering out short taps.

## Implementation
- New enum case `HotkeyMode.delayedHold` (with `displayName = "Hold to Start"`)
- Key-down spawns a delayed `Task` that re-checks press state after `hybridPressThreshold` (existing 0.5s constant). Recording only starts if:
  - the key is still held (`currentKeyState`)
  - it's still the same press (`keyPressEventTime == pressStartTime`)
  - the recorder isn't already visible
  - `canProcessHotkeyAction` is true
- Key-up stops recording only if a recording is actually running. Short taps are no-ops.
- Race conditions handled via `keyPressEventTime` snapshot comparison so only the most recent press wins.
- Mirrored implementation in both `processKeyPress` (NSEvent monitor) and `handleCustomShortcutKey*` (KeyboardShortcuts library).

## UI changes
None beyond the new dropdown entry — `HotkeyMode.allCases` already drives the Picker in `SettingsView`, so the new mode appears automatically.

## Test plan
- [x] Tap Left Ctrl < 500ms → no recording
- [x] Hold Left Ctrl ≥ 500ms → recording starts at threshold
- [x] Release while holding → recording stops
- [x] Cmd+V continues to paste without triggering recording
- [x] Rapid taps don't spawn ghost recordings
- [x] Local build via \`make local\` succeeds, no warnings introduced

Built and verified locally on macOS with the existing \`make local\` workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new HotkeyMode “Hold to Start” that begins recording only after a 500ms hold and stops on key release. This filters out quick taps and avoids conflicts with common shortcuts when using modifier keys as PTT.

- **New Features**
  - Added `HotkeyMode.delayedHold` (“Hold to Start”): ignores taps <500ms; starts on hold; stops on release.
  - Uses existing 0.5s `hybridPressThreshold` with a delayed task and press-state checks.
  - Guards against races using event-time snapshots so only the latest press can start recording.
  - Implemented in both NSEvent monitoring and the `KeyboardShortcuts` path.
  - No UI work; the new mode appears in Settings automatically.

<sup>Written for commit 2c04ccd5dde1d3e52b411a5202d957fc85a0a162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

