### PR TITLE
Add Apple Intelligence as an Enhancement provider

### DIFF
--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -142,7 +142,18 @@ class AIEnhancementService: ObservableObject {
         lastRequestTime = Date()
     }
 
-    private func getSystemMessage(for mode: EnhancementPrompt) async -> String {
+    private struct EnhancementContextSections {
+        var selectedText: String
+        var clipboard: String
+        var screenCapture: String
+        var customVocabulary: String
+
+        var concatenated: String {
+            selectedText + clipboard + screenCapture + customVocabulary
+        }
+    }
+
+    private func collectContextSections() async -> EnhancementContextSections {
         let selectedTextContext: String
         if AXIsProcessTrusted() {
             if let selectedText = await SelectedTextService.fetchSelectedText(), !selectedText.isEmpty {
@@ -171,9 +182,6 @@ class AIEnhancementService: ObservableObject {
         }
 
         let customVocabulary = customVocabularyService.getCustomVocabulary(from: modelContext)
-
-        let allContextSections = selectedTextContext + clipboardContext + screenCaptureContext
-
         let customVocabularySection = if !customVocabulary.isEmpty {
             """
 
@@ -187,19 +195,84 @@ class AIEnhancementService: ObservableObject {
             ""
         }
 
-        let finalContextSection = allContextSections + customVocabularySection
+        return EnhancementContextSections(
+            selectedText: selectedTextContext,
+            clipboard: clipboardContext,
+            screenCapture: screenCaptureContext,
+            customVocabulary: customVocabularySection
+        )
+    }
 
+    private func basePromptText() -> String {
         if let activePrompt = activePrompt {
             if activePrompt.id == PredefinedPrompts.assistantPromptId {
-                return activePrompt.promptText + finalContextSection
+                return activePrompt.promptText
             } else {
-                return activePrompt.finalPromptText + finalContextSection
+                return activePrompt.finalPromptText
             }
         } else {
             let defaultPrompt = allPrompts.first(where: { $0.id == PredefinedPrompts.defaultPromptId }) ?? allPrompts.first!
-            return defaultPrompt.finalPromptText + finalContextSection
+            return defaultPrompt.finalPromptText
         }
     }
+
+    private func getSystemMessage(for mode: EnhancementPrompt) async -> String {
+        let basePrompt = basePromptText()
+        let context = await collectContextSections()
+        return basePrompt + context.concatenated
+    }
+
+    /// Budgets the system prompt for providers with a small context window
+    /// (currently only Apple Intelligence). Drops context sections in priority
+    /// order — screen capture, then clipboard, then selected text — until the
+    /// total character count fits the budget. The base prompt and custom
+    /// vocabulary are preserved so spelling guidance and the user's chosen
+    /// behaviour are never silently lost.
+    private func getBudgetedSystemMessage(
+        for mode: EnhancementPrompt,
+        transcriptLength: Int,
+        characterBudget: Int
+    ) async -> String {
+        let basePrompt = basePromptText()
+        var context = await collectContextSections()
+
+        let nonTrimmableLength = basePrompt.count + context.customVocabulary.count + transcriptLength
+        var remaining = max(0, characterBudget - nonTrimmableLength)
+
+        let totalContextLength = context.selectedText.count + context.clipboard.count + context.screenCapture.count
+        if totalContextLength <= remaining {
+            return basePrompt + context.concatenated
+        }
+
+        // Keep highest-priority sections first; drop the lowest-priority
+        // section (screen capture) if budget runs out before we get to it.
+        if context.selectedText.count <= remaining {
+            remaining -= context.selectedText.count
+        } else {
+            logger.info("Dropping selected text context (\(context.selectedText.count, privacy: .public) chars) to fit Apple Intelligence budget")
+            context.selectedText = ""
+        }
+
+        if context.clipboard.count <= remaining {
+            remaining -= context.clipboard.count
+        } else {
+            logger.info("Dropping clipboard context (\(context.clipboard.count, privacy: .public) chars) to fit Apple Intelligence budget")
+            context.clipboard = ""
+        }
+
+        if context.screenCapture.count > remaining {
+            logger.info("Dropping screen capture context (\(context.screenCapture.count, privacy: .public) chars) to fit Apple Intelligence budget")
+            context.screenCapture = ""
+        }
+
+        return basePrompt + context.concatenated
+    }
+
+    /// Approximate character budget for the system prompt + transcript when
+    /// targeting Apple Intelligence's ~4k-token on-device window. We reserve
+    /// headroom for the model's response and prompt scaffolding using a rough
+    /// 4 chars/token heuristic.
+    private static let appleIntelligenceCharacterBudget = 10_000
 
     private func makeRequest(text: String, mode: EnhancementPrompt) async throws -> String {
         guard isConfigured else {
@@ -211,7 +284,16 @@ class AIEnhancementService: ObservableObject {
         }
 
         let formattedText = "\n<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
-        let systemMessage = await getSystemMessage(for: mode)
+        let systemMessage: String
+        if aiService.selectedProvider == .appleIntelligence {
+            systemMessage = await getBudgetedSystemMessage(
+                for: mode,
+                transcriptLength: formattedText.count,
+                characterBudget: Self.appleIntelligenceCharacterBudget
+            )
+        } else {
+            systemMessage = await getSystemMessage(for: mode)
+        }
 
         await MainActor.run {
             self.lastSystemMessageSent = systemMessage
@@ -241,6 +323,22 @@ class AIEnhancementService: ObservableObject {
                 } else {
                     throw EnhancementError.customError(error.localizedDescription)
                 }
+            }
+        }
+
+        if aiService.selectedProvider == .appleIntelligence {
+            do {
+                let result = try await aiService.enhanceWithAppleIntelligence(systemPrompt: systemMessage, userPrompt: formattedText)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as AppleIntelligenceError {
+                switch error {
+                case .guardrailViolation:
+                    throw EnhancementError.guardrailViolation
+                case .notAvailable, .requestFailed:
+                    throw EnhancementError.customError(error.errorDescription ?? "An unknown Apple Intelligence error occurred.")
+                }
+            } catch {
+                throw EnhancementError.customError(error.localizedDescription)
             }
         }
 
@@ -465,6 +563,7 @@ enum EnhancementError: Error {
     case serverError
     case rateLimitExceeded
     case timeout
+    case guardrailViolation
     case customError(String)
 }
 
@@ -485,6 +584,8 @@ extension EnhancementError: LocalizedError {
             return "Rate limit exceeded. Please try again later."
         case .timeout:
             return "Enhancement request timed out. Check your connection or increase the timeout duration."
+        case .guardrailViolation:
+            return "Apple Intelligence declined to process this text because it triggered the on-device safety filter. Try rephrasing or switch to another provider for this transcript."
         case .customError(let message):
             return message
         }

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -161,7 +161,7 @@ enum AIProvider: String, CaseIterable {
         case .localCLI:
             return []
         case .appleIntelligence:
-            return ["system"]
+            return []
         case .custom:
             return []
         case .openRouter:

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -16,6 +16,7 @@ enum AIProvider: String, CaseIterable {
     case assemblyAI = "AssemblyAI"
     case ollama = "Ollama"
     case localCLI = "Local CLI"
+    case appleIntelligence = "Apple Intelligence"
     case custom = "Custom"
     
     
@@ -48,6 +49,8 @@ enum AIProvider: String, CaseIterable {
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         case .localCLI:
+            return ""
+        case .appleIntelligence:
             return ""
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderBaseURL") ?? ""
@@ -82,6 +85,8 @@ enum AIProvider: String, CaseIterable {
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
         case .localCLI:
             return "local-cli"
+        case .appleIntelligence:
+            return "system"
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderModel") ?? ""
         case .openRouter:
@@ -155,6 +160,8 @@ enum AIProvider: String, CaseIterable {
             return []
         case .localCLI:
             return []
+        case .appleIntelligence:
+            return ["system"]
         case .custom:
             return []
         case .openRouter:
@@ -164,7 +171,7 @@ enum AIProvider: String, CaseIterable {
     
     var requiresAPIKey: Bool {
         switch self {
-        case .ollama, .localCLI:
+        case .ollama, .localCLI, .appleIntelligence:
             return false
         default:
             return true
@@ -198,7 +205,14 @@ class AIService: ObservableObject {
                 }
             } else {
                 self.apiKey = ""
-                self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
+                switch selectedProvider {
+                case .localCLI:
+                    self.isAPIKeyValid = localCLIService.isConfigured
+                case .appleIntelligence:
+                    self.isAPIKeyValid = appleIntelligenceService.isConfigured
+                default:
+                    self.isAPIKeyValid = true
+                }
                 if selectedProvider == .ollama {
                     Task {
                         await ollamaService.checkConnection()
@@ -214,6 +228,7 @@ class AIService: ObservableObject {
     private let userDefaults = UserDefaults.standard
     private lazy var ollamaService = OllamaService()
     private lazy var localCLIService = LocalCLIService()
+    private lazy var appleIntelligenceService = AppleIntelligenceService()
     
     @Published private var openRouterModels: [String] = []
     
@@ -223,6 +238,8 @@ class AIService: ObservableObject {
                 return ollamaService.isConnected
             } else if provider == .localCLI {
                 return localCLIService.isConfigured
+            } else if provider == .appleIntelligence {
+                return appleIntelligenceService.isConfigured
             } else if provider.requiresAPIKey {
                 return APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue)
             }
@@ -282,7 +299,14 @@ class AIService: ObservableObject {
                 self.isAPIKeyValid = true
             }
         } else {
-            self.isAPIKeyValid = selectedProvider == .localCLI ? localCLIService.isConfigured : true
+            switch selectedProvider {
+            case .localCLI:
+                self.isAPIKeyValid = localCLIService.isConfigured
+            case .appleIntelligence:
+                self.isAPIKeyValid = appleIntelligenceService.isConfigured
+            default:
+                self.isAPIKeyValid = true
+            }
         }
 
         loadSavedModelSelections()
@@ -451,6 +475,22 @@ class AIService: ObservableObject {
 
     func enhanceWithLocalCLI(systemPrompt: String, userPrompt: String) async throws -> String {
         try await localCLIService.enhance(systemPrompt: systemPrompt, userPrompt: userPrompt)
+    }
+
+    var appleIntelligenceAvailability: AppleIntelligenceAvailability {
+        appleIntelligenceService.availability
+    }
+
+    func refreshAppleIntelligenceAvailability() {
+        if selectedProvider == .appleIntelligence {
+            isAPIKeyValid = appleIntelligenceService.isConfigured
+        }
+        objectWillChange.send()
+        NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
+    }
+
+    func enhanceWithAppleIntelligence(systemPrompt: String, userPrompt: String) async throws -> String {
+        try await appleIntelligenceService.enhance(systemPrompt: systemPrompt, userPrompt: userPrompt)
     }
 
     private func refreshLocalCLIConfigurationState() {

--- a/VoiceInk/Services/AIEnhancement/AppleIntelligenceService.swift
+++ b/VoiceInk/Services/AIEnhancement/AppleIntelligenceService.swift
@@ -1,0 +1,134 @@
+import Foundation
+import os
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+enum AppleIntelligenceAvailability: Equatable {
+    case available
+    case unsupportedOS
+    case deviceNotEligible
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case unknown(String)
+
+    var isAvailable: Bool {
+        if case .available = self { return true }
+        return false
+    }
+
+    var userFacingMessage: String {
+        switch self {
+        case .available:
+            return "Apple Intelligence is ready."
+        case .unsupportedOS:
+            return "Apple Intelligence requires macOS 26 or later."
+        case .deviceNotEligible:
+            return "This Mac does not support Apple Intelligence."
+        case .appleIntelligenceNotEnabled:
+            return "Enable Apple Intelligence in System Settings to use this provider."
+        case .modelNotReady:
+            return "Apple Intelligence is downloading the on-device model. Try again shortly."
+        case .unknown(let detail):
+            return "Apple Intelligence is unavailable: \(detail)"
+        }
+    }
+}
+
+enum AppleIntelligenceError: Error, LocalizedError {
+    case notAvailable(AppleIntelligenceAvailability)
+    case guardrailViolation
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAvailable(let availability):
+            return availability.userFacingMessage
+        case .guardrailViolation:
+            return "Apple Intelligence declined to process this text because it triggered the on-device safety filter. Try rephrasing or switch to another provider for this transcript."
+        case .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+final class AppleIntelligenceService {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "AppleIntelligenceService")
+
+    var availability: AppleIntelligenceAvailability {
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            return Self.resolveAvailability()
+        } else {
+            return .unsupportedOS
+        }
+        #else
+        return .unsupportedOS
+        #endif
+    }
+
+    var isConfigured: Bool {
+        availability.isAvailable
+    }
+
+    func enhance(systemPrompt: String, userPrompt: String) async throws -> String {
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            return try await Self.respond(systemPrompt: systemPrompt, userPrompt: userPrompt, logger: logger)
+        } else {
+            throw AppleIntelligenceError.notAvailable(.unsupportedOS)
+        }
+        #else
+        throw AppleIntelligenceError.notAvailable(.unsupportedOS)
+        #endif
+    }
+
+    #if canImport(FoundationModels)
+    @available(macOS 26.0, *)
+    private static func resolveAvailability() -> AppleIntelligenceAvailability {
+        let model = SystemLanguageModel.default
+        switch model.availability {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            switch reason {
+            case .deviceNotEligible:
+                return .deviceNotEligible
+            case .appleIntelligenceNotEnabled:
+                return .appleIntelligenceNotEnabled
+            case .modelNotReady:
+                return .modelNotReady
+            @unknown default:
+                return .unknown("Unrecognised availability state")
+            }
+        }
+    }
+
+    @available(macOS 26.0, *)
+    private static func respond(systemPrompt: String, userPrompt: String, logger: Logger) async throws -> String {
+        let availability = resolveAvailability()
+        guard availability.isAvailable else {
+            throw AppleIntelligenceError.notAvailable(availability)
+        }
+
+        do {
+            let session = LanguageModelSession(instructions: systemPrompt)
+            let response = try await session.respond(to: userPrompt)
+            return response.content
+        } catch let error as LanguageModelSession.GenerationError {
+            switch error {
+            case .guardrailViolation:
+                logger.warning("Apple Intelligence guardrail violation")
+                throw AppleIntelligenceError.guardrailViolation
+            default:
+                logger.error("Apple Intelligence generation error: \(error.localizedDescription, privacy: .public)")
+                throw AppleIntelligenceError.requestFailed(error.localizedDescription)
+            }
+        } catch {
+            logger.error("Apple Intelligence request failed: \(error.localizedDescription, privacy: .public)")
+            throw AppleIntelligenceError.requestFailed(error.localizedDescription)
+        }
+    }
+    #endif
+}

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -20,14 +20,26 @@ struct APIKeyManagementView: View {
         Section("AI Provider Integration") {
             HStack {
                 Picker("Provider", selection: $aiService.selectedProvider) {
-                    ForEach(AIProvider.allCases.filter { $0 != .elevenLabs && $0 != .deepgram && $0 != .soniox && $0 != .speechmatics && $0 != .assemblyAI }, id: \.self) { provider in
+                    ForEach(AIProvider.allCases.filter { provider in
+                        if provider == .elevenLabs || provider == .deepgram || provider == .soniox || provider == .speechmatics || provider == .assemblyAI {
+                            return false
+                        }
+                        if provider == .appleIntelligence {
+                            if #available(macOS 26.0, *) {
+                                return true
+                            } else {
+                                return false
+                            }
+                        }
+                        return true
+                    }, id: \.self) { provider in
                         Text(provider.rawValue).tag(provider)
                     }
                 }
                 .pickerStyle(.automatic)
                 .tint(.blue)
                 
-                if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama {
+                if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama && aiService.selectedProvider != .appleIntelligence {
                     Spacer()
                     Circle()
                         .fill(Color.green)
@@ -55,6 +67,15 @@ struct APIKeyManagementView: View {
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                     }
+                } else if aiService.selectedProvider == .appleIntelligence {
+                    Spacer()
+                    let isReady = aiService.appleIntelligenceAvailability.isAvailable
+                    Circle()
+                        .fill(isReady ? Color.green : Color.orange)
+                        .frame(width: 8, height: 8)
+                    Text(isReady ? "Ready" : "Unavailable")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
                 }
             }
             .onChange(of: aiService.selectedProvider) { oldValue, newValue in
@@ -63,6 +84,9 @@ struct APIKeyManagementView: View {
                 }
                 if aiService.selectedProvider == .localCLI {
                     syncLocalCLIStateFromService()
+                }
+                if aiService.selectedProvider == .appleIntelligence {
+                    aiService.refreshAppleIntelligenceAvailability()
                 }
             }
 
@@ -107,7 +131,8 @@ struct APIKeyManagementView: View {
                     
                 } else if !aiService.availableModels.isEmpty &&
                             aiService.selectedProvider != .ollama &&
-                            aiService.selectedProvider != .custom {
+                            aiService.selectedProvider != .custom &&
+                            aiService.selectedProvider != .appleIntelligence {
                     Picker("Model", selection: Binding(
                         get: { aiService.currentModel },
                         set: { aiService.selectModel($0) }
@@ -221,6 +246,31 @@ struct APIKeyManagementView: View {
                             .foregroundColor(.orange)
                     }
 
+                } else if aiService.selectedProvider == .appleIntelligence {
+                    let availability = aiService.appleIntelligenceAvailability
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: availability.isAvailable ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                            .foregroundColor(availability.isAvailable ? .green : .orange)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(availability.userFacingMessage)
+                                .font(.subheadline)
+                            if availability == .appleIntelligenceNotEnabled {
+                                Link("Open System Settings", destination: URL(string: "x-apple.systempreferences:com.apple.Siri-Settings.extension")!)
+                                    .font(.caption)
+                            }
+                            Text("Runs entirely on-device. No data leaves your Mac. Best suited for short transcripts — context is automatically trimmed to fit Apple Intelligence's smaller window.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Button(action: {
+                            aiService.refreshAppleIntelligenceAvailability()
+                        }) {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .help("Re-check availability")
+                    }
+
                 } else if aiService.selectedProvider == .custom {
                     TextField("API Endpoint URL", text: $aiService.customBaseURL, prompt: Text("e.g. https://api.openai.com/v1/chat/completions"))
                         .textFieldStyle(.roundedBorder)
@@ -327,6 +377,9 @@ struct APIKeyManagementView: View {
             }
             if aiService.selectedProvider == .localCLI {
                 syncLocalCLIStateFromService()
+            }
+            if aiService.selectedProvider == .appleIntelligence {
+                aiService.refreshAppleIntelligenceAvailability()
             }
         }
     }


### PR DESCRIPTION
Adds Apple's on-device FoundationModels framework as a new no-API-key provider for the text Enhancement feature, alongside the existing cloud LLM and local options.

## What's new

- **`AppleIntelligenceService`** wraps `SystemLanguageModel` / `LanguageModelSession`, gated by `@available(macOS 26.0, *)` and `#if canImport(FoundationModels)` so the project keeps building on older SDKs.
- Reports availability with user-facing messages (`deviceNotEligible`, `appleIntelligenceNotEnabled`, `modelNotReady`, `unsupportedOS`).
- New **`EnhancementError.guardrailViolation`**, mapped from `LanguageModelSession.GenerationError.guardrailViolation`, so on-device safety refusals get a tailored message instead of being flattened into a generic error.
- **Provider-aware context budgeting**: when targeting Apple Intelligence, the system prompt is trimmed to fit the smaller on-device window. Highest-priority sections (selected text, then clipboard) are kept; screen capture is dropped first. Base prompt, custom vocabulary, and the transcript are always preserved.
- **Settings UI** shows an Apple Intelligence status row, a re-check button, and a deep link to the Apple Intelligence & Siri pane in System Settings when the feature is disabled. Hidden from the picker on macOS < 26.

## Notes

- No new dependencies; FoundationModels is provided by macOS 26.
- Existing providers are unchanged — the guardrail error is only mapped from Apple Intelligence.
- Built and smoke-tested on macOS 26 with `make local`.

## Screenshots

### With Apple Intelligence not yet available

<img width="1162" height="1024" alt="CleanShot 2026-05-15 at 16 40 30" src="https://github.com/user-attachments/assets/094f766a-3f2f-4612-9287-c6ce216c52b2" />

### With Apple Intelligence ready


<img width="1162" height="1024" alt="CleanShot 2026-05-15 at 18 04 12" src="https://github.com/user-attachments/assets/e4cc0e69-d4eb-46a7-8f70-bcb6c17cf3e7" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Apple Intelligence as a no-API-key, on-device provider for text Enhancement via macOS `FoundationModels`. Includes availability checks, settings UI, context budgeting for the smaller on‑device window, and shows “No models available” in Power Mode for this provider.

- **New Features**
  - `AppleIntelligenceService` wraps `SystemLanguageModel`/`LanguageModelSession`, gated by `@available(macOS 26.0, *)` and `#if canImport(FoundationModels)`. Reports `unsupportedOS`, `deviceNotEligible`, `appleIntelligenceNotEnabled`, and `modelNotReady`.
  - Settings: selectable “Apple Intelligence” on macOS 26+, no API key. Status row with re-check and deep link to enable. Hidden on older macOS.
  - Power Mode: AI Model shows “No models available” when Apple Intelligence is selected (single on-device model, no picker).
  - Context budgeting for Apple Intelligence: preserves base prompt, custom vocabulary, and transcript; trims additional context to fit a ~10k character budget.
  - New `EnhancementError.guardrailViolation` mapped from on-device guardrail refusals for clearer feedback.

<sup>Written for commit a98e9b463d093a306013f42b3ec300ab1b301f21. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/707?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

