### PR TITLE
Add GitHub Copilot CLI as a Local CLI template

### DIFF
--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -26,7 +26,7 @@ enum LocalCLITemplate: String, CaseIterable, Identifiable {
         case .codex:
             return "TMPFILE=$(mktemp) && codex exec --skip-git-repo-check --output-last-message \"$TMPFILE\" \"$VOICEINK_FULL_PROMPT\" > /dev/null 2>&1 && cat \"$TMPFILE\" && rm \"$TMPFILE\""
         case .copilot:
-            return "copilot -p \"$VOICEINK_FULL_PROMPT\" -s --no-ask-user 2>/dev/null"
+            return "copilot -p \"$VOICEINK_FULL_PROMPT\" -s --no-ask-user --deny-tool=\"shell,write,read,url,memory\" 2>/dev/null"
         }
     }
 }

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -26,7 +26,7 @@ enum LocalCLITemplate: String, CaseIterable, Identifiable {
         case .codex:
             return "TMPFILE=$(mktemp) && codex exec --skip-git-repo-check --output-last-message \"$TMPFILE\" \"$VOICEINK_FULL_PROMPT\" > /dev/null 2>&1 && cat \"$TMPFILE\" && rm \"$TMPFILE\""
         case .copilot:
-            return "copilot -p \"$VOICEINK_FULL_PROMPT\" -s --no-ask-user --deny-tool=\"shell,write,read,url,memory\" 2>/dev/null"
+            return "copilot -p \"$VOICEINK_FULL_PROMPT\" -s --no-ask-user --available-tools=__none__ 2>/dev/null"
         }
     }
 }

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -4,6 +4,7 @@ enum LocalCLITemplate: String, CaseIterable, Identifiable {
     case pi
     case claude
     case codex
+    case copilot
 
     var id: String { rawValue }
 
@@ -12,6 +13,7 @@ enum LocalCLITemplate: String, CaseIterable, Identifiable {
         case .pi: return "Pi"
         case .claude: return "Claude"
         case .codex: return "Codex"
+        case .copilot: return "Copilot"
         }
     }
 
@@ -23,6 +25,8 @@ enum LocalCLITemplate: String, CaseIterable, Identifiable {
             return "claude -p \"$VOICEINK_FULL_PROMPT\""
         case .codex:
             return "TMPFILE=$(mktemp) && codex exec --skip-git-repo-check --output-last-message \"$TMPFILE\" \"$VOICEINK_FULL_PROMPT\" > /dev/null 2>&1 && cat \"$TMPFILE\" && rm \"$TMPFILE\""
+        case .copilot:
+            return "copilot -p \"$VOICEINK_FULL_PROMPT\" -s --no-ask-user 2>/dev/null"
         }
     }
 }


### PR DESCRIPTION
Adds a new `Copilot` template to the `Local CLI` provider, using the Copilot CLI alongside the existing Pi, Claude, and Codex options.

### Command

```
copilot -p "$VOICEINK_FULL_PROMPT" -s --no-ask-user --available-tools=__none__ 2>/dev/null
```

- `-p` runs Copilot CLI in non-interactive mode and exits when done.
- `-s` suppresses stats and decoration so only the agent's response is written to stdout.
- `--no-ask-user` prevents the agent from pausing to ask follow-up questions.
- `--available-tools=__none__` sets a tool allowlist containing only an unknown name. This blocks **every** built-in, MCP, and external tool the agent could otherwise call (shell, file editing, web fetch, etc.) — analogous to Pi's `--no-tools`. The harmless "unknown tool name" warning is hidden by `-s`.
- `2>/dev/null` discards stderr noise.

### Notes

- Picked up automatically by the existing UI (`LocalCLITemplate.allCases` in `APIKeyManagementView`).
- Verified locally with `make local`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Copilot CLI template to the Local CLI provider so users can run text enhancement via `copilot` with clean, non-interactive output. Appears alongside Pi, Claude, and Codex in the UI.

- **New Features**
  - Adds `Copilot` template using `copilot -p "$VOICEINK_FULL_PROMPT" -s --no-ask-user --available-tools=__none__ 2>/dev/null` to return only the final response, block all tools, and drop stderr noise.

<sup>Written for commit b3e738fe08bf7848f65d2bd041ebb8ffb0714bfb. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/708?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

