### PR TITLE
Feature/punctuation cleanup mode

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -1,6 +1,17 @@
 import Foundation
 
 enum AppDefaults {
+    static func migrateDefaultsIfNeeded() {
+        guard UserDefaults.standard.object(forKey: PunctuationCleanupMode.userDefaultsKey) == nil else {
+            return
+        }
+
+        if UserDefaults.standard.object(forKey: PunctuationCleanupMode.legacyRemovePunctuationKey) != nil {
+            let mode: PunctuationCleanupMode = UserDefaults.standard.bool(forKey: PunctuationCleanupMode.legacyRemovePunctuationKey) ? .all : .keep
+            PunctuationCleanupMode.persist(mode)
+        }
+    }
+
     static func registerDefaults() {
         UserDefaults.standard.register(defaults: [
             // Onboarding & General
@@ -22,6 +33,7 @@ enum AppDefaults {
             "IsTextFormattingEnabled": true,
             "IsVADEnabled": true,
             "RemoveFillerWords": true,
+            "PunctuationCleanupMode": PunctuationCleanupMode.keep.rawValue,
             "RemovePunctuation": false,
             "LowercaseTranscription": false,
             "SelectedLanguage": "en",

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -31,7 +31,21 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var selectedTranscriptionModelName: String?
     var selectedLanguage: String?
     var isTextFormattingEnabled: Bool = false
-    var removePunctuation: Bool = false
+    var punctuationCleanupModeRawValue: String = PunctuationCleanupMode.keep.rawValue
+    var removePunctuation: Bool {
+        get { punctuationCleanupMode.removesAllPunctuation }
+        set {
+            if newValue {
+                punctuationCleanupMode = .all
+            } else if punctuationCleanupMode == .all {
+                punctuationCleanupMode = .keep
+            }
+        }
+    }
+    var punctuationCleanupMode: PunctuationCleanupMode {
+        get { PunctuationCleanupMode.mode(rawValue: punctuationCleanupModeRawValue, legacyRemovePunctuation: false) }
+        set { punctuationCleanupModeRawValue = newValue.rawValue }
+    }
     var lowercaseTranscription: Bool = false
     var useScreenCapture: Bool
     var selectedAIProvider: String?
@@ -41,7 +55,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var isDefault: Bool = false
         
     enum CodingKeys: String, CodingKey {
-        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, removePunctuation, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
+        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, punctuationCleanupMode, removePunctuation, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
         case selectedWhisperModel
         case selectedTranscriptionModelName
     }
@@ -50,6 +64,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
          urlConfigs: [URLConfig]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, selectedLanguage: String? = nil, useScreenCapture: Bool = false,
          isTextFormattingEnabled: Bool = false, removePunctuation: Bool = false, lowercaseTranscription: Bool = false,
+         punctuationCleanupModeRawValue: String? = nil,
          selectedAIProvider: String? = nil, selectedAIModel: String? = nil, autoSendKey: AutoSendKey = .none, isEnabled: Bool = true, isDefault: Bool = false) {
         self.id = id
         self.name = name
@@ -65,7 +80,10 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         self.selectedTranscriptionModelName = selectedTranscriptionModelName ?? UserDefaults.standard.string(forKey: "CurrentTranscriptionModel")
         self.selectedLanguage = selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
         self.isTextFormattingEnabled = isTextFormattingEnabled
-        self.removePunctuation = removePunctuation
+        self.punctuationCleanupModeRawValue = PunctuationCleanupMode.mode(
+            rawValue: punctuationCleanupModeRawValue,
+            legacyRemovePunctuation: removePunctuation
+        ).rawValue
         self.lowercaseTranscription = lowercaseTranscription
         self.isEnabled = isEnabled
         self.isDefault = isDefault
@@ -82,7 +100,12 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         selectedPrompt = try container.decodeIfPresent(String.self, forKey: .selectedPrompt)
         selectedLanguage = try container.decodeIfPresent(String.self, forKey: .selectedLanguage)
         isTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isTextFormattingEnabled) ?? false
-        removePunctuation = try container.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+        let legacyRemovePunctuation = try container.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+        let rawPunctuationCleanupMode = try container.decodeIfPresent(String.self, forKey: .punctuationCleanupMode)
+        punctuationCleanupModeRawValue = PunctuationCleanupMode.mode(
+            rawValue: rawPunctuationCleanupMode,
+            legacyRemovePunctuation: legacyRemovePunctuation
+        ).rawValue
         lowercaseTranscription = try container.decodeIfPresent(Bool.self, forKey: .lowercaseTranscription) ?? false
         useScreenCapture = try container.decode(Bool.self, forKey: .useScreenCapture)
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
@@ -119,6 +142,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         try container.encodeIfPresent(selectedPrompt, forKey: .selectedPrompt)
         try container.encodeIfPresent(selectedLanguage, forKey: .selectedLanguage)
         try container.encode(isTextFormattingEnabled, forKey: .isTextFormattingEnabled)
+        try container.encode(punctuationCleanupModeRawValue, forKey: .punctuationCleanupMode)
         try container.encode(removePunctuation, forKey: .removePunctuation)
         try container.encode(lowercaseTranscription, forKey: .lowercaseTranscription)
         try container.encode(useScreenCapture, forKey: .useScreenCapture)

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -377,7 +377,7 @@ struct ConfigurationView: View {
                             } label: {
                                 HStack(spacing: 4) {
                                     Text("Punctuation")
-                                    InfoTip("Choose whether VoiceInk keeps punctuation, removes only a final period, or removes all punctuation from transcription output.")
+                                    InfoTip("Choose whether VoiceInk keeps punctuation, removes punctuation only from the end, or removes all punctuation from transcription output.")
                                 }
                             }
                             .pickerStyle(.menu)

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -18,7 +18,7 @@ struct ConfigurationView: View {
     @State private var selectedTranscriptionModelName: String?
     @State private var selectedLanguage: String?
     @State private var isTextFormattingEnabled = false
-    @State private var removePunctuation = false
+    @State private var punctuationCleanupMode = PunctuationCleanupMode.keep
     @State private var lowercaseTranscription = false
     @State private var installedApps: [(url: URL, name: String, bundleId: String, icon: NSImage)] = []
     @State private var searchText = ""
@@ -83,7 +83,7 @@ struct ConfigurationView: View {
             _selectedTranscriptionModelName = State(initialValue: nil)
             _selectedLanguage = State(initialValue: nil)
             _isTextFormattingEnabled = State(initialValue: false)
-            _removePunctuation = State(initialValue: false)
+            _punctuationCleanupMode = State(initialValue: .keep)
             _lowercaseTranscription = State(initialValue: false)
             _configName = State(initialValue: "")
             _selectedEmoji = State(initialValue: "✏️")
@@ -103,7 +103,7 @@ struct ConfigurationView: View {
             _selectedTranscriptionModelName = State(initialValue: latestConfig.selectedTranscriptionModelName)
             _selectedLanguage = State(initialValue: latestConfig.selectedLanguage)
             _isTextFormattingEnabled = State(initialValue: latestConfig.isTextFormattingEnabled)
-            _removePunctuation = State(initialValue: latestConfig.removePunctuation)
+            _punctuationCleanupMode = State(initialValue: latestConfig.punctuationCleanupMode)
             _lowercaseTranscription = State(initialValue: latestConfig.lowercaseTranscription)
             _configName = State(initialValue: latestConfig.name)
             _selectedEmoji = State(initialValue: latestConfig.emoji)
@@ -114,7 +114,7 @@ struct ConfigurationView: View {
             _isDefault = State(initialValue: latestConfig.isDefault)
             _selectedAIProvider = State(initialValue: latestConfig.selectedAIProvider)
             _selectedAIModel = State(initialValue: latestConfig.selectedAIModel)
-            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.removePunctuation || latestConfig.lowercaseTranscription)
+            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.punctuationCleanupMode != .keep || latestConfig.lowercaseTranscription)
         }
     }
 
@@ -370,12 +370,17 @@ struct ConfigurationView: View {
                                 }
                             }
 
-                            Toggle(isOn: $removePunctuation) {
+                            Picker(selection: $punctuationCleanupMode) {
+                                ForEach(PunctuationCleanupMode.allCases, id: \.self) { mode in
+                                    Text(mode.displayName).tag(mode)
+                                }
+                            } label: {
                                 HStack(spacing: 4) {
-                                    Text("Remove punctuation")
-                                    InfoTip("Remove punctuation marks from transcription output.")
+                                    Text("Punctuation")
+                                    InfoTip("Choose whether VoiceInk keeps punctuation, removes only a final period, or removes all punctuation from transcription output.")
                                 }
                             }
+                            .pickerStyle(.menu)
 
                             Toggle(isOn: $lowercaseTranscription) {
                                 HStack(spacing: 4) {
@@ -630,8 +635,8 @@ struct ConfigurationView: View {
                 selectedLanguage: selectedLanguage,
                 useScreenCapture: useScreenCapture,
                 isTextFormattingEnabled: isTextFormattingEnabled,
-                removePunctuation: removePunctuation,
                 lowercaseTranscription: lowercaseTranscription,
+                punctuationCleanupModeRawValue: punctuationCleanupMode.rawValue,
                 selectedAIProvider: selectedAIProvider,
                 selectedAIModel: selectedAIModel,
                 autoSendKey: autoSendKey,
@@ -646,7 +651,7 @@ struct ConfigurationView: View {
             updatedConfig.selectedTranscriptionModelName = selectedTranscriptionModelName
             updatedConfig.selectedLanguage = selectedLanguage
             updatedConfig.isTextFormattingEnabled = isTextFormattingEnabled
-            updatedConfig.removePunctuation = removePunctuation
+            updatedConfig.punctuationCleanupMode = punctuationCleanupMode
             updatedConfig.lowercaseTranscription = lowercaseTranscription
             updatedConfig.appConfigs = selectedAppConfigs.isEmpty ? nil : selectedAppConfigs
             updatedConfig.urlConfigs = websiteConfigs.isEmpty ? nil : websiteConfigs

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -10,6 +10,7 @@ struct ApplicationState: Codable {
     var selectedLanguage: String?
     var transcriptionModelName: String?
     var isTextFormattingEnabled: Bool?
+    var punctuationCleanupModeRawValue: String?
     var removePunctuation: Bool?
     var lowercaseTranscription: Bool?
 }
@@ -56,6 +57,7 @@ class PowerModeSessionManager {
                 selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
                 transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
                 isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
+                punctuationCleanupModeRawValue: PunctuationCleanupMode.current.rawValue,
                 removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
                 lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
             )
@@ -108,6 +110,7 @@ class PowerModeSessionManager {
             selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
             transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
+            punctuationCleanupModeRawValue: PunctuationCleanupMode.current.rawValue,
             removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
             lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
         )
@@ -140,7 +143,7 @@ class PowerModeSessionManager {
             }
 
             UserDefaults.standard.set(config.isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
-            UserDefaults.standard.set(config.removePunctuation, forKey: "RemovePunctuation")
+            PunctuationCleanupMode.persist(config.punctuationCleanupMode)
             UserDefaults.standard.set(config.lowercaseTranscription, forKey: "LowercaseTranscription")
         }
 
@@ -180,8 +183,10 @@ class PowerModeSessionManager {
             if let isTextFormattingEnabled = state.isTextFormattingEnabled {
                 UserDefaults.standard.set(isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
             }
-            if let removePunctuation = state.removePunctuation {
-                UserDefaults.standard.set(removePunctuation, forKey: "RemovePunctuation")
+            if let punctuationCleanupModeRawValue = state.punctuationCleanupModeRawValue {
+                PunctuationCleanupMode.persist(rawValue: punctuationCleanupModeRawValue)
+            } else if let removePunctuation = state.removePunctuation {
+                PunctuationCleanupMode.persist(removePunctuation ? .all : .keep)
             }
             if let lowercaseTranscription = state.lowercaseTranscription {
                 UserDefaults.standard.set(lowercaseTranscription, forKey: "LowercaseTranscription")

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -20,7 +20,6 @@ enum BackupImporter {
     private static let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
     private static let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
-    private static let keyRemovePunctuation = "RemovePunctuation"
     private static let keyLowercaseTranscription = "LowercaseTranscription"
 
     @MainActor
@@ -188,8 +187,11 @@ enum BackupImporter {
         if let textFormattingEnabled = general.isTextFormattingEnabled {
             UserDefaults.standard.set(textFormattingEnabled, forKey: keyIsTextFormattingEnabled)
         }
-        if let removePunctuation = general.removePunctuation {
-            UserDefaults.standard.set(removePunctuation, forKey: keyRemovePunctuation)
+        if let punctuationCleanupMode = general.punctuationCleanupMode,
+           let mode = PunctuationCleanupMode(rawValue: punctuationCleanupMode) {
+            PunctuationCleanupMode.persist(mode)
+        } else if let removePunctuation = general.removePunctuation {
+            PunctuationCleanupMode.persist(removePunctuation ? .all : .keep)
         }
         if let lowercaseTranscription = general.lowercaseTranscription {
             UserDefaults.standard.set(lowercaseTranscription, forKey: keyLowercaseTranscription)

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -95,6 +95,7 @@ struct GeneralBackup: Codable {
     let isPauseMediaEnabled: Bool?
     let audioResumptionDelay: Double?
     let isTextFormattingEnabled: Bool?
+    let punctuationCleanupMode: String?
     let removePunctuation: Bool?
     let lowercaseTranscription: Bool?
     let isExperimentalFeaturesEnabled: Bool?

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -111,7 +111,6 @@ class ImportExportService {
     private let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
     private let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
-    private let keyRemovePunctuation = "RemovePunctuation"
     private let keyLowercaseTranscription = "LowercaseTranscription"
 
     private init() {
@@ -181,7 +180,8 @@ class ImportExportService {
             isPauseMediaEnabled: playbackController.isPauseMediaEnabled,
             audioResumptionDelay: mediaController.audioResumptionDelay,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: keyIsTextFormattingEnabled),
-            removePunctuation: UserDefaults.standard.bool(forKey: keyRemovePunctuation),
+            punctuationCleanupMode: PunctuationCleanupMode.current.rawValue,
+            removePunctuation: PunctuationCleanupMode.current.removesAllPunctuation,
             lowercaseTranscription: UserDefaults.standard.bool(forKey: keyLowercaseTranscription),
             isExperimentalFeaturesEnabled: UserDefaults.standard.bool(forKey: "isExperimentalFeaturesEnabled"),
             restoreClipboardAfterPaste: UserDefaults.standard.bool(forKey: "restoreClipboardAfterPaste"),

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum PunctuationCleanupMode: String, CaseIterable, Codable {
     case keep
-    case trailingPeriod
+    case trailingPunctuation
     case all
 
     static let userDefaultsKey = "PunctuationCleanupMode"
@@ -12,8 +12,8 @@ enum PunctuationCleanupMode: String, CaseIterable, Codable {
         switch self {
         case .keep:
             return "Keep punctuation"
-        case .trailingPeriod:
-            return "Remove trailing period"
+        case .trailingPunctuation:
+            return "Remove trailing punctuation"
         case .all:
             return "Remove all punctuation"
         }
@@ -31,6 +31,10 @@ enum PunctuationCleanupMode: String, CaseIterable, Codable {
     }
 
     static func mode(rawValue: String?, legacyRemovePunctuation: Bool) -> PunctuationCleanupMode {
+        if rawValue == "trailingPeriod" {
+            return .trailingPunctuation
+        }
+
         if let rawValue, let mode = PunctuationCleanupMode(rawValue: rawValue) {
             return mode
         }
@@ -51,6 +55,7 @@ enum PunctuationCleanupMode: String, CaseIterable, Codable {
 struct TranscriptionOutputFilter {
     private static let lowercaseTranscriptionKey = "LowercaseTranscription"
     private static let apostropheLikeCharacters = CharacterSet(charactersIn: "'’‘ʼ＇")
+    private static let trailingPunctuationCharacters = CharacterSet.punctuationCharacters.subtracting(apostropheLikeCharacters)
     
     private static let hallucinationPatterns = [
         #"\[.*?\]"#,     // []
@@ -106,8 +111,8 @@ struct TranscriptionOutputFilter {
         switch punctuationCleanupMode {
         case .keep:
             break
-        case .trailingPeriod:
-            cleanedText = removeTrailingPeriod(from: cleanedText)
+        case .trailingPunctuation:
+            cleanedText = removeTrailingPunctuation(from: cleanedText)
         case .all:
             cleanedText = removePunctuation(from: cleanedText)
         }
@@ -137,7 +142,7 @@ struct TranscriptionOutputFilter {
         return normalizeWhitespace(cleanedScalars.joined())
     }
 
-    static func removeTrailingPeriod(from text: String) -> String {
+    static func removeTrailingPunctuation(from text: String) -> String {
         guard !text.isEmpty else { return text }
 
         var endOfContent = text.endIndex
@@ -152,19 +157,23 @@ struct TranscriptionOutputFilter {
 
         guard endOfContent > text.startIndex else { return text }
 
-        let lastCharacterIndex = text.index(before: endOfContent)
-        guard text[lastCharacterIndex] == "." else { return text }
-
-        if lastCharacterIndex > text.startIndex {
-            let previousIndex = text.index(before: lastCharacterIndex)
-            if text[previousIndex] == "." {
-                return text
+        var punctuationStart = endOfContent
+        while punctuationStart > text.startIndex {
+            let previousIndex = text.index(before: punctuationStart)
+            if isTrailingPunctuation(text[previousIndex]) {
+                punctuationStart = previousIndex
+            } else {
+                break
             }
         }
 
-        var cleanedText = text
-        cleanedText.remove(at: lastCharacterIndex)
-        return cleanedText
+        guard punctuationStart < endOfContent else { return text }
+
+        return String(text[..<punctuationStart] + text[endOfContent...])
+    }
+
+    private static func isTrailingPunctuation(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { trailingPunctuationCharacters.contains($0) }
     }
 
     private static func normalizeWhitespace(_ text: String) -> String {

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -1,7 +1,54 @@
 import Foundation
 
+enum PunctuationCleanupMode: String, CaseIterable, Codable {
+    case keep
+    case trailingPeriod
+    case all
+
+    static let userDefaultsKey = "PunctuationCleanupMode"
+    static let legacyRemovePunctuationKey = "RemovePunctuation"
+
+    var displayName: String {
+        switch self {
+        case .keep:
+            return "Keep punctuation"
+        case .trailingPeriod:
+            return "Remove trailing period"
+        case .all:
+            return "Remove all punctuation"
+        }
+    }
+
+    var removesAllPunctuation: Bool {
+        self == .all
+    }
+
+    static var current: PunctuationCleanupMode {
+        mode(
+            rawValue: UserDefaults.standard.string(forKey: userDefaultsKey),
+            legacyRemovePunctuation: UserDefaults.standard.bool(forKey: legacyRemovePunctuationKey)
+        )
+    }
+
+    static func mode(rawValue: String?, legacyRemovePunctuation: Bool) -> PunctuationCleanupMode {
+        if let rawValue, let mode = PunctuationCleanupMode(rawValue: rawValue) {
+            return mode
+        }
+
+        return legacyRemovePunctuation ? .all : .keep
+    }
+
+    static func persist(_ mode: PunctuationCleanupMode) {
+        UserDefaults.standard.set(mode.rawValue, forKey: userDefaultsKey)
+        UserDefaults.standard.set(mode.removesAllPunctuation, forKey: legacyRemovePunctuationKey)
+    }
+
+    static func persist(rawValue: String) {
+        persist(PunctuationCleanupMode(rawValue: rawValue) ?? .keep)
+    }
+}
+
 struct TranscriptionOutputFilter {
-    private static let removePunctuationKey = "RemovePunctuation"
     private static let lowercaseTranscriptionKey = "LowercaseTranscription"
     private static let apostropheLikeCharacters = CharacterSet(charactersIn: "'’‘ʼ＇")
     
@@ -48,15 +95,20 @@ struct TranscriptionOutputFilter {
     }
 
     static func applyUserCleanupPreferences(_ text: String) -> String {
-        let shouldRemovePunctuation = UserDefaults.standard.bool(forKey: removePunctuationKey)
+        let punctuationCleanupMode = PunctuationCleanupMode.current
         let shouldLowercase = UserDefaults.standard.bool(forKey: lowercaseTranscriptionKey)
 
-        guard shouldRemovePunctuation || shouldLowercase else {
+        guard punctuationCleanupMode != .keep || shouldLowercase else {
             return text
         }
 
         var cleanedText = text
-        if shouldRemovePunctuation {
+        switch punctuationCleanupMode {
+        case .keep:
+            break
+        case .trailingPeriod:
+            cleanedText = removeTrailingPeriod(from: cleanedText)
+        case .all:
             cleanedText = removePunctuation(from: cleanedText)
         }
         if shouldLowercase {
@@ -83,6 +135,36 @@ struct TranscriptionOutputFilter {
         }
 
         return normalizeWhitespace(cleanedScalars.joined())
+    }
+
+    static func removeTrailingPeriod(from text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        var endOfContent = text.endIndex
+        while endOfContent > text.startIndex {
+            let previousIndex = text.index(before: endOfContent)
+            if text[previousIndex].isWhitespace {
+                endOfContent = previousIndex
+            } else {
+                break
+            }
+        }
+
+        guard endOfContent > text.startIndex else { return text }
+
+        let lastCharacterIndex = text.index(before: endOfContent)
+        guard text[lastCharacterIndex] == "." else { return text }
+
+        if lastCharacterIndex > text.startIndex {
+            let previousIndex = text.index(before: lastCharacterIndex)
+            if text[previousIndex] == "." {
+                return text
+            }
+        }
+
+        var cleanedText = text
+        cleanedText.remove(at: lastCharacterIndex)
+        return cleanedText
     }
 
     private static func normalizeWhitespace(_ text: String) -> String {

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -76,7 +76,7 @@ struct ModelSettingsView: View {
                 } label: {
                     HStack(spacing: 4) {
                         Text("Punctuation")
-                        InfoTip("Choose whether VoiceInk keeps punctuation, removes only a final period, or removes all punctuation from transcription output.")
+                        InfoTip("Choose whether VoiceInk keeps punctuation, removes punctuation only from the end, or removes all punctuation from transcription output.")
                     }
                 }
                 .pickerStyle(.menu)

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -4,7 +4,7 @@ struct ModelSettingsView: View {
     @ObservedObject var whisperPrompt: WhisperPrompt
     @AppStorage("SelectedLanguage") private var selectedLanguage: String = "en"
     @AppStorage("IsTextFormattingEnabled") private var isTextFormattingEnabled = true
-    @AppStorage("RemovePunctuation") private var removePunctuation = false
+    @AppStorage(PunctuationCleanupMode.userDefaultsKey) private var punctuationCleanupModeRawValue = PunctuationCleanupMode.keep.rawValue
     @AppStorage("LowercaseTranscription") private var lowercaseTranscription = false
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("AppendTrailingSpace") private var appendTrailingSpace = true
@@ -12,6 +12,16 @@ struct ModelSettingsView: View {
     @AppStorage("showLiveTextPreview") private var showLiveTextPreview = false
     @State private var customPrompt: String = ""
     @State private var isEditing: Bool = false
+
+    private var punctuationCleanupMode: Binding<PunctuationCleanupMode> {
+        Binding(
+            get: { PunctuationCleanupMode(rawValue: punctuationCleanupModeRawValue) ?? .keep },
+            set: { mode in
+                punctuationCleanupModeRawValue = mode.rawValue
+                PunctuationCleanupMode.persist(mode)
+            }
+        )
+    }
 
     var body: some View {
         Form {
@@ -59,13 +69,17 @@ struct ModelSettingsView: View {
                 }
                 .toggleStyle(.switch)
 
-                Toggle(isOn: $removePunctuation) {
+                Picker(selection: punctuationCleanupMode) {
+                    ForEach(PunctuationCleanupMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                } label: {
                     HStack(spacing: 4) {
-                        Text("Remove punctuation")
-                        InfoTip("Remove punctuation marks from transcription output.")
+                        Text("Punctuation")
+                        InfoTip("Choose whether VoiceInk keeps punctuation, removes only a final period, or removes all punctuation from transcription output.")
                     }
                 }
-                .toggleStyle(.switch)
+                .pickerStyle(.menu)
 
                 Toggle(isOn: $lowercaseTranscription) {
                     HStack(spacing: 4) {

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -40,6 +40,7 @@ struct VoiceInkApp: App {
         // Disable HTTP response caching — prevents API responses from being stored in Cache.db
         URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0)
 
+        AppDefaults.migrateDefaultsIfNeeded()
         AppDefaults.registerDefaults()
 
         if UserDefaults.standard.object(forKey: "powerModeUIFlag") == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a three-mode punctuation cleanup setting for transcriptions: keep, remove trailing punctuation, or remove all. Replaces the old Remove Punctuation toggle across settings, Power Mode, backups, and processing.

- New Features
  - Added `PunctuationCleanupMode` with Keep, Remove trailing punctuation, and Remove all.
  - Implemented trailing punctuation removal in the output filter (apostrophes are preserved).
  - Switched settings and Power Mode UI to a picker; default is Keep.
  - Power Mode config/session now persist and restore the new mode; `removePunctuation` is derived for legacy paths.

- Migration
  - On launch, old `RemovePunctuation` values are migrated to `PunctuationCleanupMode`.
  - Backup import/export reads/writes `punctuationCleanupMode` and still includes derived `removePunctuation` for compatibility.
  - No user action required.

<sup>Written for commit d39689b38812209f53b6392b3289e58368d09e8d. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/709?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

