### PR TITLE
Add punctuation mode picker with three modes: Keep, remove trailing, and remove all

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum AppDefaults {
     static func registerDefaults() {
+        PunctuationMode.migrateLegacyDefaultIfNeeded()
+
         UserDefaults.standard.register(defaults: [
             // Onboarding & General
             "hasCompletedOnboarding": false,
@@ -22,7 +24,7 @@ enum AppDefaults {
             "IsTextFormattingEnabled": true,
             "IsVADEnabled": true,
             "RemoveFillerWords": true,
-            "RemovePunctuation": false,
+            PunctuationMode.defaultsKey: PunctuationMode.keep.rawValue,
             "LowercaseTranscription": false,
             "SelectedLanguage": "en",
             "AppendTrailingSpace": true,

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -31,7 +31,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var selectedTranscriptionModelName: String?
     var selectedLanguage: String?
     var isTextFormattingEnabled: Bool = false
-    var removePunctuation: Bool = false
+    var punctuationMode: PunctuationMode = .keep
     var lowercaseTranscription: Bool = false
     var useScreenCapture: Bool
     var selectedAIProvider: String?
@@ -40,16 +40,20 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var isEnabled: Bool = true
     var isDefault: Bool = false
         
-    enum CodingKeys: String, CodingKey {
-        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, removePunctuation, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
+    private enum CodingKeys: String, CodingKey {
+        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, punctuationMode, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
         case selectedWhisperModel
         case selectedTranscriptionModelName
+    }
+
+    private enum LegacyCodingKeys: String, CodingKey {
+        case removePunctuation
     }
     
     init(id: UUID = UUID(), name: String, emoji: String, appConfigs: [AppConfig]? = nil,
          urlConfigs: [URLConfig]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, selectedLanguage: String? = nil, useScreenCapture: Bool = false,
-         isTextFormattingEnabled: Bool = false, removePunctuation: Bool = false, lowercaseTranscription: Bool = false,
+         isTextFormattingEnabled: Bool = false, punctuationMode: PunctuationMode = .keep, lowercaseTranscription: Bool = false,
          selectedAIProvider: String? = nil, selectedAIModel: String? = nil, autoSendKey: AutoSendKey = .none, isEnabled: Bool = true, isDefault: Bool = false) {
         self.id = id
         self.name = name
@@ -65,7 +69,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         self.selectedTranscriptionModelName = selectedTranscriptionModelName ?? UserDefaults.standard.string(forKey: "CurrentTranscriptionModel")
         self.selectedLanguage = selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
         self.isTextFormattingEnabled = isTextFormattingEnabled
-        self.removePunctuation = removePunctuation
+        self.punctuationMode = punctuationMode
         self.lowercaseTranscription = lowercaseTranscription
         self.isEnabled = isEnabled
         self.isDefault = isDefault
@@ -73,6 +77,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         emoji = try container.decode(String.self, forKey: .emoji)
@@ -82,7 +87,13 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         selectedPrompt = try container.decodeIfPresent(String.self, forKey: .selectedPrompt)
         selectedLanguage = try container.decodeIfPresent(String.self, forKey: .selectedLanguage)
         isTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isTextFormattingEnabled) ?? false
-        removePunctuation = try container.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+        if let rawPunctuationMode = try container.decodeIfPresent(String.self, forKey: .punctuationMode),
+           let decodedPunctuationMode = PunctuationMode(rawValue: rawPunctuationMode) {
+            punctuationMode = decodedPunctuationMode
+        } else {
+            let legacyRemovePunctuation = try legacyContainer.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+            punctuationMode = PunctuationMode(removePunctuation: legacyRemovePunctuation)
+        }
         lowercaseTranscription = try container.decodeIfPresent(Bool.self, forKey: .lowercaseTranscription) ?? false
         useScreenCapture = try container.decode(Bool.self, forKey: .useScreenCapture)
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
@@ -119,7 +130,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         try container.encodeIfPresent(selectedPrompt, forKey: .selectedPrompt)
         try container.encodeIfPresent(selectedLanguage, forKey: .selectedLanguage)
         try container.encode(isTextFormattingEnabled, forKey: .isTextFormattingEnabled)
-        try container.encode(removePunctuation, forKey: .removePunctuation)
+        try container.encode(punctuationMode, forKey: .punctuationMode)
         try container.encode(lowercaseTranscription, forKey: .lowercaseTranscription)
         try container.encode(useScreenCapture, forKey: .useScreenCapture)
         try container.encodeIfPresent(selectedAIProvider, forKey: .selectedAIProvider)

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -18,7 +18,7 @@ struct ConfigurationView: View {
     @State private var selectedTranscriptionModelName: String?
     @State private var selectedLanguage: String?
     @State private var isTextFormattingEnabled = false
-    @State private var removePunctuation = false
+    @State private var punctuationMode: PunctuationMode = .keep
     @State private var lowercaseTranscription = false
     @State private var installedApps: [(url: URL, name: String, bundleId: String, icon: NSImage)] = []
     @State private var searchText = ""
@@ -83,7 +83,7 @@ struct ConfigurationView: View {
             _selectedTranscriptionModelName = State(initialValue: nil)
             _selectedLanguage = State(initialValue: nil)
             _isTextFormattingEnabled = State(initialValue: false)
-            _removePunctuation = State(initialValue: false)
+            _punctuationMode = State(initialValue: .keep)
             _lowercaseTranscription = State(initialValue: false)
             _configName = State(initialValue: "")
             _selectedEmoji = State(initialValue: "✏️")
@@ -103,7 +103,7 @@ struct ConfigurationView: View {
             _selectedTranscriptionModelName = State(initialValue: latestConfig.selectedTranscriptionModelName)
             _selectedLanguage = State(initialValue: latestConfig.selectedLanguage)
             _isTextFormattingEnabled = State(initialValue: latestConfig.isTextFormattingEnabled)
-            _removePunctuation = State(initialValue: latestConfig.removePunctuation)
+            _punctuationMode = State(initialValue: latestConfig.punctuationMode)
             _lowercaseTranscription = State(initialValue: latestConfig.lowercaseTranscription)
             _configName = State(initialValue: latestConfig.name)
             _selectedEmoji = State(initialValue: latestConfig.emoji)
@@ -114,7 +114,7 @@ struct ConfigurationView: View {
             _isDefault = State(initialValue: latestConfig.isDefault)
             _selectedAIProvider = State(initialValue: latestConfig.selectedAIProvider)
             _selectedAIModel = State(initialValue: latestConfig.selectedAIModel)
-            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.removePunctuation || latestConfig.lowercaseTranscription)
+            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.punctuationMode != .keep || latestConfig.lowercaseTranscription)
         }
     }
 
@@ -370,12 +370,17 @@ struct ConfigurationView: View {
                                 }
                             }
 
-                            Toggle(isOn: $removePunctuation) {
+                            Picker(selection: $punctuationMode) {
+                                ForEach(PunctuationMode.allCases) { mode in
+                                    Text(mode.displayName).tag(mode)
+                                }
+                            } label: {
                                 HStack(spacing: 4) {
-                                    Text("Remove punctuation")
-                                    InfoTip("Remove punctuation marks from transcription output.")
+                                    Text("Punctuation")
+                                    InfoTip("Choose how you want punctuation handled in recording transcriptions. Keep leaves punctuation as-is, Remove ending removes punctuation from the end, and Remove all removes punctuation throughout the entire transcription text.")
                                 }
                             }
+                            .pickerStyle(.menu)
 
                             Toggle(isOn: $lowercaseTranscription) {
                                 HStack(spacing: 4) {
@@ -630,7 +635,7 @@ struct ConfigurationView: View {
                 selectedLanguage: selectedLanguage,
                 useScreenCapture: useScreenCapture,
                 isTextFormattingEnabled: isTextFormattingEnabled,
-                removePunctuation: removePunctuation,
+                punctuationMode: punctuationMode,
                 lowercaseTranscription: lowercaseTranscription,
                 selectedAIProvider: selectedAIProvider,
                 selectedAIModel: selectedAIModel,
@@ -646,7 +651,7 @@ struct ConfigurationView: View {
             updatedConfig.selectedTranscriptionModelName = selectedTranscriptionModelName
             updatedConfig.selectedLanguage = selectedLanguage
             updatedConfig.isTextFormattingEnabled = isTextFormattingEnabled
-            updatedConfig.removePunctuation = removePunctuation
+            updatedConfig.punctuationMode = punctuationMode
             updatedConfig.lowercaseTranscription = lowercaseTranscription
             updatedConfig.appConfigs = selectedAppConfigs.isEmpty ? nil : selectedAppConfigs
             updatedConfig.urlConfigs = websiteConfigs.isEmpty ? nil : websiteConfigs

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -10,6 +10,7 @@ struct ApplicationState: Codable {
     var selectedLanguage: String?
     var transcriptionModelName: String?
     var isTextFormattingEnabled: Bool?
+    var punctuationMode: PunctuationMode?
     var removePunctuation: Bool?
     var lowercaseTranscription: Bool?
 }
@@ -56,7 +57,8 @@ class PowerModeSessionManager {
                 selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
                 transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
                 isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
-                removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
+                punctuationMode: UserDefaults.standard.punctuationMode,
+                removePunctuation: nil,
                 lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
             )
 
@@ -108,7 +110,8 @@ class PowerModeSessionManager {
             selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
             transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
-            removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
+            punctuationMode: UserDefaults.standard.punctuationMode,
+            removePunctuation: nil,
             lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
         )
 
@@ -140,7 +143,7 @@ class PowerModeSessionManager {
             }
 
             UserDefaults.standard.set(config.isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
-            UserDefaults.standard.set(config.removePunctuation, forKey: "RemovePunctuation")
+            UserDefaults.standard.punctuationMode = config.punctuationMode
             UserDefaults.standard.set(config.lowercaseTranscription, forKey: "LowercaseTranscription")
         }
 
@@ -180,8 +183,10 @@ class PowerModeSessionManager {
             if let isTextFormattingEnabled = state.isTextFormattingEnabled {
                 UserDefaults.standard.set(isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
             }
-            if let removePunctuation = state.removePunctuation {
-                UserDefaults.standard.set(removePunctuation, forKey: "RemovePunctuation")
+            if let punctuationMode = state.punctuationMode {
+                UserDefaults.standard.punctuationMode = punctuationMode
+            } else if let removePunctuation = state.removePunctuation {
+                UserDefaults.standard.punctuationMode = PunctuationMode(removePunctuation: removePunctuation)
             }
             if let lowercaseTranscription = state.lowercaseTranscription {
                 UserDefaults.standard.set(lowercaseTranscription, forKey: "LowercaseTranscription")

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -20,7 +20,6 @@ enum BackupImporter {
     private static let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
     private static let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
-    private static let keyRemovePunctuation = "RemovePunctuation"
     private static let keyLowercaseTranscription = "LowercaseTranscription"
 
     @MainActor
@@ -188,8 +187,10 @@ enum BackupImporter {
         if let textFormattingEnabled = general.isTextFormattingEnabled {
             UserDefaults.standard.set(textFormattingEnabled, forKey: keyIsTextFormattingEnabled)
         }
-        if let removePunctuation = general.removePunctuation {
-            UserDefaults.standard.set(removePunctuation, forKey: keyRemovePunctuation)
+        if let punctuationMode = general.punctuationMode {
+            UserDefaults.standard.punctuationMode = punctuationMode
+        } else {
+            UserDefaults.standard.punctuationMode = .keep
         }
         if let lowercaseTranscription = general.lowercaseTranscription {
             UserDefaults.standard.set(lowercaseTranscription, forKey: keyLowercaseTranscription)

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -95,7 +95,7 @@ struct GeneralBackup: Codable {
     let isPauseMediaEnabled: Bool?
     let audioResumptionDelay: Double?
     let isTextFormattingEnabled: Bool?
-    let removePunctuation: Bool?
+    let punctuationMode: PunctuationMode?
     let lowercaseTranscription: Bool?
     let isExperimentalFeaturesEnabled: Bool?
     let restoreClipboardAfterPaste: Bool?

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -111,7 +111,6 @@ class ImportExportService {
     private let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
     private let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
-    private let keyRemovePunctuation = "RemovePunctuation"
     private let keyLowercaseTranscription = "LowercaseTranscription"
 
     private init() {
@@ -152,6 +151,7 @@ class ImportExportService {
             exportedWordReplacements = Dictionary(replacements.map { ($0.originalText, $0.replacementText) }, uniquingKeysWith: { _, last in last })
         }
 
+        let punctuationMode = UserDefaults.standard.punctuationMode
         let generalSettingsToExport = GeneralBackup(
             primaryRecordingShortcut: ShortcutStore.shortcut(for: .primaryRecording).map(ShortcutBackup.init),
             secondaryRecordingShortcut: ShortcutStore.shortcut(for: .secondaryRecording).map(ShortcutBackup.init),
@@ -181,7 +181,7 @@ class ImportExportService {
             isPauseMediaEnabled: playbackController.isPauseMediaEnabled,
             audioResumptionDelay: mediaController.audioResumptionDelay,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: keyIsTextFormattingEnabled),
-            removePunctuation: UserDefaults.standard.bool(forKey: keyRemovePunctuation),
+            punctuationMode: punctuationMode,
             lowercaseTranscription: UserDefaults.standard.bool(forKey: keyLowercaseTranscription),
             isExperimentalFeaturesEnabled: UserDefaults.standard.bool(forKey: "isExperimentalFeaturesEnabled"),
             restoreClipboardAfterPaste: UserDefaults.standard.bool(forKey: "restoreClipboardAfterPaste"),

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -80,7 +80,7 @@ class TranscriptionPipeline {
             }
 
             text = WordReplacementService.shared.applyReplacements(to: text, using: modelContext)
-            let cleanedText = TranscriptionOutputFilter.applyUserCleanupPreferences(text)
+            let cleanedText = TranscriptionOutputFilter.applyRecordingCleanupPreferences(text)
 
             let audioAsset = AVURLAsset(url: audioURL)
             let actualDuration = (try? CMTimeGetSeconds(await audioAsset.load(.duration))) ?? 0.0

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -1,7 +1,74 @@
 import Foundation
 
+enum PunctuationMode: String, Codable, CaseIterable, Identifiable {
+    case keep
+    case removeTrailing
+    case removeAll
+
+    static let defaultsKey = "PunctuationMode"
+    static let legacyRemovePunctuationKey = "RemovePunctuation"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .keep:
+            return "Keep"
+        case .removeTrailing:
+            return "Remove ending"
+        case .removeAll:
+            return "Remove all"
+        }
+    }
+
+    var helpText: String {
+        switch self {
+        case .keep:
+            return "Keep punctuation from recording transcription output."
+        case .removeTrailing:
+            return "Remove punctuation only from the end of recording transcription output."
+        case .removeAll:
+            return "Remove all punctuation marks from recording transcription output."
+        }
+    }
+
+    init(removePunctuation: Bool) {
+        self = removePunctuation ? .removeAll : .keep
+    }
+
+    static func stored(in defaults: UserDefaults = .standard) -> PunctuationMode {
+        if let rawValue = defaults.string(forKey: defaultsKey),
+           let mode = PunctuationMode(rawValue: rawValue) {
+            return mode
+        }
+
+        return PunctuationMode(
+            removePunctuation: defaults.bool(forKey: legacyRemovePunctuationKey)
+        )
+    }
+
+    static func persist(_ mode: PunctuationMode, in defaults: UserDefaults = .standard) {
+        defaults.set(mode.rawValue, forKey: defaultsKey)
+    }
+
+    static func migrateLegacyDefaultIfNeeded(in defaults: UserDefaults = .standard) {
+        guard defaults.object(forKey: defaultsKey) == nil else { return }
+        persist(stored(in: defaults), in: defaults)
+    }
+}
+
+extension UserDefaults {
+    var punctuationMode: PunctuationMode {
+        get {
+            PunctuationMode.stored(in: self)
+        }
+        set {
+            PunctuationMode.persist(newValue, in: self)
+        }
+    }
+}
+
 struct TranscriptionOutputFilter {
-    private static let removePunctuationKey = "RemovePunctuation"
     private static let lowercaseTranscriptionKey = "LowercaseTranscription"
     private static let apostropheLikeCharacters = CharacterSet(charactersIn: "'’‘ʼ＇")
     
@@ -48,17 +115,30 @@ struct TranscriptionOutputFilter {
     }
 
     static func applyUserCleanupPreferences(_ text: String) -> String {
-        let shouldRemovePunctuation = UserDefaults.standard.bool(forKey: removePunctuationKey)
+        applyCleanupPreferences(text, punctuationMode: .keep)
+    }
+
+    static func applyRecordingCleanupPreferences(_ text: String) -> String {
+        applyCleanupPreferences(text, punctuationMode: UserDefaults.standard.punctuationMode)
+    }
+
+    private static func applyCleanupPreferences(_ text: String, punctuationMode: PunctuationMode) -> String {
         let shouldLowercase = UserDefaults.standard.bool(forKey: lowercaseTranscriptionKey)
 
-        guard shouldRemovePunctuation || shouldLowercase else {
+        guard punctuationMode != .keep || shouldLowercase else {
             return text
         }
 
         var cleanedText = text
-        if shouldRemovePunctuation {
+        switch punctuationMode {
+        case .keep:
+            break
+        case .removeTrailing:
+            cleanedText = removeTrailingPunctuation(from: cleanedText)
+        case .removeAll:
             cleanedText = removePunctuation(from: cleanedText)
         }
+
         if shouldLowercase {
             cleanedText = cleanedText.lowercased()
         }
@@ -83,6 +163,21 @@ struct TranscriptionOutputFilter {
         }
 
         return normalizeWhitespace(cleanedScalars.joined())
+    }
+
+    static func removeTrailingPunctuation(from text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        let punctuationCharacters = CharacterSet.punctuationCharacters.union(apostropheLikeCharacters)
+        var cleanedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        while let lastScalar = cleanedText.unicodeScalars.last,
+              punctuationCharacters.contains(lastScalar) {
+            cleanedText.removeLast()
+            cleanedText = cleanedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return cleanedText
     }
 
     private static func normalizeWhitespace(_ text: String) -> String {

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -4,7 +4,7 @@ struct ModelSettingsView: View {
     @ObservedObject var whisperPrompt: WhisperPrompt
     @AppStorage("SelectedLanguage") private var selectedLanguage: String = "en"
     @AppStorage("IsTextFormattingEnabled") private var isTextFormattingEnabled = true
-    @AppStorage("RemovePunctuation") private var removePunctuation = false
+    @AppStorage(PunctuationMode.defaultsKey) private var punctuationMode: PunctuationMode = .keep
     @AppStorage("LowercaseTranscription") private var lowercaseTranscription = false
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("AppendTrailingSpace") private var appendTrailingSpace = true
@@ -12,6 +12,16 @@ struct ModelSettingsView: View {
     @AppStorage("showLiveTextPreview") private var showLiveTextPreview = false
     @State private var customPrompt: String = ""
     @State private var isEditing: Bool = false
+
+    private var punctuationModeBinding: Binding<PunctuationMode> {
+        Binding(
+            get: { punctuationMode },
+            set: { newValue in
+                punctuationMode = newValue
+                UserDefaults.standard.punctuationMode = newValue
+            }
+        )
+    }
 
     var body: some View {
         Form {
@@ -59,13 +69,17 @@ struct ModelSettingsView: View {
                 }
                 .toggleStyle(.switch)
 
-                Toggle(isOn: $removePunctuation) {
+                Picker(selection: punctuationModeBinding) {
+                    ForEach(PunctuationMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                } label: {
                     HStack(spacing: 4) {
-                        Text("Remove punctuation")
-                        InfoTip("Remove punctuation marks from transcription output.")
+                        Text("Punctuation")
+                        InfoTip("Choose how you want punctuation handled in recording transcriptions. Keep leaves punctuation as-is, Remove ending removes punctuation from the end, and Remove all removes punctuation throughout the entire transcription text.")
                     }
                 }
-                .toggleStyle(.switch)
+                .pickerStyle(.menu)
 
                 Toggle(isOn: $lowercaseTranscription) {
                     HStack(spacing: 4) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a punctuation mode picker for recording transcriptions with three options: Keep, Remove ending, and Remove all. Replaces the old “Remove punctuation” toggle and applies during recording cleanup.

- New Features
  - Introduced `PunctuationMode` (`keep`, `removeTrailing`, `removeAll`) with `UserDefaults` support.
  - Replaced the toggle with a picker in Model Settings and Power Mode.
  - Recording cleanup pipeline respects the selected mode.
  - Updated Power Mode config, session state, and backup import/export to store `punctuationMode`.

- Migration
  - Legacy `RemovePunctuation` maps to `punctuationMode` (`true` → `removeAll`, `false` → `keep`).
  - Defaults migrate on startup; decoding supports legacy; encoding writes the new key.

<sup>Written for commit 6f5681ebd31993d33da5c9cf95a14da00d7e88a4. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/710?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

