### PR TITLE
Add punctuation cleanup mode

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -52,5 +52,7 @@ enum AppDefaults {
             "PrewarmModelOnWake": true,
 
         ])
+
+        PunctuationCleanupMode.migrateLegacyUserDefaultIfNeeded()
     }
 }

--- a/VoiceInk/PowerMode/PowerModeConfig.swift
+++ b/VoiceInk/PowerMode/PowerModeConfig.swift
@@ -31,7 +31,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var selectedTranscriptionModelName: String?
     var selectedLanguage: String?
     var isTextFormattingEnabled: Bool = false
-    var removePunctuation: Bool = false
+    var punctuationCleanupMode: PunctuationCleanupMode = .keep
     var lowercaseTranscription: Bool = false
     var useScreenCapture: Bool
     var selectedAIProvider: String?
@@ -41,7 +41,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     var isDefault: Bool = false
         
     enum CodingKeys: String, CodingKey {
-        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, removePunctuation, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
+        case id, name, emoji, appConfigs, urlConfigs, isAIEnhancementEnabled, selectedPrompt, selectedLanguage, isTextFormattingEnabled, punctuationCleanupMode, removePunctuation, lowercaseTranscription, useScreenCapture, selectedAIProvider, selectedAIModel, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
         case selectedWhisperModel
         case selectedTranscriptionModelName
     }
@@ -49,7 +49,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
     init(id: UUID = UUID(), name: String, emoji: String, appConfigs: [AppConfig]? = nil,
          urlConfigs: [URLConfig]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, selectedLanguage: String? = nil, useScreenCapture: Bool = false,
-         isTextFormattingEnabled: Bool = false, removePunctuation: Bool = false, lowercaseTranscription: Bool = false,
+         isTextFormattingEnabled: Bool = false, punctuationCleanupMode: PunctuationCleanupMode = .keep, lowercaseTranscription: Bool = false,
          selectedAIProvider: String? = nil, selectedAIModel: String? = nil, autoSendKey: AutoSendKey = .none, isEnabled: Bool = true, isDefault: Bool = false) {
         self.id = id
         self.name = name
@@ -65,7 +65,7 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         self.selectedTranscriptionModelName = selectedTranscriptionModelName ?? UserDefaults.standard.string(forKey: "CurrentTranscriptionModel")
         self.selectedLanguage = selectedLanguage ?? UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
         self.isTextFormattingEnabled = isTextFormattingEnabled
-        self.removePunctuation = removePunctuation
+        self.punctuationCleanupMode = punctuationCleanupMode
         self.lowercaseTranscription = lowercaseTranscription
         self.isEnabled = isEnabled
         self.isDefault = isDefault
@@ -82,7 +82,12 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         selectedPrompt = try container.decodeIfPresent(String.self, forKey: .selectedPrompt)
         selectedLanguage = try container.decodeIfPresent(String.self, forKey: .selectedLanguage)
         isTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isTextFormattingEnabled) ?? false
-        removePunctuation = try container.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+        if let mode = try container.decodeIfPresent(PunctuationCleanupMode.self, forKey: .punctuationCleanupMode) {
+            punctuationCleanupMode = mode
+        } else {
+            let removePunctuation = try container.decodeIfPresent(Bool.self, forKey: .removePunctuation) ?? false
+            punctuationCleanupMode = removePunctuation ? .removeAll : .keep
+        }
         lowercaseTranscription = try container.decodeIfPresent(Bool.self, forKey: .lowercaseTranscription) ?? false
         useScreenCapture = try container.decode(Bool.self, forKey: .useScreenCapture)
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
@@ -119,7 +124,8 @@ struct PowerModeConfig: Codable, Identifiable, Equatable {
         try container.encodeIfPresent(selectedPrompt, forKey: .selectedPrompt)
         try container.encodeIfPresent(selectedLanguage, forKey: .selectedLanguage)
         try container.encode(isTextFormattingEnabled, forKey: .isTextFormattingEnabled)
-        try container.encode(removePunctuation, forKey: .removePunctuation)
+        try container.encode(punctuationCleanupMode, forKey: .punctuationCleanupMode)
+        try container.encode(punctuationCleanupMode == .removeAll, forKey: .removePunctuation)
         try container.encode(lowercaseTranscription, forKey: .lowercaseTranscription)
         try container.encode(useScreenCapture, forKey: .useScreenCapture)
         try container.encodeIfPresent(selectedAIProvider, forKey: .selectedAIProvider)

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -18,7 +18,7 @@ struct ConfigurationView: View {
     @State private var selectedTranscriptionModelName: String?
     @State private var selectedLanguage: String?
     @State private var isTextFormattingEnabled = false
-    @State private var removePunctuation = false
+    @State private var punctuationCleanupMode: PunctuationCleanupMode = .keep
     @State private var lowercaseTranscription = false
     @State private var installedApps: [(url: URL, name: String, bundleId: String, icon: NSImage)] = []
     @State private var searchText = ""
@@ -83,7 +83,7 @@ struct ConfigurationView: View {
             _selectedTranscriptionModelName = State(initialValue: nil)
             _selectedLanguage = State(initialValue: nil)
             _isTextFormattingEnabled = State(initialValue: false)
-            _removePunctuation = State(initialValue: false)
+            _punctuationCleanupMode = State(initialValue: .keep)
             _lowercaseTranscription = State(initialValue: false)
             _configName = State(initialValue: "")
             _selectedEmoji = State(initialValue: "✏️")
@@ -103,7 +103,7 @@ struct ConfigurationView: View {
             _selectedTranscriptionModelName = State(initialValue: latestConfig.selectedTranscriptionModelName)
             _selectedLanguage = State(initialValue: latestConfig.selectedLanguage)
             _isTextFormattingEnabled = State(initialValue: latestConfig.isTextFormattingEnabled)
-            _removePunctuation = State(initialValue: latestConfig.removePunctuation)
+            _punctuationCleanupMode = State(initialValue: latestConfig.punctuationCleanupMode)
             _lowercaseTranscription = State(initialValue: latestConfig.lowercaseTranscription)
             _configName = State(initialValue: latestConfig.name)
             _selectedEmoji = State(initialValue: latestConfig.emoji)
@@ -114,7 +114,7 @@ struct ConfigurationView: View {
             _isDefault = State(initialValue: latestConfig.isDefault)
             _selectedAIProvider = State(initialValue: latestConfig.selectedAIProvider)
             _selectedAIModel = State(initialValue: latestConfig.selectedAIModel)
-            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.removePunctuation || latestConfig.lowercaseTranscription)
+            _isTranscriptFormattingExpanded = State(initialValue: latestConfig.isTextFormattingEnabled || latestConfig.punctuationCleanupMode != .keep || latestConfig.lowercaseTranscription)
         }
     }
 
@@ -370,12 +370,17 @@ struct ConfigurationView: View {
                                 }
                             }
 
-                            Toggle(isOn: $removePunctuation) {
+                            Picker(selection: $punctuationCleanupMode) {
+                                ForEach(PunctuationCleanupMode.allCases) { mode in
+                                    Text(mode.displayName).tag(mode)
+                                }
+                            } label: {
                                 HStack(spacing: 4) {
-                                    Text("Remove punctuation")
-                                    InfoTip("Remove punctuation marks from transcription output.")
+                                    Text("Punctuation")
+                                    InfoTip("Keep preserves punctuation as transcribed. Remove all strips punctuation marks from the transcribed text. Remove trailing period only removes a final period from the transcribed text.")
                                 }
                             }
+                            .pickerStyle(.menu)
 
                             Toggle(isOn: $lowercaseTranscription) {
                                 HStack(spacing: 4) {
@@ -630,7 +635,7 @@ struct ConfigurationView: View {
                 selectedLanguage: selectedLanguage,
                 useScreenCapture: useScreenCapture,
                 isTextFormattingEnabled: isTextFormattingEnabled,
-                removePunctuation: removePunctuation,
+                punctuationCleanupMode: punctuationCleanupMode,
                 lowercaseTranscription: lowercaseTranscription,
                 selectedAIProvider: selectedAIProvider,
                 selectedAIModel: selectedAIModel,
@@ -646,7 +651,7 @@ struct ConfigurationView: View {
             updatedConfig.selectedTranscriptionModelName = selectedTranscriptionModelName
             updatedConfig.selectedLanguage = selectedLanguage
             updatedConfig.isTextFormattingEnabled = isTextFormattingEnabled
-            updatedConfig.removePunctuation = removePunctuation
+            updatedConfig.punctuationCleanupMode = punctuationCleanupMode
             updatedConfig.lowercaseTranscription = lowercaseTranscription
             updatedConfig.appConfigs = selectedAppConfigs.isEmpty ? nil : selectedAppConfigs
             updatedConfig.urlConfigs = websiteConfigs.isEmpty ? nil : websiteConfigs

--- a/VoiceInk/PowerMode/PowerModeSessionManager.swift
+++ b/VoiceInk/PowerMode/PowerModeSessionManager.swift
@@ -10,6 +10,7 @@ struct ApplicationState: Codable {
     var selectedLanguage: String?
     var transcriptionModelName: String?
     var isTextFormattingEnabled: Bool?
+    var punctuationCleanupMode: PunctuationCleanupMode?
     var removePunctuation: Bool?
     var lowercaseTranscription: Bool?
 }
@@ -47,6 +48,7 @@ class PowerModeSessionManager {
 
         // Only capture baseline if NO session exists
         if loadSession() == nil {
+            let punctuationCleanupMode = PunctuationCleanupMode.current()
             let originalState = ApplicationState(
                 isEnhancementEnabled: enhancementService.isEnhancementEnabled,
                 useScreenCaptureContext: enhancementService.useScreenCaptureContext,
@@ -56,7 +58,8 @@ class PowerModeSessionManager {
                 selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
                 transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
                 isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
-                removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
+                punctuationCleanupMode: punctuationCleanupMode,
+                removePunctuation: punctuationCleanupMode == .removeAll,
                 lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
             )
 
@@ -99,6 +102,7 @@ class PowerModeSessionManager {
               let stateProvider = stateProvider,
               let enhancementService = enhancementService else { return }
 
+        let punctuationCleanupMode = PunctuationCleanupMode.current()
         let updatedState = ApplicationState(
             isEnhancementEnabled: enhancementService.isEnhancementEnabled,
             useScreenCaptureContext: enhancementService.useScreenCaptureContext,
@@ -108,7 +112,8 @@ class PowerModeSessionManager {
             selectedLanguage: UserDefaults.standard.string(forKey: "SelectedLanguage"),
             transcriptionModelName: stateProvider.currentTranscriptionModel?.name,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: "IsTextFormattingEnabled"),
-            removePunctuation: UserDefaults.standard.bool(forKey: "RemovePunctuation"),
+            punctuationCleanupMode: punctuationCleanupMode,
+            removePunctuation: punctuationCleanupMode == .removeAll,
             lowercaseTranscription: UserDefaults.standard.bool(forKey: "LowercaseTranscription")
         )
 
@@ -140,7 +145,7 @@ class PowerModeSessionManager {
             }
 
             UserDefaults.standard.set(config.isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
-            UserDefaults.standard.set(config.removePunctuation, forKey: "RemovePunctuation")
+            PunctuationCleanupMode.setCurrent(config.punctuationCleanupMode)
             UserDefaults.standard.set(config.lowercaseTranscription, forKey: "LowercaseTranscription")
         }
 
@@ -180,8 +185,10 @@ class PowerModeSessionManager {
             if let isTextFormattingEnabled = state.isTextFormattingEnabled {
                 UserDefaults.standard.set(isTextFormattingEnabled, forKey: "IsTextFormattingEnabled")
             }
-            if let removePunctuation = state.removePunctuation {
-                UserDefaults.standard.set(removePunctuation, forKey: "RemovePunctuation")
+            if let punctuationCleanupMode = state.punctuationCleanupMode {
+                PunctuationCleanupMode.setCurrent(punctuationCleanupMode)
+            } else if let removePunctuation = state.removePunctuation {
+                PunctuationCleanupMode.setCurrent(removePunctuation ? .removeAll : .keep)
             }
             if let lowercaseTranscription = state.lowercaseTranscription {
                 UserDefaults.standard.set(lowercaseTranscription, forKey: "LowercaseTranscription")

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -20,7 +20,6 @@ enum BackupImporter {
     private static let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
     private static let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
-    private static let keyRemovePunctuation = "RemovePunctuation"
     private static let keyLowercaseTranscription = "LowercaseTranscription"
 
     @MainActor
@@ -188,8 +187,10 @@ enum BackupImporter {
         if let textFormattingEnabled = general.isTextFormattingEnabled {
             UserDefaults.standard.set(textFormattingEnabled, forKey: keyIsTextFormattingEnabled)
         }
-        if let removePunctuation = general.removePunctuation {
-            UserDefaults.standard.set(removePunctuation, forKey: keyRemovePunctuation)
+        if let punctuationCleanupMode = general.punctuationCleanupMode {
+            PunctuationCleanupMode.setCurrent(punctuationCleanupMode)
+        } else if let removePunctuation = general.removePunctuation {
+            PunctuationCleanupMode.setCurrent(removePunctuation ? .removeAll : .keep)
         }
         if let lowercaseTranscription = general.lowercaseTranscription {
             UserDefaults.standard.set(lowercaseTranscription, forKey: keyLowercaseTranscription)

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -95,6 +95,7 @@ struct GeneralBackup: Codable {
     let isPauseMediaEnabled: Bool?
     let audioResumptionDelay: Double?
     let isTextFormattingEnabled: Bool?
+    let punctuationCleanupMode: PunctuationCleanupMode?
     let removePunctuation: Bool?
     let lowercaseTranscription: Bool?
     let isExperimentalFeaturesEnabled: Bool?

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -111,7 +111,6 @@ class ImportExportService {
     private let keyAudioRetentionPeriod = "AudioRetentionPeriod"
 
     private let keyIsTextFormattingEnabled = "IsTextFormattingEnabled"
-    private let keyRemovePunctuation = "RemovePunctuation"
     private let keyLowercaseTranscription = "LowercaseTranscription"
 
     private init() {
@@ -152,6 +151,7 @@ class ImportExportService {
             exportedWordReplacements = Dictionary(replacements.map { ($0.originalText, $0.replacementText) }, uniquingKeysWith: { _, last in last })
         }
 
+        let punctuationCleanupMode = PunctuationCleanupMode.current()
         let generalSettingsToExport = GeneralBackup(
             primaryRecordingShortcut: ShortcutStore.shortcut(for: .primaryRecording).map(ShortcutBackup.init),
             secondaryRecordingShortcut: ShortcutStore.shortcut(for: .secondaryRecording).map(ShortcutBackup.init),
@@ -181,7 +181,8 @@ class ImportExportService {
             isPauseMediaEnabled: playbackController.isPauseMediaEnabled,
             audioResumptionDelay: mediaController.audioResumptionDelay,
             isTextFormattingEnabled: UserDefaults.standard.bool(forKey: keyIsTextFormattingEnabled),
-            removePunctuation: UserDefaults.standard.bool(forKey: keyRemovePunctuation),
+            punctuationCleanupMode: punctuationCleanupMode,
+            removePunctuation: punctuationCleanupMode == .removeAll,
             lowercaseTranscription: UserDefaults.standard.bool(forKey: keyLowercaseTranscription),
             isExperimentalFeaturesEnabled: UserDefaults.standard.bool(forKey: "isExperimentalFeaturesEnabled"),
             restoreClipboardAfterPaste: UserDefaults.standard.bool(forKey: "restoreClipboardAfterPaste"),

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -1,7 +1,51 @@
 import Foundation
 
+enum PunctuationCleanupMode: String, Codable, CaseIterable, Identifiable {
+    case keep = "keep"
+    case removeAll = "removeAll"
+    case removeTrailingPeriod = "removeTrailingPeriod"
+
+    static let userDefaultsKey = "PunctuationCleanupMode"
+    static let legacyRemovePunctuationKey = "RemovePunctuation"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .keep:
+            return "Keep"
+        case .removeAll:
+            return "Remove all"
+        case .removeTrailingPeriod:
+            return "Remove trailing period"
+        }
+    }
+
+    static func current(in defaults: UserDefaults = .standard) -> PunctuationCleanupMode {
+        if let rawValue = defaults.string(forKey: userDefaultsKey),
+           let mode = PunctuationCleanupMode(rawValue: rawValue) {
+            return mode
+        }
+
+        return defaults.bool(forKey: legacyRemovePunctuationKey) ? .removeAll : .keep
+    }
+
+    static func setCurrent(_ mode: PunctuationCleanupMode, in defaults: UserDefaults = .standard) {
+        defaults.set(mode.rawValue, forKey: userDefaultsKey)
+        defaults.set(mode == .removeAll, forKey: legacyRemovePunctuationKey)
+    }
+
+    static func migrateLegacyUserDefaultIfNeeded(in defaults: UserDefaults = .standard) {
+        if let rawValue = defaults.string(forKey: userDefaultsKey),
+           PunctuationCleanupMode(rawValue: rawValue) != nil {
+            return
+        }
+
+        setCurrent(defaults.bool(forKey: legacyRemovePunctuationKey) ? .removeAll : .keep, in: defaults)
+    }
+}
+
 struct TranscriptionOutputFilter {
-    private static let removePunctuationKey = "RemovePunctuation"
     private static let lowercaseTranscriptionKey = "LowercaseTranscription"
     private static let apostropheLikeCharacters = CharacterSet(charactersIn: "'’‘ʼ＇")
     
@@ -48,22 +92,52 @@ struct TranscriptionOutputFilter {
     }
 
     static func applyUserCleanupPreferences(_ text: String) -> String {
-        let shouldRemovePunctuation = UserDefaults.standard.bool(forKey: removePunctuationKey)
+        let punctuationMode = PunctuationCleanupMode.current()
         let shouldLowercase = UserDefaults.standard.bool(forKey: lowercaseTranscriptionKey)
 
-        guard shouldRemovePunctuation || shouldLowercase else {
+        return applyCleanupPreferences(text, punctuationMode: punctuationMode, shouldLowercase: shouldLowercase)
+    }
+
+    static func applyCleanupPreferences(_ text: String, punctuationMode: PunctuationCleanupMode, shouldLowercase: Bool) -> String {
+        guard punctuationMode != .keep || shouldLowercase else {
             return text
         }
 
         var cleanedText = text
-        if shouldRemovePunctuation {
+        switch punctuationMode {
+        case .keep:
+            break
+        case .removeAll:
             cleanedText = removePunctuation(from: cleanedText)
+        case .removeTrailingPeriod:
+            cleanedText = removeTrailingPeriod(from: cleanedText)
         }
+
         if shouldLowercase {
             cleanedText = cleanedText.lowercased()
         }
 
         return cleanedText
+    }
+
+    static func removeTrailingPeriod(from text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        let trailingWhitespace = text.reversed().prefix { $0.isWhitespace }
+        let trimmedEndIndex = text.index(text.endIndex, offsetBy: -trailingWhitespace.count)
+        guard trimmedEndIndex > text.startIndex else { return text }
+
+        let lastCharIndex = text.index(before: trimmedEndIndex)
+        guard text[lastCharIndex] == "." else { return text }
+
+        if lastCharIndex > text.startIndex {
+            let previousCharIndex = text.index(before: lastCharIndex)
+            guard text[previousCharIndex] != "." else { return text }
+        }
+
+        var result = text
+        result.remove(at: lastCharIndex)
+        return result
     }
 
     static func removePunctuation(from text: String) -> String {

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -4,7 +4,7 @@ struct ModelSettingsView: View {
     @ObservedObject var whisperPrompt: WhisperPrompt
     @AppStorage("SelectedLanguage") private var selectedLanguage: String = "en"
     @AppStorage("IsTextFormattingEnabled") private var isTextFormattingEnabled = true
-    @AppStorage("RemovePunctuation") private var removePunctuation = false
+    @AppStorage(PunctuationCleanupMode.userDefaultsKey) private var punctuationCleanupModeRaw = PunctuationCleanupMode.current().rawValue
     @AppStorage("LowercaseTranscription") private var lowercaseTranscription = false
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("AppendTrailingSpace") private var appendTrailingSpace = true
@@ -12,6 +12,18 @@ struct ModelSettingsView: View {
     @AppStorage("showLiveTextPreview") private var showLiveTextPreview = false
     @State private var customPrompt: String = ""
     @State private var isEditing: Bool = false
+
+    private var punctuationCleanupMode: Binding<PunctuationCleanupMode> {
+        Binding(
+            get: {
+                PunctuationCleanupMode(rawValue: punctuationCleanupModeRaw) ?? PunctuationCleanupMode.current()
+            },
+            set: { newMode in
+                punctuationCleanupModeRaw = newMode.rawValue
+                PunctuationCleanupMode.setCurrent(newMode)
+            }
+        )
+    }
 
     var body: some View {
         Form {
@@ -59,13 +71,17 @@ struct ModelSettingsView: View {
                 }
                 .toggleStyle(.switch)
 
-                Toggle(isOn: $removePunctuation) {
+                Picker(selection: punctuationCleanupMode) {
+                    ForEach(PunctuationCleanupMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                } label: {
                     HStack(spacing: 4) {
-                        Text("Remove punctuation")
-                        InfoTip("Remove punctuation marks from transcription output.")
+                        Text("Punctuation")
+                        InfoTip("Keep preserves punctuation as transcribed. Remove all strips punctuation marks from the transcribed text. Remove trailing period only removes a final period from the transcribed text.")
                     }
                 }
-                .toggleStyle(.switch)
+                .pickerStyle(.menu)
 
                 Toggle(isOn: $lowercaseTranscription) {
                     HStack(spacing: 4) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new punctuation cleanup mode with three options (Keep, Remove all, Remove trailing period) and replaces the old remove-punctuation toggle with a picker across settings. Transcription output now respects the chosen mode, and existing settings migrate automatically.

- **New Features**
  - Introduced `PunctuationCleanupMode` (`keep`, `removeAll`, `removeTrailingPeriod`) stored under `PunctuationCleanupMode`.
  - Replaced “Remove punctuation” toggles with a menu picker in Model Settings and Power Mode config, with updated help text.
  - Updated transcription filter to apply the selected mode; added `removeTrailingPeriod` and `applyCleanupPreferences`.
  - Added `punctuationCleanupMode` to `PowerModeConfig`; UI and session manager read/write this setting. Encoding preserves legacy `removePunctuation` for backward compatibility.
  - Import/Export and Backup now include `punctuationCleanupMode`, with fallback to legacy `removePunctuation`.

- **Migration**
  - Existing users are auto-migrated on launch via `migrateLegacyUserDefaultIfNeeded()`; no user action needed.
  - Replace uses of `removePunctuation` with `punctuationCleanupMode`, and prefer `PunctuationCleanupMode.current()` / `setCurrent()` over direct `UserDefaults` access.

<sup>Written for commit 9705283653da6ec88257164ddf1f682bde8d65de. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

