### PR TITLE
Improve FluidAudio ASR handling

### DIFF
--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "a53aff438bed437bc23490bf0f8d1b57fa3845c7"
+        "revision" : "9782d877bc24b23bd99c66ad70fd8d2669377fa7"
       }
     },
     {

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -55,7 +55,7 @@ struct ConfigurationView: View {
         guard let selectedModelName = effectiveModelName,
               let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName })
         else { return false }
-        return model.provider == .fluidAudio || model.provider == .gemini
+        return model.provider == .gemini
     }
 
     private func availableLanguages(for model: any TranscriptionModel) -> [String: String] {
@@ -300,7 +300,7 @@ struct ConfigurationView: View {
                         .onChange(of: selectedTranscriptionModelName) { _, newModelName in
                             if let modelName = newModelName ?? transcriptionModelManager.currentTranscriptionModel?.name,
                                let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }) {
-                                if model.provider == .fluidAudio || model.provider == .gemini {
+                                if model.provider == .gemini {
                                     selectedLanguage = "auto"
                                 } else {
                                     useCompatibleLanguage(for: model)
@@ -564,7 +564,6 @@ struct ConfigurationView: View {
 
                 if let selectedModelName = effectiveModelName,
                    let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName }),
-                   model.provider != .fluidAudio,
                    model.provider != .gemini {
                     useCompatibleLanguage(for: model)
                 }

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -16,6 +16,15 @@ class FluidAudioTranscriptionService: TranscriptionService {
         FluidAudioModelManager.asrVersion(for: model.name)
     }
 
+    static func languageHint(from selectedLanguage: String?, model: any TranscriptionModel) -> Language? {
+        guard model.provider == .fluidAudio,
+              let selectedLanguage,
+              selectedLanguage != "auto" else {
+            return nil
+        }
+        return Language(rawValue: selectedLanguage)
+    }
+
     private func ensureModelsLoaded(for version: AsrModelVersion) async throws {
         if asrManager != nil, activeVersion == version {
             return
@@ -83,6 +92,10 @@ class FluidAudioTranscriptionService: TranscriptionService {
             throw ASRError.notInitialized
         }
 
+        let languageHint = Self.languageHint(
+            from: UserDefaults.standard.string(forKey: "SelectedLanguage"),
+            model: model
+        )
         let audioSamples = try readAudioSamples(from: audioURL)
 
         let durationSeconds = Double(audioSamples.count) / 16000.0
@@ -119,7 +132,11 @@ class FluidAudioTranscriptionService: TranscriptionService {
         }
 
         var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
-        let result = try await asrManager.transcribe(speechAudio, decoderState: &decoderState)
+        let result = try await asrManager.transcribe(
+            speechAudio,
+            decoderState: &decoderState,
+            language: languageHint
+        )
 
         return TextNormalizer.shared.normalizeSentence(result.text)
     }

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -19,6 +19,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
     private var asrManager: AsrManager?
     private var decoderLayerCount: Int = 0
+    private var languageHint: Language?
     private let agreementEngine: WordAgreementEngine
     private let config: AgreementConfig
 
@@ -26,6 +27,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
     private var isTranscribing = false
     private var lastTranscribedSampleCount = 0
     private let minNewSamples = 8000 // ~0.5s
+    private let maxBufferSamples = 480_000 // 30s hard cap
 
     init(fluidAudioService: FluidAudioTranscriptionService, config: AgreementConfig = AgreementConfig()) {
         self.fluidAudioService = fluidAudioService
@@ -50,6 +52,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         try await manager.loadModels(models)
         self.asrManager = manager
         self.decoderLayerCount = await manager.decoderLayerCount
+        self.languageHint = FluidAudioTranscriptionService.languageHint(from: language, model: model)
 
         agreementEngine.reset()
         audioBuffer = []
@@ -87,6 +90,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         await asrManager?.cleanup()
         asrManager = nil
         decoderLayerCount = 0
+        languageHint = nil
 
         bufferLock.lock()
         audioBuffer = []
@@ -157,7 +161,11 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
         do {
             var state = TdtDecoderState.make(decoderLayers: decoderLayerCount)
-            let result = try await asrManager.transcribe(audioSlice, decoderState: &state)
+            let result = try await asrManager.transcribe(
+                audioSlice,
+                decoderState: &state,
+                language: languageHint
+            )
             lastTranscribedSampleCount = absoluteSampleCount
 
             guard let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty else {
@@ -195,6 +203,23 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
                 }
             }
 
+            // Hard cap: if no words are confirmed for a while, keep memory bounded.
+            bufferLock.lock()
+            if audioBuffer.count > maxBufferSamples {
+                let trimTarget: Int
+                if agreementEngine.confirmedEndTime > 0 {
+                    trimTarget = max(0, Int(agreementEngine.confirmedEndTime * sampleRate) - trimmedSampleCount)
+                } else {
+                    trimTarget = audioBuffer.count - maxBufferSamples
+                }
+                let actualTrim = min(max(trimTarget, audioBuffer.count - maxBufferSamples), audioBuffer.count)
+                if actualTrim > 0 {
+                    audioBuffer.removeFirst(actualTrim)
+                    trimmedSampleCount += actualTrim
+                }
+            }
+            bufferLock.unlock()
+
         } catch {
             logger.error("Transcription pass failed: \(error.localizedDescription, privacy: .public)")
             eventsContinuation?.yield(.error(error))
@@ -229,7 +254,11 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
         do {
             var state = TdtDecoderState.make(decoderLayers: decoderLayerCount)
-            let result = try await asrManager.transcribe(samples, decoderState: &state)
+            let result = try await asrManager.transcribe(
+                samples,
+                decoderState: &state,
+                language: languageHint
+            )
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
             return TextNormalizer.shared.normalizeSentence(text)

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -39,7 +39,7 @@ struct LanguageSelectionView: View {
         guard let provider = transcriptionModelManager.currentTranscriptionModel?.provider else {
             return false
         }
-        return provider == .fluidAudio || provider == .gemini
+        return provider == .gemini
     }
 
     private func isNativeAppleModelSelected() -> Bool {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add language hinting and manual language selection for FluidAudio ASR, and hard-cap the streaming buffer for stability. Also updates `FluidAudio` to the latest revision.

- New Features
  - Pass the selected language to FluidAudio ASR in both batch and streaming paths (ignored when set to "auto").
  - Enable manual language selection for FluidAudio models in the UI; only `gemini` stays auto-language.

- Bug Fixes
  - Bound the streaming audio buffer to 30s with smart trimming around confirmed words to prevent unbounded memory growth.

<sup>Written for commit 8b6298e82464d13d7560753357bbcdb7bc1262ba. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/712?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

