### PR TITLE
Improve fluid audio updates

### DIFF
--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -55,7 +55,7 @@ struct ConfigurationView: View {
         guard let selectedModelName = effectiveModelName,
               let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName })
         else { return false }
-        return model.provider == .fluidAudio || model.provider == .gemini
+        return model.provider == .gemini
     }
 
     private func availableLanguages(for model: any TranscriptionModel) -> [String: String] {
@@ -300,7 +300,7 @@ struct ConfigurationView: View {
                         .onChange(of: selectedTranscriptionModelName) { _, newModelName in
                             if let modelName = newModelName ?? transcriptionModelManager.currentTranscriptionModel?.name,
                                let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }) {
-                                if model.provider == .fluidAudio || model.provider == .gemini {
+                                if model.provider == .gemini {
                                     selectedLanguage = "auto"
                                 } else {
                                     useCompatibleLanguage(for: model)
@@ -564,7 +564,6 @@ struct ConfigurationView: View {
 
                 if let selectedModelName = effectiveModelName,
                    let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == selectedModelName }),
-                   model.provider != .fluidAudio,
                    model.provider != .gemini {
                     useCompatibleLanguage(for: model)
                 }

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
@@ -28,6 +28,15 @@ class FluidAudioModelManager: ObservableObject {
         modelVersionMap[modelName] ?? .v3
     }
 
+    nonisolated static func languageHint(from languageCode: String?, for modelName: String) -> Language? {
+        guard asrVersion(for: modelName) == .v3,
+              let languageCode,
+              languageCode != "auto"
+        else { return nil }
+
+        return Language(rawValue: languageCode)
+    }
+
     init() {}
 
     // MARK: - Query helpers

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -119,7 +119,11 @@ class FluidAudioTranscriptionService: TranscriptionService {
         }
 
         var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
-        let result = try await asrManager.transcribe(speechAudio, decoderState: &decoderState)
+        let languageHint = FluidAudioModelManager.languageHint(
+            from: UserDefaults.standard.string(forKey: "SelectedLanguage"),
+            for: model.name
+        )
+        let result = try await asrManager.transcribe(speechAudio, decoderState: &decoderState, language: languageHint)
 
         return TextNormalizer.shared.normalizeSentence(result.text)
     }

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -25,7 +25,8 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
     private var transcriptionTask: Task<Void, Never>?
     private var isTranscribing = false
     private var lastTranscribedSampleCount = 0
-    private let minNewSamples = 8000 // ~0.5s
+    private let minimumAudioSamples = ASRConstants.minimumRequiredSamples(forSampleRate: ASRConstants.sampleRate)
+    private let minNewSamples = ASRConstants.minimumRequiredSamples(forSampleRate: ASRConstants.sampleRate)
 
     init(fluidAudioService: FluidAudioTranscriptionService, config: AgreementConfig = AgreementConfig()) {
         self.fluidAudioService = fluidAudioService
@@ -125,7 +126,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         bufferLock.unlock()
 
         guard absoluteSampleCount - lastTranscribedSampleCount >= minNewSamples else { return }
-        guard absoluteSampleCount >= Int(sampleRate) else { return }
+        guard absoluteSampleCount >= minimumAudioSamples else { return }
 
         isTranscribing = true
         defer { isTranscribing = false }
@@ -153,7 +154,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
             audioSlice += [Float](repeating: 0, count: trailingSilenceSamples)
         }
 
-        guard audioSlice.count >= Int(sampleRate) else { return }
+        guard audioSlice.count >= minimumAudioSamples else { return }
 
         do {
             var state = TdtDecoderState.make(decoderLayers: decoderLayerCount)
@@ -219,7 +220,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         var samples = Array(audioBuffer[bufferRelativeSeek...])
         bufferLock.unlock()
 
-        guard samples.count >= Int(sampleRate) else { return nil }
+        guard samples.count >= minimumAudioSamples else { return nil }
 
         let trailingSilenceSamples = 16_000
         let maxSingleChunkSamples = 240_000

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -19,6 +19,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
     private var asrManager: AsrManager?
     private var decoderLayerCount: Int = 0
+    private var languageHint: Language?
     private let agreementEngine: WordAgreementEngine
     private let config: AgreementConfig
 
@@ -51,6 +52,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         try await manager.loadModels(models)
         self.asrManager = manager
         self.decoderLayerCount = await manager.decoderLayerCount
+        self.languageHint = FluidAudioModelManager.languageHint(from: language, for: model.name)
 
         agreementEngine.reset()
         audioBuffer = []
@@ -88,6 +90,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         await asrManager?.cleanup()
         asrManager = nil
         decoderLayerCount = 0
+        languageHint = nil
 
         bufferLock.lock()
         audioBuffer = []
@@ -158,7 +161,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
         do {
             var state = TdtDecoderState.make(decoderLayers: decoderLayerCount)
-            let result = try await asrManager.transcribe(audioSlice, decoderState: &state)
+            let result = try await asrManager.transcribe(audioSlice, decoderState: &state, language: languageHint)
             lastTranscribedSampleCount = absoluteSampleCount
 
             guard let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty else {
@@ -230,7 +233,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
         do {
             var state = TdtDecoderState.make(decoderLayers: decoderLayerCount)
-            let result = try await asrManager.transcribe(samples, decoderState: &state)
+            let result = try await asrManager.transcribe(samples, decoderState: &state, language: languageHint)
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
             return TextNormalizer.shared.normalizeSentence(text)

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -39,7 +39,7 @@ struct LanguageSelectionView: View {
         guard let provider = transcriptionModelManager.currentTranscriptionModel?.provider else {
             return false
         }
-        return provider == .fluidAudio || provider == .gemini
+        return provider == .gemini
     }
 
     private func isNativeAppleModelSelected() -> Bool {

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -110,17 +110,13 @@ struct LanguageSelectionView: View {
             Text("Transcription Language")
                 .font(.headline)
 
-            if let currentModel = transcriptionModelManager.currentTranscriptionModel
+            if transcriptionModelManager.currentTranscriptionModel != nil
             {
                 if languageSelectionDisabled() {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Language: Autodetected")
                             .font(.subheadline)
                             .foregroundColor(.primary)
-
-                        Text("Current model: \(currentModel.displayName)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
 
                         Text("The transcription language is automatically detected by the model.")
                             .font(.caption)
@@ -149,10 +145,6 @@ struct LanguageSelectionView: View {
                             }
                         }
 
-                        Text("Current model: \(currentModel.displayName)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-
                         Text(
                             "This model supports multiple languages. Select a specific language or auto-detect(if available)"
                         )
@@ -165,10 +157,6 @@ struct LanguageSelectionView: View {
                         Text("Language: English")
                             .font(.subheadline)
                             .foregroundColor(.primary)
-
-                        Text("Current model: \(currentModel.displayName)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
 
                         Text(
                             "This is an English-optimized model and only supports English transcription."


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable language hints for FluidAudio v3 and tune streaming thresholds for smoother, lower-latency transcription. The UI now allows manual language selection for FluidAudio; auto-detect is restricted to `gemini`.

- **New Features**
  - Pass user-selected language hints to FluidAudio v3 via `FluidAudioModelManager.languageHint(...)`.
  - Allow manual language selection for FluidAudio; auto-detect is enforced only for `gemini`.
  - Clean up language UI by removing duplicate “Current model” labels.

- **Performance**
  - Use shared `ASRConstants.minimumRequiredSamples` for initial and incremental streaming guards to improve stability and responsiveness.

<sup>Written for commit 07afc5964d34c70107d5d11a9263e4ffc5f506db. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/718?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

