### PR TITLE
Fix recorder session lifecycle and cleanup

### DIFF
--- a/VoiceInk/Models/Transcription.swift
+++ b/VoiceInk/Models/Transcription.swift
@@ -9,6 +9,8 @@ enum TranscriptionStatus: String, Codable {
 
 @Model
 final class Transcription {
+    static let canceledTranscriptionText = "The transcription was canceled."
+
     var id: UUID
     var text: String
     var enhancedText: String?
@@ -56,5 +58,26 @@ final class Transcription {
         self.powerModeName = powerModeName
         self.powerModeEmoji = powerModeEmoji
         self.transcriptionStatus = transcriptionStatus.rawValue
+    }
+
+    func markAsCanceledTranscription(
+        duration: TimeInterval? = nil,
+        modelName: String? = nil
+    ) {
+        text = Self.canceledTranscriptionText
+        enhancedText = nil
+        transcriptionStatus = TranscriptionStatus.failed.rawValue
+        if let duration {
+            self.duration = duration
+        }
+        if let modelName {
+            transcriptionModelName = modelName
+        }
+        transcriptionDuration = nil
+        enhancementDuration = nil
+        aiEnhancementModelName = nil
+        promptName = nil
+        aiRequestSystemMessage = nil
+        aiRequestUserMessage = nil
     }
 }

--- a/VoiceInk/Models/Transcription.swift
+++ b/VoiceInk/Models/Transcription.swift
@@ -5,6 +5,7 @@ enum TranscriptionStatus: String, Codable {
     case pending
     case completed
     case failed
+    case canceled
 }
 
 @Model
@@ -66,7 +67,7 @@ final class Transcription {
     ) {
         text = Self.canceledTranscriptionText
         enhancedText = nil
-        transcriptionStatus = TranscriptionStatus.failed.rawValue
+        transcriptionStatus = TranscriptionStatus.canceled.rawValue
         if let duration {
             self.duration = duration
         }

--- a/VoiceInk/Shortcuts/MiniRecorderShortcutManager.swift
+++ b/VoiceInk/Shortcuts/MiniRecorderShortcutManager.swift
@@ -138,7 +138,6 @@ class MiniRecorderShortcutManager: ObservableObject {
         }
 
         firstEscapePressTime = now
-        SoundManager.shared.playEscSound()
         NotificationManager.shared.showNotification(
             title: "Press ESC again to cancel recording",
             type: .info,

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -86,90 +86,47 @@ class RecorderUIManager: ObservableObject {
         logger.notice("toggleMiniRecorder called – visible=\(self.isMiniRecorderVisible, privacy: .public), state=\(String(describing: engine.recordingState), privacy: .public)")
 
         if isMiniRecorderVisible {
-            if engine.recordingState == .recording {
+            switch engine.recordingState {
+            case .recording:
                 logger.notice("toggleMiniRecorder: stopping recording (was recording)")
                 await engine.toggleRecord(powerModeId: powerModeId)
-            } else {
-                logger.notice("toggleMiniRecorder: cancelling (was not recording)")
+            case .starting, .transcribing, .enhancing:
+                logger.notice("toggleMiniRecorder: cancelling active recorder work")
                 await cancelRecording()
+            case .idle, .busy:
+                logger.notice("toggleMiniRecorder: dismissing recorder UI")
+                await dismissMiniRecorder()
             }
         } else {
             SoundManager.shared.playStartSound()
-            await MainActor.run { isMiniRecorderVisible = true }
+            isMiniRecorderVisible = true
             await engine.toggleRecord(powerModeId: powerModeId)
         }
     }
 
     func dismissMiniRecorder() async {
-        guard let engine = engine, let recorder = recorder else { return }
+        guard let engine = engine else { return }
         logger.notice("dismissMiniRecorder called – state=\(String(describing: engine.recordingState), privacy: .public)")
 
-        if engine.recordingState == .busy {
-            logger.notice("dismissMiniRecorder: early return, state is busy")
-            return
-        }
-
-        let wasRecording = engine.recordingState == .recording || engine.recordingState == .starting
-
-        await MainActor.run {
-            engine.recordingState = .busy
-        }
-
-        // Cancel and release any active streaming session to prevent resource leaks.
-        engine.currentSession?.cancel()
-        engine.currentSession = nil
-
-        if wasRecording {
-            await recorder.stopRecording()
-        }
-
         hideRecorderPanel()
+        isMiniRecorderVisible = false
 
-        // Clear captured context when the recorder is dismissed
-        if let enhancementService = engine.enhancementService {
-            await MainActor.run {
-                enhancementService.clearCapturedContexts()
-            }
-        }
-
-        await MainActor.run {
-            isMiniRecorderVisible = false
-        }
-
-        await engine.cleanupResources()
-
-        if !UserDefaults.standard.bool(forKey: "powerModePersistConfig") {
-            await PowerModeSessionManager.shared.endSession()
-            await MainActor.run {
-                PowerModeManager.shared.setActiveConfiguration(nil)
-            }
-        }
-
-        await MainActor.run {
-            engine.recordingState = .idle
-        }
         logger.notice("dismissMiniRecorder completed")
     }
 
     func resetOnLaunch() async {
-        guard let engine = engine, let recorder = recorder else { return }
+        guard let engine = engine else { return }
         logger.notice("Resetting recording state on launch")
-        await recorder.stopRecording()
+        await engine.resetRecordingSession()
         hideRecorderPanel()
-        await MainActor.run {
-            isMiniRecorderVisible = false
-            engine.shouldCancelRecording = false
-            miniRecorderError = nil
-            engine.recordingState = .idle
-        }
-        await engine.cleanupResources()
+        isMiniRecorderVisible = false
+        miniRecorderError = nil
     }
 
     func cancelRecording() async {
         guard let engine = engine else { return }
         logger.notice("cancelRecording called")
-        SoundManager.shared.playEscSound()
-        engine.shouldCancelRecording = true
+        await engine.cancelRecording()
         await dismissMiniRecorder()
     }
 
@@ -200,7 +157,12 @@ class RecorderUIManager: ObservableObject {
     @objc public func handleDismissMiniRecorder() {
         logger.notice("handleDismissMiniRecorder: .dismissMiniRecorder notification received")
         Task {
-            await dismissMiniRecorder()
+            switch engine?.recordingState {
+            case .starting, .recording, .transcribing, .enhancing:
+                await cancelRecording()
+            case .idle, .busy, nil:
+                await dismissMiniRecorder()
+            }
         }
     }
 }

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AVFoundation
 import SwiftData
 import os
 
@@ -34,7 +33,7 @@ class TranscriptionPipeline {
     ///   - session: An active streaming session if one was prepared, otherwise nil.
     ///   - onStateChange: Called when the pipeline moves to a new recording state (e.g. `.enhancing`).
     ///   - shouldCancel: Returns true if the user requested cancellation.
-    ///   - onCleanup: Called when cancellation is detected to release model resources.
+    ///   - onCancel: Called when cancellation is detected to cancel active session state.
     ///   - onDismiss: Called as soon as paste is initiated to dismiss the recorder panel.
     func run(
         transcription: Transcription,
@@ -43,17 +42,55 @@ class TranscriptionPipeline {
         session: TranscriptionSession?,
         onStateChange: @escaping (RecordingState) -> Void,
         shouldCancel: () -> Bool,
-        onCleanup: @escaping () async -> Void,
+        onCancel: @escaping () async -> Void,
         onDismiss: @escaping () async -> Void
     ) async {
-        if shouldCancel() {
-            await onCleanup()
-            return
-        }
-
         var finalPastedText: String?
         var promptDetectionResult: PromptDetectionService.PromptDetectionResult?
         var didInsertSessionMetric = false
+
+        func restorePromptDetectionSettingsIfNeeded() async {
+            if let result = promptDetectionResult,
+               let enhancementService,
+               result.shouldEnableAI {
+                await promptDetectionService.restoreOriginalSettings(result, to: enhancementService)
+            }
+        }
+
+        func restorePromptDetectionSettingsAndDismiss(afterRestore: () -> Void = {}) async {
+            await restorePromptDetectionSettingsIfNeeded()
+            afterRestore()
+            await onDismiss()
+        }
+
+        func finishCanceledTranscription() async {
+            await onCancel()
+            await restorePromptDetectionSettingsIfNeeded()
+
+            let canceledDuration: TimeInterval?
+            if transcription.duration > 0 {
+                canceledDuration = nil
+            } else {
+                let duration = await AudioFileMetadata.duration(for: audioURL)
+                canceledDuration = duration > 0 ? duration : nil
+            }
+
+            transcription.markAsCanceledTranscription(
+                duration: canceledDuration,
+                modelName: transcription.transcriptionModelName ?? model.displayName
+            )
+
+            do {
+                try modelContext.save()
+            } catch {
+                logger.error("Failed to save canceled transcription: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        if shouldCancel() {
+            await finishCanceledTranscription()
+            return
+        }
 
         do {
             let transcriptionStart = Date()
@@ -66,12 +103,7 @@ class TranscriptionPipeline {
             text = TranscriptionOutputFilter.filter(text)
             let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
-            let powerModeManager = PowerModeManager.shared
-            let activePowerModeConfig = powerModeManager.currentActiveConfiguration
-            let powerModeName = (activePowerModeConfig?.isEnabled == true) ? activePowerModeConfig?.name : nil
-            let powerModeEmoji = (activePowerModeConfig?.isEnabled == true) ? activePowerModeConfig?.emoji : nil
-
-            if shouldCancel() { await onCleanup(); return }
+            if shouldCancel() { await finishCanceledTranscription(); return }
 
             text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -82,19 +114,16 @@ class TranscriptionPipeline {
             text = WordReplacementService.shared.applyReplacements(to: text, using: modelContext)
             let cleanedText = TranscriptionOutputFilter.applyUserCleanupPreferences(text)
 
-            let audioAsset = AVURLAsset(url: audioURL)
-            let actualDuration = (try? CMTimeGetSeconds(await audioAsset.load(.duration))) ?? 0.0
+            let actualDuration = await AudioFileMetadata.duration(for: audioURL)
 
             transcription.text = cleanedText
             transcription.duration = actualDuration
             transcription.transcriptionModelName = model.displayName
             transcription.transcriptionDuration = transcriptionDuration
-            transcription.powerModeName = powerModeName
-            transcription.powerModeEmoji = powerModeEmoji
             finalPastedText = cleanedText
 
             if let enhancementService, enhancementService.isConfigured {
-                let detectionResult = await promptDetectionService.analyzeText(text, with: enhancementService)
+                let detectionResult = promptDetectionService.analyzeText(text, with: enhancementService)
                 promptDetectionResult = detectionResult
                 await promptDetectionService.applyDetectionResult(detectionResult, to: enhancementService)
             }
@@ -108,7 +137,7 @@ class TranscriptionPipeline {
                enhancementService.isEnhancementEnabled,
                enhancementService.isConfigured,
                !shouldSkipEnhancement {
-                if shouldCancel() { await onCleanup(); return }
+                if shouldCancel() { await finishCanceledTranscription(); return }
 
                 onStateChange(.enhancing)
                 let textForAI = promptDetectionResult?.processedText ?? text
@@ -132,7 +161,7 @@ class TranscriptionPipeline {
                             type: .warning
                         )
                     }
-                    if shouldCancel() { await onCleanup(); return }
+                    if shouldCancel() { await finishCanceledTranscription(); return }
                 }
             }
 
@@ -179,17 +208,8 @@ class TranscriptionPipeline {
             }
         }
 
-        func restorePromptDetectionSettingsIfNeeded() async {
-            if let result = promptDetectionResult,
-               let enhancementService,
-               result.shouldEnableAI {
-                await promptDetectionService.restoreOriginalSettings(result, to: enhancementService)
-            }
-        }
-
         if shouldCancel() {
-            await onCleanup()
-            saveTranscriptionAndPostCompletion()
+            await finishCanceledTranscription()
             return
         }
 
@@ -207,19 +227,16 @@ class TranscriptionPipeline {
             CursorPaster.startPasteAtCursor(pastedText)
             let autoSendKey = PowerModeManager.shared.currentActiveConfiguration?.autoSendKey
             SoundManager.shared.playStopSound()
-            await restorePromptDetectionSettingsIfNeeded()
-
-            if let autoSendKey, autoSendKey.isEnabled {
-                Task { @MainActor in
-                    try? await Task.sleep(nanoseconds: 500_000_000)
-                    CursorPaster.performAutoSend(autoSendKey)
+            await restorePromptDetectionSettingsAndDismiss {
+                if let autoSendKey, autoSendKey.isEnabled {
+                    Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        CursorPaster.performAutoSend(autoSendKey)
+                    }
                 }
             }
-
-            await onDismiss()
         } else {
-            await restorePromptDetectionSettingsIfNeeded()
-            await onDismiss()
+            await restorePromptDetectionSettingsAndDismiss()
         }
 
         saveTranscriptionAndPostCompletion()

--- a/VoiceInk/Transcription/Engine/TranscriptionSession.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionSession.swift
@@ -52,6 +52,8 @@ final class StreamingTranscriptionSession: TranscriptionSession {
     private let fallbackService: TranscriptionService
     private var model: (any TranscriptionModel)?
     private var streamingFailed = false
+    private var startupTask: Task<Void, Never>?
+    private var startupTaskID: UUID?
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "StreamingTranscriptionSession")
 
     init(streamingService: StreamingTranscriptionService, fallbackService: TranscriptionService) {
@@ -69,13 +71,31 @@ final class StreamingTranscriptionSession: TranscriptionSession {
             service?.sendAudioChunk(data)
         }
 
-        Task { [weak self] in
+        startupTask?.cancel()
+        let taskID = UUID()
+        startupTaskID = taskID
+        startupTask = Task { [weak self] in
             guard let self = self else { return }
+            defer {
+                if self.startupTaskID == taskID {
+                    self.startupTask = nil
+                    self.startupTaskID = nil
+                }
+            }
+            guard !Task.isCancelled else { return }
+
             do {
                 let start = Date()
                 try await self.streamingService.startStreaming(model: model)
+                guard !Task.isCancelled else {
+                    self.streamingService.cancel()
+                    return
+                }
                 self.logger.notice("Streaming session connected model=\(model.displayName, privacy: .public) elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s")
+            } catch is CancellationError {
+                self.streamingService.cancel()
             } catch {
+                guard !Task.isCancelled else { return }
                 let desc = error.localizedDescription
                 self.logger.error("❌ Failed to start streaming, will fall back to batch: \(desc, privacy: .public)")
                 self.streamingFailed = true
@@ -113,6 +133,9 @@ final class StreamingTranscriptionSession: TranscriptionSession {
     }
 
     func cancel() {
+        startupTask?.cancel()
+        startupTask = nil
+        startupTaskID = nil
         streamingService.cancel()
     }
 }

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -372,7 +372,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
             for: recordedFile,
             text: Transcription.canceledTranscriptionText,
             duration: duration,
-            transcriptionStatus: .failed
+            transcriptionStatus: .canceled
         )
 
         modelContext.insert(transcription)

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -12,6 +12,8 @@ class VoiceInkEngine: NSObject, ObservableObject {
     var partialTranscript: String = ""
     var currentSession: TranscriptionSession?
     private var activeRecordingStartID: UUID?
+    private var activePipelineTranscriptionID: UUID?
+    private var canceledPipelineTranscriptionIDs = Set<UUID>()
 
     let recorder = Recorder()
     var recordedFile: URL? = nil
@@ -84,11 +86,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
         if recordingState == .starting {
             logger.notice("toggleRecord: cancelling in-flight recording start")
-            shouldCancelRecording = true
-            activeRecordingStartID = nil
-            await recorder.stopRecording()
-            recordedFile = nil
-            recordingState = .idle
+            await cancelRecording()
             return
         }
 
@@ -100,10 +98,10 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
             if let recordedFile {
                 if !shouldCancelRecording {
-                    let transcription = Transcription(
+                    let transcription = makeRecordingTranscription(
+                        for: recordedFile,
                         text: "",
                         duration: 0,
-                        audioFileURL: recordedFile.absoluteString,
                         transcriptionStatus: .pending
                     )
                     modelContext.insert(transcription)
@@ -112,16 +110,13 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
                     await runPipeline(on: transcription, audioURL: recordedFile)
                 } else {
-                    currentSession?.cancel()
-                    currentSession = nil
-                    try? FileManager.default.removeItem(at: recordedFile)
-                    recordingState = .idle
-                    await cleanupResources()
+                    await finishActiveRecorderCancellation()
                 }
             } else {
-                logger.error("❌ No recorded file found after stopping recording")
-                currentSession?.cancel()
-                currentSession = nil
+                cancelCurrentSession()
+                if !shouldCancelRecording {
+                    logger.error("❌ No recorded file found after stopping recording")
+                }
                 recordingState = .idle
                 await cleanupResources()
             }
@@ -131,6 +126,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                 NotificationManager.shared.showNotification(title: "No AI Model Selected", type: .error)
                 return
             }
+            activePipelineTranscriptionID = nil
             shouldCancelRecording = false
             partialTranscript = ""
 
@@ -159,9 +155,12 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             guard self.activeRecordingStartID == startID,
                                   self.recorderUIManager?.isMiniRecorderVisible ?? false,
                                   !self.shouldCancelRecording else {
+                                let shouldKeepRecordingFile = self.shouldCancelRecording
                                 if self.activeRecordingStartID == startID {
                                     await self.recorder.stopRecording()
-                                    self.recordedFile = nil
+                                    if !shouldKeepRecordingFile {
+                                        self.recordedFile = nil
+                                    }
                                     self.recordingState = .idle
                                     self.activeRecordingStartID = nil
                                 }
@@ -200,27 +199,25 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                 }
                             }
 
-                            Task.detached { [weak self] in
+                            Task { @MainActor [weak self] in
                                 guard let self else { return }
 
-                                if let model = await self.transcriptionModelManager.currentTranscriptionModel,
+                                if let model = self.transcriptionModelManager.currentTranscriptionModel,
                                    model.provider == .whisper {
-                                    if let localWhisperModel = await self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
-                                       await self.whisperModelManager.whisperContext == nil {
+                                    if let localWhisperModel = self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
+                                       self.whisperModelManager.whisperContext == nil {
                                         do {
                                             try await self.whisperModelManager.loadModel(localWhisperModel)
                                         } catch {
-                                            await self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
+                                            self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
                                         }
                                     }
-                                } else if let fluidAudioModel = await self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
+                                } else if let fluidAudioModel = self.transcriptionModelManager.currentTranscriptionModel as? FluidAudioModel {
                                     try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
                                 }
 
-                                if let enhancementService = await self.enhancementService {
-                                    await MainActor.run {
-                                        enhancementService.captureClipboardContext()
-                                    }
+                                if let enhancementService = self.enhancementService {
+                                    enhancementService.captureClipboardContext()
                                     await enhancementService.captureScreenContext()
                                 }
                             }
@@ -230,7 +227,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             self.recordingState = .idle
                             self.recordedFile = nil
                             self.activeRecordingStartID = nil
-                            await NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
+                            NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
                             self.logger.notice("toggleRecord: calling dismissMiniRecorder from error handler")
                             await self.recorderUIManager?.dismissMiniRecorder()
                         }
@@ -258,26 +255,193 @@ class VoiceInkEngine: NSObject, ObservableObject {
         }
 
         let session = currentSession
-        currentSession = nil
+        let transcriptionID = transcription.id
+        activePipelineTranscriptionID = transcriptionID
 
         await pipeline.run(
             transcription: transcription,
             audioURL: audioURL,
             model: model,
             session: session,
-            onStateChange: { [weak self] state in self?.recordingState = state },
-            shouldCancel: { [weak self] in self?.shouldCancelRecording ?? false },
-            onCleanup: { [weak self] in await self?.cleanupResources() },
-            onDismiss: { [weak self] in await self?.recorderUIManager?.dismissMiniRecorder() }
+            onStateChange: { [weak self] state in
+                guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
+                self.recordingState = state
+            },
+            shouldCancel: { [weak self] in
+                guard let self else { return false }
+                return self.canceledPipelineTranscriptionIDs.contains(transcriptionID)
+                    || (self.activePipelineTranscriptionID == transcriptionID && self.shouldCancelRecording)
+            },
+            onCancel: { [weak self, session] in
+                guard let self else { return }
+                self.cancelPipelineSession(transcriptionID: transcriptionID, session: session)
+            },
+            onDismiss: { [weak self] in
+                guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
+                await self.recorderUIManager?.dismissMiniRecorder()
+            }
         )
 
-        shouldCancelRecording = false
-        if recordingState != .idle {
+        let didFinishActivePipeline = activePipelineTranscriptionID == transcriptionID
+        if didFinishActivePipeline {
+            await finishRecorderSession()
+            await cleanupResources()
+            activePipelineTranscriptionID = nil
+            currentSession = nil
+            recordedFile = nil
+            shouldCancelRecording = false
+        }
+        canceledPipelineTranscriptionIDs.remove(transcriptionID)
+
+        if didFinishActivePipeline &&
+            (recordingState == .transcribing || recordingState == .enhancing || recordingState == .busy) {
             recordingState = .idle
         }
     }
 
+    // MARK: - Cancellation
+
+    func cancelRecording() async {
+        logger.notice("cancelRecording called – state=\(String(describing: self.recordingState), privacy: .public)")
+
+        let shouldFinishSessionImmediately: Bool
+        switch recordingState {
+        case .starting, .recording:
+            requestRecordingCancellation()
+            await finishActiveRecorderCancellation()
+            shouldFinishSessionImmediately = true
+        case .transcribing, .enhancing:
+            requestRecordingCancellation()
+            partialTranscript = ""
+            recordingState = .idle
+            shouldFinishSessionImmediately = false
+        case .idle, .busy:
+            partialTranscript = ""
+            shouldCancelRecording = false
+            recordingState = .idle
+            shouldFinishSessionImmediately = true
+        }
+
+        if shouldFinishSessionImmediately {
+            await finishRecorderSession()
+        }
+    }
+
+    func resetRecordingSession() async {
+        cancelCurrentSession()
+        activeRecordingStartID = nil
+        activePipelineTranscriptionID = nil
+        canceledPipelineTranscriptionIDs.removeAll()
+        shouldCancelRecording = false
+        partialTranscript = ""
+        await recorder.stopRecording()
+        recordedFile = nil
+        recordingState = .idle
+        await cleanupResources()
+        await finishRecorderSession()
+    }
+
+    private func requestRecordingCancellation() {
+        shouldCancelRecording = true
+
+        if (recordingState == .transcribing || recordingState == .enhancing),
+           let activePipelineTranscriptionID {
+            canceledPipelineTranscriptionIDs.insert(activePipelineTranscriptionID)
+        }
+
+        cancelCurrentSession()
+    }
+
+    private func finishActiveRecorderCancellation() async {
+        activeRecordingStartID = nil
+        await recorder.stopRecording()
+        await saveCanceledRecording()
+        recordedFile = nil
+        partialTranscript = ""
+        recordingState = .idle
+        await cleanupResources()
+    }
+
+    private func saveCanceledRecording() async {
+        guard let recordedFile,
+              FileManager.default.fileExists(atPath: recordedFile.path)
+        else { return }
+
+        let duration = await AudioFileMetadata.duration(for: recordedFile)
+        let transcription = makeRecordingTranscription(
+            for: recordedFile,
+            text: Transcription.canceledTranscriptionText,
+            duration: duration,
+            transcriptionStatus: .failed
+        )
+
+        modelContext.insert(transcription)
+
+        do {
+            try modelContext.save()
+            NotificationCenter.default.post(name: .transcriptionCreated, object: transcription)
+        } catch {
+            logger.error("Failed to save canceled recording: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func makeRecordingTranscription(
+        for audioURL: URL,
+        text: String,
+        duration: TimeInterval,
+        transcriptionStatus: TranscriptionStatus
+    ) -> Transcription {
+        let powerModeMetadata = currentPowerModeMetadata()
+
+        return Transcription(
+            text: text,
+            duration: duration,
+            audioFileURL: audioURL.absoluteString,
+            transcriptionModelName: transcriptionModelManager.currentTranscriptionModel?.displayName,
+            powerModeName: powerModeMetadata.name,
+            powerModeEmoji: powerModeMetadata.emoji,
+            transcriptionStatus: transcriptionStatus
+        )
+    }
+
+    private func currentPowerModeMetadata() -> (name: String?, emoji: String?) {
+        guard let powerMode = PowerModeManager.shared.currentActiveConfiguration,
+              powerMode.isEnabled else {
+            return (nil, nil)
+        }
+
+        return (powerMode.name, powerMode.emoji)
+    }
+
     // MARK: - Resource Cleanup
+
+    private func cancelPipelineSession(transcriptionID: UUID, session: TranscriptionSession?) {
+        session?.cancel()
+
+        guard activePipelineTranscriptionID == transcriptionID else {
+            logger.notice("Skipping stale pipeline cleanup")
+            return
+        }
+
+        currentSession = nil
+    }
+
+    private func cancelCurrentSession() {
+        currentSession?.cancel()
+        currentSession = nil
+    }
+
+    private func finishRecorderSession() async {
+        enhancementService?.clearCapturedContexts()
+        await restorePowerModeIfNeeded()
+    }
+
+    private func restorePowerModeIfNeeded() async {
+        guard !UserDefaults.standard.bool(forKey: "powerModePersistConfig") else { return }
+
+        await PowerModeSessionManager.shared.endSession()
+        PowerModeManager.shared.setActiveConfiguration(nil)
+    }
 
     func cleanupResources() async {
         logger.notice("cleanupResources: releasing model resources")
@@ -316,5 +480,14 @@ class VoiceInkEngine: NSObject, ObservableObject {
                 await context.setPrompt(currentPrompt)
             }
         }
+    }
+}
+
+enum AudioFileMetadata {
+    static func duration(for url: URL) async -> TimeInterval {
+        let asset = AVURLAsset(url: url)
+        guard let duration = try? await asset.load(.duration) else { return 0 }
+        let seconds = CMTimeGetSeconds(duration)
+        return seconds.isFinite ? seconds : 0
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes recorder/transcription lifecycle and cancellation to prevent leaks, race conditions, and stuck states. Cancellation now creates a “canceled” transcription with model and duration and reliably cleans up resources.

- **Bug Fixes**
  - Centralized cancel flow in `VoiceInkEngine.cancelRecording`; UI delegates to the engine.
  - Prevented stale updates by tracking the active pipeline with an ID; only the active run can change state or dismiss UI.
  - Tracked and canceled streaming startup tasks; ensured `streamingService.cancel()` is called.
  - Always clear enhancement contexts and restore Power Mode when finishing or canceling.
  - Recorder panel dismiss now only hides the UI; cleanup is owned by the engine.

- **Refactors**
  - Pipeline: switched `onCleanup` to `onCancel`, restores prompt-detection settings, and saves a canceled transcription with duration/model.
  - Added `TranscriptionStatus.canceled`, `Transcription.markAsCanceledTranscription`, and `AudioFileMetadata.duration`.
  - Engine creates consistent transcription records for both completed and canceled recordings.
  - App launch uses `resetRecordingSession`; removed first-ESC sound.

<sup>Written for commit 150f1b67f260353c5fc63aa83c63dac15514f58d. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/723?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

