### PR TITLE
Fix/recording shortcut interruption

### DIFF
--- a/VoiceInk/Shortcuts/PowerModeShortcutManager.swift
+++ b/VoiceInk/Shortcuts/PowerModeShortcutManager.swift
@@ -5,6 +5,7 @@ class PowerModeShortcutManager {
     private weak var engine: VoiceInkEngine?
     private let shortcutMonitor = ShortcutMonitor()
     private var shortcutChangeObserver: NSObjectProtocol?
+    private var interruptedPowerModeActions = Set<ShortcutAction>()
 
     init(engine: VoiceInkEngine) {
         self.engine = engine
@@ -67,11 +68,17 @@ class PowerModeShortcutManager {
 
         shortcutMonitor.start(
             shortcuts: shortcuts,
+            interruptibleActions: Set(shortcuts.keys),
             onKeyDown: { _, _ in },
             onKeyUp: { [weak self] action, _ in
                 Task { @MainActor in
                     guard case .powerMode(let powerModeId) = action else { return }
                     await self?.handlePowerModeShortcut(powerModeId: powerModeId)
+                }
+            },
+            onShortcutInterrupted: { [weak self] action, _ in
+                Task { @MainActor in
+                    self?.handlePowerModeShortcutInterruption(action)
                 }
             }
         )
@@ -87,12 +94,32 @@ class PowerModeShortcutManager {
             return
         }
 
+        let action = ShortcutAction.powerMode(powerModeId)
+        if interruptedPowerModeActions.remove(action) != nil,
+           canCurrentShortcutPressCancelAccidentalStart(engine: engine) {
+            return
+        }
+
         await engine.recorderUIManager?.toggleMiniRecorder(powerModeId: powerModeId)
+    }
+
+    private func handlePowerModeShortcutInterruption(_ action: ShortcutAction) {
+        guard case .powerMode = action,
+              let engine,
+              canCurrentShortcutPressCancelAccidentalStart(engine: engine) else {
+            return
+        }
+
+        interruptedPowerModeActions.insert(action)
     }
 
     private func canHandleShortcutAction(engine: VoiceInkEngine) -> Bool {
         engine.recordingState != .transcribing &&
         engine.recordingState != .enhancing &&
         engine.recordingState != .busy
+    }
+
+    private func canCurrentShortcutPressCancelAccidentalStart(engine: VoiceInkEngine) -> Bool {
+        engine.recorderUIManager?.isMiniRecorderVisible != true && engine.recordingState == .idle
     }
 }

--- a/VoiceInk/Shortcuts/PowerModeShortcutManager.swift
+++ b/VoiceInk/Shortcuts/PowerModeShortcutManager.swift
@@ -2,13 +2,17 @@ import Foundation
 
 @MainActor
 class PowerModeShortcutManager {
-    private weak var engine: VoiceInkEngine?
     private let shortcutMonitor = ShortcutMonitor()
+    private let modeProvider: @MainActor () -> RecordingShortcutManager.Mode
+    private let shortcutModeHandler: RecordingShortcutModeHandler
     private var shortcutChangeObserver: NSObjectProtocol?
-    private var interruptedPowerModeActions = Set<ShortcutAction>()
 
-    init(engine: VoiceInkEngine) {
-        self.engine = engine
+    init(
+        modeProvider: @escaping @MainActor () -> RecordingShortcutManager.Mode,
+        shortcutModeHandler: RecordingShortcutModeHandler
+    ) {
+        self.modeProvider = modeProvider
+        self.shortcutModeHandler = shortcutModeHandler
 
         refreshPowerModeShortcuts()
 
@@ -69,57 +73,53 @@ class PowerModeShortcutManager {
         shortcutMonitor.start(
             shortcuts: shortcuts,
             interruptibleActions: Set(shortcuts.keys),
-            onKeyDown: { _, _ in },
-            onKeyUp: { [weak self] action, _ in
+            onKeyDown: { [weak self] action, eventTime in
                 Task { @MainActor in
-                    guard case .powerMode(let powerModeId) = action else { return }
-                    await self?.handlePowerModeShortcut(powerModeId: powerModeId)
+                    guard let self,
+                          let powerModeId = self.powerModeId(for: action) else {
+                        return
+                    }
+
+                    await self.shortcutModeHandler.handleKeyDown(
+                        action: action,
+                        eventTime: eventTime,
+                        mode: self.modeProvider(),
+                        powerModeId: powerModeId
+                    )
+                }
+            },
+            onKeyUp: { [weak self] action, eventTime in
+                Task { @MainActor in
+                    guard let self,
+                          let powerModeId = self.powerModeId(for: action) else {
+                        return
+                    }
+
+                    await self.shortcutModeHandler.handleKeyUp(
+                        action: action,
+                        eventTime: eventTime,
+                        mode: self.modeProvider(),
+                        powerModeId: powerModeId
+                    )
                 }
             },
             onShortcutInterrupted: { [weak self] action, _ in
                 Task { @MainActor in
-                    self?.handlePowerModeShortcutInterruption(action)
+                    guard let self, case .powerMode = action else { return }
+                    await self.shortcutModeHandler.handleInterruption(action: action)
                 }
             }
         )
     }
 
-    private func handlePowerModeShortcut(powerModeId: UUID) async {
-        guard let engine = engine,
-              canHandleShortcutAction(engine: engine) else { return }
-
-        guard let config = PowerModeManager.shared.getConfiguration(with: powerModeId),
+    private func powerModeId(for action: ShortcutAction) -> UUID? {
+        guard case .powerMode(let powerModeId) = action,
+              let config = PowerModeManager.shared.getConfiguration(with: powerModeId),
               config.isEnabled,
               ShortcutStore.shortcut(for: .powerMode(config.id)) != nil else {
-            return
+            return nil
         }
 
-        let action = ShortcutAction.powerMode(powerModeId)
-        if interruptedPowerModeActions.remove(action) != nil,
-           canCurrentShortcutPressCancelAccidentalStart(engine: engine) {
-            return
-        }
-
-        await engine.recorderUIManager?.toggleMiniRecorder(powerModeId: powerModeId)
-    }
-
-    private func handlePowerModeShortcutInterruption(_ action: ShortcutAction) {
-        guard case .powerMode = action,
-              let engine,
-              canCurrentShortcutPressCancelAccidentalStart(engine: engine) else {
-            return
-        }
-
-        interruptedPowerModeActions.insert(action)
-    }
-
-    private func canHandleShortcutAction(engine: VoiceInkEngine) -> Bool {
-        engine.recordingState != .transcribing &&
-        engine.recordingState != .enhancing &&
-        engine.recordingState != .busy
-    }
-
-    private func canCurrentShortcutPressCancelAccidentalStart(engine: VoiceInkEngine) -> Bool {
-        engine.recorderUIManager?.isMiniRecorderVisible != true && engine.recordingState == .idle
+        return powerModeId
     }
 }

--- a/VoiceInk/Shortcuts/PowerModeShortcutManager.swift
+++ b/VoiceInk/Shortcuts/PowerModeShortcutManager.swift
@@ -91,7 +91,7 @@ class PowerModeShortcutManager {
             onKeyUp: { [weak self] action, eventTime in
                 Task { @MainActor in
                     guard let self,
-                          let powerModeId = self.powerModeId(for: action) else {
+                          case .powerMode(let powerModeId) = action else {
                         return
                     }
 

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -22,6 +22,7 @@ class RecordingShortcutManager: ObservableObject {
     @Published var primaryRecordingShortcutMode: Mode {
         didSet {
             UserDefaults.standard.set(primaryRecordingShortcutMode.rawValue, forKey: "primaryRecordingShortcutMode")
+            primaryRecordingShortcutModeSource.primaryMode = primaryRecordingShortcutMode
         }
     }
     @Published var secondaryRecordingShortcutMode: Mode {
@@ -41,34 +42,23 @@ class RecordingShortcutManager: ObservableObject {
         }
     }
     
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "RecordingShortcutManager")
     private var engine: VoiceInkEngine
     private var recorderUIManager: RecorderUIManager
     private var miniRecorderShortcutManager: MiniRecorderShortcutManager
-    private var powerModeShortcutManager: PowerModeShortcutManager
+    private let powerModeShortcutManager: PowerModeShortcutManager
     private let shortcutMonitor = ShortcutMonitor()
     private var shortcutChangeObserver: NSObjectProtocol?
+    private let shortcutModeHandler: RecordingShortcutModeHandler
+    private let primaryRecordingShortcutModeSource: RecordingShortcutModeSource
 
     // MARK: - Helper Properties
     private var canHandleShortcutAction: Bool {
-        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy
+        Self.canHandleShortcutAction(for: engine.recordingState)
     }
     
     // Middle-click event monitoring
     private var middleClickMonitors: [Any?] = []
     private var middleClickTask: Task<Void, Never>?
-
-    // Keyboard shortcut state tracking
-    private var shortcutPressStartTime: TimeInterval?
-    private var isHandsFreeRecording = false
-    private var isShortcutPressed = false
-    private var activeRecordingShortcutAction: ShortcutAction?
-    private var interruptedRecordingActions = Set<ShortcutAction>()
-    private var activeShortcutCanCancelAccidentalStart = false
-    private var lastShortcutPressTime: Date?
-    private let shortcutPressCooldown: TimeInterval = 0.5
-
-    private static let hybridPressThreshold: TimeInterval = 0.5
 
     enum Mode: String, CaseIterable {
         case toggle = "toggle"
@@ -96,6 +86,12 @@ class RecordingShortcutManager: ObservableObject {
         }
     }
 
+    private static func canHandleShortcutAction(for recordingState: RecordingState) -> Bool {
+        recordingState != .transcribing &&
+        recordingState != .enhancing &&
+        recordingState != .busy
+    }
+
     init(engine: VoiceInkEngine, recorderUIManager: RecorderUIManager) {
         ShortcutMigration.migrateLegacyShortcutsIfNeeded()
 
@@ -108,9 +104,10 @@ class RecordingShortcutManager: ObservableObject {
             allowsNone: true
         )
 
-        self.primaryRecordingShortcutMode = ShortcutMigration.migrateShortcutMode(
+        let primaryRecordingShortcutMode = ShortcutMigration.migrateShortcutMode(
             for: .primaryRecording
         )
+        self.primaryRecordingShortcutMode = primaryRecordingShortcutMode
         self.secondaryRecordingShortcutMode = ShortcutMigration.migrateShortcutMode(
             for: .secondaryRecording
         )
@@ -118,10 +115,41 @@ class RecordingShortcutManager: ObservableObject {
         self.isMiddleClickToggleEnabled = UserDefaults.standard.bool(forKey: "isMiddleClickToggleEnabled")
         self.middleClickActivationDelay = UserDefaults.standard.integer(forKey: "middleClickActivationDelay")
 
+        let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "RecordingShortcutManager")
+        let shortcutModeHandler = RecordingShortcutModeHandler(
+            logger: logger,
+            canHandleShortcutAction: {
+                Self.canHandleShortcutAction(for: engine.recordingState)
+            },
+            isRecorderVisible: {
+                recorderUIManager.isMiniRecorderVisible
+            },
+            recordingState: {
+                engine.recordingState
+            },
+            toggleMiniRecorder: { powerModeId in
+                await recorderUIManager.toggleMiniRecorder(powerModeId: powerModeId)
+            },
+            cancelRecording: {
+                await recorderUIManager.cancelRecording()
+            }
+        )
+
+        let primaryRecordingShortcutModeSource = RecordingShortcutModeSource(
+            primaryMode: primaryRecordingShortcutMode
+        )
+
         self.engine = engine
         self.recorderUIManager = recorderUIManager
         self.miniRecorderShortcutManager = MiniRecorderShortcutManager(engine: engine, recorderUIManager: recorderUIManager)
-        self.powerModeShortcutManager = PowerModeShortcutManager(engine: engine)
+        self.shortcutModeHandler = shortcutModeHandler
+        self.primaryRecordingShortcutModeSource = primaryRecordingShortcutModeSource
+        self.powerModeShortcutManager = PowerModeShortcutManager(
+            modeProvider: {
+                primaryRecordingShortcutModeSource.primaryMode
+            },
+            shortcutModeHandler: shortcutModeHandler
+        )
 
         shortcutChangeObserver = NotificationCenter.default.addObserver(
             forName: ShortcutStore.shortcutDidChange,
@@ -203,22 +231,31 @@ class RecordingShortcutManager: ObservableObject {
                 Task { @MainActor in
                     guard let self else { return }
                     guard let mode = self.recordingMode(for: action) else { return }
-                    await self.handleShortcutKeyDown(action: action, eventTime: eventTime, mode: mode)
+                    await self.shortcutModeHandler.handleKeyDown(
+                        action: action,
+                        eventTime: eventTime,
+                        mode: mode
+                    )
                 }
             },
             onKeyUp: { [weak self] action, eventTime in
                 Task { @MainActor in
                     guard let self else { return }
                     if let mode = self.recordingMode(for: action) {
-                        await self.handleShortcutKeyUp(action: action, eventTime: eventTime, mode: mode)
+                        await self.shortcutModeHandler.handleKeyUp(
+                            action: action,
+                            eventTime: eventTime,
+                            mode: mode
+                        )
                     } else {
                         await self.handleGlobalShortcut(action)
                     }
                 }
             },
-            onShortcutInterrupted: { [weak self] action, eventTime in
+            onShortcutInterrupted: { [weak self] action, _ in
                 Task { @MainActor in
-                    await self?.handleShortcutInterruption(action: action, eventTime: eventTime)
+                    guard let self, self.recordingMode(for: action) != nil else { return }
+                    await self.shortcutModeHandler.handleInterruption(action: action)
                 }
             }
         )
@@ -271,110 +308,7 @@ class RecordingShortcutManager: ObservableObject {
         middleClickMonitors = []
         middleClickTask?.cancel()
         
-        resetKeyStates()
-    }
-    
-    private func resetKeyStates() {
-        isShortcutPressed = false
-        shortcutPressStartTime = nil
-        isHandsFreeRecording = false
-        activeRecordingShortcutAction = nil
-        interruptedRecordingActions.removeAll()
-        activeShortcutCanCancelAccidentalStart = false
-    }
-    
-    private func handleShortcutKeyDown(action: ShortcutAction, eventTime: TimeInterval, mode: Mode) async {
-        if interruptedRecordingActions.remove(action) != nil {
-            return
-        }
-
-        if let lastTrigger = lastShortcutPressTime,
-           Date().timeIntervalSince(lastTrigger) < shortcutPressCooldown {
-            return
-        }
-
-        guard !isShortcutPressed else { return }
-        isShortcutPressed = true
-        activeRecordingShortcutAction = action
-        activeShortcutCanCancelAccidentalStart = canCurrentShortcutPressCancelAccidentalStart
-        lastShortcutPressTime = Date()
-        shortcutPressStartTime = eventTime
-
-        switch mode {
-        case .toggle, .hybrid:
-            if isHandsFreeRecording {
-                isHandsFreeRecording = false
-                guard canHandleShortcutAction else { return }
-                logger.notice("handleShortcutKeyDown: toggling mini recorder (hands-free toggle)")
-                await recorderUIManager.toggleMiniRecorder()
-                return
-            }
-
-            if !recorderUIManager.isMiniRecorderVisible {
-                guard canHandleShortcutAction else { return }
-                logger.notice("handleShortcutKeyDown: toggling mini recorder (key down while not visible)")
-                await recorderUIManager.toggleMiniRecorder()
-            }
-
-        case .pushToTalk:
-            if !recorderUIManager.isMiniRecorderVisible {
-                guard canHandleShortcutAction else { return }
-                logger.notice("handleShortcutKeyDown: starting recording (push-to-talk key down)")
-                await recorderUIManager.toggleMiniRecorder()
-            }
-        }
-    }
-
-    private func handleShortcutKeyUp(action: ShortcutAction, eventTime: TimeInterval, mode: Mode) async {
-        guard isShortcutPressed, activeRecordingShortcutAction == action else { return }
-        isShortcutPressed = false
-        activeRecordingShortcutAction = nil
-        activeShortcutCanCancelAccidentalStart = false
-
-        switch mode {
-        case .toggle:
-            isHandsFreeRecording = true
-
-        case .pushToTalk:
-            if recorderUIManager.isMiniRecorderVisible {
-                guard canHandleShortcutAction else { return }
-                logger.notice("handleShortcutKeyUp: stopping recording (push-to-talk key up)")
-                await recorderUIManager.toggleMiniRecorder()
-            }
-
-        case .hybrid:
-            let pressDuration = shortcutPressStartTime.map { eventTime - $0 } ?? 0
-            if pressDuration >= Self.hybridPressThreshold && engine.recordingState == .recording {
-                guard canHandleShortcutAction else { return }
-                logger.notice("handleShortcutKeyUp: stopping recording (hybrid push-to-talk, duration=\(pressDuration, privacy: .public)s)")
-                await recorderUIManager.toggleMiniRecorder()
-            } else {
-                isHandsFreeRecording = true
-            }
-        }
-
-        shortcutPressStartTime = nil
-    }
-
-    private func handleShortcutInterruption(action: ShortcutAction, eventTime _: TimeInterval) async {
-        guard recordingMode(for: action) != nil else { return }
-
-        guard isShortcutPressed, activeRecordingShortcutAction == action else {
-            if canCurrentShortcutPressCancelAccidentalStart {
-                interruptedRecordingActions.insert(action)
-            }
-            return
-        }
-
-        guard activeShortcutCanCancelAccidentalStart else { return }
-
-        logger.notice("handleShortcutInterruption: cancelling recording shortcut that became part of a larger key chord")
-        resetKeyStates()
-        await recorderUIManager.cancelRecording()
-    }
-
-    private var canCurrentShortcutPressCancelAccidentalStart: Bool {
-        !recorderUIManager.isMiniRecorderVisible && engine.recordingState == .idle
+        shortcutModeHandler.reset()
     }
     
     var isShortcutConfigured: Bool {
@@ -396,5 +330,162 @@ class RecordingShortcutManager: ObservableObject {
         MainActor.assumeIsolated {
             removeAllMonitoring()
         }
+    }
+}
+
+@MainActor
+private final class RecordingShortcutModeSource {
+    var primaryMode: RecordingShortcutManager.Mode
+
+    init(primaryMode: RecordingShortcutManager.Mode) {
+        self.primaryMode = primaryMode
+    }
+}
+
+@MainActor
+final class RecordingShortcutModeHandler {
+    private let logger: Logger
+    private let canHandleShortcutAction: @MainActor () -> Bool
+    private let isRecorderVisible: @MainActor () -> Bool
+    private let recordingState: @MainActor () -> RecordingState
+    private let toggleMiniRecorder: @MainActor (UUID?) async -> Void
+    private let cancelRecording: @MainActor () async -> Void
+
+    private var shortcutPressStartTime: TimeInterval?
+    private var isHandsFreeRecording = false
+    private var isShortcutPressed = false
+    private var activeRecordingShortcutAction: ShortcutAction?
+    private var interruptedRecordingActions = Set<ShortcutAction>()
+    private var activeShortcutCanCancelAccidentalStart = false
+    private var lastShortcutPressTime: Date?
+
+    private let shortcutPressCooldown: TimeInterval = 0.5
+    private let hybridPressThreshold: TimeInterval = 0.5
+
+    init(
+        logger: Logger,
+        canHandleShortcutAction: @escaping @MainActor () -> Bool,
+        isRecorderVisible: @escaping @MainActor () -> Bool,
+        recordingState: @escaping @MainActor () -> RecordingState,
+        toggleMiniRecorder: @escaping @MainActor (UUID?) async -> Void,
+        cancelRecording: @escaping @MainActor () async -> Void
+    ) {
+        self.logger = logger
+        self.canHandleShortcutAction = canHandleShortcutAction
+        self.isRecorderVisible = isRecorderVisible
+        self.recordingState = recordingState
+        self.toggleMiniRecorder = toggleMiniRecorder
+        self.cancelRecording = cancelRecording
+    }
+
+    func reset() {
+        isShortcutPressed = false
+        shortcutPressStartTime = nil
+        isHandsFreeRecording = false
+        activeRecordingShortcutAction = nil
+        interruptedRecordingActions.removeAll()
+        activeShortcutCanCancelAccidentalStart = false
+    }
+
+    func handleKeyDown(
+        action: ShortcutAction,
+        eventTime: TimeInterval,
+        mode: RecordingShortcutManager.Mode,
+        powerModeId: UUID? = nil
+    ) async {
+        if interruptedRecordingActions.remove(action) != nil {
+            return
+        }
+
+        if let lastTrigger = lastShortcutPressTime,
+           Date().timeIntervalSince(lastTrigger) < shortcutPressCooldown {
+            return
+        }
+
+        guard !isShortcutPressed else { return }
+        isShortcutPressed = true
+        activeRecordingShortcutAction = action
+        activeShortcutCanCancelAccidentalStart = canCurrentShortcutPressCancelAccidentalStart
+        lastShortcutPressTime = Date()
+        shortcutPressStartTime = eventTime
+
+        switch mode {
+        case .toggle, .hybrid:
+            if isHandsFreeRecording {
+                isHandsFreeRecording = false
+                guard canHandleShortcutAction() else { return }
+                logger.notice("handleShortcutKeyDown: toggling mini recorder (hands-free toggle)")
+                await toggleMiniRecorder(powerModeId)
+                return
+            }
+
+            if !isRecorderVisible() {
+                guard canHandleShortcutAction() else { return }
+                logger.notice("handleShortcutKeyDown: toggling mini recorder (key down while not visible)")
+                await toggleMiniRecorder(powerModeId)
+            }
+
+        case .pushToTalk:
+            if !isRecorderVisible() {
+                guard canHandleShortcutAction() else { return }
+                logger.notice("handleShortcutKeyDown: starting recording (push-to-talk key down)")
+                await toggleMiniRecorder(powerModeId)
+            }
+        }
+    }
+
+    func handleKeyUp(
+        action: ShortcutAction,
+        eventTime: TimeInterval,
+        mode: RecordingShortcutManager.Mode,
+        powerModeId: UUID? = nil
+    ) async {
+        guard isShortcutPressed, activeRecordingShortcutAction == action else { return }
+        isShortcutPressed = false
+        activeRecordingShortcutAction = nil
+        activeShortcutCanCancelAccidentalStart = false
+
+        switch mode {
+        case .toggle:
+            isHandsFreeRecording = true
+
+        case .pushToTalk:
+            if isRecorderVisible() {
+                guard canHandleShortcutAction() else { return }
+                logger.notice("handleShortcutKeyUp: stopping recording (push-to-talk key up)")
+                await toggleMiniRecorder(powerModeId)
+            }
+
+        case .hybrid:
+            let pressDuration = shortcutPressStartTime.map { eventTime - $0 } ?? 0
+            if pressDuration >= hybridPressThreshold && recordingState() == .recording {
+                guard canHandleShortcutAction() else { return }
+                logger.notice("handleShortcutKeyUp: stopping recording (hybrid push-to-talk, duration=\(pressDuration, privacy: .public)s)")
+                await toggleMiniRecorder(powerModeId)
+            } else {
+                isHandsFreeRecording = true
+            }
+        }
+
+        shortcutPressStartTime = nil
+    }
+
+    func handleInterruption(action: ShortcutAction) async {
+        guard isShortcutPressed, activeRecordingShortcutAction == action else {
+            if canCurrentShortcutPressCancelAccidentalStart {
+                interruptedRecordingActions.insert(action)
+            }
+            return
+        }
+
+        guard activeShortcutCanCancelAccidentalStart else { return }
+
+        logger.notice("handleShortcutInterruption: cancelling recording shortcut that became part of a larger key chord")
+        reset()
+        await cancelRecording()
+    }
+
+    private var canCurrentShortcutPressCancelAccidentalStart: Bool {
+        !isRecorderVisible() && recordingState() == .idle
     }
 }

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -62,6 +62,8 @@ class RecordingShortcutManager: ObservableObject {
     private var shortcutPressStartTime: TimeInterval?
     private var isHandsFreeRecording = false
     private var isShortcutPressed = false
+    private var activeRecordingShortcutAction: ShortcutAction?
+    private var interruptedRecordingActions = Set<ShortcutAction>()
     private var lastShortcutPressTime: Date?
     private let shortcutPressCooldown: TimeInterval = 0.5
 
@@ -181,32 +183,41 @@ class RecordingShortcutManager: ObservableObject {
         let primaryShortcut = primaryRecordingShortcut == .custom ? ShortcutStore.shortcut(for: .primaryRecording) : nil
         let secondaryShortcut = secondaryRecordingShortcut == .custom ? ShortcutStore.shortcut(for: .secondaryRecording) : nil
         var shortcuts = ShortcutStore.shortcuts(for: ShortcutAction.globalUtilityActions)
+        var interruptibleRecordingActions = Set<ShortcutAction>()
 
         if let primaryShortcut {
             shortcuts[.primaryRecording] = primaryShortcut
+            interruptibleRecordingActions.insert(.primaryRecording)
         }
 
         if let secondaryShortcut {
             shortcuts[.secondaryRecording] = secondaryShortcut
+            interruptibleRecordingActions.insert(.secondaryRecording)
         }
 
         shortcutMonitor.start(
             shortcuts: shortcuts,
+            interruptibleActions: interruptibleRecordingActions,
             onKeyDown: { [weak self] action, eventTime in
                 Task { @MainActor in
                     guard let self else { return }
                     guard let mode = self.recordingMode(for: action) else { return }
-                    await self.handleShortcutKeyDown(eventTime: eventTime, mode: mode)
+                    await self.handleShortcutKeyDown(action: action, eventTime: eventTime, mode: mode)
                 }
             },
             onKeyUp: { [weak self] action, eventTime in
                 Task { @MainActor in
                     guard let self else { return }
                     if let mode = self.recordingMode(for: action) {
-                        await self.handleShortcutKeyUp(eventTime: eventTime, mode: mode)
+                        await self.handleShortcutKeyUp(action: action, eventTime: eventTime, mode: mode)
                     } else {
                         await self.handleGlobalShortcut(action)
                     }
+                }
+            },
+            onShortcutInterrupted: { [weak self] action, eventTime in
+                Task { @MainActor in
+                    await self?.handleShortcutInterruption(action: action, eventTime: eventTime)
                 }
             }
         )
@@ -266,9 +277,15 @@ class RecordingShortcutManager: ObservableObject {
         isShortcutPressed = false
         shortcutPressStartTime = nil
         isHandsFreeRecording = false
+        activeRecordingShortcutAction = nil
+        interruptedRecordingActions.removeAll()
     }
     
-    private func handleShortcutKeyDown(eventTime: TimeInterval, mode: Mode) async {
+    private func handleShortcutKeyDown(action: ShortcutAction, eventTime: TimeInterval, mode: Mode) async {
+        if interruptedRecordingActions.remove(action) != nil {
+            return
+        }
+
         if let lastTrigger = lastShortcutPressTime,
            Date().timeIntervalSince(lastTrigger) < shortcutPressCooldown {
             return
@@ -276,6 +293,7 @@ class RecordingShortcutManager: ObservableObject {
 
         guard !isShortcutPressed else { return }
         isShortcutPressed = true
+        activeRecordingShortcutAction = action
         lastShortcutPressTime = Date()
         shortcutPressStartTime = eventTime
 
@@ -304,9 +322,10 @@ class RecordingShortcutManager: ObservableObject {
         }
     }
 
-    private func handleShortcutKeyUp(eventTime: TimeInterval, mode: Mode) async {
-        guard isShortcutPressed else { return }
+    private func handleShortcutKeyUp(action: ShortcutAction, eventTime: TimeInterval, mode: Mode) async {
+        guard isShortcutPressed, activeRecordingShortcutAction == action else { return }
         isShortcutPressed = false
+        activeRecordingShortcutAction = nil
 
         switch mode {
         case .toggle:
@@ -331,6 +350,19 @@ class RecordingShortcutManager: ObservableObject {
         }
 
         shortcutPressStartTime = nil
+    }
+
+    private func handleShortcutInterruption(action: ShortcutAction, eventTime _: TimeInterval) async {
+        guard recordingMode(for: action) != nil else { return }
+
+        guard isShortcutPressed, activeRecordingShortcutAction == action else {
+            interruptedRecordingActions.insert(action)
+            return
+        }
+
+        logger.notice("handleShortcutInterruption: cancelling recording shortcut that became part of a larger key chord")
+        resetKeyStates()
+        await recorderUIManager.cancelRecording(playFeedback: false)
     }
     
     var isShortcutConfigured: Bool {

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -64,6 +64,7 @@ class RecordingShortcutManager: ObservableObject {
     private var isShortcutPressed = false
     private var activeRecordingShortcutAction: ShortcutAction?
     private var interruptedRecordingActions = Set<ShortcutAction>()
+    private var activeShortcutCanCancelAccidentalStart = false
     private var lastShortcutPressTime: Date?
     private let shortcutPressCooldown: TimeInterval = 0.5
 
@@ -279,6 +280,7 @@ class RecordingShortcutManager: ObservableObject {
         isHandsFreeRecording = false
         activeRecordingShortcutAction = nil
         interruptedRecordingActions.removeAll()
+        activeShortcutCanCancelAccidentalStart = false
     }
     
     private func handleShortcutKeyDown(action: ShortcutAction, eventTime: TimeInterval, mode: Mode) async {
@@ -294,6 +296,7 @@ class RecordingShortcutManager: ObservableObject {
         guard !isShortcutPressed else { return }
         isShortcutPressed = true
         activeRecordingShortcutAction = action
+        activeShortcutCanCancelAccidentalStart = canCurrentShortcutPressCancelAccidentalStart
         lastShortcutPressTime = Date()
         shortcutPressStartTime = eventTime
 
@@ -326,6 +329,7 @@ class RecordingShortcutManager: ObservableObject {
         guard isShortcutPressed, activeRecordingShortcutAction == action else { return }
         isShortcutPressed = false
         activeRecordingShortcutAction = nil
+        activeShortcutCanCancelAccidentalStart = false
 
         switch mode {
         case .toggle:
@@ -356,13 +360,21 @@ class RecordingShortcutManager: ObservableObject {
         guard recordingMode(for: action) != nil else { return }
 
         guard isShortcutPressed, activeRecordingShortcutAction == action else {
-            interruptedRecordingActions.insert(action)
+            if canCurrentShortcutPressCancelAccidentalStart {
+                interruptedRecordingActions.insert(action)
+            }
             return
         }
+
+        guard activeShortcutCanCancelAccidentalStart else { return }
 
         logger.notice("handleShortcutInterruption: cancelling recording shortcut that became part of a larger key chord")
         resetKeyStates()
         await recorderUIManager.cancelRecording(playFeedback: false)
+    }
+
+    private var canCurrentShortcutPressCancelAccidentalStart: Bool {
+        !recorderUIManager.isMiniRecorderVisible && engine.recordingState == .idle
     }
     
     var isShortcutConfigured: Bool {

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -370,7 +370,7 @@ class RecordingShortcutManager: ObservableObject {
 
         logger.notice("handleShortcutInterruption: cancelling recording shortcut that became part of a larger key chord")
         resetKeyStates()
-        await recorderUIManager.cancelRecording(playFeedback: false)
+        await recorderUIManager.cancelRecording()
     }
 
     private var canCurrentShortcutPressCancelAccidentalStart: Bool {

--- a/VoiceInk/Shortcuts/Shortcut.swift
+++ b/VoiceInk/Shortcuts/Shortcut.swift
@@ -110,6 +110,15 @@ struct Shortcut: Codable, Equatable {
         return keyCode == eventKeyCode
     }
 
+    func isInterruptedByAdditionalKeyDown(keyCode eventKeyCode: UInt16) -> Bool {
+        switch kind {
+        case .modifierOnly:
+            return true
+        case .key:
+            return keyCode != eventKeyCode
+        }
+    }
+
     static func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
         modifierKeyCodes.contains(keyCode)
     }

--- a/VoiceInk/Shortcuts/ShortcutMonitor.swift
+++ b/VoiceInk/Shortcuts/ShortcutMonitor.swift
@@ -12,15 +12,20 @@ final class ShortcutMonitor {
     private struct ShortcutState {
         var shortcut: Shortcut
         var isDown = false
+        var pressedAt: TimeInterval?
+        var isInterrupted = false
     }
 
     private var shortcuts: [ShortcutAction: ShortcutState] = [:]
+    private var interruptibleActions: Set<ShortcutAction> = []
     private var onKeyDown: ((ShortcutAction, TimeInterval) -> Void)?
     private var onKeyUp: ((ShortcutAction, TimeInterval) -> Void)?
+    private var onShortcutInterrupted: ((ShortcutAction, TimeInterval) -> Void)?
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
 
     private static var hasRequestedListenEventAccess = false
+    private static let shortcutInterruptionWindow: TimeInterval = 1.0
 
     deinit {
         stop()
@@ -29,8 +34,10 @@ final class ShortcutMonitor {
     @discardableResult
     func start(
         shortcuts: [ShortcutAction: Shortcut],
+        interruptibleActions: Set<ShortcutAction> = [],
         onKeyDown: @escaping (ShortcutAction, TimeInterval) -> Void,
-        onKeyUp: @escaping (ShortcutAction, TimeInterval) -> Void
+        onKeyUp: @escaping (ShortcutAction, TimeInterval) -> Void,
+        onShortcutInterrupted: ((ShortcutAction, TimeInterval) -> Void)? = nil
     ) -> Bool {
         stop()
 
@@ -42,8 +49,10 @@ final class ShortcutMonitor {
             return true
         }
 
+        self.interruptibleActions = interruptibleActions
         self.onKeyDown = onKeyDown
         self.onKeyUp = onKeyUp
+        self.onShortcutInterrupted = onShortcutInterrupted
 
         return installEventTap()
     }
@@ -60,8 +69,10 @@ final class ShortcutMonitor {
         }
 
         shortcuts = [:]
+        interruptibleActions = []
         onKeyDown = nil
         onKeyUp = nil
+        onShortcutInterrupted = nil
     }
 
     private func installEventTap() -> Bool {
@@ -142,19 +153,23 @@ final class ShortcutMonitor {
     private func resetPressedShortcutsAfterTapInterruption() {
         let eventTime = ProcessInfo.processInfo.systemUptime
         let pressedActions = shortcuts.compactMap { action, state in
-            state.isDown ? action : nil
+            state.isDown ? (action, state.isInterrupted) : nil
         }
 
         guard !pressedActions.isEmpty else {
             return
         }
 
-        for action in pressedActions {
+        for (action, wasInterrupted) in pressedActions {
             if var state = shortcuts[action] {
                 state.isDown = false
+                state.pressedAt = nil
+                state.isInterrupted = false
                 shortcuts[action] = state
             }
-            dispatchKeyUp(for: action, eventTime: eventTime)
+            if !wasInterrupted {
+                dispatchKeyUp(for: action, eventTime: eventTime)
+            }
         }
     }
 
@@ -165,6 +180,10 @@ final class ShortcutMonitor {
         eventTime: TimeInterval
     ) -> Bool {
         var shouldSuppress = false
+
+        if kind == .keyDown {
+            handleShortcutInterruptions(keyCode: keyCode, eventTime: eventTime)
+        }
 
         for action in Array(shortcuts.keys) {
             guard var state = shortcuts[action] else {
@@ -198,14 +217,21 @@ final class ShortcutMonitor {
                 shouldSuppress = true
             case .keyDown:
                 state.isDown = true
+                state.pressedAt = eventTime
+                state.isInterrupted = false
                 shortcuts[action] = state
                 shouldSuppress = true
                 dispatchKeyDown(for: action, eventTime: eventTime)
             case .keyUp:
+                let wasInterrupted = state.isInterrupted
                 state.isDown = false
+                state.pressedAt = nil
+                state.isInterrupted = false
                 shortcuts[action] = state
                 shouldSuppress = true
-                dispatchKeyUp(for: action, eventTime: eventTime)
+                if !wasInterrupted {
+                    dispatchKeyUp(for: action, eventTime: eventTime)
+                }
             }
         }
 
@@ -264,9 +290,14 @@ final class ShortcutMonitor {
 
         if state.isDown {
             if state.shortcut.shouldReleaseModifierEvent(keyCode: keyCode, modifierFlags: modifierFlags) {
+                let wasInterrupted = state.isInterrupted
                 state.isDown = false
+                state.pressedAt = nil
+                state.isInterrupted = false
                 shortcuts[action] = state
-                dispatchKeyUp(for: action, eventTime: eventTime)
+                if !wasInterrupted {
+                    dispatchKeyUp(for: action, eventTime: eventTime)
+                }
             }
 
             return
@@ -274,8 +305,32 @@ final class ShortcutMonitor {
 
         if state.shortcut.matchesModifierEvent(keyCode: keyCode, modifierFlags: modifierFlags) {
             state.isDown = true
+            state.pressedAt = eventTime
+            state.isInterrupted = false
             shortcuts[action] = state
             dispatchKeyDown(for: action, eventTime: eventTime)
+        }
+    }
+
+    private func handleShortcutInterruptions(keyCode: UInt16, eventTime: TimeInterval) {
+        guard !Shortcut.isModifierKeyCode(keyCode) else {
+            return
+        }
+
+        for action in interruptibleActions {
+            guard var state = shortcuts[action],
+                  state.isDown,
+                  !state.isInterrupted,
+                  let pressedAt = state.pressedAt,
+                  eventTime - pressedAt <= Self.shortcutInterruptionWindow,
+                  state.shortcut.isInterruptedByAdditionalKeyDown(keyCode: keyCode)
+            else {
+                continue
+            }
+
+            state.isInterrupted = true
+            shortcuts[action] = state
+            dispatchShortcutInterrupted(for: action, eventTime: eventTime)
         }
     }
 
@@ -288,6 +343,12 @@ final class ShortcutMonitor {
     private func dispatchKeyUp(for action: ShortcutAction, eventTime: TimeInterval) {
         DispatchQueue.main.async { [onKeyUp] in
             onKeyUp?(action, eventTime)
+        }
+    }
+
+    private func dispatchShortcutInterrupted(for action: ShortcutAction, eventTime: TimeInterval) {
+        DispatchQueue.main.async { [onShortcutInterrupted] in
+            onShortcutInterrupted?(action, eventTime)
         }
     }
 

--- a/VoiceInk/Shortcuts/ShortcutMonitor.swift
+++ b/VoiceInk/Shortcuts/ShortcutMonitor.swift
@@ -153,23 +153,21 @@ final class ShortcutMonitor {
     private func resetPressedShortcutsAfterTapInterruption() {
         let eventTime = ProcessInfo.processInfo.systemUptime
         let pressedActions = shortcuts.compactMap { action, state in
-            state.isDown ? (action, state.isInterrupted) : nil
+            state.isDown ? action : nil
         }
 
         guard !pressedActions.isEmpty else {
             return
         }
 
-        for (action, wasInterrupted) in pressedActions {
+        for action in pressedActions {
             if var state = shortcuts[action] {
                 state.isDown = false
                 state.pressedAt = nil
                 state.isInterrupted = false
                 shortcuts[action] = state
             }
-            if !wasInterrupted {
-                dispatchKeyUp(for: action, eventTime: eventTime)
-            }
+            dispatchKeyUp(for: action, eventTime: eventTime)
         }
     }
 
@@ -223,15 +221,12 @@ final class ShortcutMonitor {
                 shouldSuppress = true
                 dispatchKeyDown(for: action, eventTime: eventTime)
             case .keyUp:
-                let wasInterrupted = state.isInterrupted
                 state.isDown = false
                 state.pressedAt = nil
                 state.isInterrupted = false
                 shortcuts[action] = state
                 shouldSuppress = true
-                if !wasInterrupted {
-                    dispatchKeyUp(for: action, eventTime: eventTime)
-                }
+                dispatchKeyUp(for: action, eventTime: eventTime)
             }
         }
 
@@ -290,14 +285,11 @@ final class ShortcutMonitor {
 
         if state.isDown {
             if state.shortcut.shouldReleaseModifierEvent(keyCode: keyCode, modifierFlags: modifierFlags) {
-                let wasInterrupted = state.isInterrupted
                 state.isDown = false
                 state.pressedAt = nil
                 state.isInterrupted = false
                 shortcuts[action] = state
-                if !wasInterrupted {
-                    dispatchKeyUp(for: action, eventTime: eventTime)
-                }
+                dispatchKeyUp(for: action, eventTime: eventTime)
             }
 
             return

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -165,12 +165,9 @@ class RecorderUIManager: ObservableObject {
         await engine.cleanupResources()
     }
 
-    func cancelRecording(playFeedback: Bool = true) async {
+    func cancelRecording() async {
         guard let engine = engine else { return }
         logger.notice("cancelRecording called")
-        if playFeedback {
-            SoundManager.shared.playEscSound()
-        }
         engine.shouldCancelRecording = true
         await dismissMiniRecorder()
     }

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -165,10 +165,12 @@ class RecorderUIManager: ObservableObject {
         await engine.cleanupResources()
     }
 
-    func cancelRecording() async {
+    func cancelRecording(playFeedback: Bool = true) async {
         guard let engine = engine else { return }
         logger.notice("cancelRecording called")
-        SoundManager.shared.playEscSound()
+        if playFeedback {
+            SoundManager.shared.playEscSound()
+        }
         engine.shouldCancelRecording = true
         await dismissMiniRecorder()
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes accidental recording starts when a recording shortcut becomes part of a larger key chord. Adds interruption detection and safe cancellation for recording and Power Mode, and relaxes Power Mode key-up handling to avoid stuck states.

- **Bug Fixes**
  - Detect interruptions within 1s when an extra non‑modifier key is pressed; cancel accidental starts only if the recorder is hidden and idle.
  - Keep toggle, push‑to‑talk, and hybrid modes working after interruptions.
  - Power Mode shortcuts use the same interruption handling.
  - Relax Power Mode key‑up validation so releases are handled even if config changes mid-press, preventing stuck states.

- **Refactors**
  - Added RecordingShortcutModeHandler to centralize mode/timing and cancellation; introduced RecordingShortcutModeSource to share the primary mode with Power Mode.
  - Enhanced ShortcutMonitor with interruptible actions, pressedAt/isInterrupted tracking, and onShortcutInterrupted.
  - PowerModeShortcutManager now uses a modeProvider and the shared handler; removed direct engine coupling.
  - Added Shortcut.isInterruptedByAdditionalKeyDown; removed the ESC cancel sound.

<sup>Written for commit 73d21e14a271cff0f841d5739e5482c1659ef328. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/724?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

