### PR TITLE
Allow make local to work with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ local: check setup
 		CODE_SIGNING_REQUIRED=NO \
 		CODE_SIGNING_ALLOWED=YES \
 		DEVELOPMENT_TEAM="" \
-		CODE_SIGN_ENTITLEMENTS=$(CURDIR)/VoiceInk/VoiceInk.local.entitlements \
+		CODE_SIGN_ENTITLEMENTS="$(CURDIR)/VoiceInk/VoiceInk.local.entitlements" \
 		SWIFT_ACTIVE_COMPILATION_CONDITIONS='$$(inherited) LOCAL_BUILD' \
 		build
 	@APP_PATH="$(LOCAL_DERIVED_DATA)/Build/Products/Debug/VoiceInk.app" && \


### PR DESCRIPTION
Allow make local to work when repo is cloned into a directory with spaces



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes make local when the repository path contains spaces by quoting the CODE_SIGN_ENTITLEMENTS path in the Makefile.

<sup>Written for commit 0972df0d62b064c003ce1bff0ecff07b34e1608d. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/725?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

