### PR TITLE
Improve paste reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ local: check setup
 		CODE_SIGNING_REQUIRED=NO \
 		CODE_SIGNING_ALLOWED=YES \
 		DEVELOPMENT_TEAM="" \
-		CODE_SIGN_ENTITLEMENTS=$(CURDIR)/VoiceInk/VoiceInk.local.entitlements \
+		CODE_SIGN_ENTITLEMENTS="$(CURDIR)/VoiceInk/VoiceInk.local.entitlements" \
 		SWIFT_ACTIVE_COMPILATION_CONDITIONS='$$(inherited) LOCAL_BUILD' \
 		build
 	@APP_PATH="$(LOCAL_DERIVED_DATA)/Build/Products/Debug/VoiceInk.app" && \

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "9782d877bc24b23bd99c66ad70fd8d2669377fa7"
+        "revision" : "50aa07193e84b9cf192d8f36041c24a9a4867cd6"
       }
     },
     {

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -176,11 +176,12 @@ struct SettingsView: View {
                     }
                 }
 
-                // Restore Clipboard
+                // Keep Clipboard Content
                 ExpandableSettingsRow(
                     isExpanded: $isRestoreClipboardExpanded,
                     isEnabled: $restoreClipboardAfterPaste,
-                    label: "Restore Clipboard After Paste"
+                    label: "Keep Clipboard Content",
+                    infoMessage: "VoiceInk temporarily uses the clipboard to paste transcription. When enabled, it restores your previous clipboard content after the selected delay. When disabled, the pasted transcription stays on your clipboard."
                 ) {
                     Picker("Restore Delay", selection: $clipboardRestoreDelay) {
                         Text("250ms").tag(0.25)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves paste reliability and clarity by renaming the clipboard setting and adding an info message on restore timing. Also fixes `make local` in paths with spaces and updates the `FluidAudio` pin.

- **Bug Fixes**
  - Quote `CODE_SIGN_ENTITLEMENTS` in `make local` so builds work when the repo path contains spaces.
  - Rename the setting to "Keep Clipboard Content" and add info text explaining temporary clipboard use and the restore delay.

- **Dependencies**
  - Update `FluidAudio` SPM pin to revision `50aa0719`.

<sup>Written for commit 81bb63dd1e408cec5142970c45685025296b9834. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/728?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

