### PR TITLE
Allow prompt switching while holding modifier push-to-talk keys

### DIFF
--- a/VoiceInk/Shortcuts/MiniRecorderShortcutManager.swift
+++ b/VoiceInk/Shortcuts/MiniRecorderShortcutManager.swift
@@ -6,6 +6,7 @@ import Carbon.HIToolbox
 class MiniRecorderShortcutManager: ObservableObject {
     private var engine: VoiceInkEngine
     private var recorderUIManager: RecorderUIManager
+    private let activeHeldModifierFlags: @MainActor () -> NSEvent.ModifierFlags
     private var visibilityTask: Task<Void, Never>?
     private var shortcutChangeObserver: NSObjectProtocol?
     private let visibleRecorderMonitor = ShortcutMonitor()
@@ -15,9 +16,14 @@ class MiniRecorderShortcutManager: ObservableObject {
     private let escapeDoublePressThreshold: TimeInterval = 1.5
     private var escapeTimeoutTask: Task<Void, Never>?
     
-    init(engine: VoiceInkEngine, recorderUIManager: RecorderUIManager) {
+    init(
+        engine: VoiceInkEngine,
+        recorderUIManager: RecorderUIManager,
+        activeHeldModifierFlags: @escaping @MainActor () -> NSEvent.ModifierFlags = { [] }
+    ) {
         self.engine = engine
         self.recorderUIManager = recorderUIManager
+        self.activeHeldModifierFlags = activeHeldModifierFlags
         setupShortcutChangeObserver()
         setupVisibilityObserver()
     }
@@ -65,7 +71,7 @@ class MiniRecorderShortcutManager: ObservableObject {
         escapeTimeoutTask = nil
     }
     
-    private func refreshVisibleShortcuts() {
+    func refreshVisibleShortcuts() {
         guard recorderUIManager.isMiniRecorderVisible else {
             visibleRecorderMonitor.stop()
             resetEscapeState()
@@ -78,18 +84,21 @@ class MiniRecorderShortcutManager: ObservableObject {
             shortcuts[.miniRecorderEscape] = .key(keyCode: UInt16(kVK_Escape), modifierFlags: [])
         }
 
+        let ambientModifierFlags = activeHeldModifierFlags()
+
         for (index, keyCode) in Self.digitKeyCodes.enumerated() {
             shortcuts[.miniRecorderPrompt(index)] = .key(
                 keyCode: keyCode,
-                modifierFlags: [.command]
+                modifierFlags: Self.promptDigitModifierFlags(ambientModifierFlags: ambientModifierFlags)
             )
         }
 
-        if canUsePowerModeShortcuts {
+        if canUsePowerModeShortcuts,
+           Self.shouldRegisterPowerModeDigitShortcuts(ambientModifierFlags: ambientModifierFlags) {
             for (index, keyCode) in Self.digitKeyCodes.enumerated() {
                 shortcuts[.miniRecorderPowerMode(index)] = .key(
                     keyCode: keyCode,
-                    modifierFlags: [.option]
+                    modifierFlags: Self.powerModeDigitModifierFlags(ambientModifierFlags: ambientModifierFlags)
                 )
             }
         }
@@ -203,4 +212,17 @@ class MiniRecorderShortcutManager: ObservableObject {
         UInt16(kVK_ANSI_9),
         UInt16(kVK_ANSI_0)
     ]
+
+    static func promptDigitModifierFlags(ambientModifierFlags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        [.command].union(ambientModifierFlags)
+    }
+
+    static func powerModeDigitModifierFlags(ambientModifierFlags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        [.option].union(ambientModifierFlags)
+    }
+
+    static func shouldRegisterPowerModeDigitShortcuts(ambientModifierFlags: NSEvent.ModifierFlags) -> Bool {
+        powerModeDigitModifierFlags(ambientModifierFlags: ambientModifierFlags) !=
+            promptDigitModifierFlags(ambientModifierFlags: ambientModifierFlags)
+    }
 }

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -141,8 +141,14 @@ class RecordingShortcutManager: ObservableObject {
 
         self.engine = engine
         self.recorderUIManager = recorderUIManager
-        self.miniRecorderShortcutManager = MiniRecorderShortcutManager(engine: engine, recorderUIManager: recorderUIManager)
         self.shortcutModeHandler = shortcutModeHandler
+        self.miniRecorderShortcutManager = MiniRecorderShortcutManager(
+            engine: engine,
+            recorderUIManager: recorderUIManager,
+            activeHeldModifierFlags: { [weak shortcutModeHandler] in
+                shortcutModeHandler?.activeHeldModifierFlags ?? []
+            }
+        )
         self.primaryRecordingShortcutModeSource = primaryRecordingShortcutModeSource
         self.powerModeShortcutManager = PowerModeShortcutManager(
             modeProvider: {
@@ -247,6 +253,7 @@ class RecordingShortcutManager: ObservableObject {
                             eventTime: eventTime,
                             mode: mode
                         )
+                        self.miniRecorderShortcutManager.refreshVisibleShortcuts()
                     } else {
                         await self.handleGlobalShortcut(action)
                     }
@@ -385,6 +392,14 @@ final class RecordingShortcutModeHandler {
         activeRecordingShortcutAction = nil
         interruptedRecordingActions.removeAll()
         activeShortcutCanCancelAccidentalStart = false
+    }
+
+    var activeHeldModifierFlags: NSEvent.ModifierFlags {
+        guard isShortcutPressed, let activeRecordingShortcutAction else {
+            return []
+        }
+
+        return ShortcutStore.shortcut(for: activeRecordingShortcutAction)?.modifierFlags ?? []
     }
 
     func handleKeyDown(

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -6,12 +6,50 @@
 //
 
 import Testing
+import AppKit
 @testable import VoiceInk
 
+@MainActor
 struct VoiceInkTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func miniRecorderDigitShortcutsUseDefaultModifiersWithoutHeldRecordingModifiers() {
+        #expect(MiniRecorderShortcutManager.promptDigitModifierFlags(ambientModifierFlags: []) == [.command])
+        #expect(MiniRecorderShortcutManager.powerModeDigitModifierFlags(ambientModifierFlags: []) == [.option])
+        #expect(MiniRecorderShortcutManager.shouldRegisterPowerModeDigitShortcuts(ambientModifierFlags: []))
+    }
+
+    @Test func miniRecorderPromptShortcutsIncludeHeldRecordingModifiers() {
+        let modifierFlags = MiniRecorderShortcutManager.promptDigitModifierFlags(
+            ambientModifierFlags: [.option]
+        )
+
+        #expect(modifierFlags == [.command, .option])
+    }
+
+    @Test func miniRecorderPowerModeShortcutsDoNotCollideWithPromptShortcutsWhenOptionIsHeld() {
+        let promptModifierFlags = MiniRecorderShortcutManager.promptDigitModifierFlags(
+            ambientModifierFlags: [.option]
+        )
+        let powerModeModifierFlags = MiniRecorderShortcutManager.powerModeDigitModifierFlags(
+            ambientModifierFlags: [.option]
+        )
+
+        #expect(promptModifierFlags == [.command, .option])
+        #expect(powerModeModifierFlags == [.option])
+        #expect(promptModifierFlags != powerModeModifierFlags)
+        #expect(MiniRecorderShortcutManager.shouldRegisterPowerModeDigitShortcuts(ambientModifierFlags: [.option]))
+    }
+
+    @Test func miniRecorderPowerModeShortcutsAreSkippedWhenFoldedModifiersWouldCollide() {
+        let promptModifierFlags = MiniRecorderShortcutManager.promptDigitModifierFlags(
+            ambientModifierFlags: [.command, .option]
+        )
+        let powerModeModifierFlags = MiniRecorderShortcutManager.powerModeDigitModifierFlags(
+            ambientModifierFlags: [.command, .option]
+        )
+
+        #expect(promptModifierFlags == powerModeModifierFlags)
+        #expect(!MiniRecorderShortcutManager.shouldRegisterPowerModeDigitShortcuts(ambientModifierFlags: [.command, .option]))
     }
 
 }


### PR DESCRIPTION
## Summary

VoiceInk currently lets users switch enhancement prompts from the Mini Recorder with `Cmd + 1...0`. This works when recording is started in toggle mode, but it fails during push-to-talk if the recording shortcut is a held modifier key, such as Right Option.

The reason is that while Right Option is held for push-to-talk, pressing `Cmd + 1` produces an event with both `Option` and `Command` modifiers. VoiceInk's prompt shortcut is registered as exactly `Command + 1`, so the shortcut does not match. As a result, users can enable AI enhancement during push-to-talk, but cannot choose which enhancement prompt to use before releasing the recording key.

This is especially noticeable because Right Option is a natural push-to-talk key on macOS: it is easy to hold, rarely used by other apps, and VoiceInk already supports modifier-only recording shortcuts.

## Changes

- Fold the currently held recording shortcut modifiers into Mini Recorder prompt digit shortcuts while the recorder is visible.
- Refresh Mini Recorder shortcut registrations after recording key release so toggle and hybrid hands-free sessions return to plain `Cmd + 1...0`.
- Avoid registering Power Mode digit shortcuts when folded modifiers would collide with prompt digit shortcuts.
- Add focused Swift Testing coverage for the modifier combinations.

## Reproduction

1. Set the recording shortcut to `Right Option`.
2. Set recording mode to `Push to Talk`.
3. Start recording by holding `Right Option`.
4. While still holding `Right Option`, press `Cmd + 1`, `Cmd + 2`, etc.
5. The active enhancement prompt does not change.
6. Switch recording mode to `Toggle`, start recording without holding `Right Option`, then press `Cmd + 1...0`.
7. Prompt switching works.

## Expected

`Cmd + 1...0` should switch enhancement prompts while the Mini Recorder is visible, even if the user is currently holding a modifier-only push-to-talk key.

## Testing

- `git diff --check`

I could not run the Xcode test suite in my local environment because `xcodebuild` requires full Xcode, but the active developer directory is Command Line Tools:

```text
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```

`swift test` is not applicable because this repository is an Xcode project rather than a Swift Package.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows switching enhancement prompts with Cmd+1…0 while holding a modifier-only push‑to‑talk key (e.g., Right Option) in the Mini Recorder. Prevents shortcut collisions and restores normal behavior after key release.

- **Bug Fixes**
  - Fold held recording modifiers into Mini Recorder prompt digit shortcuts while visible.
  - Refresh Mini Recorder shortcuts after recording key release to revert to plain Cmd+1…0.
  - Skip Power Mode digit shortcuts when folded modifiers would collide with prompt digits.
  - Add Swift tests covering modifier combinations.

<sup>Written for commit 49992f633479ff9e3e983b3b2b61d28428555ccc. Summary will update on new commits. <a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/732?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

