### PR TITLE
Add setting to display/hide menu bar icon

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -39,6 +39,7 @@ enum AppDefaults {
 
             // UI & Behavior
             "IsMenuBarOnly": false,
+            "ShowMenuBarIcon": true,
             "powerModePersistConfig": false,
             // Shortcuts
             "isMiddleClickToggleEnabled": false,

--- a/VoiceInk/AppDelegate.swift
+++ b/VoiceInk/AppDelegate.swift
@@ -10,7 +10,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag, let menuBarManager = menuBarManager, !menuBarManager.isMenuBarOnly {
+        if !flag {
             if WindowManager.shared.showMainWindow() != nil {
                 return false
             }

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -146,8 +146,15 @@ enum BackupImporter {
         if let launch = general.launchAtLoginEnabled {
             LaunchAtLogin.isEnabled = launch
         }
+        let showMenuBarIcon = general.showMenuBarIcon
+            ?? (UserDefaults.standard.object(forKey: "ShowMenuBarIcon") as? Bool ?? true)
+        if let showMenuBarIcon = general.showMenuBarIcon {
+            UserDefaults.standard.set(showMenuBarIcon, forKey: "ShowMenuBarIcon")
+        }
         if let menuOnly = general.isMenuBarOnly {
-            menuBarManager.isMenuBarOnly = menuOnly
+            menuBarManager.isMenuBarOnly = menuOnly && showMenuBarIcon
+        } else if !showMenuBarIcon {
+            menuBarManager.isMenuBarOnly = false
         }
         if let recType = general.recorderType {
             recorderUIManager.recorderType = recType

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -146,10 +146,11 @@ enum BackupImporter {
         if let launch = general.launchAtLoginEnabled {
             LaunchAtLogin.isEnabled = launch
         }
-        let showMenuBarIcon = general.showMenuBarIcon
-            ?? (UserDefaults.standard.object(forKey: "ShowMenuBarIcon") as? Bool ?? true)
+        let showMenuBarIcon = general.showMenuBarIcon ?? true
         if let showMenuBarIcon = general.showMenuBarIcon {
             UserDefaults.standard.set(showMenuBarIcon, forKey: "ShowMenuBarIcon")
+        } else if general.isMenuBarOnly == true {
+            UserDefaults.standard.set(true, forKey: "ShowMenuBarIcon")
         }
         if let menuOnly = general.isMenuBarOnly {
             menuBarManager.isMenuBarOnly = menuOnly && showMenuBarIcon

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -146,15 +146,13 @@ enum BackupImporter {
         if let launch = general.launchAtLoginEnabled {
             LaunchAtLogin.isEnabled = launch
         }
-        let showMenuBarIcon = general.showMenuBarIcon ?? true
-        if let showMenuBarIcon = general.showMenuBarIcon {
-            UserDefaults.standard.set(showMenuBarIcon, forKey: "ShowMenuBarIcon")
-        } else if general.isMenuBarOnly == true {
-            UserDefaults.standard.set(true, forKey: "ShowMenuBarIcon")
+        let shouldShowMenuBarIcon = general.showMenuBarIcon ?? true
+        if general.showMenuBarIcon != nil || general.isMenuBarOnly == true {
+            UserDefaults.standard.set(shouldShowMenuBarIcon, forKey: "ShowMenuBarIcon")
         }
         if let menuOnly = general.isMenuBarOnly {
-            menuBarManager.isMenuBarOnly = menuOnly && showMenuBarIcon
-        } else if !showMenuBarIcon {
+            menuBarManager.isMenuBarOnly = menuOnly && shouldShowMenuBarIcon
+        } else if !shouldShowMenuBarIcon {
             menuBarManager.isMenuBarOnly = false
         }
         if let recType = general.recorderType {

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -84,6 +84,7 @@ struct GeneralBackup: Codable {
     let middleClickActivationDelay: Int?
     let launchAtLoginEnabled: Bool?
     let isMenuBarOnly: Bool?
+    let showMenuBarIcon: Bool?
     let recorderType: String?
     let isTranscriptionCleanupEnabled: Bool?
     let transcriptionRetentionMinutes: Int?

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -170,6 +170,7 @@ class ImportExportService {
             middleClickActivationDelay: recordingShortcutManager.middleClickActivationDelay,
             launchAtLoginEnabled: LaunchAtLogin.isEnabled,
             isMenuBarOnly: menuBarManager.isMenuBarOnly,
+            showMenuBarIcon: UserDefaults.standard.object(forKey: "ShowMenuBarIcon") as? Bool ?? true,
             recorderType: recorderUIManager.recorderType,
             isTranscriptionCleanupEnabled: UserDefaults.standard.bool(forKey: keyIsTranscriptionCleanupEnabled),
             transcriptionRetentionMinutes: UserDefaults.standard.integer(forKey: keyTranscriptionRetentionMinutes),

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -48,6 +48,7 @@ class RecordingShortcutManager: ObservableObject {
     private let powerModeShortcutManager: PowerModeShortcutManager
     private let shortcutMonitor = ShortcutMonitor()
     private var shortcutChangeObserver: NSObjectProtocol?
+    private var appDidBecomeActiveObserver: NSObjectProtocol?
     private let shortcutModeHandler: RecordingShortcutModeHandler
     private let primaryRecordingShortcutModeSource: RecordingShortcutModeSource
 
@@ -153,6 +154,16 @@ class RecordingShortcutManager: ObservableObject {
 
         shortcutChangeObserver = NotificationCenter.default.addObserver(
             forName: ShortcutStore.shortcutDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshShortcutMonitoring()
+            }
+        }
+
+        appDidBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -325,6 +336,9 @@ class RecordingShortcutManager: ObservableObject {
     deinit {
         if let shortcutChangeObserver {
             NotificationCenter.default.removeObserver(shortcutChangeObserver)
+        }
+        if let appDidBecomeActiveObserver {
+            NotificationCenter.default.removeObserver(appDidBecomeActiveObserver)
         }
 
         MainActor.assumeIsolated {

--- a/VoiceInk/Shortcuts/ShortcutMonitor.swift
+++ b/VoiceInk/Shortcuts/ShortcutMonitor.swift
@@ -76,7 +76,7 @@ final class ShortcutMonitor {
     }
 
     private func installEventTap() -> Bool {
-        guard Self.hasListenEventAccess() else {
+        guard Self.requestListenEventAccessIfNeeded() else {
             return false
         }
 
@@ -122,7 +122,11 @@ final class ShortcutMonitor {
         return true
     }
 
-    private static func hasListenEventAccess() -> Bool {
+    static func hasListenEventAccess() -> Bool {
+        CGPreflightListenEventAccess()
+    }
+
+    private static func requestListenEventAccessIfNeeded() -> Bool {
         if CGPreflightListenEventAccess() {
             return true
         }

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -15,6 +15,7 @@ struct MenuBarView: View {
     @State private var launchAtLoginEnabled = LaunchAtLogin.isEnabled
     @State private var menuRefreshTrigger = false
     @State private var isHovered = false
+    @AppStorage("ShowMenuBarIcon") private var showMenuBarIcon = true
     
     var body: some View {
         VStack {
@@ -220,6 +221,11 @@ struct MenuBarView: View {
                 menuBarManager.toggleMenuBarOnly()
             }
             .keyboardShortcut("d", modifiers: [.command, .shift])
+
+            Button("Hide Menu Bar Icon") {
+                menuBarManager.isMenuBarOnly = false
+                showMenuBarIcon = false
+            }
             
             Toggle("Launch at Login", isOn: $launchAtLoginEnabled)
                 .onChange(of: launchAtLoginEnabled) { oldValue, newValue in

--- a/VoiceInk/Views/Metrics/MetricsContent.swift
+++ b/VoiceInk/Views/Metrics/MetricsContent.swift
@@ -101,13 +101,7 @@ struct MetricsContent: View {
                 GeometryReader { geometry in
                     ScrollView {
                         VStack(spacing: 24) {
-                            if !isInputMonitoringEnabled {
-                                inputMonitoringPermissionCallout
-                            }
-
-                            if !isAccessibilityEnabled {
-                                accessibilityPermissionCallout
-                            }
+                            permissionCallouts
 
                             heroSection
                             metricsSection
@@ -173,6 +167,17 @@ struct MetricsContent: View {
             }
         }
         .animation(.smooth(duration: 0.3), value: isModelStatsPanelPresented)
+    }
+
+    @ViewBuilder
+    private var permissionCallouts: some View {
+        if !isInputMonitoringEnabled {
+            inputMonitoringPermissionCallout
+        }
+
+        if !isAccessibilityEnabled {
+            accessibilityPermissionCallout
+        }
     }
 
     private var inputMonitoringPermissionCallout: some View {
@@ -250,13 +255,7 @@ struct MetricsContent: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(spacing: 24) {
-                    if !isInputMonitoringEnabled {
-                        inputMonitoringPermissionCallout
-                    }
-
-                    if !isAccessibilityEnabled {
-                        accessibilityPermissionCallout
-                    }
+                    permissionCallouts
 
                     VStack(spacing: 20) {
                         Image(systemName: "waveform")

--- a/VoiceInk/Views/Metrics/MetricsContent.swift
+++ b/VoiceInk/Views/Metrics/MetricsContent.swift
@@ -80,6 +80,7 @@ struct MetricsContent: View {
     @State private var metricsTask: Task<Void, Never>?
     @State private var isModelStatsPanelPresented = false
     @State private var isAccessibilityEnabled = AXIsProcessTrusted()
+    @State private var isInputMonitoringEnabled = ShortcutMonitor.hasListenEventAccess()
 
     init(modelContext: ModelContext, licenseState: LicenseViewModel.LicenseState) {
         self.modelContext = modelContext
@@ -100,6 +101,10 @@ struct MetricsContent: View {
                 GeometryReader { geometry in
                     ScrollView {
                         VStack(spacing: 24) {
+                            if !isInputMonitoringEnabled {
+                                inputMonitoringPermissionCallout
+                            }
+
                             if !isAccessibilityEnabled {
                                 accessibilityPermissionCallout
                             }
@@ -170,6 +175,19 @@ struct MetricsContent: View {
         .animation(.smooth(duration: 0.3), value: isModelStatsPanelPresented)
     }
 
+    private var inputMonitoringPermissionCallout: some View {
+        PermissionCard(
+            icon: "keyboard",
+            title: "Input Monitoring Access",
+            description: "VoiceInk needs Input Monitoring permission for global shortcuts like Fn",
+            isGranted: isInputMonitoringEnabled,
+            buttonTitle: "Open System Settings",
+            buttonAction: openInputMonitoringSettings,
+            checkPermission: refreshAccessibilityStatus,
+            infoTipMessage: "macOS separates global keyboard shortcut access from Accessibility."
+        )
+    }
+
     private var accessibilityPermissionCallout: some View {
         PermissionCard(
             icon: "hand.raised",
@@ -185,6 +203,14 @@ struct MetricsContent: View {
 
     private func refreshAccessibilityStatus() {
         isAccessibilityEnabled = AXIsProcessTrusted()
+        isInputMonitoringEnabled = ShortcutMonitor.hasListenEventAccess()
+    }
+
+    private func openInputMonitoringSettings() {
+        _ = CGRequestListenEventAccess()
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     private func openAccessibilitySettings() {
@@ -224,6 +250,10 @@ struct MetricsContent: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(spacing: 24) {
+                    if !isInputMonitoringEnabled {
+                        inputMonitoringPermissionCallout
+                    }
+
                     if !isAccessibilityEnabled {
                         accessibilityPermissionCallout
                     }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @AppStorage("restoreClipboardAfterPaste") private var restoreClipboardAfterPaste = true
     @AppStorage("clipboardRestoreDelay") private var clipboardRestoreDelay = 2.0
     @AppStorage(PasteMethod.userDefaultsKey) private var pasteMethodRawValue = PasteMethod.standard.rawValue
+    @AppStorage("ShowMenuBarIcon") private var showMenuBarIcon = true
     @State private var showResetOnboardingAlert = false
     @State private var hasCancelRecordingShortcut = ShortcutStore.shortcut(for: .cancelRecorder) != nil
     @State private var cancelRecordingShortcutRecorderResetID = 0
@@ -233,7 +234,15 @@ struct SettingsView: View {
 
             // MARK: - General
             Section("General") {
+                Toggle("Show Menu Bar Icon", isOn: $showMenuBarIcon)
+                    .onChange(of: showMenuBarIcon) { _, newValue in
+                        if !newValue {
+                            menuBarManager.isMenuBarOnly = false
+                        }
+                    }
+
                 Toggle("Hide Dock Icon", isOn: $menuBarManager.isMenuBarOnly)
+                    .disabled(!showMenuBarIcon)
 
                 LaunchAtLogin.Toggle("Launch at Login")
 

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -25,7 +25,7 @@ struct VoiceInkApp: App {
     @StateObject private var activeWindowService = ActiveWindowService.shared
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("enableAnnouncements") private var enableAnnouncements = true
-    @State private var showMenuBarIcon = true
+    @AppStorage("ShowMenuBarIcon") private var showMenuBarIcon = true
 
     // Audio cleanup manager for automatic deletion of old audio files
     private let audioCleanupManager = AudioCleanupManager.shared

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -7,11 +7,35 @@
 
 import Testing
 @testable import VoiceInk
+import Foundation
 
 struct VoiceInkTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func generalBackupDecodesWithoutMenuBarIconPreference() throws {
+        let data = Data("""
+        {
+          "launchAtLoginEnabled": true,
+          "isMenuBarOnly": true
+        }
+        """.utf8)
+
+        let backup = try JSONDecoder().decode(GeneralBackup.self, from: data)
+
+        #expect(backup.launchAtLoginEnabled == true)
+        #expect(backup.isMenuBarOnly == true)
+        #expect(backup.showMenuBarIcon == nil)
+    }
+
+    @Test func generalBackupDecodesMenuBarIconPreference() throws {
+        let data = Data("""
+        {
+          "showMenuBarIcon": false
+        }
+        """.utf8)
+
+        let backup = try JSONDecoder().decode(GeneralBackup.self, from: data)
+
+        #expect(backup.showMenuBarIcon == false)
     }
 
 }

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -7,6 +7,8 @@
 
 import Testing
 @testable import VoiceInk
+import AppKit
+import Carbon.HIToolbox
 import Foundation
 
 struct VoiceInkTests {
@@ -36,6 +38,22 @@ struct VoiceInkTests {
         let backup = try JSONDecoder().decode(GeneralBackup.self, from: data)
 
         #expect(backup.showMenuBarIcon == false)
+    }
+
+    @Test func functionModifierShortcutMatchesFnFlagsChangedEvent() throws {
+        let shortcut = Shortcut.modifierOnly(
+            keyCode: UInt16(kVK_Function),
+            modifierFlags: [.function]
+        )
+
+        #expect(shortcut.matchesModifierEvent(
+            keyCode: UInt16(kVK_Function),
+            modifierFlags: [.function]
+        ))
+        #expect(shortcut.shouldReleaseModifierEvent(
+            keyCode: UInt16(kVK_Function),
+            modifierFlags: []
+        ))
     }
 
 }


### PR DESCRIPTION
## Summary
- Adds a persisted `Show Menu Bar Icon` preference so the menu bar icon can be hidden from Settings or from the menu bar menu.
- Keeps the app recoverable by forcing `Hide Dock Icon` off when the menu bar icon is hidden.
- Includes the menu bar icon preference in backup export/import while preserving backward compatibility with older backups.
- Guards backup import so an older backup cannot leave the app with both the Dock icon and menu bar icon hidden.

## Style / Architecture Fit
- Uses the app's existing `@AppStorage` preference pattern and registers the new default in `AppDefaults`.
- Wires visibility through SwiftUI's existing `MenuBarExtra(isInserted:)` path instead of adding a second menu bar manager.
- Keeps Dock visibility behavior in the existing `MenuBarManager` flow.
- Extends the existing backup model/import/export types instead of adding separate settings persistence.

## Tests / Verification
- Added Swift Testing coverage for `GeneralBackup` decoding with and without the new `showMenuBarIcon` field.
- Ran focused `VoiceInkTests`; result: `TEST SUCCEEDED`.
- Manual verification: installed and ran the app, toggled `Show Menu Bar Icon` off/on from Settings, and confirmed the app remains reachable through the Dock when the menu bar icon is hidden.

## Screenshots

### Menu bar icon hidden
![Show Menu Bar Icon off](https://raw.githubusercontent.com/haydenholligan/VoiceInk/pr-assets-753/.github/pr-assets/753/menu-bar-icon-off.png)

### Menu bar icon shown
![Show Menu Bar Icon on](https://raw.githubusercontent.com/haydenholligan/VoiceInk/pr-assets-753/.github/pr-assets/753/menu-bar-icon-on.png)
