### PR TITLE
Add opt-in "Paste in Chunks" option for terminal AI agents (e.g. Claude Code)

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -11,6 +11,8 @@ enum AppDefaults {
             "restoreClipboardAfterPaste": true,
             "clipboardRestoreDelay": 2.0,
             "useAppleScriptPaste": false,
+            "pasteInChunks": false,
+            "pasteChunkSize": 250,
 
             // Audio & Media
             "isSystemMuteEnabled": true,

--- a/VoiceInk/Paste/CursorPaster.swift
+++ b/VoiceInk/Paste/CursorPaster.swift
@@ -20,6 +20,9 @@ class CursorPaster {
     private static let prePasteDelay: TimeInterval = 0.10
     private static let pasteShortcutEventDelay: TimeInterval = 0.01
     private static let minimumClipboardRestoreDelay: TimeInterval = 0.25
+    // Delay between consecutive chunk pastes so the target app processes each
+    // paste before the clipboard is replaced with the next chunk.
+    private static let interChunkPasteDelay: TimeInterval = 0.12
 
     static func pasteAtCursor(_ text: String) {
         Task {
@@ -50,28 +53,78 @@ class CursorPaster {
         let savedContents = shouldRestoreClipboard ? snapshotClipboard(from: pasteboard) : []
         let sessionID = UUID().uuidString
 
-        guard ClipboardManager.setClipboard(
-            text,
-            transient: shouldRestoreClipboard,
-            sessionID: shouldRestoreClipboard ? sessionID : nil
-        ) else {
-            logger.error("Failed to prepare clipboard for paste")
-            return .commandNotPosted
+        let chunks = chunksForPaste(text)
+        var pasteResult: PasteResult = .commandNotPosted
+
+        for (index, chunk) in chunks.enumerated() {
+            guard ClipboardManager.setClipboard(
+                chunk,
+                transient: shouldRestoreClipboard,
+                sessionID: shouldRestoreClipboard ? sessionID : nil
+            ) else {
+                logger.error("Failed to prepare clipboard for paste")
+                return .commandNotPosted
+            }
+
+            await wait(prePasteDelay)
+            pasteResult = await postPasteCommand()
+
+            // Pause before replacing the clipboard with the next chunk so the
+            // target app has time to consume this one.
+            if index < chunks.count - 1 {
+                await wait(interChunkPasteDelay)
+            }
         }
 
-        await wait(prePasteDelay)
-
-        let pasteResult = await postPasteCommand()
         if shouldRestoreClipboard {
             scheduleClipboardRestore(
                 savedContents,
-                expectedText: text,
+                expectedText: chunks.last ?? text,
                 sessionID: sessionID,
                 on: pasteboard
             )
         }
 
         return pasteResult
+    }
+
+    // MARK: - Chunking
+
+    // Some destinations (notably terminal CLIs like Claude Code) collapse a
+    // single large paste into a "[Pasted text]" placeholder. Pasting the text
+    // in several smaller pieces keeps each paste below that threshold so the
+    // full content stays visible inline. Disabled by default.
+    private static func chunksForPaste(_ text: String) -> [String] {
+        guard UserDefaults.standard.bool(forKey: "pasteInChunks") else { return [text] }
+        let chunkSize = UserDefaults.standard.integer(forKey: "pasteChunkSize")
+        guard chunkSize > 0, text.count > chunkSize else { return [text] }
+        return splitIntoChunks(text, maxLength: chunkSize)
+    }
+
+    // Splits on the last whitespace at or before maxLength so words and lines
+    // are not torn apart; falls back to a hard split for a single oversized run.
+    private static func splitIntoChunks(_ text: String, maxLength: Int) -> [String] {
+        guard maxLength > 0, text.count > maxLength else { return [text] }
+
+        var chunks: [String] = []
+        var remainder = Substring(text)
+
+        while remainder.count > maxLength {
+            let hardEnd = remainder.index(remainder.startIndex, offsetBy: maxLength)
+            var breakIndex = hardEnd
+            if let whitespace = remainder[..<hardEnd].lastIndex(where: { $0 == " " || $0 == "\n" || $0 == "\t" }) {
+                // Keep the whitespace with the preceding chunk.
+                breakIndex = remainder.index(after: whitespace)
+            }
+            chunks.append(String(remainder[..<breakIndex]))
+            remainder = remainder[breakIndex...]
+        }
+
+        if !remainder.isEmpty {
+            chunks.append(String(remainder))
+        }
+
+        return chunks
     }
 
     private static func snapshotClipboard(from pasteboard: NSPasteboard) -> ClipboardSnapshot {

--- a/VoiceInk/Paste/CursorPaster.swift
+++ b/VoiceInk/Paste/CursorPaster.swift
@@ -54,7 +54,8 @@ class CursorPaster {
         let sessionID = UUID().uuidString
 
         let chunks = chunksForPaste(text)
-        var pasteResult: PasteResult = .commandNotPosted
+        var allChunksPosted = true
+        var lastPreparedChunk: String?
 
         for (index, chunk) in chunks.enumerated() {
             guard ClipboardManager.setClipboard(
@@ -63,11 +64,15 @@ class CursorPaster {
                 sessionID: shouldRestoreClipboard ? sessionID : nil
             ) else {
                 logger.error("Failed to prepare clipboard for paste")
-                return .commandNotPosted
+                allChunksPosted = false
+                break
             }
+            lastPreparedChunk = chunk
 
             await wait(prePasteDelay)
-            pasteResult = await postPasteCommand()
+            if await postPasteCommand() == .commandNotPosted {
+                allChunksPosted = false
+            }
 
             // Pause before replacing the clipboard with the next chunk so the
             // target app has time to consume this one.
@@ -76,16 +81,18 @@ class CursorPaster {
             }
         }
 
+        // Always schedule the restore, even if a chunk failed partway through,
+        // so a partial paste does not leave the user's clipboard clobbered.
         if shouldRestoreClipboard {
             scheduleClipboardRestore(
                 savedContents,
-                expectedText: chunks.last ?? text,
+                expectedText: lastPreparedChunk ?? text,
                 sessionID: sessionID,
                 on: pasteboard
             )
         }
 
-        return pasteResult
+        return allChunksPosted ? .commandPosted : .commandNotPosted
     }
 
     // MARK: - Chunking
@@ -97,20 +104,23 @@ class CursorPaster {
     private static func chunksForPaste(_ text: String) -> [String] {
         guard UserDefaults.standard.bool(forKey: "pasteInChunks") else { return [text] }
         let chunkSize = UserDefaults.standard.integer(forKey: "pasteChunkSize")
-        guard chunkSize > 0, text.count > chunkSize else { return [text] }
+        guard chunkSize > 0 else { return [text] }
         return splitIntoChunks(text, maxLength: chunkSize)
     }
 
     // Splits on the last whitespace at or before maxLength so words and lines
     // are not torn apart; falls back to a hard split for a single oversized run.
-    private static func splitIntoChunks(_ text: String, maxLength: Int) -> [String] {
-        guard maxLength > 0, text.count > maxLength else { return [text] }
+    // Advances by index arithmetic rather than `remainder.count`, which is O(n)
+    // per call on Swift strings (grapheme-cluster counting) and would otherwise
+    // make splitting O(n^2) for large transcriptions.
+    static func splitIntoChunks(_ text: String, maxLength: Int) -> [String] {
+        guard maxLength > 0 else { return [text] }
 
         var chunks: [String] = []
         var remainder = Substring(text)
 
-        while remainder.count > maxLength {
-            let hardEnd = remainder.index(remainder.startIndex, offsetBy: maxLength)
+        while let hardEnd = remainder.index(remainder.startIndex, offsetBy: maxLength, limitedBy: remainder.endIndex),
+              hardEnd != remainder.endIndex {
             var breakIndex = hardEnd
             if let whitespace = remainder[..<hardEnd].lastIndex(where: { $0 == " " || $0 == "\n" || $0 == "\t" }) {
                 // Keep the whitespace with the preceding chunk.
@@ -124,7 +134,7 @@ class CursorPaster {
             chunks.append(String(remainder))
         }
 
-        return chunks
+        return chunks.isEmpty ? [text] : chunks
     }
 
     private static func snapshotClipboard(from pasteboard: NSPasteboard) -> ClipboardSnapshot {

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -20,6 +20,8 @@ struct SettingsView: View {
     @AppStorage("enableAnnouncements") private var enableAnnouncements = true
     @AppStorage("restoreClipboardAfterPaste") private var restoreClipboardAfterPaste = true
     @AppStorage("clipboardRestoreDelay") private var clipboardRestoreDelay = 2.0
+    @AppStorage("pasteInChunks") private var pasteInChunks = false
+    @AppStorage("pasteChunkSize") private var pasteChunkSize = 250
     @AppStorage(PasteMethod.userDefaultsKey) private var pasteMethodRawValue = PasteMethod.standard.rawValue
     @State private var showResetOnboardingAlert = false
     @State private var hasCancelRecordingShortcut = ShortcutStore.shortcut(for: .cancelRecorder) != nil
@@ -30,6 +32,7 @@ struct SettingsView: View {
     @State private var isSoundFeedbackExpanded = false
     @State private var isMuteSystemExpanded = false
     @State private var isRestoreClipboardExpanded = false
+    @State private var isPasteInChunksExpanded = false
 
     var body: some View {
         Form {
@@ -212,6 +215,21 @@ struct SettingsView: View {
                         return
                     }
                     PasteMethod.setCurrent(method)
+                }
+
+                // Paste in Chunks
+                ExpandableSettingsRow(
+                    isExpanded: $isPasteInChunksExpanded,
+                    isEnabled: $pasteInChunks,
+                    label: "Paste in Chunks",
+                    infoMessage: "Some terminal apps (such as Claude Code) collapse a single large paste into a \"[Pasted text]\" placeholder. When enabled, VoiceInk pastes the transcription in smaller pieces so the full text stays visible inline. A smaller chunk size avoids the placeholder in more apps but makes pasting slightly slower."
+                ) {
+                    Picker("Chunk Size", selection: $pasteChunkSize) {
+                        Text("250 characters").tag(250)
+                        Text("500 characters").tag(500)
+                        Text("750 characters").tag(750)
+                        Text("1000 characters").tag(1000)
+                    }
                 }
             }
 

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -15,3 +15,75 @@ struct VoiceInkTests {
     }
 
 }
+
+struct ChunkSplittingTests {
+
+    @Test func shortTextIsReturnedAsSingleChunk() {
+        let text = "hello world"
+        #expect(CursorPaster.splitIntoChunks(text, maxLength: 250) == [text])
+    }
+
+    @Test func textEqualToMaxLengthIsNotSplit() {
+        let text = String(repeating: "a", count: 100)
+        #expect(CursorPaster.splitIntoChunks(text, maxLength: 100) == [text])
+    }
+
+    @Test func reassemblyReproducesOriginalExactly() {
+        let text = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 50)
+        let chunks = CursorPaster.splitIntoChunks(text, maxLength: 100)
+        #expect(chunks.count > 1)
+        #expect(chunks.joined() == text)
+    }
+
+    @Test func chunksStayWithinMaxLengthWhenWhitespaceIsAvailable() {
+        let text = String(repeating: "word ", count: 200)
+        let maxLength = 80
+        let chunks = CursorPaster.splitIntoChunks(text, maxLength: maxLength)
+        for chunk in chunks {
+            #expect(chunk.count <= maxLength)
+        }
+        #expect(chunks.joined() == text)
+    }
+
+    @Test func splitsOnWhitespaceRatherThanMidWord() {
+        let text = "aaaa bbbb cccc dddd eeee"
+        let chunks = CursorPaster.splitIntoChunks(text, maxLength: 10)
+        #expect(chunks.joined() == text)
+        // Every chunk but the last should end on the whitespace it broke at,
+        // so no four-letter word is torn across a boundary.
+        for chunk in chunks.dropLast() {
+            #expect(chunk.hasSuffix(" "))
+        }
+    }
+
+    @Test func oversizedRunWithoutWhitespaceHardSplits() {
+        let text = String(repeating: "x", count: 1000)
+        let maxLength = 250
+        let chunks = CursorPaster.splitIntoChunks(text, maxLength: maxLength)
+        #expect(chunks.count == 4)
+        for chunk in chunks {
+            #expect(chunk.count <= maxLength)
+        }
+        #expect(chunks.joined() == text)
+    }
+
+    @Test func multilineTextReassembles() {
+        let text = "line one\nline two\n\nparagraph two is a little longer than the rest of them"
+        let chunks = CursorPaster.splitIntoChunks(text, maxLength: 16)
+        #expect(chunks.joined() == text)
+    }
+
+    @Test func nonPositiveMaxLengthReturnsWholeText() {
+        let text = "anything"
+        #expect(CursorPaster.splitIntoChunks(text, maxLength: 0) == [text])
+        #expect(CursorPaster.splitIntoChunks(text, maxLength: -10) == [text])
+    }
+
+    @Test func graphemeClustersAreNotCorrupted() {
+        // Emoji with a skin-tone modifier is a single multi-scalar grapheme;
+        // index-based splitting must keep each cluster intact.
+        let text = String(repeating: "👍🏽 ", count: 100)
+        let chunks = CursorPaster.splitIntoChunks(text, maxLength: 20)
+        #expect(chunks.joined() == text)
+    }
+}


### PR DESCRIPTION
## Problem

When a long transcription is pasted into a terminal-based AI agent such as Claude Code, the destination collapses the single large paste into a placeholder (for example `[Pasted text #N +M lines]`) rather than showing it inline. The full text is still delivered, but the user cannot read or edit it before pressing Enter.

**Before** — a long dictation collapses into a placeholder:

![Before: collapsed pasted-text placeholder](https://raw.githubusercontent.com/leochen4891/VoiceInk/pr-assets/docs/before-collapsed.png)

**After** — with "Paste in Chunks" enabled, the same dictation lands as full, editable inline text:

![After: full inline text](https://raw.githubusercontent.com/leochen4891/VoiceInk/pr-assets/docs/after-inline.png)

## Approach

Add an opt-in **Paste in Chunks** setting. When enabled, VoiceInk pastes the transcription in smaller pieces so each paste stays below the destination's collapse threshold, and the text renders as visible, editable inline text.

This mirrors the behavior Wispr Flow documents for Claude Code (auto-splitting long dictations into chunks).

It is a layer on top of the existing clipboard paste — a separate toggle plus chunk-size picker that composes with both the Default and AppleScript paste methods, rather than a new mutually-exclusive method. It is complementary to the Direct Typing work in #701: Direct Typing reaches destinations where the clipboard does not work at all (for example remote desktop), whereas chunking keeps a working clipboard paste from being collapsed.

## Changes

- `CursorPaster`: the paste session now iterates over chunks with a short inter-chunk delay; splitting prefers whitespace and newline boundaries and falls back to a hard split for a single oversized run.
- Settings: new "Paste in Chunks" toggle and chunk-size picker (250 / 500 / 750 / 1000 characters).
- Defaults registered; **off by default**, so there is no behavior change unless enabled. Default chunk size is 250 characters.
