### PR TITLE
Fix/cloudkit crash logging

### DIFF
--- a/VoiceInk/Models/Transcription.swift
+++ b/VoiceInk/Models/Transcription.swift
@@ -12,11 +12,11 @@ enum TranscriptionStatus: String, Codable {
 final class Transcription {
     static let canceledTranscriptionText = "The transcription was canceled."
 
-    var id: UUID
-    var text: String
+    var id: UUID = UUID()
+    var text: String = ""
     var enhancedText: String?
-    var timestamp: Date
-    var duration: TimeInterval
+    var timestamp: Date = Date()
+    var duration: TimeInterval = 0
     var audioFileURL: String?
     var transcriptionModelName: String?
     var aiEnhancementModelName: String?

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -10,7 +10,6 @@ import FluidAudio
 struct VoiceInkApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     let container: ModelContainer
-    let containerInitializationFailed: Bool
 
     @StateObject private var engine: VoiceInkEngine
     @StateObject private var whisperModelManager: WhisperModelManager
@@ -52,7 +51,6 @@ struct VoiceInkApp: App {
             WordReplacement.self,
             SessionMetric.self
         ])
-        var initializationFailed = false
         let resolvedContainer: ModelContainer
 
         // Attempt 1: Try persistent storage
@@ -62,7 +60,6 @@ struct VoiceInkApp: App {
             // Attempt 2: Try in-memory storage
             do {
                 resolvedContainer = try Self.createInMemoryContainer(schema: schema, logger: logger)
-                initializationFailed = true
                 logger.warning("Using in-memory storage as fallback. Data will not persist between sessions.")
 
                 DispatchQueue.main.async {
@@ -74,16 +71,14 @@ struct VoiceInkApp: App {
                     alert.runModal()
                 }
             } catch let memoryError {
-                let persistentDetail = (persistentError as NSError).debugDescription
-                let memoryDetail = (memoryError as NSError).debugDescription
-                // Both attempts failed — crash with full NSError detail so Apple's crash reporter captures domain/code/userInfo chain
-                logger.critical("❌ All ModelContainer init attempts failed.\nPersistent: \(persistentDetail, privacy: .public)\nIn-memory: \(memoryDetail, privacy: .public)")
-                fatalError("VoiceInk failed to initialize storage.\nPersistent: \(persistentDetail)\nIn-memory: \(memoryDetail)")
+                let persistentDetail = Self.fullErrorDescription(persistentError)
+                let memoryDetail = Self.fullErrorDescription(memoryError)
+                logger.critical("❌ All ModelContainer init attempts failed.\nPersistent:\n\(persistentDetail, privacy: .public)\nIn-memory:\n\(memoryDetail, privacy: .public)")
+                fatalError("VoiceInk failed to initialize storage.\nPersistent:\n\(persistentDetail)\nIn-memory:\n\(memoryDetail)")
             }
         }
 
         container = resolvedContainer
-        containerInitializationFailed = initializationFailed
         DictionaryService.removeExactDuplicateContent(context: resolvedContainer.mainContext, source: "launch")
 
         // Initialize services with proper sharing of instances
@@ -176,6 +171,30 @@ struct VoiceInkApp: App {
 
     // MARK: - Container Creation Helpers
 
+    private static func fullErrorDescription(_ error: Error, depth: Int = 0) -> String {
+        let ns = error as NSError
+        let indent = String(repeating: "  ", count: depth)
+        var lines: [String] = []
+        lines.append("\(indent)[\(ns.domain) \(ns.code)] \(ns.localizedDescription)")
+        for (key, value) in ns.userInfo {
+            let keyStr = (key as? NSErrorUserInfoKey)?.rawValue ?? "\(key)"
+            if keyStr == NSUnderlyingErrorKey || keyStr == "NSDetailedErrors" { continue }
+            lines.append("\(indent)  \(keyStr): \(value)")
+        }
+        if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? Error {
+            lines.append("\(indent)  Underlying:")
+            lines.append(fullErrorDescription(underlying, depth: depth + 2))
+        }
+        if let details = ns.userInfo["NSDetailedErrors"] as? [Error] {
+            lines.append("\(indent)  DetailedErrors (\(details.count)):")
+            for (i, detail) in details.enumerated() {
+                lines.append("\(indent)    [\(i)]:")
+                lines.append(fullErrorDescription(detail, depth: depth + 3))
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
     private static func createPersistentContainer(schema: Schema, logger: Logger) throws -> ModelContainer {
         let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("com.prakashjoshipax.VoiceInk", isDirectory: true)
@@ -218,7 +237,7 @@ struct VoiceInkApp: App {
         do {
             return try ModelContainer(for: schema, configurations: transcriptConfig, dictionaryConfig, statsConfig)
         } catch {
-            logger.error("❌ Failed to create persistent ModelContainer: \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ Failed to create persistent ModelContainer:\n\(Self.fullErrorDescription(error), privacy: .public)")
             throw error
         }
     }
@@ -236,7 +255,7 @@ struct VoiceInkApp: App {
         do {
             return try ModelContainer(for: schema, configurations: transcriptConfig, dictionaryConfig, statsConfig)
         } catch {
-            logger.error("❌ Failed to create in-memory ModelContainer: \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ Failed to create in-memory ModelContainer:\n\(Self.fullErrorDescription(error), privacy: .public)")
             throw error
         }
     }
@@ -258,19 +277,6 @@ struct VoiceInkApp: App {
                         .environmentObject(enhancementService)
                         .modelContainer(container)
                         .onAppear {
-                            // Check if container initialization failed
-                            if containerInitializationFailed {
-                                let alert = NSAlert()
-                                alert.messageText = "Critical Storage Error"
-                                alert.informativeText = "VoiceInk cannot initialize its storage system. The app cannot continue.\n\nPlease try reinstalling the app or contact support if the issue persists."
-                                alert.alertStyle = .critical
-                                alert.addButton(withTitle: "Quit")
-                                alert.runModal()
-
-                                NSApplication.shared.terminate(nil)
-                                return
-                            }
-
                             if enableAnnouncements {
                                 AnnouncementsService.shared.start()
                             }

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -56,41 +56,30 @@ struct VoiceInkApp: App {
         let resolvedContainer: ModelContainer
 
         // Attempt 1: Try persistent storage
-        if let persistentContainer = Self.createPersistentContainer(schema: schema, logger: logger) {
-            resolvedContainer = persistentContainer
-        }
-        // Attempt 2: Try in-memory storage
-        else if let memoryContainer = Self.createInMemoryContainer(schema: schema, logger: logger) {
-            resolvedContainer = memoryContainer
+        do {
+            resolvedContainer = try Self.createPersistentContainer(schema: schema, logger: logger)
+        } catch let persistentError {
+            // Attempt 2: Try in-memory storage
+            do {
+                resolvedContainer = try Self.createInMemoryContainer(schema: schema, logger: logger)
+                initializationFailed = true
+                logger.warning("Using in-memory storage as fallback. Data will not persist between sessions.")
 
-            logger.warning("Using in-memory storage as fallback. Data will not persist between sessions.")
-
-            // Show alert to user about storage issue
-            DispatchQueue.main.async {
-                let alert = NSAlert()
-                alert.messageText = "Storage Warning"
-                alert.informativeText = "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions."
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "OK")
-                alert.runModal()
+                DispatchQueue.main.async {
+                    let alert = NSAlert()
+                    alert.messageText = "Storage Warning"
+                    alert.informativeText = "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions."
+                    alert.alertStyle = .warning
+                    alert.addButton(withTitle: "OK")
+                    alert.runModal()
+                }
+            } catch let memoryError {
+                let persistentDetail = (persistentError as NSError).debugDescription
+                let memoryDetail = (memoryError as NSError).debugDescription
+                // Both attempts failed — crash with full NSError detail so Apple's crash reporter captures domain/code/userInfo chain
+                logger.critical("❌ All ModelContainer init attempts failed.\nPersistent: \(persistentDetail, privacy: .public)\nIn-memory: \(memoryDetail, privacy: .public)")
+                fatalError("VoiceInk failed to initialize storage.\nPersistent: \(persistentDetail)\nIn-memory: \(memoryDetail)")
             }
-        }
-        // All attempts failed
-        else {
-            logger.critical("ModelContainer initialization failed")
-            initializationFailed = true
-
-            // Create minimal in-memory container to satisfy initialization
-            let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-            resolvedContainer = (try? ModelContainer(for: schema, configurations: [config])) ?? {
-                let alert = NSAlert()
-                alert.messageText = "VoiceInk Could Not Start"
-                alert.informativeText = "VoiceInk failed to initialize and must quit.\n\nTry restarting your Mac. If the problem persists, please contact support."
-                alert.alertStyle = .critical
-                alert.addButton(withTitle: "Quit")
-                alert.runModal()
-                exit(1)
-            }()
         }
 
         container = resolvedContainer
@@ -187,96 +176,68 @@ struct VoiceInkApp: App {
 
     // MARK: - Container Creation Helpers
 
-    private static func createPersistentContainer(schema: Schema, logger: Logger) -> ModelContainer? {
+    private static func createPersistentContainer(schema: Schema, logger: Logger) throws -> ModelContainer {
+        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.prakashjoshipax.VoiceInk", isDirectory: true)
+
+        try? FileManager.default.createDirectory(at: appSupportURL, withIntermediateDirectories: true)
+
+        let defaultStoreURL = appSupportURL.appendingPathComponent("default.store")
+        let dictionaryStoreURL = appSupportURL.appendingPathComponent("dictionary.store")
+        let statsStoreURL = appSupportURL.appendingPathComponent("stats.store")
+
+        let transcriptSchema = Schema([Transcription.self])
+        let transcriptConfig = ModelConfiguration(
+            "default",
+            schema: transcriptSchema,
+            url: defaultStoreURL,
+            cloudKitDatabase: .none
+        )
+
+        let dictionarySchema = Schema([VocabularyWord.self, WordReplacement.self])
+        #if LOCAL_BUILD
+        let dictionaryCloudKit: ModelConfiguration.CloudKitDatabase = .none
+        #else
+        let dictionaryCloudKit: ModelConfiguration.CloudKitDatabase = .private("iCloud.com.prakashjoshipax.VoiceInk")
+        #endif
+        let dictionaryConfig = ModelConfiguration(
+            "dictionary",
+            schema: dictionarySchema,
+            url: dictionaryStoreURL,
+            cloudKitDatabase: dictionaryCloudKit
+        )
+
+        let statsSchema = Schema([SessionMetric.self])
+        let statsConfig = ModelConfiguration(
+            "stats",
+            schema: statsSchema,
+            url: statsStoreURL,
+            cloudKitDatabase: .none
+        )
+
         do {
-            // Create app-specific Application Support directory URL
-            let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-                .appendingPathComponent("com.prakashjoshipax.VoiceInk", isDirectory: true)
-
-            // Create the directory if it doesn't exist
-            try? FileManager.default.createDirectory(at: appSupportURL, withIntermediateDirectories: true)
-
-            // Define storage locations
-            let defaultStoreURL = appSupportURL.appendingPathComponent("default.store")
-            let dictionaryStoreURL = appSupportURL.appendingPathComponent("dictionary.store")
-            let statsStoreURL = appSupportURL.appendingPathComponent("stats.store")
-
-            // Transcript configuration
-            let transcriptSchema = Schema([
-                Transcription.self
-            ])
-            let transcriptConfig = ModelConfiguration(
-                "default",
-                schema: transcriptSchema,
-                url: defaultStoreURL,
-                cloudKitDatabase: .none
-            )
-
-            // Dictionary configuration
-            let dictionarySchema = Schema([VocabularyWord.self, WordReplacement.self])
-            #if LOCAL_BUILD
-            let dictionaryCloudKit: ModelConfiguration.CloudKitDatabase = .none
-            #else
-            let dictionaryCloudKit: ModelConfiguration.CloudKitDatabase = .private("iCloud.com.prakashjoshipax.VoiceInk")
-            #endif
-            let dictionaryConfig = ModelConfiguration(
-                "dictionary",
-                schema: dictionarySchema,
-                url: dictionaryStoreURL,
-                cloudKitDatabase: dictionaryCloudKit
-            )
-
-            // Recorder session metrics configuration
-            let statsSchema = Schema([SessionMetric.self])
-            let statsConfig = ModelConfiguration(
-                "stats",
-                schema: statsSchema,
-                url: statsStoreURL,
-                cloudKitDatabase: .none
-            )
-
-            // Initialize container
-            return try ModelContainer(
-                for: schema,
-                configurations: transcriptConfig, dictionaryConfig, statsConfig
-            )
+            return try ModelContainer(for: schema, configurations: transcriptConfig, dictionaryConfig, statsConfig)
         } catch {
             logger.error("❌ Failed to create persistent ModelContainer: \(error.localizedDescription, privacy: .public)")
-            return nil
+            throw error
         }
     }
 
-    private static func createInMemoryContainer(schema: Schema, logger: Logger) -> ModelContainer? {
+    private static func createInMemoryContainer(schema: Schema, logger: Logger) throws -> ModelContainer {
+        let transcriptSchema = Schema([Transcription.self])
+        let transcriptConfig = ModelConfiguration("default", schema: transcriptSchema, isStoredInMemoryOnly: true)
+
+        let dictionarySchema = Schema([VocabularyWord.self, WordReplacement.self])
+        let dictionaryConfig = ModelConfiguration("dictionary", schema: dictionarySchema, isStoredInMemoryOnly: true)
+
+        let statsSchema = Schema([SessionMetric.self])
+        let statsConfig = ModelConfiguration("stats", schema: statsSchema, isStoredInMemoryOnly: true)
+
         do {
-            // Transcript configuration
-            let transcriptSchema = Schema([
-                Transcription.self
-            ])
-            let transcriptConfig = ModelConfiguration(
-                "default",
-                schema: transcriptSchema,
-                isStoredInMemoryOnly: true
-            )
-
-            // Dictionary configuration
-            let dictionarySchema = Schema([VocabularyWord.self, WordReplacement.self])
-            let dictionaryConfig = ModelConfiguration(
-                "dictionary",
-                schema: dictionarySchema,
-                isStoredInMemoryOnly: true
-            )
-
-            let statsSchema = Schema([SessionMetric.self])
-            let statsConfig = ModelConfiguration(
-                "stats",
-                schema: statsSchema,
-                isStoredInMemoryOnly: true
-            )
-
             return try ModelContainer(for: schema, configurations: transcriptConfig, dictionaryConfig, statsConfig)
         } catch {
             logger.error("❌ Failed to create in-memory ModelContainer: \(error.localizedDescription, privacy: .public)")
-            return nil
+            throw error
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash during CloudKit sync by giving Transcription safe default values and improves storage initialization with clear fallback, detailed logs, and fail-fast behavior.

- **Bug Fixes**
  - Added default values for Transcription id, text, timestamp, and duration to align with the CloudKit/SwiftData schema and prevent decode crashes.

- **Refactors**
  - Reworked ModelContainer setup to use try/catch: try persistent first, fall back to in-memory with a user warning, and fatalError if both fail.
  - Added deep error introspection to log full nested SwiftData errors; removed the unused containerInitializationFailed flag and the delayed quit path.

<sup>Written for commit 65cda9596e8abda87ee3575416ad7d934b425cfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

