### PR TITLE
German localization support

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
 			);
 			mainGroup = E11473A72CBE0F0A00318EE4;
 			minimizedProjectReferenceProxies = 1;

--- a/VoiceInk/AppIntents/DismissMiniRecorderIntent.swift
+++ b/VoiceInk/AppIntents/DismissMiniRecorderIntent.swift
@@ -12,7 +12,7 @@ struct DismissMiniRecorderIntent: AppIntent {
     func perform() async throws -> some IntentResult & ProvidesDialog {
         NotificationCenter.default.post(name: .dismissRecorderPanel, object: nil)
         
-        let dialog = IntentDialog(stringLiteral: "VoiceInk recorder dismissed")
+        let dialog: IntentDialog = "VoiceInk recorder dismissed"
         return .result(dialog: dialog)
     }
 }

--- a/VoiceInk/AppIntents/ToggleMiniRecorderIntent.swift
+++ b/VoiceInk/AppIntents/ToggleMiniRecorderIntent.swift
@@ -12,7 +12,7 @@ struct ToggleMiniRecorderIntent: AppIntent {
     func perform() async throws -> some IntentResult & ProvidesDialog {
         NotificationCenter.default.post(name: .toggleRecorderPanel, object: nil)
         
-        let dialog = IntentDialog(stringLiteral: "VoiceInk recorder toggled")
+        let dialog: IntentDialog = "VoiceInk recorder toggled"
         return .result(dialog: dialog)
     }
 }
@@ -24,9 +24,9 @@ enum IntentError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .appNotAvailable:
-            return "VoiceInk app is not available"
+            return String(localized: "VoiceInk app is not available")
         case .serviceNotAvailable:
-            return "VoiceInk recording service is not available"
+            return String(localized: "VoiceInk recording service is not available")
         }
     }
 }

--- a/VoiceInk/CoreAudioRecorder.swift
+++ b/VoiceInk/CoreAudioRecorder.swift
@@ -974,33 +974,33 @@ enum CoreAudioRecorderError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .audioUnitNotFound:
-            return "HAL Output AudioUnit not found"
+            return String(localized: "HAL Output AudioUnit not found")
         case .audioUnitNotInitialized:
-            return "AudioUnit not initialized"
+            return String(localized: "AudioUnit not initialized")
         case .deviceNotAvailable:
-            return "Audio device is no longer available"
+            return String(localized: "Audio device is no longer available")
         case .failedToCreateAudioUnit(let status):
-            return "Failed to create AudioUnit: \(status)"
+            return String(format: String(localized: "Failed to create AudioUnit: %lld"), Int64(status))
         case .failedToEnableInput(let status):
-            return "Failed to enable input: \(status)"
+            return String(format: String(localized: "Failed to enable input: %lld"), Int64(status))
         case .failedToDisableOutput(let status):
-            return "Failed to disable output: \(status)"
+            return String(format: String(localized: "Failed to disable output: %lld"), Int64(status))
         case .failedToSetDevice(let status):
-            return "Failed to set input device: \(status)"
+            return String(format: String(localized: "Failed to set input device: %lld"), Int64(status))
         case .failedToGetDeviceFormat(let status):
-            return "Failed to get device format: \(status)"
+            return String(format: String(localized: "Failed to get device format: %lld"), Int64(status))
         case .failedToSetFormat(let status):
-            return "Failed to set audio format: \(status)"
+            return String(format: String(localized: "Failed to set audio format: %lld"), Int64(status))
         case .failedToSetCallback(let status):
-            return "Failed to set input callback: \(status)"
+            return String(format: String(localized: "Failed to set input callback: %lld"), Int64(status))
         case .failedToCreateFile(let status):
-            return "Failed to create audio file: \(status)"
+            return String(format: String(localized: "Failed to create audio file: %lld"), Int64(status))
         case .failedToSetFileFormat(let status):
-            return "Failed to set file format: \(status)"
+            return String(format: String(localized: "Failed to set file format: %lld"), Int64(status))
         case .failedToInitialize(let status):
-            return "Failed to initialize AudioUnit: \(status)"
+            return String(format: String(localized: "Failed to initialize AudioUnit: %lld"), Int64(status))
         case .failedToStart(let status):
-            return "Failed to start AudioUnit: \(status)"
+            return String(format: String(localized: "Failed to start AudioUnit: %lld"), Int64(status))
         }
     }
 }

--- a/VoiceInk/CustomSoundManager.swift
+++ b/VoiceInk/CustomSoundManager.swift
@@ -402,15 +402,15 @@ enum CustomSoundError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .fileNotFound:
-            return "Audio file not found"
+            return String(localized: "Audio file not found")
         case .invalidAudioFile:
-            return "Invalid audio file format"
+            return String(localized: "Invalid audio file format")
         case .durationTooLong(let duration, let maxDuration):
-            return String(format: "Audio file is %.1f seconds long. Please use an audio file that is %.0f seconds or shorter for start and stop sounds.", duration, maxDuration)
+            return String(format: String(localized: "Audio file is %.1f seconds long. Please use an audio file that is %.0f seconds or shorter for start and stop sounds."), duration, maxDuration)
         case .directoryCreationFailed:
-            return "Failed to create custom sounds directory"
+            return String(localized: "Failed to create custom sounds directory")
         case .fileCopyFailed:
-            return "Failed to copy audio file"
+            return String(localized: "Failed to copy audio file")
         }
     }
 }

--- a/VoiceInk/HistoryWindowController.swift
+++ b/VoiceInk/HistoryWindowController.swift
@@ -46,7 +46,7 @@ class HistoryWindowController: NSObject, NSWindowDelegate {
         )
 
         window.contentViewController = hostingController
-        window.title = "History"
+        window.title = String(localized: "History")
         window.identifier = windowIdentifier
         window.delegate = self
         window.titlebarAppearsTransparent = true

--- a/VoiceInk/InfoPlist.xcstrings
+++ b/VoiceInk/InfoPlist.xcstrings
@@ -1,0 +1,125 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "CFBundleDisplayName": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "VoiceInk"
+          }
+        }
+      }
+    },
+    "CFBundleName": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "VoiceInk"
+          }
+        }
+      }
+    },
+    "CFBundleTypeName": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-/Videodatei"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio/Video File"
+          }
+        }
+      }
+    },
+    "NSAppleEventsUsageDescription": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk muss mit Ihrem Browser interagieren, um die aktuelle Website zu erkennen und website-spezifische Konfigurationen anzuwenden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "VoiceInk needs to interact with your browser to detect the current website for applying website-specific configurations."
+          }
+        }
+      }
+    },
+    "NSHumanReadableCopyright": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
+          }
+        }
+      }
+    },
+    "NSMicrophoneUsageDescription": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk benötigt Zugriff auf Ihr Mikrofon, um Audio für die Transkription aufzunehmen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "VoiceInk needs access to your microphone to record audio for transcription."
+          }
+        }
+      }
+    },
+    "NSScreenCaptureUsageDescription": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk benötigt Zugriff auf die Bildschirmaufnahme, um Kontext von Ihrem Bildschirm für eine höhere Transkriptionsgenauigkeit zu erfassen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "VoiceInk needs screen recording access to understand context from your screen for improved transcription accuracy."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -131,132 +131,12 @@
         }
       }
     },
-    "%d files": {
-      "localizations": {
-        "de": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Datei"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Dateien"
-                }
-              }
-            }
-          }
-        },
-        "en": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d file"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d files"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "%d seconds": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
             "value": "%d Sekunden"
-          }
-        }
-      }
-    },
-    "%d sessions": {
-      "localizations": {
-        "de": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Sitzung"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Sitzungen"
-                }
-              }
-            }
-          }
-        },
-        "en": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d session"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d sessions"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%d transcripts": {
-      "localizations": {
-        "de": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Transkription"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Transkriptionen"
-                }
-              }
-            }
-          }
-        },
-        "en": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d transcript"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d transcripts"
-                }
-              }
-            }
           }
         }
       }
@@ -294,46 +174,6 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%d Websites"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%d words": {
-      "localizations": {
-        "de": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Wort"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d Wörter"
-                }
-              }
-            }
-          }
-        },
-        "en": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d word"
-                }
-              },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%d words"
                 }
               }
             }
@@ -10491,7 +10331,7 @@
         }
       }
     },
-    "Dictated %1$@ words across %2$lld sessions.": {
+    "Dictated %@ words across %lld sessions.": {
       "comment": "Hero subtitle showing word count and session count",
       "localizations": {
         "en": {
@@ -10525,6 +10365,166 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "Sie haben %1$@ Wörter in %2$lld Sitzungen diktiert."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld transcripts": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkription"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkriptionen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld transcript"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld transcripts"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld sessions": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Sitzung"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Sitzungen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld session"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld sessions"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld files": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Datei"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Dateien"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld file"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld files"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld words": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Wort"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Wörter"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld word"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld words"
                 }
               }
             }

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -1,0 +1,10526 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
+          }
+        }
+      }
+    },
+    " ": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " "
+          }
+        }
+      }
+    },
+    " (drag to reorder)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (zum Neuordnen ziehen)"
+          }
+        }
+      }
+    },
+    "'%@' already exists in word replacements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' existiert bereits in den Wortersetzungen"
+          }
+        }
+      }
+    },
+    "'%@' is already in the vocabulary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' ist bereits im Vokabular enthalten"
+          }
+        }
+      }
+    },
+    "%@ API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API-Schlüssel"
+          }
+        }
+      }
+    },
+    "%@ connection verified.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Verbindung verifiziert."
+          }
+        }
+      }
+    },
+    "%@ Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Modus"
+          }
+        }
+      }
+    },
+    "%@ requires macOS 26 or later": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ erfordert macOS 26 oder neuer"
+          }
+        }
+      }
+    },
+    "%d Apps": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d App"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Apps"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d App"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Apps"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%d files": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Datei"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Dateien"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d file"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d files"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%d seconds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d Sekunden"
+          }
+        }
+      }
+    },
+    "%d sessions": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Sitzung"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Sitzungen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d session"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d sessions"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%d transcripts": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Transkription"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Transkriptionen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d transcript"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d transcripts"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%d Websites": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Website"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Websites"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Website"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Websites"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%d words": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Wort"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d Wörter"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d word"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%d words"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
+          }
+        }
+      }
+    },
+    "%lld apps": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld Apps": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld days left in trial": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Noch %lld Tag in der Testphase"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Noch %lld Tage in der Testphase"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld day left in trial"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld days left in trial"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld Enhancement models": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Verbesserungsmodell"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Verbesserungsmodelle"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Enhancement model"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Enhancement models"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld models": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modell"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modelle"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld model"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld models"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld models available": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modell verfügbar"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modelle verfügbar"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld model available"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld models available"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld seconds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Sekunden"
+          }
+        }
+      }
+    },
+    "%lld selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ausgewählt"
+          }
+        }
+      }
+    },
+    "%lld Transcription models": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkriptionsmodell"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkriptionsmodelle"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transcription model"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transcription models"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld websites": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Website"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Websites"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld website"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld websites"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld Websites": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Website"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Websites"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Website"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Websites"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld%%": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld %%"
+          }
+        }
+      }
+    },
+    "••••••••": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "••••••••"
+          }
+        }
+      }
+    },
+    "↵": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "↵"
+          }
+        }
+      }
+    },
+    "+": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+"
+          }
+        }
+      }
+    },
+    "+%lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld"
+          }
+        }
+      }
+    },
+    "0s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0 s"
+          }
+        }
+      }
+    },
+    "1 day": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Tag"
+          }
+        }
+      }
+    },
+    "1 hour": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Stunde"
+          }
+        }
+      }
+    },
+    "1.5×": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1,5×"
+          }
+        }
+      }
+    },
+    "1×": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1×"
+          }
+        }
+      }
+    },
+    "1s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 s"
+          }
+        }
+      }
+    },
+    "2×": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2×"
+          }
+        }
+      }
+    },
+    "2s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 s"
+          }
+        }
+      }
+    },
+    "3 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Tage"
+          }
+        }
+      }
+    },
+    "3s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 s"
+          }
+        }
+      }
+    },
+    "4s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4 s"
+          }
+        }
+      }
+    },
+    "5s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 s"
+          }
+        }
+      }
+    },
+    "7 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 Tage"
+          }
+        }
+      }
+    },
+    "14 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "14 Tage"
+          }
+        }
+      }
+    },
+    "15s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 s"
+          }
+        }
+      }
+    },
+    "25+ languages": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25+ Sprachen"
+          }
+        }
+      }
+    },
+    "30 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 Tage"
+          }
+        }
+      }
+    },
+    "30% OFF": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30% RABATT"
+          }
+        }
+      }
+    },
+    "30s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 s"
+          }
+        }
+      }
+    },
+    "45s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "45 s"
+          }
+        }
+      }
+    },
+    "60s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "60 s"
+          }
+        }
+      }
+    },
+    "90s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 s"
+          }
+        }
+      }
+    },
+    "120s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "120 s"
+          }
+        }
+      }
+    },
+    "180s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "180 s"
+          }
+        }
+      }
+    },
+    "250ms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "250 ms"
+          }
+        }
+      }
+    },
+    "300s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "300 s"
+          }
+        }
+      }
+    },
+    "500ms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "500 ms"
+          }
+        }
+      }
+    },
+    "A custom enhancement model with this display name already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein benutzerdefiniertes Verbesserungsmodell mit diesem Anzeigenamen existiert bereits"
+          }
+        }
+      }
+    },
+    "A custom enhancement model with this model name already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein benutzerdefiniertes Verbesserungsmodell mit diesem Modellnamen existiert bereits"
+          }
+        }
+      }
+    },
+    "A mode with the name '%@' already exists.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Modus mit dem Namen '%@' existiert bereits."
+          }
+        }
+      }
+    },
+    "A model named %@.bin already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Modell namens %@.bin existiert bereits"
+          }
+        }
+      }
+    },
+    "A model with this name already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Modell mit diesem Namen existiert bereits"
+          }
+        }
+      }
+    },
+    "A network error occurred: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Netzwerkfehler ist aufgetreten: %@"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen"
+          }
+        }
+      }
+    },
+    "Accessibility permission is not provided": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Zugriff auf Bedienungshilfen"
+          }
+        }
+      }
+    },
+    "Accuracy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genauigkeit"
+          }
+        }
+      }
+    },
+    "Activate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren"
+          }
+        }
+      }
+    },
+    "Activate a license to continue using VoiceInk.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie eine Lizenz, um VoiceInk weiter zu verwenden."
+          }
+        }
+      }
+    },
+    "Activate an existing key, purchase a license, or start a 7-day free trial.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie einen vorhandenen Schlüssel, kaufen Sie eine Lizenz oder starten Sie eine 7-tägige kostenlose Testversion."
+          }
+        }
+      }
+    },
+    "Activate License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz aktivieren"
+          }
+        }
+      }
+    },
+    "Activating": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aktiviert"
+          }
+        }
+      }
+    },
+    "Activation Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivierungsverzögerung"
+          }
+        }
+      }
+    },
+    "Active": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiv"
+          }
+        }
+      }
+    },
+    "Add": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
+          }
+        }
+      }
+    },
+    "Add %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hinzufügen"
+          }
+        }
+      }
+    },
+    "Add a custom fine-tuned whisper model to use with VoiceInk. Select the downloaded .bin file.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein benutzerdefiniertes, feinjustiertes Whisper-Modell für VoiceInk hinzufügen. Wählen Sie die heruntergeladene .bin-Datei aus."
+          }
+        }
+      }
+    },
+    "Add a new mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Modus hinzufügen"
+          }
+        }
+      }
+    },
+    "Add a trailing space after pasted transcription output.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein abschließendes Leerzeichen nach der eingefügten Transkription hinzufügen."
+          }
+        }
+      }
+    },
+    "Add app or website...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App oder Website hinzufügen..."
+          }
+        }
+      }
+    },
+    "Add custom emoji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Emoji hinzufügen"
+          }
+        }
+      }
+    },
+    "Add Custom Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add custom model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigenes Modell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add Custom Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Transkriptionsmodell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add customized modes for different contexts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Modi für verschiedene Kontexte hinzufügen"
+          }
+        }
+      }
+    },
+    "Add enhancement model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien hinzufügen"
+          }
+        }
+      }
+    },
+    "Add filler word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwort hinzufügen"
+          }
+        }
+      }
+    },
+    "Add Filler Word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwort hinzufügen"
+          }
+        }
+      }
+    },
+    "Add microphones in the order VoiceInk should try them.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofone in der Reihenfolge hinzufügen, in der VoiceInk sie verwenden soll."
+          }
+        }
+      }
+    },
+    "Add model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add New": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neu hinzufügen"
+          }
+        }
+      }
+    },
+    "Add New Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Modus hinzufügen"
+          }
+        }
+      }
+    },
+    "Add new prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Prompt hinzufügen"
+          }
+        }
+      }
+    },
+    "Add prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt hinzufügen"
+          }
+        }
+      }
+    },
+    "Add Second Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zweites Tastenkürzel hinzufügen"
+          }
+        }
+      }
+    },
+    "Add Space After Paste": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leerzeichen nach dem Einfügen hinzufügen"
+          }
+        }
+      }
+    },
+    "Add transcription model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell hinzufügen"
+          }
+        }
+      }
+    },
+    "Add trigger": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser hinzufügen"
+          }
+        }
+      }
+    },
+    "Add website": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website hinzufügen"
+          }
+        }
+      }
+    },
+    "Add word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort hinzufügen"
+          }
+        }
+      }
+    },
+    "Add word replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzung hinzufügen"
+          }
+        }
+      }
+    },
+    "Add word to vocabulary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort zum Vokabular hinzufügen"
+          }
+        }
+      }
+    },
+    "Additional Shortcuts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Tastaturkürzel"
+          }
+        }
+      }
+    },
+    "Advanced": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erweitert"
+          }
+        }
+      }
+    },
+    "Affiliate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partnerprogramm"
+          }
+        }
+      }
+    },
+    "AFFILIATE 30%": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AFFILIATE 30%"
+          }
+        }
+      }
+    },
+    "AI Enhancement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verbesserung"
+          }
+        }
+      }
+    },
+    "AI enhancement failed to process the text.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die KI-Verbesserung konnte den Text nicht verarbeiten."
+          }
+        }
+      }
+    },
+    "AI Enhancement is not enabled or configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verbesserung ist nicht aktiviert oder konfiguriert"
+          }
+        }
+      }
+    },
+    "AI Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Modell"
+          }
+        }
+      }
+    },
+    "AI Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Modelle"
+          }
+        }
+      }
+    },
+    "AI Provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter"
+          }
+        }
+      }
+    },
+    "AI Provider Integration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter-Integration"
+          }
+        }
+      }
+    },
+    "AI provider not configured. Please check your API key.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter nicht konfiguriert. Bitte überprüfen Sie Ihren API-Schlüssel."
+          }
+        }
+      }
+    },
+    "AI Request": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anfrage"
+          }
+        }
+      }
+    },
+    "All settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Einstellungen"
+          }
+        }
+      }
+    },
+    "All Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesamt"
+          }
+        }
+      }
+    },
+    "Allow": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlauben"
+          }
+        }
+      }
+    },
+    "Allow Permissions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigungen erlauben"
+          }
+        }
+      }
+    },
+    "Allow VoiceInk to work across all your apps.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlauben Sie VoiceInk, app-übergreifend zu funktionieren."
+          }
+        }
+      }
+    },
+    "An unexpected error occurred. Please try again or contact support at %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support unter %@"
+          }
+        }
+      }
+    },
+    "An unknown error occurred.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein unbekannter Fehler ist aufgetreten."
+          }
+        }
+      }
+    },
+    "Analyzable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysierbar"
+          }
+        }
+      }
+    },
+    "Analyze": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysieren"
+          }
+        }
+      }
+    },
+    "Analyzing...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird analysiert..."
+          }
+        }
+      }
+    },
+    "API Endpoint": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Endpunkt"
+          }
+        }
+      }
+    },
+    "API endpoint cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Endpunkt darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "API endpoint must be a valid URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Endpunkt muss eine gültige URL sein"
+          }
+        }
+      }
+    },
+    "API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        }
+      }
+    },
+    "API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        }
+      }
+    },
+    "API key cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "API Key Configuration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel-Konfiguration"
+          }
+        }
+      }
+    },
+    "API key for this service is missing. Please configure it in the settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der API-Schlüssel für diesen Dienst fehlt. Bitte konfigurieren Sie ihn in den Einstellungen."
+          }
+        }
+      }
+    },
+    "API key not configured for streaming transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel für Streaming-Transkription ist nicht konfiguriert"
+          }
+        }
+      }
+    },
+    "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech kann bis zu 5 Sprachen reservieren. Wählen Sie eine Sprache zum Entfernen aus, bevor Sie die ausgewählte Sprache herunterladen."
+          }
+        }
+      }
+    },
+    "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech kann bis zu 5 Sprachen reservieren. Verwalten Sie reservierte Sprachen in den Moduseinstellungen."
+          }
+        }
+      }
+    },
+    "Apple Speech could not reserve language assets for %@. Manage reserved Apple Speech languages in settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech konnte die Sprachressourcen für %@ nicht reservieren. Verwalten Sie reservierte Apple-Speech-Sprachen in den Einstellungen."
+          }
+        }
+      }
+    },
+    "Apple Speech did not finish returning transcription results.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech hat die Rückgabe der Transkriptionsergebnisse nicht abgeschlossen."
+          }
+        }
+      }
+    },
+    "Apple Speech does not support this language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech unterstützt diese Sprache nicht."
+          }
+        }
+      }
+    },
+    "Apple Speech language download failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download der Apple-Speech-Sprache fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Apple Speech language downloads are not available on this system.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads für Apple-Speech-Sprachen sind auf diesem System nicht verfügbar."
+          }
+        }
+      }
+    },
+    "Apple Speech language is downloaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Apple-Speech-Sprache wurde heruntergeladen."
+          }
+        }
+      }
+    },
+    "AppleScript": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppleScript"
+          }
+        }
+      }
+    },
+    "Apply intelligent text formatting to break large block of text into paragraphs.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intelligente Textformatierung anwenden, um große Textblöcke in Absätze zu unterteilen."
+          }
+        }
+      }
+    },
+    "Are you sure you want to delete '%@' prompt? This action cannot be undone.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soll der Prompt „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
+          }
+        }
+      }
+    },
+    "Are you sure you want to delete '%@'? This action cannot be undone.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soll „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
+          }
+        }
+      }
+    },
+    "Are you sure you want to delete the custom enhancement model '%@'?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie das benutzerdefinierte Verbesserungsmodell '%@' wirklich löschen?"
+          }
+        }
+      }
+    },
+    "Are you sure you want to delete the custom model '%@'?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie das benutzerdefinierte Modell '%@' wirklich löschen?"
+          }
+        }
+      }
+    },
+    "Are you sure you want to delete the model '%@'?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie das Modell '%@' wirklich löschen?"
+          }
+        }
+      }
+    },
+    "Arrow": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfeil"
+          }
+        }
+      }
+    },
+    "Ask": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fragen"
+          }
+        }
+      }
+    },
+    "Assistant": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistent"
+          }
+        }
+      }
+    },
+    "Assistant response was not saved: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistentenantwort wurde nicht gespeichert: %@"
+          }
+        }
+      }
+    },
+    "Audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio"
+          }
+        }
+      }
+    },
+    "Audio Cleanup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-Bereinigung"
+          }
+        }
+      }
+    },
+    "Audio device is no longer available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiogerät ist nicht mehr verfügbar"
+          }
+        }
+      }
+    },
+    "Audio file is %.1f seconds long. Please use an audio file that is %.0f seconds or shorter for start and stop sounds.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Audiodatei ist %.1f Sekunden lang. Bitte verwenden Sie für Start- und Stopptöne eine Audiodatei, die %.0f Sekunden oder kürzer ist."
+          }
+        }
+      }
+    },
+    "Audio file not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei nicht gefunden"
+          }
+        }
+      }
+    },
+    "Audio Input": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioeingabe"
+          }
+        }
+      }
+    },
+    "AudioUnit not initialized": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit nicht initialisiert"
+          }
+        }
+      }
+    },
+    "Auto Send": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch senden"
+          }
+        }
+      }
+    },
+    "Auto-check Updates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates automatisch prüfen"
+          }
+        }
+      }
+    },
+    "Auto-delete Audio Files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodateien automatisch löschen"
+          }
+        }
+      }
+    },
+    "Auto-delete Transcripts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen automatisch löschen"
+          }
+        }
+      }
+    },
+    "Autodetected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch erkannt"
+          }
+        }
+      }
+    },
+    "Automatically delete audio recordings while keeping text transcripts intact.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioaufnahmen automatisch löschen, während Texttranskriptionen erhalten bleiben."
+          }
+        }
+      }
+    },
+    "Automatically delete transcript history based on the retention period you set.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionshistorie automatisch basierend auf dem festgelegten Aufbewahrungszeitraum löschen."
+          }
+        }
+      }
+    },
+    "Automatically presses a key combination after pasting text. Useful for chat applications or forms that use different send shortcuts.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drückt nach dem Einfügen automatisch eine Tastenkombination. Nützlich für Chat-Apps oder Formulare mit abweichenden Sendekürzeln."
+          }
+        }
+      }
+    },
+    "Automatically remove configured filler words like 'uh', 'um', or 'hmm' from transcriptions. If no filler words are configured, this cleanup is skipped.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurierte Füllwörter wie „ähm“, „äh“ oder „hmm“ automatisch aus Transkriptionen entfernen. Wenn keine Füllwörter konfiguriert sind, wird diese Bereinigung übersprungen."
+          }
+        }
+      }
+    },
+    "Automatically skip AI enhancement when the transcription has very few words. Short phrases like \"yes\", \"thank you\", or quick commands don't benefit from enhancement.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verbesserung automatisch überspringen, wenn die Transkription sehr wenige Wörter enthält. Kurze Phrasen wie „ja“, „danke“ oder schnelle Befehle profitieren nicht von der Verbesserung."
+          }
+        }
+      }
+    },
+    "Available Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Verbesserungsmodelle"
+          }
+        }
+      }
+    },
+    "Available Microphones": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Mikrofone"
+          }
+        }
+      }
+    },
+    "Available Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Transkriptionsmodelle"
+          }
+        }
+      }
+    },
+    "Avg. Audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Audio"
+          }
+        }
+      }
+    },
+    "Avg. Enhancement Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Verbesserungszeit"
+          }
+        }
+      }
+    },
+    "Avg. Process Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Verarbeitungszeit"
+          }
+        }
+      }
+    },
+    "Avg. Processing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Verarbeitungszeit"
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück"
+          }
+        }
+      }
+    },
+    "Backup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sicherung"
+          }
+        }
+      }
+    },
+    "Base URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basis-URL"
+          }
+        }
+      }
+    },
+    "Base URL cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basis-URL darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Base URL must be a valid URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basis-URL muss eine gültige URL sein"
+          }
+        }
+      }
+    },
+    "Buy License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz kaufen"
+          }
+        }
+      }
+    },
+    "Buy VoiceInk License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Lizenz kaufen"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
+          }
+        }
+      }
+    },
+    "Cancel Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme abbrechen"
+          }
+        }
+      }
+    },
+    "Cancel transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription abbrechen"
+          }
+        }
+      }
+    },
+    "Cannot retry: Audio file not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholung nicht möglich: Audiodatei nicht gefunden"
+          }
+        }
+      }
+    },
+    "Cannot Save Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus kann nicht gespeichert werden"
+          }
+        }
+      }
+    },
+    "Changelog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungsprotokoll"
+          }
+        }
+      }
+    },
+    "Check for Updates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen"
+          }
+        }
+      }
+    },
+    "Check for Updates…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen …"
+          }
+        }
+      }
+    },
+    "Check the default model try again. If the problem persists, try a different model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie das Standardmodell und versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wählen Sie ein anderes Modell."
+          }
+        }
+      }
+    },
+    "Checking": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft"
+          }
+        }
+      }
+    },
+    "Checking cached models...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischengespeicherte Modelle werden geprüft..."
+          }
+        }
+      }
+    },
+    "Checking whether this Apple Speech language is downloaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wird geprüft, ob diese Apple-Speech-Sprache heruntergeladen ist."
+          }
+        }
+      }
+    },
+    "Choose": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswählen"
+          }
+        }
+      }
+    },
+    "Choose %@ Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Klang auswählen"
+          }
+        }
+      }
+    },
+    "Choose a Language to Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache zum Entfernen auswählen"
+          }
+        }
+      }
+    },
+    "Choose a location to save your settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie einen Speicherort für Ihre Einstellungen."
+          }
+        }
+      }
+    },
+    "Choose a settings backup, then select what you want to import.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie ein Einstellungs-Backup und dann aus, was importiert werden soll."
+          }
+        }
+      }
+    },
+    "Choose Files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien auswählen"
+          }
+        }
+      }
+    },
+    "Choose Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon auswählen"
+          }
+        }
+      }
+    },
+    "Choose what to import from this backup.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie aus, was aus diesem Backup importiert werden soll."
+          }
+        }
+      }
+    },
+    "Claude, Codex, scripts, or any command": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude, Codex, Skripte oder beliebige Befehle"
+          }
+        }
+      }
+    },
+    "Cleanup Complete": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigung abgeschlossen"
+          }
+        }
+      }
+    },
+    "Cleanup complete.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigung abgeschlossen."
+          }
+        }
+      }
+    },
+    "Clear": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeren"
+          }
+        }
+      }
+    },
+    "Clear all items": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Elemente löschen"
+          }
+        }
+      }
+    },
+    "Clipboard": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischenablage"
+          }
+        }
+      }
+    },
+    "Close": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
+          }
+        }
+      }
+    },
+    "Cloud": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud"
+          }
+        }
+      }
+    },
+    "Cloud Providers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-Anbieter"
+          }
+        }
+      }
+    },
+    "Command": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehl"
+          }
+        }
+      }
+    },
+    "Command + Return (⌘⏎)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehlstaste + Eingabe (⌘⏎)"
+          }
+        }
+      }
+    },
+    "Compiling %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird kompiliert"
+          }
+        }
+      }
+    },
+    "Complete Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung abschließen"
+          }
+        }
+      }
+    },
+    "Configure": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurieren"
+          }
+        }
+      }
+    },
+    "Configure API Keys": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel konfigurieren"
+          }
+        }
+      }
+    },
+    "Configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguriert"
+          }
+        }
+      }
+    },
+    "Connect": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
+          }
+        }
+      }
+    },
+    "Connect a microphone or allow microphone access, then refresh.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen Sie ein Mikrofon an oder erlauben Sie den Mikrofonzugriff und aktualisieren Sie dann."
+          }
+        }
+      }
+    },
+    "Connect providers here, then choose models inside Modes.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter hier verbinden, dann Modelle in Modi auswählen."
+          }
+        }
+      }
+    },
+    "Connected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
+          }
+        }
+      }
+    },
+    "Connection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung"
+          }
+        }
+      }
+    },
+    "Connection verified.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung verifiziert."
+          }
+        }
+      }
+    },
+    "Context Awareness": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontexterkennung"
+          }
+        }
+      }
+    },
+    "Continue": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
+          }
+        }
+      }
+    },
+    "Control how VoiceInk handles your transcription data and audio recordings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steuern Sie, wie VoiceInk Ihre Transkriptionsdaten und Audioaufnahmen verwaltet."
+          }
+        }
+      }
+    },
+    "Convert transcription output to lowercase.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsausgabe in Kleinbuchstaben umwandeln."
+          }
+        }
+      }
+    },
+    "Copied": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert"
+          }
+        }
+      }
+    },
+    "Copied to clipboard": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Zwischenablage kopiert"
+          }
+        }
+      }
+    },
+    "Copied!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert!"
+          }
+        }
+      }
+    },
+    "Copy Last Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription kopieren"
+          }
+        }
+      }
+    },
+    "Copy License Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel kopieren"
+          }
+        }
+      }
+    },
+    "Copy System Info": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeminfo kopieren"
+          }
+        }
+      }
+    },
+    "Copy to clipboard": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Zwischenablage kopieren"
+          }
+        }
+      }
+    },
+    "Could not add emoji.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji konnte nicht hinzugefügt werden."
+          }
+        }
+      }
+    },
+    "Could not encode settings to JSON: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen konnten nicht als JSON kodiert werden: %@"
+          }
+        }
+      }
+    },
+    "Could not get the file URL from the open panel.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datei-URL konnte nicht aus dem Öffnen-Dialog ermittelt werden."
+          }
+        }
+      }
+    },
+    "Could not reach the server. Please check your internet connection and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Server konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."
+          }
+        }
+      }
+    },
+    "Could not remove %@ from reserved Apple Speech languages.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte nicht aus den reservierten Apple-Speech-Sprachen entfernt werden."
+          }
+        }
+      }
+    },
+    "Could not save settings to file: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen konnten nicht in der Datei gespeichert werden: %@"
+          }
+        }
+      }
+    },
+    "Could not verify this API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser API-Schlüssel konnte nicht verifiziert werden"
+          }
+        }
+      }
+    },
+    "Could not verify this API key. Check the key and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser API-Schlüssel konnte nicht verifiziert werden. Überprüfen Sie den Schlüssel und versuchen Sie es erneut."
+          }
+        }
+      }
+    },
+    "Create & Select": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen & auswählen"
+          }
+        }
+      }
+    },
+    "Create first mode to automate your VoiceInk workflow based on apps/website you are using": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen Sie Ihren ersten Modus, um Ihren VoiceInk-Workflow basierend auf verwendeten Apps und Websites zu automatisieren"
+          }
+        }
+      }
+    },
+    "Created": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellt"
+          }
+        }
+      }
+    },
+    "Custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
+          }
+        }
+      }
+    },
+    "Custom Device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Gerät"
+          }
+        }
+      }
+    },
+    "Custom Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Verbesserungsmodelle"
+          }
+        }
+      }
+    },
+    "Custom Model Definitions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Modelldefinitionen"
+          }
+        }
+      }
+    },
+    "Custom Prompts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Prompts"
+          }
+        }
+      }
+    },
+    "Custom Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Transkriptionsmodelle"
+          }
+        }
+      }
+    },
+    "Custom: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert: %@"
+          }
+        }
+      }
+    },
+    "Dashboard": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dashboard"
+          }
+        }
+      }
+    },
+    "Date": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum"
+          }
+        }
+      }
+    },
+    "Deactivate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktivieren"
+          }
+        }
+      }
+    },
+    "Deactivate License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz deaktivieren"
+          }
+        }
+      }
+    },
+    "Deactivate License?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz deaktivieren?"
+          }
+        }
+      }
+    },
+    "Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        }
+      }
+    },
+    "Default mode is used when no app or website matches": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt"
+          }
+        }
+      }
+    },
+    "Default mode is used when no specific app or website matches are found.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt."
+          }
+        }
+      }
+    },
+    "Default uses simulated Cmd+V key events. AppleScript can help when custom keyboard layouts do not paste correctly.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard verwendet simulierte Cmd+V-Ereignisse. AppleScript kann helfen, wenn benutzerdefinierte Tastaturlayouts nicht korrekt einfügen."
+          }
+        }
+      }
+    },
+    "Delete": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        }
+      }
+    },
+    "Delete %lld Files": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Datei löschen"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Dateien löschen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Delete %lld File"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Delete %lld Files"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Delete After": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen nach"
+          }
+        }
+      }
+    },
+    "Delete Custom Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell löschen"
+          }
+        }
+      }
+    },
+    "Delete Custom Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Modell löschen"
+          }
+        }
+      }
+    },
+    "Delete Mode?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus löschen?"
+          }
+        }
+      }
+    },
+    "Delete Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell löschen"
+          }
+        }
+      }
+    },
+    "Delete Prompt?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt löschen?"
+          }
+        }
+      }
+    },
+    "Delete Selected Items?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Elemente löschen?"
+          }
+        }
+      }
+    },
+    "Deleted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelöscht"
+          }
+        }
+      }
+    },
+    "Deleted %lld audio files.": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodatei gelöscht."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodateien gelöscht."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Deleted %lld audio file."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Deleted %lld audio files."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Deleted files: %lld. Failed: %lld.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelöschte Dateien: %lld. Fehlgeschlagen: %lld."
+          }
+        }
+      }
+    },
+    "Denied": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verweigert"
+          }
+        }
+      }
+    },
+    "Deselect All": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle abwählen"
+          }
+        }
+      }
+    },
+    "Details": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details"
+          }
+        }
+      }
+    },
+    "Detect speech segments and filter out silence to improve accuracy of local models.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachsegmente erkennen und Stille herausfiltern, um die Genauigkeit lokaler Modelle zu verbessern."
+          }
+        }
+      }
+    },
+    "Device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerät"
+          }
+        }
+      }
+    },
+    "Diagnostics": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose"
+          }
+        }
+      }
+    },
+    "Dictated %@ words across %d %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben %@ Wörter in %d %@ diktiert."
+          }
+        }
+      }
+    },
+    "Dictation": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktat"
+          }
+        }
+      }
+    },
+    "Dictionary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörterbuch"
+          }
+        }
+      }
+    },
+    "Dictionary Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörterbuch-Einstellungen"
+          }
+        }
+      }
+    },
+    "Disabled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktiviert"
+          }
+        }
+      }
+    },
+    "Disconnected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Getrennt"
+          }
+        }
+      }
+    },
+    "Dismiss": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
+          }
+        }
+      }
+    },
+    "Dismiss Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme schließen"
+          }
+        }
+      }
+    },
+    "Dismiss shortcut tip": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel-Hinweis schließen"
+          }
+        }
+      }
+    },
+    "Dismiss the VoiceInk recorder and cancel any active recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme schließen und aktive Aufnahme abbrechen."
+          }
+        }
+      }
+    },
+    "Dismiss this promotion": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Angebot ausblenden"
+          }
+        }
+      }
+    },
+    "Dismiss VoiceInk Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme schließen"
+          }
+        }
+      }
+    },
+    "Display Name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigename"
+          }
+        }
+      }
+    },
+    "Display name cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigename darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Docs": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokumentation"
+          }
+        }
+      }
+    },
+    "Documentation": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokumentation"
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        }
+      }
+    },
+    "Double-click to edit • Right-click for more options": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doppelklick zum Bearbeiten • Rechtsklick für weitere Optionen"
+          }
+        }
+      }
+    },
+    "Download": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herunterladen"
+          }
+        }
+      }
+    },
+    "Download Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell herunterladen"
+          }
+        }
+      }
+    },
+    "Download required for %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download für %@ erforderlich."
+          }
+        }
+      }
+    },
+    "Download this Apple Speech language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Apple-Speech-Sprache herunterladen."
+          }
+        }
+      }
+    },
+    "Download Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell herunterladen"
+          }
+        }
+      }
+    },
+    "Downloaded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading %@ Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Modell wird heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading assets for the selected Apple Speech language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ressourcen für die ausgewählte Apple-Speech-Sprache werden heruntergeladen."
+          }
+        }
+      }
+    },
+    "Downloading Core ML Model for %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Core-ML-Modell für %@ wird heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading model files: %lld/%lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelldateien werden heruntergeladen: %lld/%lld"
+          }
+        }
+      }
+    },
+    "Downloading...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird heruntergeladen..."
+          }
+        }
+      }
+    },
+    "Drop audio or video files here": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio- oder Videodateien hier ablegen"
+          }
+        }
+      }
+    },
+    "Drop files anywhere to add more": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien irgendwo ablegen, um weitere hinzuzufügen"
+          }
+        }
+      }
+    },
+    "Drop to add files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ablegen zum Hinzufügen"
+          }
+        }
+      }
+    },
+    "Duration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dauer"
+          }
+        }
+      }
+    },
+    "During recording, press Option + 1-9 to switch modes quickly.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drücken Sie während der Aufnahme Option + 1-9, um schnell den Modus zu wechseln."
+          }
+        }
+      }
+    },
+    "e.g. my email, my mail": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. meine E-Mail, meine Mail"
+          }
+        }
+      }
+    },
+    "e.g. Prakash, VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. Prakash, VoiceInk"
+          }
+        }
+      }
+    },
+    "e.g. support@tryvoiceink.com": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. support@tryvoiceink.com"
+          }
+        }
+      }
+    },
+    "Earn With The VoiceInk Affiliate Program": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit dem VoiceInk-Partnerprogramm Geld verdienen"
+          }
+        }
+      }
+    },
+    "Edit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Custom Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Custom Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Transkriptionsmodell bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit the apps and websites in this group.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps und Websites in dieser Gruppe bearbeiten."
+          }
+        }
+      }
+    },
+    "Edit trigger group": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslösergruppe bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Word Replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzung bearbeiten"
+          }
+        }
+      }
+    },
+    "Email": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E-Mail"
+          }
+        }
+      }
+    },
+    "Email Support": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E-Mail-Support"
+          }
+        }
+      }
+    },
+    "Emoji already exists.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji existiert bereits."
+          }
+        }
+      }
+    },
+    "Emoji cannot be empty.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji darf nicht leer sein."
+          }
+        }
+      }
+    },
+    "Enable Accessibility Access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen aktivieren"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert"
+          }
+        }
+      }
+    },
+    "Enhance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbessern"
+          }
+        }
+      }
+    },
+    "Enhanced": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbessert"
+          }
+        }
+      }
+    },
+    "Enhancement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserung"
+          }
+        }
+      }
+    },
+    "Enhancement failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserung fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodell"
+          }
+        }
+      }
+    },
+    "Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodelle"
+          }
+        }
+      }
+    },
+    "Enhancement modes and AI actions will stay off. You can always set it up later in the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodi und KI-Aktionen bleiben deaktiviert. Sie können dies später einrichten."
+          }
+        }
+      }
+    },
+    "Enhancement request timed out. Check your connection or increase the timeout duration.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung bei der Verbesserungsanfrage. Überprüfen Sie Ihre Verbindung oder verlängern Sie die maximale Wartezeit."
+          }
+        }
+      }
+    },
+    "Enhancement Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungseinstellungen"
+          }
+        }
+      }
+    },
+    "Enhancement Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungszeit"
+          }
+        }
+      }
+    },
+    "Enhancing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verbessert"
+          }
+        }
+      }
+    },
+    "Enhancing recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme wird verbessert"
+          }
+        }
+      }
+    },
+    "Enhancing...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verbessert..."
+          }
+        }
+      }
+    },
+    "Enter License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz eingeben"
+          }
+        }
+      }
+    },
+    "Enter License Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel eingeben"
+          }
+        }
+      }
+    },
+    "Enter word or phrase to replace (use commas for multiple)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort oder Ausdruck eingeben (mehrere mit Komma trennen)"
+          }
+        }
+      }
+    },
+    "Enter your": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie Ihren"
+          }
+        }
+      }
+    },
+    "Enter your %@ API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API-Schlüssel eingeben"
+          }
+        }
+      }
+    },
+    "Environment variables available: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk also writes VOICEINK_FULL_PROMPT to stdin for every command.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Umgebungsvariablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk schreibt außerdem VOICEINK_FULL_PROMPT für jeden Befehl nach stdin."
+          }
+        }
+      }
+    },
+    "Error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
+          }
+        }
+      }
+    },
+    "Error importing settings: %@. The file might be corrupted or not in the correct format.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Importieren der Einstellungen: %@. Die Datei könnte beschädigt oder im falschen Format sein."
+          }
+        }
+      }
+    },
+    "esc": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esc"
+          }
+        }
+      }
+    },
+    "Examples": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispiele"
+          }
+        }
+      }
+    },
+    "Experience VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erleben"
+          }
+        }
+      }
+    },
+    "Explore Affiliate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partnerprogramm erkunden"
+          }
+        }
+      }
+    },
+    "Export": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportieren"
+          }
+        }
+      }
+    },
+    "Export all settings, or choose specific categories when importing a backup.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Einstellungen exportieren oder beim Importieren bestimmte Kategorien wählen."
+          }
+        }
+      }
+    },
+    "Export Canceled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export abgebrochen"
+          }
+        }
+      }
+    },
+    "Export Error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportfehler"
+          }
+        }
+      }
+    },
+    "Export Failed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Export Logs": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolle exportieren"
+          }
+        }
+      }
+    },
+    "Export Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen exportieren"
+          }
+        }
+      }
+    },
+    "Export Successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export erfolgreich"
+          }
+        }
+      }
+    },
+    "Export VoiceInk Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Einstellungen exportieren"
+          }
+        }
+      }
+    },
+    "Fail immediately": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sofort abbrechen"
+          }
+        }
+      }
+    },
+    "Failed to add '%@': %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' konnte nicht hinzugefügt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to add replacement: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung konnte nicht hinzugefügt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to convert the audio format": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioformat konnte nicht konvertiert werden"
+          }
+        }
+      }
+    },
+    "Failed to copy audio file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei konnte nicht kopiert werden"
+          }
+        }
+      }
+    },
+    "Failed to copy transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription konnte nicht kopiert werden"
+          }
+        }
+      }
+    },
+    "Failed to create audio file: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei konnte nicht erstellt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to create AudioUnit: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit konnte nicht erstellt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to create custom sounds directory": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordner für benutzerdefinierte Töne konnte nicht erstellt werden"
+          }
+        }
+      }
+    },
+    "Failed to disable output: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe konnte nicht deaktiviert werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to enable input: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe konnte nicht aktiviert werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to encode the request body.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfragetext konnte nicht codiert werden."
+          }
+        }
+      }
+    },
+    "Failed to execute Local CLI command: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl konnte nicht ausgeführt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to export the processed audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verarbeitete Audiodatei konnte nicht exportiert werden"
+          }
+        }
+      }
+    },
+    "Failed to extract audio samples": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiosamples konnten nicht extrahiert werden"
+          }
+        }
+      }
+    },
+    "Failed to get device format: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geräteformat konnte nicht gelesen werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to import model: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell konnte nicht importiert werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to initialize AudioUnit: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit konnte nicht initialisiert werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to load the transcription model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell konnte nicht geladen werden."
+          }
+        }
+      }
+    },
+    "Failed to remove replacement: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung konnte nicht entfernt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to remove word: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort konnte nicht entfernt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to save API key securely": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel konnte nicht sicher gespeichert werden"
+          }
+        }
+      }
+    },
+    "Failed to save changes: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen konnten nicht gespeichert werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to save custom enhancement model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell konnte nicht gespeichert werden"
+          }
+        }
+      }
+    },
+    "Failed to save imported %@: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importiertes %@ konnte nicht gespeichert werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to set audio format: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioformat konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to set file format: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateiformat konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to set input callback: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe-Callback konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to set input device: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabegerät konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to start AudioUnit: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit konnte nicht gestartet werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to transcribe the audio.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio konnte nicht transkribiert werden."
+          }
+        }
+      }
+    },
+    "Failed to unzip the downloaded Core ML model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heruntergeladenes Core-ML-Modell konnte nicht entpackt werden."
+          }
+        }
+      }
+    },
+    "Fast multilingual transcription that runs locally on Mac.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnelle mehrsprachige Transkription, die lokal auf dem Mac läuft."
+          }
+        }
+      }
+    },
+    "Faster than Real-time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schneller als Echtzeit"
+          }
+        }
+      }
+    },
+    "Feedback or Issues?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback oder Probleme?"
+          }
+        }
+      }
+    },
+    "fewer keystrokes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "weniger Tastenanschläge"
+          }
+        }
+      }
+    },
+    "Filler word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwort"
+          }
+        }
+      }
+    },
+    "Finalizing models...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle werden fertiggestellt..."
+          }
+        }
+      }
+    },
+    "Finish Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung abschließen"
+          }
+        }
+      }
+    },
+    "Free updates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kostenlose Updates"
+          }
+        }
+      }
+    },
+    "General": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
+          }
+        }
+      }
+    },
+    "General Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemeine Einstellungen"
+          }
+        }
+      }
+    },
+    "Get %@ API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-API-Schlüssel abrufen"
+          }
+        }
+      }
+    },
+    "Get API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel abrufen"
+          }
+        }
+      }
+    },
+    "Get API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel abrufen"
+          }
+        }
+      }
+    },
+    "Granted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gewährt"
+          }
+        }
+      }
+    },
+    "HAL Output AudioUnit not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HAL Output AudioUnit nicht gefunden"
+          }
+        }
+      }
+    },
+    "Have a license key?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haben Sie einen Lizenzschlüssel?"
+          }
+        }
+      }
+    },
+    "Have feedback, a bug report, or something that feels off? Send a note with system information by email, or join Discord for community discussion. Every report helps make VoiceInk more reliable and easier to use.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haben Sie Feedback, einen Fehlerbericht oder ist etwas nicht stimmig? Senden Sie eine E-Mail mit Systeminformationen oder treten Sie dem Discord für eine Diskussion mit der Community bei. Jeder Bericht hilft dabei, VoiceInk zuverlässiger und einfacher nutzbar zu machen."
+          }
+        }
+      }
+    },
+    "Help & Resources": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilfe & Ressourcen"
+          }
+        }
+      }
+    },
+    "Hide Dock Icon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock-Symbol ausblenden"
+          }
+        }
+      }
+    },
+    "History": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf"
+          }
+        }
+      }
+    },
+    "How to use Word Replacements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendung von Wortersetzungen"
+          }
+        }
+      }
+    },
+    "Hybrid": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hybrid"
+          }
+        }
+      }
+    },
+    "Immediately": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sofort"
+          }
+        }
+      }
+    },
+    "Import": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importieren"
+          }
+        }
+      }
+    },
+    "Import Canceled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import abgebrochen"
+          }
+        }
+      }
+    },
+    "Import Error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importfehler"
+          }
+        }
+      }
+    },
+    "Import Local Model…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokales Modell importieren…"
+          }
+        }
+      }
+    },
+    "Import Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen importieren"
+          }
+        }
+      }
+    },
+    "Import Successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import erfolgreich"
+          }
+        }
+      }
+    },
+    "Import VoiceInk Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Einstellungen importieren"
+          }
+        }
+      }
+    },
+    "IMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the AI Models section.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WICHTIG: Falls Sie KI-Verbesserungsfunktionen verwendet haben, konfigurieren Sie bitte Ihre API-Schlüssel im Bereich KI-Modelle neu."
+          }
+        }
+      }
+    },
+    "Imported %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ importiert"
+          }
+        }
+      }
+    },
+    "Imported local model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokales Modell importiert"
+          }
+        }
+      }
+    },
+    "Info": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        }
+      }
+    },
+    "Interface": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche"
+          }
+        }
+      }
+    },
+    "Invalid Audio File": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Audiodatei"
+          }
+        }
+      }
+    },
+    "Invalid audio file format": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Audiodateiformat"
+          }
+        }
+      }
+    },
+    "Invalid emoji.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Emoji."
+          }
+        }
+      }
+    },
+    "Invalid model type provided for Native Apple transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Modelltyp für native Apple-Transkription angegeben."
+          }
+        }
+      }
+    },
+    "Invalid Ollama server URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Ollama-Server-URL"
+          }
+        }
+      }
+    },
+    "Invalid response from AI provider.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Antwort vom KI-Anbieter."
+          }
+        }
+      }
+    },
+    "Invalid response from Ollama server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Antwort vom Ollama-Server"
+          }
+        }
+      }
+    },
+    "It is recommended that you complete the onboarding.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wird empfohlen, die Einführung abzuschließen."
+          }
+        }
+      }
+    },
+    "It is recommended to restart VoiceInk for all changes to take full effect.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wird empfohlen, VoiceInk neu zu starten, damit alle Änderungen vollständig wirksam werden."
+          }
+        }
+      }
+    },
+    "Join Discord": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord beitreten"
+          }
+        }
+      }
+    },
+    "Keep": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beibehalten"
+          }
+        }
+      }
+    },
+    "Keep Audio For": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio aufbewahren für"
+          }
+        }
+      }
+    },
+    "Keep Clipboard Content": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischenablage-Inhalt beibehalten"
+          }
+        }
+      }
+    },
+    "Keep preserves punctuation as transcribed. Remove all strips punctuation marks from the transcribed text. Remove trailing period only removes a final period from the transcribed text.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„Behalten“ bewahrt die Zeichensetzung wie transkribiert. „Alle entfernen“ entfernt alle Satzzeichen. „Nur abschließenden Punkt“ entfernt nur den letzten Punkt des Textes."
+          }
+        }
+      }
+    },
+    "Key verified": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel verifiziert"
+          }
+        }
+      }
+    },
+    "Keyboard Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturkürzel"
+          }
+        }
+      }
+    },
+    "Keystrokes Saved": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenanschläge gespart"
+          }
+        }
+      }
+    },
+    "Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache"
+          }
+        }
+      }
+    },
+    "Language: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: %@"
+          }
+        }
+      }
+    },
+    "Language: Autodetected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: Automatisch erkannt"
+          }
+        }
+      }
+    },
+    "Language: English": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: Englisch"
+          }
+        }
+      }
+    },
+    "Language: English (only)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: Nur Englisch"
+          }
+        }
+      }
+    },
+    "Last 7 Days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte 7 Tage"
+          }
+        }
+      }
+    },
+    "Last 30 Days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte 30 Tage"
+          }
+        }
+      }
+    },
+    "Last transcription copied": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription kopiert"
+          }
+        }
+      }
+    },
+    "Launch at Login": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Anmeldung starten"
+          }
+        }
+      }
+    },
+    "Learn more": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr erfahren"
+          }
+        }
+      }
+    },
+    "License activated successfully!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erfolgreich aktiviert!"
+          }
+        }
+      }
+    },
+    "License active on this Mac.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz auf diesem Mac aktiv."
+          }
+        }
+      }
+    },
+    "License key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel"
+          }
+        }
+      }
+    },
+    "License Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel"
+          }
+        }
+      }
+    },
+    "License key not found. Please double-check your key and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel nicht gefunden. Bitte überprüfen Sie Ihren Schlüssel und versuchen Sie es erneut."
+          }
+        }
+      }
+    },
+    "License Management": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzverwaltung"
+          }
+        }
+      }
+    },
+    "License required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erforderlich"
+          }
+        }
+      }
+    },
+    "License Required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erforderlich"
+          }
+        }
+      }
+    },
+    "License validated successfully!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erfolgreich validiert!"
+          }
+        }
+      }
+    },
+    "Licensed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenziert"
+          }
+        }
+      }
+    },
+    "Licensed (Pro)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenziert (Pro)"
+          }
+        }
+      }
+    },
+    "Lifetime access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lebenslanger Zugang"
+          }
+        }
+      }
+    },
+    "Lifetime access.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lebenslanger Zugang."
+          }
+        }
+      }
+    },
+    "Listing files from repository...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien aus dem Repository werden aufgelistet..."
+          }
+        }
+      }
+    },
+    "Load a template or enter a command to enable Local CLI enhancement.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laden Sie eine Vorlage oder geben Sie einen Befehl ein, um die lokale CLI-Verbesserung zu aktivieren."
+          }
+        }
+      }
+    },
+    "Load More": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr laden"
+          }
+        }
+      }
+    },
+    "Load Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlage laden"
+          }
+        }
+      }
+    },
+    "Loading": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen"
+          }
+        }
+      }
+    },
+    "Loading apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps werden geladen"
+          }
+        }
+      }
+    },
+    "Loading model...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell wird geladen..."
+          }
+        }
+      }
+    },
+    "Loading...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen …"
+          }
+        }
+      }
+    },
+    "Local": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokal"
+          }
+        }
+      }
+    },
+    "Local & CLI Providers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale & CLI-Anbieter"
+          }
+        }
+      }
+    },
+    "Local CLI": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale CLI"
+          }
+        }
+      }
+    },
+    "Local CLI command failed with exit code %lld: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Local CLI command failed with exit code %lld.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen."
+          }
+        }
+      }
+    },
+    "Local CLI command is not configured. Load a template or enter a command first.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl ist nicht konfiguriert. Laden Sie eine Vorlage oder geben Sie zuerst einen Befehl ein."
+          }
+        }
+      }
+    },
+    "Local CLI command returned empty output.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl hat eine leere Ausgabe zurückgegeben."
+          }
+        }
+      }
+    },
+    "Local CLI command timed out after %lld seconds.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung des lokalen CLI-Befehls nach %lld Sekunden."
+          }
+        }
+      }
+    },
+    "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl wurde nicht gefunden. Verwenden Sie einen absoluten Pfad oder korrigieren Sie Ihren Shell-PATH. Details: %@"
+          }
+        }
+      }
+    },
+    "Local models don't work reliably on Intel Macs": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Modelle funktionieren auf Intel-Macs nicht zuverlässig"
+          }
+        }
+      }
+    },
+    "Local server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler Server"
+          }
+        }
+      }
+    },
+    "Local Storage": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler Speicher"
+          }
+        }
+      }
+    },
+    "Locked": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesperrt"
+          }
+        }
+      }
+    },
+    "Lost Key?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel verloren?"
+          }
+        }
+      }
+    },
+    "Lowercase output": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe in Kleinbuchstaben"
+          }
+        }
+      }
+    },
+    "macOS 26+": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 26+"
+          }
+        }
+      }
+    },
+    "Manage custom enhancement models in the Custom tab.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Verbesserungsmodelle im Tab „Benutzerdefiniert“ verwalten."
+          }
+        }
+      }
+    },
+    "Manage License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz verwalten"
+          }
+        }
+      }
+    },
+    "Manage Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle verwalten"
+          }
+        }
+      }
+    },
+    "Manage Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi verwalten"
+          }
+        }
+      }
+    },
+    "Memory": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsspeicher"
+          }
+        }
+      }
+    },
+    "Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon"
+          }
+        }
+      }
+    },
+    "Microphone Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon-Modus"
+          }
+        }
+      }
+    },
+    "Middle-Click Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittelklick-Aufnahme"
+          }
+        }
+      }
+    },
+    "Mini": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mini"
+          }
+        }
+      }
+    },
+    "Minimum words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestwörter"
+          }
+        }
+      }
+    },
+    "Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus"
+          }
+        }
+      }
+    },
+    "Mode name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modusname"
+          }
+        }
+      }
+    },
+    "Mode name cannot be empty.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modusname darf nicht leer sein."
+          }
+        }
+      }
+    },
+    "Mode shortcuts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus-Tastenkürzel"
+          }
+        }
+      }
+    },
+    "Mode:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus:"
+          }
+        }
+      }
+    },
+    "Mode: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus: %@"
+          }
+        }
+      }
+    },
+    "model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        }
+      }
+    },
+    "Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        }
+      }
+    },
+    "Model Catalog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellkatalog"
+          }
+        }
+      }
+    },
+    "Model Name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellname"
+          }
+        }
+      }
+    },
+    "Model name cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellname darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Model Performance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell-Leistung"
+          }
+        }
+      }
+    },
+    "Model Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelleinstellungen"
+          }
+        }
+      }
+    },
+    "models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle"
+          }
+        }
+      }
+    },
+    "models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle verfügbar"
+          }
+        }
+      }
+    },
+    "Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi"
+          }
+        }
+      }
+    },
+    "Modes help you set up VoiceInk for different writing tasks, workflows, and scenarios.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi helfen Ihnen, VoiceInk für verschiedene Schreibaufgaben, Arbeitsabläufe und Szenarien einzurichten."
+          }
+        }
+      }
+    },
+    "Modes Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi-Einstellungen"
+          }
+        }
+      }
+    },
+    "More enhancement models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Verbesserungsmodelle verfügbar"
+          }
+        }
+      }
+    },
+    "More transcription models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Transkriptionsmodelle verfügbar"
+          }
+        }
+      }
+    },
+    "Move down": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach unten"
+          }
+        }
+      }
+    },
+    "Move up": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach oben"
+          }
+        }
+      }
+    },
+    "ms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ms"
+          }
+        }
+      }
+    },
+    "Multilingual Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehrsprachiges Modell"
+          }
+        }
+      }
+    },
+    "Mute Audio While Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio während Aufnahme stummschalten"
+          }
+        }
+      }
+    },
+    "My Custom Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mein benutzerdefiniertes Modell"
+          }
+        }
+      }
+    },
+    "My Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mein Verbesserungsmodell"
+          }
+        }
+      }
+    },
+    "my website link": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mein Website-Link"
+          }
+        }
+      }
+    },
+    "Name cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Native Apple": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Natives Apple"
+          }
+        }
+      }
+    },
+    "Needs access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff erforderlich"
+          }
+        }
+      }
+    },
+    "Network connection failed. Check your internet.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerkverbindung fehlgeschlagen. Überprüfen Sie Ihre Internetverbindung."
+          }
+        }
+      }
+    },
+    "New Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Prompt"
+          }
+        }
+      }
+    },
+    "No AI Model Selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein KI-Modell ausgewählt"
+          }
+        }
+      }
+    },
+    "No Apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Apps"
+          }
+        }
+      }
+    },
+    "No apps found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Apps gefunden"
+          }
+        }
+      }
+    },
+    "No audio files found older than %lld days.": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Keine Audiodateien gefunden, die älter als %lld Tag sind."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Keine Audiodateien gefunden, die älter als %lld Tage sind."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No audio files found older than %lld day."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No audio files found older than %lld days."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "No automatic triggers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine automatischen Auslöser"
+          }
+        }
+      }
+    },
+    "No Custom Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine benutzerdefinierten Verbesserungsmodelle"
+          }
+        }
+      }
+    },
+    "No Custom Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine benutzerdefinierten Transkriptionsmodelle"
+          }
+        }
+      }
+    },
+    "No data for this period": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Daten für diesen Zeitraum"
+          }
+        }
+      }
+    },
+    "No devices available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Geräte verfügbar"
+          }
+        }
+      }
+    },
+    "No matching apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Apps"
+          }
+        }
+      }
+    },
+    "No Metadata": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Metadaten"
+          }
+        }
+      }
+    },
+    "No microphones found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Mikrofone gefunden"
+          }
+        }
+      }
+    },
+    "No mode selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modus ausgewählt"
+          }
+        }
+      }
+    },
+    "No model configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modell konfiguriert"
+          }
+        }
+      }
+    },
+    "No model selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modell ausgewählt"
+          }
+        }
+      }
+    },
+    "No models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle"
+          }
+        }
+      }
+    },
+    "No models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle verfügbar"
+          }
+        }
+      }
+    },
+    "No models listed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle aufgelistet."
+          }
+        }
+      }
+    },
+    "No models loaded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle geladen"
+          }
+        }
+      }
+    },
+    "No models loaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle geladen."
+          }
+        }
+      }
+    },
+    "No Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modi"
+          }
+        }
+      }
+    },
+    "No modes available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modi verfügbar"
+          }
+        }
+      }
+    },
+    "No Modes Available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modi verfügbar"
+          }
+        }
+      }
+    },
+    "No Modes Yet": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Modi"
+          }
+        }
+      }
+    },
+    "No prompts available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Prompts verfügbar"
+          }
+        }
+      }
+    },
+    "No Prompts Available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Prompts verfügbar"
+          }
+        }
+      }
+    },
+    "No providers connected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Anbieter verbunden"
+          }
+        }
+      }
+    },
+    "No Recorder Sessions Yet": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Aufnahmesitzungen"
+          }
+        }
+      }
+    },
+    "No removable language reservations were found.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine entfernbaren Sprachreservierungen gefunden."
+          }
+        }
+      }
+    },
+    "No results found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Ergebnisse gefunden"
+          }
+        }
+      }
+    },
+    "No Selection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auswahl"
+          }
+        }
+      }
+    },
+    "No settings were imported.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurden keine Einstellungen importiert."
+          }
+        }
+      }
+    },
+    "No transcription available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Transkription verfügbar"
+          }
+        }
+      }
+    },
+    "No transcription model selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Transkriptionsmodell ausgewählt"
+          }
+        }
+      }
+    },
+    "No transcription models available. Please connect to a cloud service or download a local model in the AI Models tab.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Transkriptionsmodelle verfügbar. Bitte verbinden Sie sich mit einem Cloud-Dienst oder laden Sie im Tab „KI-Modelle“ ein lokales Modell herunter."
+          }
+        }
+      }
+    },
+    "No transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Transkriptionen"
+          }
+        }
+      }
+    },
+    "No transcriptions yet": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Transkriptionen"
+          }
+        }
+      }
+    },
+    "No triggers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auslöser"
+          }
+        }
+      }
+    },
+    "No triggers in this group": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auslöser in dieser Gruppe"
+          }
+        }
+      }
+    },
+    "No Websites": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Websites"
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein"
+          }
+        }
+      }
+    },
+    "None detected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts erkannt"
+          }
+        }
+      }
+    },
+    "None selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts ausgewählt"
+          }
+        }
+      }
+    },
+    "Not configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht konfiguriert"
+          }
+        }
+      }
+    },
+    "Not connected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verbunden"
+          }
+        }
+      }
+    },
+    "Not connected to streaming transcription service": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht mit dem Streaming-Transkriptionsdienst verbunden"
+          }
+        }
+      }
+    },
+    "Not Determined": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht festgelegt"
+          }
+        }
+      }
+    },
+    "Not Granted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht gewährt"
+          }
+        }
+      }
+    },
+    "Not Licensed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht lizenziert"
+          }
+        }
+      }
+    },
+    "Notch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notch"
+          }
+        }
+      }
+    },
+    "Note: Press Option 1-9 during recording to switch modes manually.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis: Drücken Sie Option 1-9 während der Aufnahme, um manuell den Modus zu wechseln."
+          }
+        }
+      }
+    },
+    "Notes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notizen"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Ollama request timed out": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung bei der Ollama-Anfrage"
+          }
+        }
+      }
+    },
+    "Ollama server error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama-Serverfehler"
+          }
+        }
+      }
+    },
+    "Ollama service is not available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama-Dienst ist nicht verfügbar"
+          }
+        }
+      }
+    },
+    "On timeout": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Timeout"
+          }
+        }
+      }
+    },
+    "On-Device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf dem Gerät"
+          }
+        }
+      }
+    },
+    "Open %@ API key page": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API-Schlüssel-Seite öffnen"
+          }
+        }
+      }
+    },
+    "Open Accessibility settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen für Bedienungshilfen öffnen"
+          }
+        }
+      }
+    },
+    "Open history from anywhere with a global shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf von überall mit einem globalen Tastenkürzel öffnen"
+          }
+        }
+      }
+    },
+    "Open History Window": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlaufsfenster öffnen"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
+          }
+        }
+      }
+    },
+    "Open Source": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Source"
+          }
+        }
+      }
+    },
+    "OpenAI Compatible": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI-kompatibel"
+          }
+        }
+      }
+    },
+    "Optimizing model for your device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell wird für Ihr Gerät optimiert"
+          }
+        }
+      }
+    },
+    "or": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "oder"
+          }
+        }
+      }
+    },
+    "Original": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original"
+          }
+        }
+      }
+    },
+    "Original Text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Originaltext"
+          }
+        }
+      }
+    },
+    "Original text (use commas for multiple)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Originaltext (mehrere mit Komma trennen)"
+          }
+        }
+      }
+    },
+    "Original:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original:"
+          }
+        }
+      }
+    },
+    "Output": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe"
+          }
+        }
+      }
+    },
+    "Paragraph breaks": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Absatzumbrüche"
+          }
+        }
+      }
+    },
+    "Paste": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügen"
+          }
+        }
+      }
+    },
+    "Paste %@ API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-API-Schlüssel einfügen"
+          }
+        }
+      }
+    },
+    "Paste API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel einfügen"
+          }
+        }
+      }
+    },
+    "Paste Last Enhanced Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte verbesserte Transkription einfügen"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription einfügen"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription (Enhanced)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription einfügen (Verbessert)"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription (Original)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription einfügen (Original)"
+          }
+        }
+      }
+    },
+    "Paste Method": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügemethode"
+          }
+        }
+      }
+    },
+    "Pasting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügen"
+          }
+        }
+      }
+    },
+    "Pause Media While Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medien während Aufnahme pausieren"
+          }
+        }
+      }
+    },
+    "Performance Analysis": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leistungsanalyse"
+          }
+        }
+      }
+    },
+    "Pick the microphone VoiceInk should use for recordings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie das Mikrofon aus, das VoiceInk für Aufnahmen verwenden soll."
+          }
+        }
+      }
+    },
+    "Playback speed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiedergabegeschwindigkeit"
+          }
+        }
+      }
+    },
+    "Please enter a license key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte geben Sie einen Lizenzschlüssel ein"
+          }
+        }
+      }
+    },
+    "Please fix the validation errors before saving.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte beheben Sie die Validierungsfehler vor dem Speichern."
+          }
+        }
+      }
+    },
+    "Please restart the application. If the problem persists, contact support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte starten Sie die Anwendung neu. Wenn das Problem weiterhin besteht, kontaktieren Sie den Support."
+          }
+        }
+      }
+    },
+    "Premium Features Activated": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premium-Funktionen aktiviert"
+          }
+        }
+      }
+    },
+    "Press Esc again to cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esc erneut drücken, um abzubrechen"
+          }
+        }
+      }
+    },
+    "Press shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel drücken"
+          }
+        }
+      }
+    },
+    "Prewarm model (Experimental)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell vorwärmen (Experimentell)"
+          }
+        }
+      }
+    },
+    "Primary Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primäres Tastenkürzel"
+          }
+        }
+      }
+    },
+    "Prioritized": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Priorisiert"
+          }
+        }
+      }
+    },
+    "Priority Order": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prioritätsreihenfolge"
+          }
+        }
+      }
+    },
+    "Priority support": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bevorzugter Support"
+          }
+        }
+      }
+    },
+    "Privacy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz"
+          }
+        }
+      }
+    },
+    "Privacy Starts Here": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz beginnt hier"
+          }
+        }
+      }
+    },
+    "PRO": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRO"
+          }
+        }
+      }
+    },
+    "Processing audio...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio wird verarbeitet..."
+          }
+        }
+      }
+    },
+    "Processor": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozessor"
+          }
+        }
+      }
+    },
+    "Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
+          }
+        }
+      }
+    },
+    "Prompt name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt-Name"
+          }
+        }
+      }
+    },
+    "Provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter"
+          }
+        }
+      }
+    },
+    "Provider is not supported": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter wird nicht unterstützt"
+          }
+        }
+      }
+    },
+    "Punctuation": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeichensetzung"
+          }
+        }
+      }
+    },
+    "Purchase License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz kaufen"
+          }
+        }
+      }
+    },
+    "Push to Talk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push-to-Talk"
+          }
+        }
+      }
+    },
+    "Quick Access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnellzugriff"
+          }
+        }
+      }
+    },
+    "Quick Add to Dictionary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnell zum Wörterbuch hinzufügen"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
+          }
+        }
+      }
+    },
+    "Quit VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk beenden"
+          }
+        }
+      }
+    },
+    "Rate limit exceeded. Please try again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ratenlimit überschritten. Bitte versuchen Sie es später erneut."
+          }
+        }
+      }
+    },
+    "Re-enhance with selected prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit ausgewähltem Prompt neu verbessern"
+          }
+        }
+      }
+    },
+    "Re-enhancement failed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Verbesserung fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Re-enhancement successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Verbesserung erfolgreich"
+          }
+        }
+      }
+    },
+    "REACH OUT": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KONTAKT"
+          }
+        }
+      }
+    },
+    "Read more about custom local models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr über benutzerdefinierte lokale Modelle erfahren"
+          }
+        }
+      }
+    },
+    "Real-time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echtzeit"
+          }
+        }
+      }
+    },
+    "Recheck": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut prüfen"
+          }
+        }
+      }
+    },
+    "Recommended": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlen"
+          }
+        }
+      }
+    },
+    "Recommended Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlene Modelle"
+          }
+        }
+      }
+    },
+    "Record": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnehmen"
+          }
+        }
+      }
+    },
+    "Record shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel aufnehmen"
+          }
+        }
+      }
+    },
+    "Recorder Cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme abbrechen"
+          }
+        }
+      }
+    },
+    "Recorder Style": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorder-Stil"
+          }
+        }
+      }
+    },
+    "Recorder unavailable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme nicht verfügbar"
+          }
+        }
+      }
+    },
+    "Recording Behavior": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmeverhalten"
+          }
+        }
+      }
+    },
+    "Recording failed to start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme konnte nicht gestartet werden"
+          }
+        }
+      }
+    },
+    "Recording Failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Recording Sounds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmesounds"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        }
+      }
+    },
+    "Refresh Microphones": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofone aktualisieren"
+          }
+        }
+      }
+    },
+    "Refresh models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle aktualisieren"
+          }
+        }
+      }
+    },
+    "Refresh Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle aktualisieren"
+          }
+        }
+      }
+    },
+    "Refreshing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aktualisiert"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        }
+      }
+    },
+    "Remove %@ from reserved Apple Speech languages.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aus reservierten Apple-Speech-Sprachen entfernen."
+          }
+        }
+      }
+    },
+    "Remove all": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle entfernen"
+          }
+        }
+      }
+    },
+    "Remove API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen"
+          }
+        }
+      }
+    },
+    "Remove API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen"
+          }
+        }
+      }
+    },
+    "Remove API Key?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen?"
+          }
+        }
+      }
+    },
+    "Remove Filler Words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwörter entfernen"
+          }
+        }
+      }
+    },
+    "Remove License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz entfernen"
+          }
+        }
+      }
+    },
+    "Remove one reserved language to download %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine reservierte Sprache entfernen, um %@ herunterzuladen."
+          }
+        }
+      }
+    },
+    "Remove replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung entfernen"
+          }
+        }
+      }
+    },
+    "Remove trailing period": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlusspunkt entfernen"
+          }
+        }
+      }
+    },
+    "Remove trigger": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser entfernen"
+          }
+        }
+      }
+    },
+    "Remove website": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website entfernen"
+          }
+        }
+      }
+    },
+    "Remove word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort entfernen"
+          }
+        }
+      }
+    },
+    "Reorder Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi neu anordnen"
+          }
+        }
+      }
+    },
+    "Replace": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzen"
+          }
+        }
+      }
+    },
+    "Replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung"
+          }
+        }
+      }
+    },
+    "Replacement text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersatztext"
+          }
+        }
+      }
+    },
+    "Replacement Text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersatztext"
+          }
+        }
+      }
+    },
+    "Replacement:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung:"
+          }
+        }
+      }
+    },
+    "Report or Feedback": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bericht oder Feedback"
+          }
+        }
+      }
+    },
+    "Request Timeout": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfrage-Timeout"
+          }
+        }
+      }
+    },
+    "Required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderlich"
+          }
+        }
+      }
+    },
+    "Required for VoiceInk shortcuts and app-wide controls to work properly.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderlich für VoiceInk-Tastaturkürzel und app-weite Steuerung."
+          }
+        }
+      }
+    },
+    "Reset": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        }
+      }
+    },
+    "Reset Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung zurücksetzen"
+          }
+        }
+      }
+    },
+    "Reset to default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf Standard zurücksetzen"
+          }
+        }
+      }
+    },
+    "Respond": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antworten"
+          }
+        }
+      }
+    },
+    "Restart VoiceInk after enabling Screen Recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk nach dem Aktivieren der Bildschirmaufnahme neu starten."
+          }
+        }
+      }
+    },
+    "Restore Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederherstellungsverzögerung"
+          }
+        }
+      }
+    },
+    "Restricted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschränkt"
+          }
+        }
+      }
+    },
+    "Resume Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederaufnahmeverzögerung"
+          }
+        }
+      }
+    },
+    "Resume Download": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download fortsetzen"
+          }
+        }
+      }
+    },
+    "Retranscribe this audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Audio neu transkribieren"
+          }
+        }
+      }
+    },
+    "Retranscription failed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Transkription fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Retranscription successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Transkription erfolgreich"
+          }
+        }
+      }
+    },
+    "Retry": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholen"
+          }
+        }
+      }
+    },
+    "Retry failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholung fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Retry Last Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription wiederholen"
+          }
+        }
+      }
+    },
+    "Return (⏎)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe (⏎)"
+          }
+        }
+      }
+    },
+    "Review how VoiceInk handles your data before choosing a license.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie, wie VoiceInk Ihre Daten handhabt, bevor Sie eine Lizenz auswählen."
+          }
+        }
+      }
+    },
+    "Rewrite": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschreiben"
+          }
+        }
+      }
+    },
+    "Run Cleanup Now": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigung jetzt ausführen"
+          }
+        }
+      }
+    },
+    "Run enhancement with Ollama on this Mac, or send it to any CLI command.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserung mit Ollama auf diesem Mac ausführen oder an einen CLI-Befehl senden."
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        }
+      }
+    },
+    "Save & Select": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern & auswählen"
+          }
+        }
+      }
+    },
+    "Save as MD": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als MD speichern"
+          }
+        }
+      }
+    },
+    "Save as TXT": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als TXT speichern"
+          }
+        }
+      }
+    },
+    "Save Changes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen speichern"
+          }
+        }
+      }
+    },
+    "Save this prompt and select it.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diesen Prompt speichern und auswählen."
+          }
+        }
+      }
+    },
+    "Save to file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Datei speichern"
+          }
+        }
+      }
+    },
+    "Save Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription speichern"
+          }
+        }
+      }
+    },
+    "Saving": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird gespeichert"
+          }
+        }
+      }
+    },
+    "Screen": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirm"
+          }
+        }
+      }
+    },
+    "Screen Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmaufnahme"
+          }
+        }
+      }
+    },
+    "Search apps or enter website...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps suchen oder Website eingeben..."
+          }
+        }
+      }
+    },
+    "Search transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen suchen"
+          }
+        }
+      }
+    },
+    "Search transcriptions...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen suchen..."
+          }
+        }
+      }
+    },
+    "Secondary Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekundäres Tastenkürzel"
+          }
+        }
+      }
+    },
+    "seconds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekunden"
+          }
+        }
+      }
+    },
+    "Select a transcription to view details": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription auswählen, um Details anzuzeigen"
+          }
+        }
+      }
+    },
+    "Select a Whisper ggml .bin model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisper-ggml-.bin-Modell auswählen"
+          }
+        }
+      }
+    },
+    "Select All": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle auswählen"
+          }
+        }
+      }
+    },
+    "Select an audio file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei auswählen"
+          }
+        }
+      }
+    },
+    "Select an enabled mode to start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivierten Modus zum Starten auswählen"
+          }
+        }
+      }
+    },
+    "Select at least one category to import.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie mindestens eine Kategorie zum Importieren aus."
+          }
+        }
+      }
+    },
+    "Select Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache auswählen"
+          }
+        }
+      }
+    },
+    "Select mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus auswählen"
+          }
+        }
+      }
+    },
+    "Select Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus auswählen"
+          }
+        }
+      }
+    },
+    "Select Mode %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus %@ auswählen"
+          }
+        }
+      }
+    },
+    "Select Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt auswählen"
+          }
+        }
+      }
+    },
+    "Select sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klang auswählen"
+          }
+        }
+      }
+    },
+    "selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ausgewählt"
+          }
+        }
+      }
+    },
+    "Selected Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewähltes Mikrofon"
+          }
+        }
+      }
+    },
+    "Selected model not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewähltes Modell nicht gefunden"
+          }
+        }
+      }
+    },
+    "Selected Text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählter Text"
+          }
+        }
+      }
+    },
+    "Send follow up": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folgenachricht senden"
+          }
+        }
+      }
+    },
+    "Separate multiple originals with commas:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehrere Originale mit Komma trennen:"
+          }
+        }
+      }
+    },
+    "Server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server"
+          }
+        }
+      }
+    },
+    "Server error (%d). Please try again later or contact support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serverfehler (%d). Bitte versuchen Sie es später erneut oder kontaktieren Sie den Support."
+          }
+        }
+      }
+    },
+    "Server:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server:"
+          }
+        }
+      }
+    },
+    "Server: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server: %@"
+          }
+        }
+      }
+    },
+    "session": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzung"
+          }
+        }
+      }
+    },
+    "sessions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzungen"
+          }
+        }
+      }
+    },
+    "Sessions Recorded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgenommene Sitzungen"
+          }
+        }
+      }
+    },
+    "Set as default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als Standard festlegen"
+          }
+        }
+      }
+    },
+    "Set how long to wait for the AI provider to respond. If no response is received within this duration, you can either fail immediately and paste the original transcription, or retry the request up to 3 attempts.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legen Sie fest, wie lange auf eine Antwort des KI-Anbieters gewartet werden soll. Wenn innerhalb dieser Dauer keine Antwort eingeht, können Sie entweder sofort abbrechen und die ursprüngliche Transkription einfügen oder die Anfrage bis zu 3-mal wiederholen."
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
+          }
+        }
+      }
+    },
+    "Settings imported successfully from %@.\n\nImported: %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen erfolgreich aus %@ importiert.\n\nImportiert: %@."
+          }
+        }
+      }
+    },
+    "Share & Unlock": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilen & freischalten"
+          }
+        }
+      }
+    },
+    "Share VoiceInk on your socials, and instantly unlock a 30% discount on VoiceInk Pro.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilen Sie VoiceInk in Ihren sozialen Netzwerken und schalten Sie sofort 30 % Rabatt auf VoiceInk Pro frei."
+          }
+        }
+      }
+    },
+    "Share VoiceInk with friends or your audience and receive 30% on every referral that upgrades.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfehlen Sie VoiceInk Freunden oder Ihrem Publikum und erhalten Sie 30 % für jede geworbene Person, die ein Upgrade durchführt."
+          }
+        }
+      }
+    },
+    "Shift + Return (⇧⏎)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschalttaste + Eingabe (⇧⏎)"
+          }
+        }
+      }
+    },
+    "Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel"
+          }
+        }
+      }
+    },
+    "Shortcut already used by %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel wird bereits von %@ verwendet"
+          }
+        }
+      }
+    },
+    "Shortcut not allowed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel nicht erlaubt: %@"
+          }
+        }
+      }
+    },
+    "Shortcut reserved by macOS: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel von macOS reserviert: %@"
+          }
+        }
+      }
+    },
+    "Shortcuts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturkürzel"
+          }
+        }
+      }
+    },
+    "Show Announcements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ankündigungen anzeigen"
+          }
+        }
+      }
+    },
+    "Show Dock Icon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock-Symbol anzeigen"
+          }
+        }
+      }
+    },
+    "Show in Finder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Finder zeigen"
+          }
+        }
+      }
+    },
+    "Skip": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überspringen"
+          }
+        }
+      }
+    },
+    "Skip API setup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Einrichtung überspringen"
+          }
+        }
+      }
+    },
+    "Skip API Setup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Einrichtung überspringen"
+          }
+        }
+      }
+    },
+    "Skip API setup?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Einrichtung überspringen?"
+          }
+        }
+      }
+    },
+    "Skip onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung überspringen"
+          }
+        }
+      }
+    },
+    "Skip Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung überspringen"
+          }
+        }
+      }
+    },
+    "Skip onboarding?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung überspringen?"
+          }
+        }
+      }
+    },
+    "Skip short transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurze Transkriptionen überspringen"
+          }
+        }
+      }
+    },
+    "Slower than Real-time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langsamer als Echtzeit"
+          }
+        }
+      }
+    },
+    "Sort alphabetically": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alphabetisch sortieren"
+          }
+        }
+      }
+    },
+    "Sort by original": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Original sortieren"
+          }
+        }
+      }
+    },
+    "Sort by replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Ersatz sortieren"
+          }
+        }
+      }
+    },
+    "Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klang"
+          }
+        }
+      }
+    },
+    "SpeechAnalyzer requires macOS 26 or later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SpeechAnalyzer erfordert macOS 26 oder neuer."
+          }
+        }
+      }
+    },
+    "Speed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschwindigkeit"
+          }
+        }
+      }
+    },
+    "Start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten"
+          }
+        }
+      }
+    },
+    "Start 7-day Trial": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7-tägige Testversion starten"
+          }
+        }
+      }
+    },
+    "Start a 7-day trial or buy VoiceInk Pro to continue using VoiceInk.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie eine 7-tägige Testversion oder kaufen Sie VoiceInk Pro, um VoiceInk weiter zu verwenden."
+          }
+        }
+      }
+    },
+    "Start or stop the VoiceInk recorder for voice transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme für Sprachtranskription starten oder stoppen."
+          }
+        }
+      }
+    },
+    "Start recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme starten"
+          }
+        }
+      }
+    },
+    "Start Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Startklang"
+          }
+        }
+      }
+    },
+    "Start transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription starten"
+          }
+        }
+      }
+    },
+    "Start with a template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit einer Vorlage beginnen"
+          }
+        }
+      }
+    },
+    "Start your first recording to unlock value insights.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie Ihre erste Aufnahme, um wertvolle Einblicke zu erhalten."
+          }
+        }
+      }
+    },
+    "Starting recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme wird gestartet"
+          }
+        }
+      }
+    },
+    "Stop recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme stoppen"
+          }
+        }
+      }
+    },
+    "Stop Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stoppklang"
+          }
+        }
+      }
+    },
+    "Storage Warning": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherwarnung"
+          }
+        }
+      }
+    },
+    "Streaming connection failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Streaming-Verbindung fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Streaming server error: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Streaming-Serverfehler: %@"
+          }
+        }
+      }
+    },
+    "Streaming transcription timed out waiting for final result": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung der Streaming-Transkription beim Warten auf das Endergebnis"
+          }
+        }
+      }
+    },
+    "Suggested": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgeschlagen"
+          }
+        }
+      }
+    },
+    "Summarize": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusammenfassen"
+          }
+        }
+      }
+    },
+    "Supports any provider that uses the same API format as OpenAI chat completion.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Chat Completion verwendet."
+          }
+        }
+      }
+    },
+    "Supports any provider that uses the same API format as OpenAI transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Transcription verwendet."
+          }
+        }
+      }
+    },
+    "Supports WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP"
+          }
+        }
+      }
+    },
+    "Switch AI provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter wechseln"
+          }
+        }
+      }
+    },
+    "Switched to: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gewechselt zu: %@"
+          }
+        }
+      }
+    },
+    "System Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemstandard"
+          }
+        }
+      }
+    },
+    "System Default (%@)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemstandard (%@)"
+          }
+        }
+      }
+    },
+    "System Information": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeminformationen"
+          }
+        }
+      }
+    },
+    "System Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemprompt"
+          }
+        }
+      }
+    },
+    "System prompt is required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemprompt ist erforderlich"
+          }
+        }
+      }
+    },
+    "Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlage"
+          }
+        }
+      }
+    },
+    "Test": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testen"
+          }
+        }
+      }
+    },
+    "Test connection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung testen"
+          }
+        }
+      }
+    },
+    "Test the connection to continue.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung testen, um fortzufahren."
+          }
+        }
+      }
+    },
+    "Testing...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird getestet..."
+          }
+        }
+      }
+    },
+    "Thank you for using VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danke, dass Sie VoiceInk verwenden"
+          }
+        }
+      }
+    },
+    "The AI provider's server encountered an error. Please try again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Server des KI-Anbieters ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut."
+          }
+        }
+      }
+    },
+    "The API request failed with status code %lld: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die API-Anfrage ist mit Statuscode %lld fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "The API returned an empty or invalid response.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die API hat eine leere oder ungültige Antwort zurückgegeben."
+          }
+        }
+      }
+    },
+    "The app '%@' is already configured in the '%@' mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die App '%@' ist bereits im Modus '%@' konfiguriert."
+          }
+        }
+      }
+    },
+    "The audio file is invalid or corrupted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Audiodatei ist ungültig oder beschädigt"
+          }
+        }
+      }
+    },
+    "The audio file to transcribe could not be found.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die zu transkribierende Audiodatei konnte nicht gefunden werden."
+          }
+        }
+      }
+    },
+    "The audio format is not supported": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Audioformat wird nicht unterstützt"
+          }
+        }
+      }
+    },
+    "The core transcription engine failed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Kern-Transkriptionsengine ist fehlgeschlagen."
+          }
+        }
+      }
+    },
+    "The downloaded Core ML model archive might be corrupted. Try deleting the model and downloading it again. Check available disk space.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das heruntergeladene Core-ML-Modellarchiv ist möglicherweise beschädigt. Löschen Sie das Modell und laden Sie es erneut herunter. Prüfen Sie den verfügbaren Speicherplatz."
+          }
+        }
+      }
+    },
+    "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die importierte Einstellungsdatei (Version %@) stammt aus einer anderen Version als Ihre Anwendung (Version %@). Der Import wird fortgesetzt, mögliche Inkompatibilitäten sind jedoch zu beachten."
+          }
+        }
+      }
+    },
+    "The key worked, but VoiceInk could not save it securely.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schlüssel funktioniert, aber VoiceInk konnte ihn nicht sicher speichern."
+          }
+        }
+      }
+    },
+    "The model provider is not supported by this service.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Modellanbieter wird von diesem Dienst nicht unterstützt."
+          }
+        }
+      }
+    },
+    "The provided API key is invalid.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der angegebene API-Schlüssel ist ungültig."
+          }
+        }
+      }
+    },
+    "The selected language is not supported by SpeechAnalyzer.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die ausgewählte Sprache wird von SpeechAnalyzer nicht unterstützt."
+          }
+        }
+      }
+    },
+    "The settings export operation was canceled.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Einstellungsexport wurde abgebrochen."
+          }
+        }
+      }
+    },
+    "The settings import operation was canceled.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Einstellungsimport wurde abgebrochen."
+          }
+        }
+      }
+    },
+    "The transcription language is automatically detected by the model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Transkriptionssprache wird vom Modell automatisch erkannt."
+          }
+        }
+      }
+    },
+    "The website '%@' is already configured in the '%@' mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Website '%@' ist bereits im Modus '%@' konfiguriert."
+          }
+        }
+      }
+    },
+    "Thinking": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verarbeitet"
+          }
+        }
+      }
+    },
+    "This action cannot be undone. Are you sure you want to delete %lld items?": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Diese Aktion kann nicht rückgängig gemacht werden. Soll wirklich %lld Element gelöscht werden?"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Diese Aktion kann nicht rückgängig gemacht werden. Sollen wirklich %lld Elemente gelöscht werden?"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This action cannot be undone. Are you sure you want to delete %lld item?"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This action cannot be undone. Are you sure you want to delete %lld items?"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "This can happen due to an issue with the audio recording or insufficient system resources. Please try again, or restart the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dies kann durch ein Problem mit der Audioaufnahme oder durch unzureichende Systemressourcen auftreten. Bitte versuchen Sie es erneut oder starten Sie die App neu."
+          }
+        }
+      }
+    },
+    "This filler word already exists.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Füllwort existiert bereits."
+          }
+        }
+      }
+    },
+    "This is an English-optimized model and only supports English transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Modell ist für Englisch optimiert und unterstützt nur Transkription auf Englisch."
+          }
+        }
+      }
+    },
+    "This license has been revoked or disabled. Please contact support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Lizenz wurde widerrufen oder deaktiviert. Bitte kontaktieren Sie den Support."
+          }
+        }
+      }
+    },
+    "This license has reached its device limit. Visit the License Management Portal to deactivate other devices.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Lizenz hat ihr Gerätelimit erreicht. Besuchen Sie das Lizenzverwaltungsportal, um andere Geräte zu deaktivieren."
+          }
+        }
+      }
+    },
+    "This model supports multiple languages. Select a specific language or auto-detect(if available)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Modell unterstützt mehrere Sprachen. Wählen Sie eine bestimmte Sprache oder die automatische Erkennung (falls verfügbar)."
+          }
+        }
+      }
+    },
+    "This removes the license from this Mac. You can activate it again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dadurch wird die Lizenz von diesem Mac entfernt. Sie können sie später wieder aktivieren."
+          }
+        }
+      }
+    },
+    "This will delete %lld audio files (%@).": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodatei (%@) wird gelöscht."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodateien (%@) werden gelöscht."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This will delete %lld audio file (%@)."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This will delete %lld audio files (%@)."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "This will remove your": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dadurch wird Ihr"
+          }
+        }
+      }
+    },
+    "This will remove your %@ API key. You can add it again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihr %@ API-Schlüssel wird entfernt. Sie können ihn später wieder hinzufügen."
+          }
+        }
+      }
+    },
+    "This Year": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Jahr"
+          }
+        }
+      }
+    },
+    "Timeout": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout"
+          }
+        }
+      }
+    },
+    "Timeout duration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout-Dauer"
+          }
+        }
+      }
+    },
+    "Toggle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschalten"
+          }
+        }
+      }
+    },
+    "Toggle Inspector": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inspektor ein-/ausblenden"
+          }
+        }
+      }
+    },
+    "Toggle Menu Bar Only": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur-Menüleistenmodus umschalten"
+          }
+        }
+      }
+    },
+    "Toggle Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme umschalten"
+          }
+        }
+      }
+    },
+    "Toggle Sidebar": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleiste ein-/ausblenden"
+          }
+        }
+      }
+    },
+    "Toggle VoiceInk Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme umschalten"
+          }
+        }
+      }
+    },
+    "Total Transcripts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen gesamt"
+          }
+        }
+      }
+    },
+    "Transcribe": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkribieren"
+          }
+        }
+      }
+    },
+    "Transcribing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird transkribiert"
+          }
+        }
+      }
+    },
+    "Transcribing recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme wird transkribiert"
+          }
+        }
+      }
+    },
+    "Transcribing...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird transkribiert..."
+          }
+        }
+      }
+    },
+    "Transcript Cleanup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptions-Bereinigung"
+          }
+        }
+      }
+    },
+    "Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription"
+          }
+        }
+      }
+    },
+    "Transcription failed using SpeechAnalyzer.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription mit SpeechAnalyzer fehlgeschlagen."
+          }
+        }
+      }
+    },
+    "Transcription Failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Transcription Failed: No model selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen: Kein Modell ausgewählt"
+          }
+        }
+      }
+    },
+    "Transcription Formatting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsformatierung"
+          }
+        }
+      }
+    },
+    "Transcription Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionssprache"
+          }
+        }
+      }
+    },
+    "Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell"
+          }
+        }
+      }
+    },
+    "Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodelle"
+          }
+        }
+      }
+    },
+    "Transcription Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionszeit"
+          }
+        }
+      }
+    },
+    "Transcription was cancelled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription wurde abgebrochen"
+          }
+        }
+      }
+    },
+    "Translate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersetzen"
+          }
+        }
+      }
+    },
+    "Trial Active": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testversion aktiv"
+          }
+        }
+      }
+    },
+    "Trial ended": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testphase beendet"
+          }
+        }
+      }
+    },
+    "Trial Ending Soon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testversion endet bald"
+          }
+        }
+      }
+    },
+    "Trial Expired": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testversion abgelaufen"
+          }
+        }
+      }
+    },
+    "Triggers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser"
+          }
+        }
+      }
+    },
+    "Try a different search term": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anderen Suchbegriff versuchen"
+          }
+        }
+      }
+    },
+    "Try a few short samples and see how VoiceInk works before you start.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probieren Sie ein paar kurze Beispiele aus und sehen Sie, wie VoiceInk funktioniert, bevor Sie beginnen."
+          }
+        }
+      }
+    },
+    "Try selecting a different model or redownloading the current model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie ein anderes Modell aus oder laden Sie das aktuelle Modell erneut herunter."
+          }
+        }
+      }
+    },
+    "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie diese Option, wenn Transkriptionen mit lokalen Modellen länger als erwartet dauern. Führt beim App-Start und Aufwachen im Hintergrund stille Transkriptionen aus, um die Optimierung anzustoßen."
+          }
+        }
+      }
+    },
+    "Unavailable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verfügbar"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannt"
+          }
+        }
+      }
+    },
+    "Unlock VoiceInk Pro For Less": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk Pro günstiger freischalten"
+          }
+        }
+      }
+    },
+    "Unsupported provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht unterstützter Anbieter"
+          }
+        }
+      }
+    },
+    "Update the word or phrase that should be automatically replaced.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Wort oder den Ausdruck aktualisieren, der automatisch ersetzt werden soll."
+          }
+        }
+      }
+    },
+    "Use captured on-screen text as context for this mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfassten Bildschirmtext als Kontext für diesen Modus verwenden."
+          }
+        }
+      }
+    },
+    "Use clipboard text as context for this mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text aus der Zwischenablage als Kontext für diesen Modus verwenden."
+          }
+        }
+      }
+    },
+    "Use Cloud": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud verwenden"
+          }
+        }
+      }
+    },
+    "Use selected text from the active app as context for this mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählten Text der aktiven App als Kontext für diesen Modus verwenden."
+          }
+        }
+      }
+    },
+    "Use System Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemvorlage verwenden"
+          }
+        }
+      }
+    },
+    "Use VoiceInk now.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk jetzt nutzen."
+          }
+        }
+      }
+    },
+    "User Message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzernachricht"
+          }
+        }
+      }
+    },
+    "Using: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendet: %@"
+          }
+        }
+      }
+    },
+    "Variables: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT"
+          }
+        }
+      }
+    },
+    "Verification Successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfung erfolgreich"
+          }
+        }
+      }
+    },
+    "Verified": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifiziert"
+          }
+        }
+      }
+    },
+    "Verify": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen"
+          }
+        }
+      }
+    },
+    "Verify and Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen und speichern"
+          }
+        }
+      }
+    },
+    "Verify API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel überprüfen"
+          }
+        }
+      }
+    },
+    "Verifying": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft"
+          }
+        }
+      }
+    },
+    "Verifying...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft..."
+          }
+        }
+      }
+    },
+    "Version %@ (%@)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ (%@)"
+          }
+        }
+      }
+    },
+    "Version Mismatch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionskonflikt"
+          }
+        }
+      }
+    },
+    "View details": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details anzeigen"
+          }
+        }
+      }
+    },
+    "View transcription and enhancement model performance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptions- und Verbesserungsmodell-Leistung anzeigen"
+          }
+        }
+      }
+    },
+    "Vocabulary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vokabular"
+          }
+        }
+      }
+    },
+    "Vocabulary is used only with AI enhancement to preserve important names, technical terms, and unique spellings in the final output.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vokabular wird nur mit KI-Verbesserung verwendet, um wichtige Namen, Fachbegriffe und besondere Schreibweisen in der finalen Ausgabe beizubehalten."
+          }
+        }
+      }
+    },
+    "Vocabulary Words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vokabular-Wörter"
+          }
+        }
+      }
+    },
+    "Vocabulary Words (%lld)": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vokabular-Wort (%lld)"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vokabular-Wörter (%lld)"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vocabulary Word (%lld)"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vocabulary Words (%lld)"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Voice Activity Detection (VAD)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachaktivitätserkennung (VAD)"
+          }
+        }
+      }
+    },
+    "VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
+        }
+      }
+    },
+    "VoiceInk app is not available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-App ist nicht verfügbar"
+          }
+        }
+      }
+    },
+    "VoiceInk automatically understands what you are working with and selects your preferred setup. You can always configure this by editing or creating new modes.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erkennt automatisch, woran Sie arbeiten, und wählt Ihre bevorzugte Konfiguration aus. Sie können dies jederzeit konfigurieren, indem Sie Modi bearbeiten oder neue Modi erstellen."
+          }
+        }
+      }
+    },
+    "VoiceInk can select the right mode from the app you are using and the rules you configure.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk kann anhand der verwendeten App und der konfigurierten Regeln den passenden Modus auswählen."
+          }
+        }
+      }
+    },
+    "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk konnte nicht auf den Speicherort zugreifen. Ihre Transkriptionen werden nicht zwischen Sitzungen gespeichert."
+          }
+        }
+      }
+    },
+    "VoiceInk Insights": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Einblicke"
+          }
+        }
+      }
+    },
+    "VoiceInk is also open source, so you can inspect every single line of code.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist auch Open Source, sodass Sie jede Codezeile einsehen können."
+          }
+        }
+      }
+    },
+    "VoiceInk is Context-Aware": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erkennt den Kontext"
+          }
+        }
+      }
+    },
+    "VoiceInk is context-aware.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erkennt den Kontext."
+          }
+        }
+      }
+    },
+    "VoiceInk is Open Source": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist Open Source"
+          }
+        }
+      }
+    },
+    "VoiceInk is private by default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist standardmäßig privat"
+          }
+        }
+      }
+    },
+    "VoiceInk is private by default. No data leaves your device unless you opt in.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist standardmäßig privat. Keine Daten verlassen Ihr Gerät, sofern Sie dem nicht zustimmen."
+          }
+        }
+      }
+    },
+    "VoiceInk Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Modi"
+          }
+        }
+      }
+    },
+    "VoiceInk modes include Dictation, Enhance, Email, Assistant, Rewrite, Ask, Summarize, and Translate.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Modi umfassen Diktat, Verbesserung, E-Mail, Assistent, Umschreiben, Fragen, Zusammenfassen und Übersetzen."
+          }
+        }
+      }
+    },
+    "VoiceInk Pro": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk Pro"
+          }
+        }
+      }
+    },
+    "VoiceInk reads visible screen content to improve the accuracy of transcripts.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk liest sichtbare Bildschirminhalte, um die Genauigkeit der Transkripte zu verbessern."
+          }
+        }
+      }
+    },
+    "VoiceInk recorder dismissed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme geschlossen"
+          }
+        }
+      }
+    },
+    "VoiceInk recorder toggled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme umgeschaltet"
+          }
+        }
+      }
+    },
+    "VoiceInk recording service is not available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahmedienst ist nicht verfügbar"
+          }
+        }
+      }
+    },
+    "VoiceInk sessions completed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Sitzungen abgeschlossen"
+          }
+        }
+      }
+    },
+    "VoiceInk temporarily uses the clipboard to paste transcription. When enabled, it restores your previous clipboard content after the selected delay. When disabled, the pasted transcription stays on your clipboard.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk nutzt die Zwischenablage vorübergehend zum Einfügen der Transkription. Wenn aktiviert, wird der frühere Inhalt der Zwischenablage nach der gewählten Verzögerung wiederhergestellt. Wenn deaktiviert, bleibt die Transkription in der Zwischenablage."
+          }
+        }
+      }
+    },
+    "VoiceInk uses Accessibility to type transcriptions directly into any app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk verwendet Bedienungshilfen, um Transkriptionen direkt in jede App einzugeben."
+          }
+        }
+      }
+    },
+    "VoiceInk uses LLMs to enhance transcripts and perform AI actions. Set up an API key before continuing.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk verwendet LLMs, um Transkripte zu verbessern und KI-Aktionen auszuführen. Richten Sie einen API-Schlüssel ein, bevor Sie fortfahren."
+          }
+        }
+      }
+    },
+    "VoiceInk uses your microphone to capture your voice.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk verwendet Ihr Mikrofon, um Ihre Stimme aufzunehmen."
+          }
+        }
+      }
+    },
+    "VoiceInk vs. typing by hand": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk vs. Tippen von Hand"
+          }
+        }
+      }
+    },
+    "VoiceInk will download NVIDIA's Parakeet model to set up fast local transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk lädt das Parakeet-Modell von NVIDIA herunter, um schnelle lokale Transkription einzurichten."
+          }
+        }
+      }
+    },
+    "Voicing, Voice ink": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voicing, Voice ink"
+          }
+        }
+      }
+    },
+    "Voicing, Voice ink, Voiceing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voicing, Voice ink, Voiceing"
+          }
+        }
+      }
+    },
+    "Waiting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet"
+          }
+        }
+      }
+    },
+    "With": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit"
+          }
+        }
+      }
+    },
+    "word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort"
+          }
+        }
+      }
+    },
+    "Word Replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzung"
+          }
+        }
+      }
+    },
+    "Word replacement examples": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispiele für Wortersetzungen"
+          }
+        }
+      }
+    },
+    "Word Replacements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzungen"
+          }
+        }
+      }
+    },
+    "Word Replacements run after transcription to replace misheard words, phrases, abbreviations, or boilerplate text.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzungen werden nach der Transkription ausgeführt, um falsch erkannte Wörter, Ausdrücke, Abkürzungen oder Textbausteine zu ersetzen."
+          }
+        }
+      }
+    },
+    "Word Replacements run after transcription. Vocabulary is used with AI enhancement to better understand names, technical terms, and unique spellings in your transcript.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzungen werden nach der Transkription angewendet. Das Vokabular wird mit KI-Verbesserung verwendet, um Namen, Fachbegriffe und besondere Schreibweisen in Ihrer Transkription besser zu verstehen."
+          }
+        }
+      }
+    },
+    "words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter"
+          }
+        }
+      }
+    },
+    "Words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter"
+          }
+        }
+      }
+    },
+    "Words Dictated": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktierte Wörter"
+          }
+        }
+      }
+    },
+    "words generated": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter generiert"
+          }
+        }
+      }
+    },
+    "Words Per Minute": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter pro Minute"
+          }
+        }
+      }
+    },
+    "Write prompt instructions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt-Anweisungen schreiben"
+          }
+        }
+      }
+    },
+    "You Control It": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben die Kontrolle"
+          }
+        }
+      }
+    },
+    "You have %lld days left in your trial": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ihre Testphase läuft noch %lld Tag"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ihre Testphase läuft noch %lld Tage"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "You have %lld day left in your trial"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "You have %lld days left in your trial"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "You have saved %@ with VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben %@ mit VoiceInk gespart"
+          }
+        }
+      }
+    },
+    "You'll see the introduction screens again the next time you launch the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim nächsten App-Start werden die Einführungsbildschirme erneut angezeigt."
+          }
+        }
+      }
+    },
+    "Your data never has to leave your device.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Daten müssen Ihr Gerät nie verlassen."
+          }
+        }
+      }
+    },
+    "Your license key is verified. VoiceInk is ready to use on this Mac.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihr Lizenzschlüssel wurde verifiziert. VoiceInk ist auf diesem Mac einsatzbereit."
+          }
+        }
+      }
+    },
+    "Your settings have been successfully exported to %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Einstellungen wurden erfolgreich in %@ exportiert."
+          }
+        }
+      }
+    },
+    "Your transcription history will appear here": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Transkriptionshistorie wird hier angezeigt"
+          }
+        }
+      }
+    },
+    "Your trial has expired. Upgrade to continue using VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Testversion ist abgelaufen. Upgraden Sie, um VoiceInk weiter zu verwenden."
+          }
+        }
+      }
+    },
+    "Your trial has expired. Upgrade to VoiceInk Pro at %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Testversion ist abgelaufen. Upgraden Sie auf VoiceInk Pro unter %@"
+          }
+        }
+      }
+    },
+    "Your usage summary will appear here.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Nutzungsübersicht wird hier angezeigt."
+          }
+        }
+      }
+    },
+    "Your VoiceInk journey starts with your first recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre VoiceInk-Reise beginnt mit der ersten Aufnahme."
+          }
+        }
+      }
+    },
+    "YouTube Videos & Guides": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YouTube-Videos & Anleitungen"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.1"
+}

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -3371,16 +3371,6 @@
         }
       }
     },
-    "Dictated %@ words across %d %@.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sie haben %@ Wörter in %d %@ diktiert."
-          }
-        }
-      }
-    },
     "Dictation": {
       "localizations": {
         "de": {
@@ -8221,26 +8211,6 @@
         }
       }
     },
-    "session": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sitzung"
-          }
-        }
-      }
-    },
-    "sessions": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sitzungen"
-          }
-        }
-      }
-    },
     "Sessions Recorded": {
       "localizations": {
         "de": {
@@ -10517,6 +10487,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "YouTube-Videos & Anleitungen"
+          }
+        }
+      }
+    },
+    "Dictated %1$@ words across %2$lld sessions.": {
+      "comment": "Hero subtitle showing word count and session count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Dictated %1$@ words across %2$lld session."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Dictated %1$@ words across %2$lld sessions."
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Sie haben %1$@ Wörter in %2$lld Sitzung diktiert."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Sie haben %1$@ Wörter in %2$lld Sitzungen diktiert."
+                }
+              }
+            }
           }
         }
       }

--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -79,11 +79,11 @@ extension CustomPrompt {
                 if let onDelete = onDelete {
                     Button(role: .destructive) {
                         let alert = NSAlert()
-                        alert.messageText = "Delete Prompt?"
-                        alert.informativeText = "Are you sure you want to delete '\(self.title)' prompt? This action cannot be undone."
+                        alert.messageText = String(localized: "Delete Prompt?")
+                        alert.informativeText = String(format: String(localized: "Are you sure you want to delete '%@' prompt? This action cannot be undone."), self.title)
                         alert.alertStyle = .warning
-                        alert.addButton(withTitle: "Delete")
-                        alert.addButton(withTitle: "Cancel")
+                        alert.addButton(withTitle: String(localized: "Delete"))
+                        alert.addButton(withTitle: String(localized: "Cancel"))
                         
                         let response = alert.runModal()
                         if response == .alertFirstButtonReturn {

--- a/VoiceInk/Models/LicenseViewModel.swift
+++ b/VoiceInk/Models/LicenseViewModel.swift
@@ -106,9 +106,12 @@ class LicenseViewModel: ObservableObject {
     var usageRestrictionMessage: String? {
         switch licenseState {
         case .unlicensed:
-            return "Start a 7-day trial or buy VoiceInk Pro to continue using VoiceInk."
+            return String(localized: "Start a 7-day trial or buy VoiceInk Pro to continue using VoiceInk.")
         case .trialExpired:
-            return "Your trial has expired. Upgrade to VoiceInk Pro at tryvoiceink.com/buy"
+            return String(
+                format: String(localized: "Your trial has expired. Upgrade to VoiceInk Pro at %@"),
+                "tryvoiceink.com/buy"
+            )
         case .trial, .licensed:
             return nil
         }
@@ -125,7 +128,7 @@ class LicenseViewModel: ObservableObject {
 
         guard !normalizedLicenseKey.isEmpty else {
             validationSuccess = false
-            validationMessage = "Please enter a license key"
+            validationMessage = String(localized: "Please enter a license key")
             return
         }
         
@@ -140,7 +143,7 @@ class LicenseViewModel: ObservableObject {
             
             if !licenseCheck.isValid {
                 validationSuccess = false
-                validationMessage = "This license has been revoked or disabled. Please contact support."
+                validationMessage = String(localized: "This license has been revoked or disabled. Please contact support.")
                 isValidating = false
                 return
             }
@@ -156,7 +159,7 @@ class LicenseViewModel: ObservableObject {
                         userDefaults.set(true, forKey: "VoiceInkLicenseRequiresActivation")
                         activationsLimit = limit
                         userDefaults.activationsLimit = limit
-                        completeSuccessfulValidation(message: "License activated successfully!")
+                        completeSuccessfulValidation(message: String(localized: "License activated successfully!"))
                         isValidating = false
                         return
                     }
@@ -183,31 +186,37 @@ class LicenseViewModel: ObservableObject {
                 userDefaults.activationsLimit = licenseCheck.activationsLimit ?? 0
 
                 // Update the license state for unlimited license
-                completeSuccessfulValidation(message: "License validated successfully!")
+                completeSuccessfulValidation(message: String(localized: "License validated successfully!"))
                 isValidating = false
                 return
             }
             
             // Update the license state for activated license
-            completeSuccessfulValidation(message: "License activated successfully!")
+            completeSuccessfulValidation(message: String(localized: "License activated successfully!"))
 
         } catch LicenseError.keyNotFound {
             validationSuccess = false
-            validationMessage = "License key not found. Please double-check your key and try again."
+            validationMessage = String(localized: "License key not found. Please double-check your key and try again.")
         } catch LicenseError.activationLimitReached {
             validationSuccess = false
-            validationMessage = "This license has reached its device limit. Visit the License Management Portal to deactivate other devices."
+            validationMessage = String(localized: "This license has reached its device limit. Visit the License Management Portal to deactivate other devices.")
         } catch LicenseError.serverError(let code) {
             validationSuccess = false
-            validationMessage = "Server error (\(code)). Please try again later or contact support."
+            validationMessage = String(
+                format: String(localized: "Server error (%d). Please try again later or contact support."),
+                code
+            )
         } catch let urlError as URLError {
             validationSuccess = false
-            logger.error("🔑 License network error: \(urlError.localizedDescription, privacy: .public)")
-            validationMessage = "Could not reach the server. Please check your internet connection and try again."
+            logger.error("🔑 License network error: \(urlError, privacy: .public)")
+            validationMessage = String(localized: "Could not reach the server. Please check your internet connection and try again.")
         } catch {
             validationSuccess = false
             logger.error("🔑 Unexpected license error: \(error, privacy: .public)")
-            validationMessage = "An unexpected error occurred. Please try again or contact support at support@tryvoiceink.com"
+            validationMessage = String(
+                format: String(localized: "An unexpected error occurred. Please try again or contact support at %@"),
+                "support@tryvoiceink.com"
+            )
         }
         
         isValidating = false

--- a/VoiceInk/Modes/ActiveWindowService.swift
+++ b/VoiceInk/Modes/ActiveWindowService.swift
@@ -61,7 +61,7 @@ class ActiveWindowService: ObservableObject {
             } catch is CancellationError {
                 return
             } catch {
-                self.logger.error("❌ Failed to get URL from \(browserType.displayName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                self.logger.error("❌ Failed to get URL from \(browserType.displayName, privacy: .public): \(error, privacy: .public)")
             }
         }
     }

--- a/VoiceInk/Modes/BrowserURLService.swift
+++ b/VoiceInk/Modes/BrowserURLService.swift
@@ -141,7 +141,7 @@ class BrowserURLService {
             }
             throw CancellationError()
         } catch {
-            logger.error("❌ AppleScript execution failed for \(browser.displayName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ AppleScript execution failed for \(browser.displayName, privacy: .public): \(error, privacy: .public)")
             throw BrowserURLError.executionFailed
         }
     }

--- a/VoiceInk/Modes/ModeConfig.swift
+++ b/VoiceInk/Modes/ModeConfig.swift
@@ -8,10 +8,10 @@ enum AutoSendKey: String, Codable, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .none: return "None"
-        case .enter: return "Return (⏎)"
-        case .shiftEnter: return "Shift + Return (⇧⏎)"
-        case .commandEnter: return "Command + Return (⌘⏎)"
+        case .none: return String(localized: "None")
+        case .enter: return String(localized: "Return (⏎)")
+        case .shiftEnter: return String(localized: "Shift + Return (⇧⏎)")
+        case .commandEnter: return String(localized: "Command + Return (⌘⏎)")
         }
     }
 
@@ -26,8 +26,8 @@ enum ModeOutputMode: String, Codable, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .paste: return "Paste"
-        case .respond: return "Respond"
+        case .paste: return String(localized: "Paste")
+        case .respond: return String(localized: "Respond")
         }
     }
 

--- a/VoiceInk/Modes/ModeConfigFormView.swift
+++ b/VoiceInk/Modes/ModeConfigFormView.swift
@@ -153,7 +153,7 @@ struct ModeConfigFormView: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Are you sure you want to delete '\(draft.name)'? This action cannot be undone.")
+            Text(String(format: String(localized: "Are you sure you want to delete '%@'? This action cannot be undone."), draft.name))
         }
         .modeValidationAlert(errors: validationErrors, isPresented: $showValidationAlert)
     }
@@ -205,7 +205,7 @@ struct ModeConfigFormView: View {
 
                     Picker(selection: $draft.punctuationCleanupMode) {
                         ForEach(PunctuationCleanupMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
+                            Text(LocalizedStringKey(mode.displayName)).tag(mode)
                         }
                     } label: {
                         HStack(spacing: 4) {
@@ -393,7 +393,7 @@ struct ModeConfigFormView: View {
             let models = aiModelOptions(for: provider)
             if models.isEmpty {
                 LabeledContent("AI Model") {
-                    Text(provider == .openRouter ? "No models loaded" : "No models available")
+                    Text(provider == .openRouter ? LocalizedStringKey("No models loaded") : LocalizedStringKey("No models available"))
                         .foregroundColor(.secondary)
                         .italic()
                 }
@@ -552,7 +552,7 @@ struct ModeConfigFormView: View {
 
                 Picker(selection: $draft.autoSendKey) {
                     ForEach(AutoSendKey.allCases, id: \.self) { key in
-                        Text(key.displayName).tag(key)
+                        Text(LocalizedStringKey(key.displayName)).tag(key)
                     }
                 } label: {
                     HStack(spacing: 6) {

--- a/VoiceInk/Modes/ModeConfigFormView.swift
+++ b/VoiceInk/Modes/ModeConfigFormView.swift
@@ -552,7 +552,7 @@ struct ModeConfigFormView: View {
 
                 Picker(selection: $draft.autoSendKey) {
                     ForEach(AutoSendKey.allCases, id: \.self) { key in
-                        Text(LocalizedStringKey(key.displayName)).tag(key)
+                        Text(key.displayName).tag(key)
                     }
                 } label: {
                     HStack(spacing: 6) {

--- a/VoiceInk/Modes/ModeConfigFormView.swift
+++ b/VoiceInk/Modes/ModeConfigFormView.swift
@@ -205,7 +205,7 @@ struct ModeConfigFormView: View {
 
                     Picker(selection: $draft.punctuationCleanupMode) {
                         ForEach(PunctuationCleanupMode.allCases) { mode in
-                            Text(LocalizedStringKey(mode.displayName)).tag(mode)
+                            Text(mode.displayName).tag(mode)
                         }
                     } label: {
                         HStack(spacing: 4) {

--- a/VoiceInk/Modes/ModeIconPickerView.swift
+++ b/VoiceInk/Modes/ModeIconPickerView.swift
@@ -126,9 +126,9 @@ struct ModeIconPickerView: View {
                             newEmojiText = cleaned
                         }
                         if !newEmojiText.isEmpty && emojiManager.allEmojis.contains(newEmojiText) {
-                            inputFeedbackMessage = "Emoji already exists."
+                            inputFeedbackMessage = String(localized: "Emoji already exists.")
                         } else if !newEmojiText.isEmpty && !newEmojiText.isValidEmoji {
-                            inputFeedbackMessage = "Invalid emoji."
+                            inputFeedbackMessage = String(localized: "Invalid emoji.")
                         }
                     }
                     .onSubmit(attemptAddCustomEmoji)
@@ -150,7 +150,7 @@ struct ModeIconPickerView: View {
             if !inputFeedbackMessage.isEmpty {
                 Text(inputFeedbackMessage)
                     .font(.caption)
-                    .foregroundColor(inputFeedbackMessage.contains("Invalid") || inputFeedbackMessage.contains("exists") ? AppTheme.Status.error : .secondary)
+                    .foregroundColor(AppTheme.Status.error)
             }
         }
         .padding(.horizontal)
@@ -160,15 +160,15 @@ struct ModeIconPickerView: View {
     private func attemptAddCustomEmoji() {
         let trimmedEmoji = newEmojiText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedEmoji.isEmpty else {
-            inputFeedbackMessage = "Emoji cannot be empty."
+            inputFeedbackMessage = String(localized: "Emoji cannot be empty.")
             return
         }
         guard trimmedEmoji.isValidEmoji else {
-            inputFeedbackMessage = "Invalid emoji."
+            inputFeedbackMessage = String(localized: "Invalid emoji.")
             return
         }
         guard !emojiManager.allEmojis.contains(trimmedEmoji) else {
-            inputFeedbackMessage = "Emoji already exists."
+            inputFeedbackMessage = String(localized: "Emoji already exists.")
             return
         }
 
@@ -179,7 +179,7 @@ struct ModeIconPickerView: View {
             newEmojiText = ""
             isPresented = false
         } else {
-            inputFeedbackMessage = "Could not add emoji."
+            inputFeedbackMessage = String(localized: "Could not add emoji.")
         }
     }
 

--- a/VoiceInk/Modes/ModeSettingsPanelView.swift
+++ b/VoiceInk/Modes/ModeSettingsPanelView.swift
@@ -209,9 +209,9 @@ private struct ModeReorderRow: View {
         }
 
         if plural == "Apps" {
-            return String.localizedStringWithFormat(String(localized: "%lld Apps"), Int64(count))
+            return String(localized: "\(count) Apps")
         } else {
-            return String.localizedStringWithFormat(String(localized: "%lld Websites"), Int64(count))
+            return String(localized: "\(count) Websites")
         }
     }
 }

--- a/VoiceInk/Modes/ModeSettingsPanelView.swift
+++ b/VoiceInk/Modes/ModeSettingsPanelView.swift
@@ -140,8 +140,8 @@ private struct ModeReorderRow: View {
                     .truncationMode(.tail)
 
                 HStack(spacing: 8) {
-                    ModeReorderMeta(icon: "app.fill", value: countText(config.allAppConfigs.count, singular: "App", plural: "Apps"))
-                    ModeReorderMeta(icon: "globe", value: countText(config.allURLConfigs.count, singular: "Website", plural: "Websites"))
+                    ModeReorderMeta(icon: "app.fill", value: countText(config.allAppConfigs.count, plural: "Apps"))
+                    ModeReorderMeta(icon: "globe", value: countText(config.allURLConfigs.count, plural: "Websites"))
                 }
             }
 
@@ -203,7 +203,7 @@ private struct ModeReorderRow: View {
         return AppTheme.Border.control.opacity(0.55)
     }
 
-    private func countText(_ count: Int, singular: String, plural: String) -> String {
+    private func countText(_ count: Int, plural: String) -> String {
         if count == 0 {
             return plural == "Apps" ? String(localized: "No Apps") : String(localized: "No Websites")
         }

--- a/VoiceInk/Modes/ModeSettingsPanelView.swift
+++ b/VoiceInk/Modes/ModeSettingsPanelView.swift
@@ -205,14 +205,14 @@ private struct ModeReorderRow: View {
 
     private func countText(_ count: Int, singular: String, plural: String) -> String {
         if count == 0 {
-            return "No \(plural)"
+            return plural == "Apps" ? String(localized: "No Apps") : String(localized: "No Websites")
         }
 
-        if count == 1 {
-            return "1 \(singular)"
+        if plural == "Apps" {
+            return String.localizedStringWithFormat(String(localized: "%lld Apps"), Int64(count))
+        } else {
+            return String.localizedStringWithFormat(String(localized: "%lld Websites"), Int64(count))
         }
-
-        return "\(count) \(plural)"
     }
 }
 
@@ -234,7 +234,7 @@ private struct ModeReorderMeta: View {
 }
 
 private struct ModeReorderBadge: View {
-    let title: String
+    let title: LocalizedStringKey
     var systemImage: String?
 
     var body: some View {

--- a/VoiceInk/Modes/ModeTriggerHelpers.swift
+++ b/VoiceInk/Modes/ModeTriggerHelpers.swift
@@ -31,8 +31,8 @@ extension ModeTriggerGroup {
 
     private func countText(_ count: Int, key: String) -> String {
         if key == "%lld apps" {
-            return String.localizedStringWithFormat(String(localized: "%lld apps"), Int64(count))
+            return String(localized: "\(count) apps")
         }
-        return String.localizedStringWithFormat(String(localized: "%lld websites"), Int64(count))
+        return String(localized: "\(count) websites")
     }
 }

--- a/VoiceInk/Modes/ModeTriggerHelpers.swift
+++ b/VoiceInk/Modes/ModeTriggerHelpers.swift
@@ -19,17 +19,20 @@ extension ModeTriggerGroup {
 
         switch (appCount, websiteCount) {
         case (0, 0):
-            return "No triggers"
+            return String(localized: "No triggers")
         case (0, _):
-            return countText(websiteCount, singular: "website", plural: "websites")
+            return countText(websiteCount, key: "%lld websites")
         case (_, 0):
-            return countText(appCount, singular: "app", plural: "apps")
+            return countText(appCount, key: "%lld apps")
         default:
-            return "\(countText(appCount, singular: "app", plural: "apps")) · \(countText(websiteCount, singular: "website", plural: "websites"))"
+            return "\(countText(appCount, key: "%lld apps")) · \(countText(websiteCount, key: "%lld websites"))"
         }
     }
 
-    private func countText(_ count: Int, singular: String, plural: String) -> String {
-        count == 1 ? "1 \(singular)" : "\(count) \(plural)"
+    private func countText(_ count: Int, key: String) -> String {
+        if key == "%lld apps" {
+            return String.localizedStringWithFormat(String(localized: "%lld apps"), Int64(count))
+        }
+        return String.localizedStringWithFormat(String(localized: "%lld websites"), Int64(count))
     }
 }

--- a/VoiceInk/Modes/ModeValidator.swift
+++ b/VoiceInk/Modes/ModeValidator.swift
@@ -19,13 +19,24 @@ enum ModeValidationError: Error, Identifiable {
     var localizedDescription: String {
         switch self {
         case .emptyName:
-            return "Mode name cannot be empty."
+            return String(localized: "Mode name cannot be empty.")
         case .duplicateName(let name):
-            return "A mode with the name '\(name)' already exists."
+            return String(
+                format: String(localized: "A mode with the name '%@' already exists."),
+                name
+            )
         case .duplicateAppTrigger(let appName, let modeName):
-            return "The app '\(appName)' is already configured in the '\(modeName)' mode."
+            return String(
+                format: String(localized: "The app '%@' is already configured in the '%@' mode."),
+                appName,
+                modeName
+            )
         case .duplicateWebsiteTrigger(let website, let modeName):
-            return "The website '\(website)' is already configured in the '\(modeName)' mode."
+            return String(
+                format: String(localized: "The website '%@' is already configured in the '%@' mode."),
+                website,
+                modeName
+            )
         }
     }
 }

--- a/VoiceInk/Modes/ModeView.swift
+++ b/VoiceInk/Modes/ModeView.swift
@@ -194,7 +194,7 @@ struct ModeView: View {
 }
 
 struct SectionHeader: View {
-    let title: String
+    let title: LocalizedStringKey
 
     var body: some View {
         Text(title)

--- a/VoiceInk/Modes/ModeViewComponents.swift
+++ b/VoiceInk/Modes/ModeViewComponents.swift
@@ -291,7 +291,7 @@ struct ConfigurationRow: View {
                         HStack(spacing: 4) {
                             Image(systemName: config.outputMode.iconName)
                                 .font(.system(size: 10))
-                            Text(LocalizedStringKey(config.outputMode.displayName))
+                            Text(config.outputMode.displayName)
                                 .font(.caption)
                         }
                         .padding(.horizontal, 6)

--- a/VoiceInk/Modes/ModeViewComponents.swift
+++ b/VoiceInk/Modes/ModeViewComponents.swift
@@ -308,7 +308,7 @@ struct ConfigurationRow: View {
                         HStack(spacing: 4) {
                             Image(systemName: "keyboard")
                                 .font(.system(size: 10))
-                            Text(LocalizedStringKey(config.autoSendKey.displayName))
+                            Text(config.autoSendKey.displayName)
                                 .font(.caption)
                         }
                         .padding(.horizontal, 6)

--- a/VoiceInk/Modes/ModeViewComponents.swift
+++ b/VoiceInk/Modes/ModeViewComponents.swift
@@ -149,12 +149,12 @@ struct ConfigurationRow: View {
     
     private var websiteText: String {
         if websiteCount == 0 { return "" }
-        return String.localizedStringWithFormat(String(localized: "%d Websites"), websiteCount)
+        return String(localized: "\(websiteCount) Websites")
     }
 
     private var appText: String {
         if appCount == 0 { return "" }
-        return String.localizedStringWithFormat(String(localized: "%d Apps"), appCount)
+        return String(localized: "\(appCount) Apps")
     }
     
     private var extraAppsCount: Int {

--- a/VoiceInk/Modes/ModeViewComponents.swift
+++ b/VoiceInk/Modes/ModeViewComponents.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct VoiceInkButton: View {
-    let title: String
+    let title: LocalizedStringKey
     let action: () -> Void
     var isDisabled: Bool = false
     
@@ -149,12 +149,12 @@ struct ConfigurationRow: View {
     
     private var websiteText: String {
         if websiteCount == 0 { return "" }
-        return websiteCount == 1 ? "1 Website" : "\(websiteCount) Websites"
+        return String.localizedStringWithFormat(String(localized: "%d Websites"), websiteCount)
     }
-    
+
     private var appText: String {
         if appCount == 0 { return "" }
-        return appCount == 1 ? "1 App" : "\(appCount) Apps"
+        return String.localizedStringWithFormat(String(localized: "%d Apps"), appCount)
     }
     
     private var extraAppsCount: Int {
@@ -291,7 +291,7 @@ struct ConfigurationRow: View {
                         HStack(spacing: 4) {
                             Image(systemName: config.outputMode.iconName)
                                 .font(.system(size: 10))
-                            Text(config.outputMode.displayName)
+                            Text(LocalizedStringKey(config.outputMode.displayName))
                                 .font(.caption)
                         }
                         .padding(.horizontal, 6)
@@ -308,7 +308,7 @@ struct ConfigurationRow: View {
                         HStack(spacing: 4) {
                             Image(systemName: "keyboard")
                                 .font(.system(size: 10))
-                            Text(config.autoSendKey.displayName)
+                            Text(LocalizedStringKey(config.autoSendKey.displayName))
                                 .font(.caption)
                         }
                         .padding(.horizontal, 6)

--- a/VoiceInk/Modes/TriggerGroupEditorView.swift
+++ b/VoiceInk/Modes/TriggerGroupEditorView.swift
@@ -122,7 +122,7 @@ struct TriggerGroupEditorView: View {
         Button(action: addWebsiteIfPossible) {
             HStack(spacing: 8) {
                 TriggerSymbol(systemName: "globe")
-                Text("Add \(websiteCandidate)")
+                Text(String(format: String(localized: "Add %@"), websiteCandidate))
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.primary)
                     .lineLimit(1)

--- a/VoiceInk/Modes/TriggerPickerPopover.swift
+++ b/VoiceInk/Modes/TriggerPickerPopover.swift
@@ -184,7 +184,7 @@ struct TriggerPickerPopover: View {
                 TriggerSymbol(systemName: isWebsiteAlreadyAdded ? "checkmark" : "globe")
 
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(isWebsiteAlreadyAdded ? "Remove website" : "Add website")
+                    Text(isWebsiteAlreadyAdded ? LocalizedStringKey("Remove website") : LocalizedStringKey("Add website"))
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(.primary)
                     Text(websiteCandidate)
@@ -243,7 +243,7 @@ struct TriggerPickerPopover: View {
     }
 
     private var emptyState: some View {
-        Text(query.isEmpty ? "No apps found" : "No matching apps")
+        Text(query.isEmpty ? LocalizedStringKey("No apps found") : LocalizedStringKey("No matching apps"))
             .font(.system(size: 12, weight: .medium))
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity)

--- a/VoiceInk/Paste/PasteMethod.swift
+++ b/VoiceInk/Paste/PasteMethod.swift
@@ -12,9 +12,9 @@ enum PasteMethod: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .standard:
-            return "Default"
+            return String(localized: "Default")
         case .appleScript:
-            return "AppleScript"
+            return String(localized: "AppleScript")
         }
     }
 

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -97,7 +97,7 @@ class Recorder: NSObject, ObservableObject {
             if let deviceName = deviceManager.availableDevices.first(where: { $0.id == newDeviceID })?.name {
                 await MainActor.run {
                     NotificationManager.shared.showNotification(
-                        title: "Switched to: \(deviceName)",
+                        title: String(format: String(localized: "Switched to: %@"), deviceName),
                         type: .info
                     )
                 }
@@ -105,7 +105,7 @@ class Recorder: NSObject, ObservableObject {
 
             logger.notice("🎙️ Successfully switched recording to device \(newDeviceID, privacy: .public)")
         } catch {
-            logger.error("❌ Failed to switch device: \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ Failed to switch device: \(error, privacy: .public)")
 
             // If switch fails, stop recording and notify user
             await handleRecordingError(error)
@@ -128,7 +128,10 @@ class Recorder: NSObject, ObservableObject {
         let lastDeviceID = UserDefaults.standard.string(forKey: "lastUsedMicrophoneDeviceID")
         if String(currentDeviceID) != lastDeviceID {
             if let deviceName = deviceManager.availableDevices.first(where: { $0.id == currentDeviceID })?.name {
-                NotificationManager.shared.showNotification(title: "Using: \(deviceName)", type: .info)
+                NotificationManager.shared.showNotification(
+                    title: String(format: String(localized: "Using: %@"), deviceName),
+                    type: .info
+                )
             }
         }
         UserDefaults.standard.set(String(currentDeviceID), forKey: "lastUsedMicrophoneDeviceID")
@@ -162,7 +165,7 @@ class Recorder: NSObject, ObservableObject {
                 await self.playbackController.pauseMedia()
             }
         } catch {
-            logger.error("Failed to start recording deviceID=\(deviceID, privacy: .public) file=\(url.lastPathComponent, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to start recording deviceID=\(deviceID, privacy: .public) file=\(url.lastPathComponent, privacy: .public) error=\(error, privacy: .public)")
             await stopRecording()
             throw RecorderError.couldNotStartRecording
         }
@@ -200,7 +203,7 @@ class Recorder: NSObject, ObservableObject {
     }
 
     private func handleRecordingError(_ error: Error) async {
-        logger.error("❌ Recording error occurred: \(error.localizedDescription, privacy: .public)")
+        logger.error("❌ Recording error occurred: \(error, privacy: .public)")
 
         // Stop the recording
         await stopRecording()
@@ -208,7 +211,7 @@ class Recorder: NSObject, ObservableObject {
         // Notify the user about the recording failure
         await MainActor.run {
             NotificationManager.shared.showNotification(
-                title: "Recording Failed: \(error.localizedDescription)",
+                title: String(format: String(localized: "Recording Failed: %@"), error.localizedDescription),
                 type: .error
             )
         }
@@ -243,7 +246,7 @@ class Recorder: NSObject, ObservableObject {
             do {
                 try coreAudioRecorder.prepare(deviceID: deviceID)
             } catch {
-                logger.warning("Recorder prepare failed reason=\(reason, privacy: .public) deviceID=\(deviceID, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                logger.warning("Recorder prepare failed reason=\(reason, privacy: .public) deviceID=\(deviceID, privacy: .public) error=\(error, privacy: .public)")
             }
         }
     }

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -500,19 +500,19 @@ extension EnhancementError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .notConfigured:
-            return "AI provider not configured. Please check your API key."
+            return String(localized: "AI provider not configured. Please check your API key.")
         case .invalidResponse:
-            return "Invalid response from AI provider."
+            return String(localized: "Invalid response from AI provider.")
         case .enhancementFailed:
-            return "AI enhancement failed to process the text."
+            return String(localized: "AI enhancement failed to process the text.")
         case .networkError:
-            return "Network connection failed. Check your internet."
+            return String(localized: "Network connection failed. Check your internet.")
         case .serverError:
-            return "The AI provider's server encountered an error. Please try again later."
+            return String(localized: "The AI provider's server encountered an error. Please try again later.")
         case .rateLimitExceeded:
-            return "Rate limit exceeded. Please try again later."
+            return String(localized: "Rate limit exceeded. Please try again later.")
         case .timeout:
-            return "Enhancement request timed out. Check your connection or increase the timeout duration."
+            return String(localized: "Enhancement request timed out. Check your connection or increase the timeout duration.")
         case .customError(let message):
             return message
         }

--- a/VoiceInk/Services/AIEnhancement/CustomAIProviderManager.swift
+++ b/VoiceInk/Services/AIEnhancement/CustomAIProviderManager.swift
@@ -160,25 +160,25 @@ final class CustomAIProviderManager: ObservableObject {
         let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if trimmedName.isEmpty {
-            errors.append("Display name cannot be empty")
+            errors.append(String(localized: "Display name cannot be empty"))
         }
 
         if trimmedURL.isEmpty {
-            errors.append("Base URL cannot be empty")
+            errors.append(String(localized: "Base URL cannot be empty"))
         } else if URL(string: trimmedURL)?.host == nil {
-            errors.append("Base URL must be a valid URL")
+            errors.append(String(localized: "Base URL must be a valid URL"))
         }
 
         if trimmedModel.isEmpty {
-            errors.append("Model name cannot be empty")
+            errors.append(String(localized: "Model name cannot be empty"))
         }
 
         if providers.contains(where: { $0.name.caseInsensitiveCompare(trimmedName) == .orderedSame && $0.id != id }) {
-            errors.append("A custom enhancement model with this display name already exists")
+            errors.append(String(localized: "A custom enhancement model with this display name already exists"))
         }
 
         if providers.contains(where: { $0.modelName.caseInsensitiveCompare(trimmedModel) == .orderedSame && $0.id != id }) {
-            errors.append("A custom enhancement model with this model name already exists")
+            errors.append(String(localized: "A custom enhancement model with this model name already exists"))
         }
 
         return errors
@@ -189,7 +189,7 @@ final class CustomAIProviderManager: ObservableObject {
         do {
             providers = try JSONDecoder().decode([CustomAIProviderConfig].self, from: data)
         } catch {
-            logger.error("Failed to decode custom AI providers: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to decode custom AI providers: \(error, privacy: .public)")
             providers = []
         }
     }
@@ -200,7 +200,7 @@ final class CustomAIProviderManager: ObservableObject {
             defaults.set(data, forKey: providersKey)
             NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
         } catch {
-            logger.error("Failed to encode custom AI providers: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to encode custom AI providers: \(error, privacy: .public)")
         }
     }
 

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -275,20 +275,20 @@ enum LocalCLIError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .commandNotConfigured:
-            return "Local CLI command is not configured. Load a template or enter a command first."
+            return String(localized: "Local CLI command is not configured. Load a template or enter a command first.")
         case .commandNotFound(let details):
-            return "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: \(details)"
+            return String(format: String(localized: "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: %@"), details)
         case .timeout(let seconds):
-            return "Local CLI command timed out after \(Int(seconds)) seconds."
+            return String(format: String(localized: "Local CLI command timed out after %lld seconds."), Int64(seconds))
         case .nonZeroExit(let status, let stderr):
             if stderr.isEmpty {
-                return "Local CLI command failed with exit code \(status)."
+                return String(format: String(localized: "Local CLI command failed with exit code %lld."), Int64(status))
             }
-            return "Local CLI command failed with exit code \(status): \(stderr)"
+            return String(format: String(localized: "Local CLI command failed with exit code %lld: %@"), Int64(status), stderr)
         case .emptyOutput:
-            return "Local CLI command returned empty output."
+            return String(localized: "Local CLI command returned empty output.")
         case .executionFailed(let message):
-            return "Failed to execute Local CLI command: \(message)"
+            return String(format: String(localized: "Failed to execute Local CLI command: %@"), message)
         }
     }
 }

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -222,7 +222,7 @@ class AudioTranscriptionManager: ObservableObject {
                         modeEmoji: modeMetadata.emoji
                     )
                 } catch {
-                    logger.error("Enhancement failed: \(error.localizedDescription, privacy: .public)")
+                    logger.error("Enhancement failed: \(error, privacy: .public)")
                     transcription = Transcription(
                         text: cleanedText,
                         duration: duration,
@@ -261,7 +261,7 @@ class AudioTranscriptionManager: ObservableObject {
             if Task.isCancelled || error is CancellationError {
                 item.status = .pending
             } else {
-                logger.error("Transcription error: \(error.localizedDescription, privacy: .public)")
+                logger.error("Transcription error: \(error, privacy: .public)")
                 item.status = .failed(message: error.localizedDescription)
             }
         }
@@ -277,9 +277,9 @@ enum TranscriptionError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .noModelSelected:
-            return "No transcription model selected"
+            return String(localized: "No transcription model selected")
         case .transcriptionCancelled:
-            return "Transcription was cancelled"
+            return String(localized: "Transcription was cancelled")
         }
     }
 }

--- a/VoiceInk/Services/AudioFileTranscriptionService.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionService.swift
@@ -87,7 +87,7 @@ class AudioTranscriptionService: ObservableObject {
             do {
                 try FileManager.default.copyItem(at: url, to: permanentURL)
             } catch {
-                logger.error("❌ Failed to create permanent copy of audio: \(error.localizedDescription, privacy: .public)")
+                logger.error("❌ Failed to create permanent copy of audio: \(error, privacy: .public)")
                 isTranscribing = false
                 throw error
             }
@@ -137,7 +137,7 @@ class AudioTranscriptionService: ObservableObject {
                         NotificationCenter.default.post(name: .transcriptionCreated, object: newTranscription)
                         NotificationCenter.default.post(name: .transcriptionCompleted, object: newTranscription)
                     } catch {
-                        logger.error("❌ Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+                        logger.error("❌ Failed to save transcription: \(error, privacy: .public)")
                     }
                     await MainActor.run {
                         isTranscribing = false
@@ -161,7 +161,7 @@ class AudioTranscriptionService: ObservableObject {
                         NotificationCenter.default.post(name: .transcriptionCreated, object: newTranscription)
                         NotificationCenter.default.post(name: .transcriptionCompleted, object: newTranscription)
                     } catch {
-                        logger.error("❌ Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+                        logger.error("❌ Failed to save transcription: \(error, privacy: .public)")
                     }
 
                     await MainActor.run {
@@ -186,7 +186,7 @@ class AudioTranscriptionService: ObservableObject {
                     try modelContext.save()
                     NotificationCenter.default.post(name: .transcriptionCompleted, object: newTranscription)
                 } catch {
-                    logger.error("❌ Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+                    logger.error("❌ Failed to save transcription: \(error, privacy: .public)")
                 }
 
                 await MainActor.run {
@@ -196,7 +196,7 @@ class AudioTranscriptionService: ObservableObject {
                 return newTranscription
             }
         } catch {
-            logger.error("❌ Transcription failed: \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ Transcription failed: \(error, privacy: .public)")
             currentError = .transcriptionFailed
             isTranscribing = false
             throw error

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -8,7 +8,7 @@ enum BackupImportError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .saveFailed(let item, let error):
-            return "Failed to save imported \(item): \(error.localizedDescription)"
+            return String(format: String(localized: "Failed to save imported %@: %@"), item, error.localizedDescription)
         }
     }
 }

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -10,15 +10,15 @@ enum BackupCategory: String, CaseIterable, Hashable {
     var title: String {
         switch self {
         case .general:
-            return "General Settings"
+            return String(localized: "General Settings")
         case .prompts:
-            return "Custom Prompts"
+            return String(localized: "Custom Prompts")
         case .modes:
-            return "Modes"
+            return String(localized: "Modes")
         case .dictionary:
-            return "Dictionary"
+            return String(localized: "Dictionary")
         case .customModels:
-            return "Custom Model Definitions"
+            return String(localized: "Custom Model Definitions")
         }
     }
 }

--- a/VoiceInk/Services/DictionaryService.swift
+++ b/VoiceInk/Services/DictionaryService.swift
@@ -1,4 +1,5 @@
 import OSLog
+import Foundation
 import SwiftData
 
 enum DictionaryService {
@@ -23,7 +24,7 @@ enum DictionaryService {
 
         if parts.count == 1, let word = parts.first {
             if existing.contains(where: { $0.word.lowercased() == word.lowercased() }) {
-                return "'\(word)' is already in the vocabulary"
+                return String(format: String(localized: "'%@' is already in the vocabulary"), word)
             }
             return insertVocabularyWord(word, context: context)
         }
@@ -51,7 +52,7 @@ enum DictionaryService {
             return nil
         } catch {
             context.delete(entry)
-            return "Failed to add '\(word)': \(error.localizedDescription)"
+            return String(format: String(localized: "Failed to add '%@': %@"), word, error.localizedDescription)
         }
     }
 
@@ -106,7 +107,7 @@ enum DictionaryService {
             return true
         } catch {
             context.rollback()
-            logger.error("Failed to remove exact dictionary duplicates from \(source, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to remove exact dictionary duplicates from \(source, privacy: .public): \(error, privacy: .public)")
             return false
         }
     }
@@ -137,7 +138,7 @@ enum DictionaryService {
 
             for token in tokens {
                 if existingTokens.contains(token.lowercased()) {
-                    return "'\(token)' already exists in word replacements"
+                    return String(format: String(localized: "'%@' already exists in word replacements"), token)
                 }
             }
         }
@@ -149,7 +150,7 @@ enum DictionaryService {
             return nil
         } catch {
             context.delete(entry)
-            return "Failed to add replacement: \(error.localizedDescription)"
+            return String(format: String(localized: "Failed to add replacement: %@"), error.localizedDescription)
         }
     }
 }

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -206,25 +206,25 @@ class ImportExportService {
             let savePanel = NSSavePanel()
             savePanel.allowedContentTypes = [UTType.json]
             savePanel.nameFieldStringValue = "VoiceInk_Settings_Backup.json"
-            savePanel.title = "Export VoiceInk Settings"
-            savePanel.message = "Choose a location to save your settings."
+            savePanel.title = String(localized: "Export VoiceInk Settings")
+            savePanel.message = String(localized: "Choose a location to save your settings.")
 
             DispatchQueue.main.async {
                 if savePanel.runModal() == .OK {
                     if let url = savePanel.url {
                         do {
                             try jsonData.write(to: url)
-                            self.showAlert(title: "Export Successful", message: "Your settings have been successfully exported to \(url.lastPathComponent).")
+                            self.showAlert(title: String(localized: "Export Successful"), message: String(format: String(localized: "Your settings have been successfully exported to %@."), url.lastPathComponent))
                         } catch {
-                            self.showAlert(title: "Export Error", message: "Could not save settings to file: \(error.localizedDescription)")
+                            self.showAlert(title: String(localized: "Export Error"), message: String(format: String(localized: "Could not save settings to file: %@"), error.localizedDescription))
                         }
                     }
                 } else {
-                    self.showAlert(title: "Export Canceled", message: "The settings export operation was canceled.")
+                    self.showAlert(title: String(localized: "Export Canceled"), message: String(localized: "The settings export operation was canceled."))
                 }
             }
         } catch {
-            self.showAlert(title: "Export Error", message: "Could not encode settings to JSON: \(error.localizedDescription)")
+            self.showAlert(title: String(localized: "Export Error"), message: String(format: String(localized: "Could not encode settings to JSON: %@"), error.localizedDescription))
         }
     }
 
@@ -235,16 +235,16 @@ class ImportExportService {
         openPanel.canChooseFiles = true
         openPanel.canChooseDirectories = false
         openPanel.allowsMultipleSelection = false
-        openPanel.title = "Import VoiceInk Settings"
-        openPanel.message = "Choose a settings backup, then select what you want to import."
+        openPanel.title = String(localized: "Import VoiceInk Settings")
+        openPanel.message = String(localized: "Choose a settings backup, then select what you want to import.")
 
         guard openPanel.runModal() == .OK else {
-            showAlert(title: "Import Canceled", message: "The settings import operation was canceled.")
+            showAlert(title: String(localized: "Import Canceled"), message: String(localized: "The settings import operation was canceled."))
             return
         }
 
         guard let url = openPanel.url else {
-            showAlert(title: "Import Error", message: "Could not get the file URL from the open panel.")
+            showAlert(title: String(localized: "Import Error"), message: String(localized: "Could not get the file URL from the open panel."))
             return
         }
 
@@ -254,16 +254,16 @@ class ImportExportService {
             let backup = try decoder.decode(BackupFile.self, from: jsonData)
 
             if backup.version != currentSettingsVersion {
-                showAlert(title: "Version Mismatch", message: "The imported settings file (version \(backup.version)) is from a different version than your application (version \(currentSettingsVersion)). Proceeding with import, but be aware of potential incompatibilities.")
+                showAlert(title: String(localized: "Version Mismatch"), message: String(format: String(localized: "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities."), backup.version, currentSettingsVersion))
             }
 
             guard let selectedCategories = presentImportSelectionDialog() else {
-                showAlert(title: "Import Canceled", message: "No settings were imported.")
+                showAlert(title: String(localized: "Import Canceled"), message: String(localized: "No settings were imported."))
                 return
             }
 
             guard !selectedCategories.isEmpty else {
-                showAlert(title: "Import Error", message: "Select at least one category to import.")
+                showAlert(title: String(localized: "Import Error"), message: String(localized: "Select at least one category to import."))
                 return
             }
 
@@ -281,22 +281,22 @@ class ImportExportService {
             )
 
             showImportSuccessAlert(
-                message: "Settings imported successfully from \(url.lastPathComponent).\n\nImported: \(categorySummary(for: selectedCategories)).",
+                message: String(format: String(localized: "Settings imported successfully from %@.\n\nImported: %@."), url.lastPathComponent, categorySummary(for: selectedCategories)),
                 needsAPIKeyReminder: needsAPIKeyReminder(for: selectedCategories)
             )
         } catch {
-            showAlert(title: "Import Error", message: "Error importing settings: \(error.localizedDescription). The file might be corrupted or not in the correct format.")
+            showAlert(title: String(localized: "Import Error"), message: String(format: String(localized: "Error importing settings: %@. The file might be corrupted or not in the correct format."), error.localizedDescription))
         }
     }
 
     private func presentImportSelectionDialog() -> Set<BackupCategory>? {
         let accessory = BackupOptions()
         let alert = NSAlert()
-        alert.messageText = "Import Settings"
-        alert.informativeText = "Choose what to import from this backup."
+        alert.messageText = String(localized: "Import Settings")
+        alert.informativeText = String(localized: "Choose what to import from this backup.")
         alert.alertStyle = .informational
         alert.accessoryView = accessory.view
-        alert.addButton(withTitle: "Import")
+        alert.addButton(withTitle: String(localized: "Import"))
         alert.addButton(withTitle: "Cancel")
 
         let response = alert.runModal()
@@ -309,7 +309,7 @@ class ImportExportService {
 
     private func categorySummary(for categories: Set<BackupCategory>) -> String {
         if categories == Set(BackupCategory.allCases) {
-            return "All settings"
+            return String(localized: "All settings")
         }
 
         return BackupCategory.allCases
@@ -328,7 +328,7 @@ class ImportExportService {
             alert.messageText = title
             alert.informativeText = message
             alert.alertStyle = .informational
-            alert.addButton(withTitle: "OK")
+            alert.addButton(withTitle: String(localized: "OK"))
             alert.runModal()
         }
     }
@@ -336,17 +336,17 @@ class ImportExportService {
     private func showImportSuccessAlert(message: String, needsAPIKeyReminder: Bool) {
         DispatchQueue.main.async {
             let alert = NSAlert()
-            alert.messageText = "Import Successful"
+            alert.messageText = String(localized: "Import Successful")
             var informativeText = message
             if needsAPIKeyReminder {
-                informativeText += "\n\nIMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the AI Models section."
+                informativeText += "\n\n" + String(localized: "IMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the AI Models section.")
             }
-            informativeText += "\n\nIt is recommended to restart VoiceInk for all changes to take full effect."
+            informativeText += "\n\n" + String(localized: "It is recommended to restart VoiceInk for all changes to take full effect.")
             alert.informativeText = informativeText
             alert.alertStyle = .informational
-            alert.addButton(withTitle: "OK")
+            alert.addButton(withTitle: String(localized: "OK"))
             if needsAPIKeyReminder {
-                alert.addButton(withTitle: "Configure API Keys")
+                alert.addButton(withTitle: String(localized: "Configure API Keys"))
             }
             
             let response = alert.runModal()

--- a/VoiceInk/Services/LastTranscriptionService.swift
+++ b/VoiceInk/Services/LastTranscriptionService.swift
@@ -22,7 +22,7 @@ class LastTranscriptionService: ObservableObject {
         guard let lastTranscription = getLastTranscription(from: modelContext) else {
             Task { @MainActor in
                 NotificationManager.shared.showNotification(
-                    title: "No transcription available",
+                    title: String(localized: "No transcription available"),
                     type: .error
                 )
             }
@@ -43,12 +43,12 @@ class LastTranscriptionService: ObservableObject {
         Task { @MainActor in
             if success {
                 NotificationManager.shared.showNotification(
-                    title: "Last transcription copied",
+                    title: String(localized: "Last transcription copied"),
                     type: .success
                 )
             } else {
                 NotificationManager.shared.showNotification(
-                    title: "Failed to copy transcription",
+                    title: String(localized: "Failed to copy transcription"),
                     type: .error
                 )
             }
@@ -59,7 +59,7 @@ class LastTranscriptionService: ObservableObject {
         guard let lastTranscription = getLastTranscription(from: modelContext) else {
             Task { @MainActor in
                 NotificationManager.shared.showNotification(
-                    title: "No transcription available",
+                    title: String(localized: "No transcription available"),
                     type: .error
                 )
             }
@@ -77,7 +77,7 @@ class LastTranscriptionService: ObservableObject {
         guard let lastTranscription = getLastTranscription(from: modelContext) else {
             Task { @MainActor in
                 NotificationManager.shared.showNotification(
-                    title: "No transcription available",
+                    title: String(localized: "No transcription available"),
                     type: .error
                 )
             }
@@ -105,7 +105,7 @@ class LastTranscriptionService: ObservableObject {
                   let audioURL = URL(string: audioURLString),
                   FileManager.default.fileExists(atPath: audioURL.path) else {
                 NotificationManager.shared.showNotification(
-                    title: "Cannot retry: Audio file not found",
+                    title: String(localized: "Cannot retry: Audio file not found"),
                     type: .error
                 )
                 return
@@ -115,7 +115,7 @@ class LastTranscriptionService: ObservableObject {
                 transcriptionModelManager: transcriptionModelManager
             ) else {
                 NotificationManager.shared.showNotification(
-                    title: "No transcription model selected",
+                    title: String(localized: "No transcription model selected"),
                     type: .error
                 )
                 return
@@ -136,12 +136,12 @@ class LastTranscriptionService: ObservableObject {
                 ClipboardManager.copyToClipboard(textToCopy)
 
                 NotificationManager.shared.showNotification(
-                    title: "Copied to clipboard",
+                    title: String(localized: "Copied to clipboard"),
                     type: .success
                 )
             } catch {
                 NotificationManager.shared.showNotification(
-                    title: "Retry failed: \(error.localizedDescription)",
+                    title: String(format: String(localized: "Retry failed: %@"), error.localizedDescription),
                     type: .error
                 )
             }

--- a/VoiceInk/Services/ModelPrewarmService.swift
+++ b/VoiceInk/Services/ModelPrewarmService.swift
@@ -93,7 +93,7 @@ final class ModelPrewarmService: ObservableObject {
             logger.notice("Prewarm completed in \(String(format: "%.2f", duration), privacy: .public)s")
 
         } catch {
-            logger.error("❌ Prewarm failed: \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ Prewarm failed: \(error, privacy: .public)")
         }
     }
 

--- a/VoiceInk/Services/OllamaService.swift
+++ b/VoiceInk/Services/OllamaService.swift
@@ -137,19 +137,19 @@ enum LocalAIError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidURL:
-            return "Invalid Ollama server URL"
+            return String(localized: "Invalid Ollama server URL")
         case .serviceUnavailable:
-            return "Ollama service is not available"
+            return String(localized: "Ollama service is not available")
         case .invalidResponse:
-            return "Invalid response from Ollama server"
+            return String(localized: "Invalid response from Ollama server")
         case .modelNotFound:
-            return "Selected model not found"
+            return String(localized: "Selected model not found")
         case .serverError:
-            return "Ollama server error"
+            return String(localized: "Ollama server error")
         case .invalidRequest:
-            return "System prompt is required"
+            return String(localized: "System prompt is required")
         case .timeout:
-            return "Ollama request timed out"
+            return String(localized: "Ollama request timed out")
         }
     }
 }

--- a/VoiceInk/Services/SelectedTextService.swift
+++ b/VoiceInk/Services/SelectedTextService.swift
@@ -22,7 +22,7 @@ final class SelectedTextService {
         do {
             return normalized(try await textManager.getSelectedText(strategies: selectedTextStrategies))
         } catch {
-            logger.debug("SelectedTextKit failed to capture selected text: \(error.localizedDescription, privacy: .public)")
+            logger.debug("SelectedTextKit failed to capture selected text: \(error, privacy: .public)")
             return nil
         }
     }

--- a/VoiceInk/Services/SessionMetricMigrationService.swift
+++ b/VoiceInk/Services/SessionMetricMigrationService.swift
@@ -77,7 +77,7 @@ final class SessionMetricMigrationService {
                 UserDefaults.standard.set(true, forKey: completionKey)
                 logger.notice("Completed stats migration with \(insertedCount, privacy: .public) session metric(s)")
             } catch {
-                logger.error("Stats migration failed: \(error.localizedDescription, privacy: .public)")
+                logger.error("Stats migration failed: \(error, privacy: .public)")
             }
 
             await MainActor.run {

--- a/VoiceInk/Services/SystemInfoService.swift
+++ b/VoiceInk/Services/SystemInfoService.swift
@@ -10,7 +10,7 @@ class SystemInfoService {
     func getSystemInfoString() -> String {
         let info = """
         === VOICEINK SYSTEM INFORMATION ===
-        Generated: \(Date().formatted(date: .long, time: .standard))
+        Generated: \(Self.englishTimestamp())
 
         APP INFORMATION:
         App Version: \(getAppVersion())
@@ -107,7 +107,8 @@ class SystemInfoService {
 
     private func getMemoryInfo() -> String {
         let totalMemory = ProcessInfo.processInfo.physicalMemory
-        return ByteCountFormatter.string(fromByteCount: Int64(totalMemory), countStyle: .memory)
+        let gibibytes = Double(totalMemory) / 1_073_741_824
+        return String(format: "%.2f GB (%llu bytes)", locale: Locale(identifier: "en_US_POSIX"), gibibytes, totalMemory)
     }
 
     private func getArchitecture() -> String {
@@ -117,7 +118,14 @@ class SystemInfoService {
     private func getAudioInputMode() -> String {
         if let mode = UserDefaults.standard.audioInputModeRawValue,
            let audioMode = AudioInputMode(rawValue: mode) {
-            return audioMode.rawValue
+            switch audioMode {
+            case .systemDefault:
+                return "System Default"
+            case .custom:
+                return "Custom Device"
+            case .prioritized:
+                return "Prioritized"
+            }
         }
         return "System Default"
     }
@@ -210,6 +218,12 @@ class SystemInfoService {
 
     private func getCurrentLanguage() -> String {
         return UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "en"
+    }
+
+    private static func englishTimestamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
     }
 
 }

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -74,7 +74,7 @@ class TranscriptionAutoCleanupService {
             do {
                 try FileManager.default.removeItem(at: url)
             } catch {
-                logger.error("Failed to delete audio file: \(error.localizedDescription, privacy: .public)")
+                logger.error("Failed to delete audio file: \(error, privacy: .public)")
             }
         }
 
@@ -84,7 +84,7 @@ class TranscriptionAutoCleanupService {
             try modelContext.save()
             NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
         } catch {
-            logger.error("Failed to save after transcription deletion: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to save after transcription deletion: \(error, privacy: .public)")
         }
     }
 
@@ -127,7 +127,7 @@ class TranscriptionAutoCleanupService {
                 }
             }
         } catch {
-            logger.error("Failed during transcription cleanup: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed during transcription cleanup: \(error, privacy: .public)")
         }
     }
 
@@ -171,7 +171,7 @@ class TranscriptionAutoCleanupService {
                 logger.notice("Cleaned up \(deletedCount, privacy: .public) orphan audio file(s)")
             }
         } catch {
-            logger.error("Failed during orphan audio cleanup: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed during orphan audio cleanup: \(error, privacy: .public)")
         }
     }
 }

--- a/VoiceInk/Shortcuts/RecorderPanelShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecorderPanelShortcutManager.swift
@@ -124,7 +124,7 @@ final class RecorderPanelShortcutManager: ObservableObject {
 
         firstEscapePressTime = now
         NotificationManager.shared.showNotification(
-            title: "Press Esc again to cancel",
+            title: String(localized: "Press Esc again to cancel"),
             type: .info,
             duration: escapeDoublePressThreshold
         )

--- a/VoiceInk/Shortcuts/RecordingShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecordingShortcutManager.swift
@@ -66,9 +66,9 @@ class RecordingShortcutManager: ObservableObject {
 
         var displayName: String {
             switch self {
-            case .toggle: return "Toggle"
-            case .pushToTalk: return "Push to Talk"
-            case .hybrid: return "Hybrid"
+            case .toggle: return String(localized: "Toggle")
+            case .pushToTalk: return String(localized: "Push to Talk")
+            case .hybrid: return String(localized: "Hybrid")
             }
         }
     }
@@ -79,8 +79,8 @@ class RecordingShortcutManager: ObservableObject {
         
         var displayName: String {
             switch self {
-            case .none: return "None"
-            case .custom: return "Custom"
+            case .none: return String(localized: "None")
+            case .custom: return String(localized: "Custom")
             }
         }
     }

--- a/VoiceInk/Shortcuts/ShortcutAction.swift
+++ b/VoiceInk/Shortcuts/ShortcutAction.swift
@@ -56,35 +56,35 @@ enum ShortcutAction: Hashable {
     var displayName: String {
         switch self {
         case .primaryRecording:
-            return "Primary Shortcut"
+            return String(localized: "Primary Shortcut")
         case .secondaryRecording:
-            return "Secondary Shortcut"
+            return String(localized: "Secondary Shortcut")
         case .pasteLastTranscription:
-            return "Paste Last Transcription"
+            return String(localized: "Paste Last Transcription")
         case .pasteLastEnhancement:
-            return "Paste Last Enhanced Transcription"
+            return String(localized: "Paste Last Enhanced Transcription")
         case .retryLastTranscription:
-            return "Retry Last Transcription"
+            return String(localized: "Retry Last Transcription")
         case .cancelRecorder:
-            return "Cancel Recording"
+            return String(localized: "Cancel Recording")
         case .openHistoryWindow:
-            return "Open History Window"
+            return String(localized: "Open History Window")
         case .quickAddToDictionary:
-            return "Quick Add to Dictionary"
+            return String(localized: "Quick Add to Dictionary")
         case .mode(let id):
             if let config = ModeManager.shared.getConfiguration(with: id) {
-                return "\(config.name) Mode"
+                return String(format: String(localized: "%@ Mode"), config.name)
             }
 
             if let template = StarterModeCatalog.templates.first(where: { $0.id == id }) {
-                return "\(template.name) Mode"
+                return String(format: String(localized: "%@ Mode"), template.name)
             }
 
-            return "Mode"
+            return String(localized: "Mode")
         case .recorderPanelEscape:
-            return "Recorder Cancel"
+            return String(localized: "Recorder Cancel")
         case .recorderPanelMode(let index):
-            return "Select Mode \(Self.displayNumber(forRecorderPanelIndex: index))"
+            return String(format: String(localized: "Select Mode %@"), Self.displayNumber(forRecorderPanelIndex: index))
         }
     }
 

--- a/VoiceInk/Shortcuts/ShortcutRecorder.swift
+++ b/VoiceInk/Shortcuts/ShortcutRecorder.swift
@@ -69,10 +69,10 @@ struct ShortcutRecorder: View {
 
     private var accessibilityLabel: String {
         if recorder.isRecording {
-            return recorder.previewShortcut?.displayString ?? "Press shortcut"
+            return recorder.previewShortcut?.displayString ?? String(localized: "Press shortcut")
         }
 
-        return displayedShortcut?.displayString ?? "Record shortcut"
+        return displayedShortcut?.displayString ?? String(localized: "Record shortcut")
     }
 
     private var displayedShortcut: Shortcut? {
@@ -103,7 +103,7 @@ private struct ShortcutVisualization: View {
                     ShortcutKeyCap(title: token, isRecording: isRecording)
                 }
             } else {
-                Text(isRecording ? "Press shortcut" : "Record")
+                Text(isRecording ? LocalizedStringKey("Press shortcut") : LocalizedStringKey("Record"))
                     .font(.system(size: 12, weight: .medium))
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)

--- a/VoiceInk/Shortcuts/ShortcutValidator.swift
+++ b/VoiceInk/Shortcuts/ShortcutValidator.swift
@@ -10,13 +10,13 @@ enum ShortcutValidationError: Equatable {
     func notificationTitle(for shortcut: Shortcut) -> String {
         switch self {
         case .plainKeyRequiresModifier:
-            return "Shortcut not allowed: \(shortcut.displayString)"
+            return String(format: String(localized: "Shortcut not allowed: %@"), shortcut.displayString)
         case .shiftTypingKeyRequiresAdditionalModifier:
-            return "Shortcut not allowed: \(shortcut.displayString)"
+            return String(format: String(localized: "Shortcut not allowed: %@"), shortcut.displayString)
         case .reservedBySystem:
-            return "Shortcut reserved by macOS: \(shortcut.displayString)"
+            return String(format: String(localized: "Shortcut reserved by macOS: %@"), shortcut.displayString)
         case .alreadyUsedBy(let actionName):
-            return "Shortcut already used by \(actionName)"
+            return String(format: String(localized: "Shortcut already used by %@"), actionName)
         }
     }
 }

--- a/VoiceInk/SoundPlaybackEngine.swift
+++ b/VoiceInk/SoundPlaybackEngine.swift
@@ -92,7 +92,7 @@ final class SoundPlaybackEngine: @unchecked Sendable {
             player.prepareToPlay()
             return player
         } catch {
-            logger.error("Failed to load sound: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to load sound: \(error, privacy: .public)")
             return nil
         }
     }

--- a/VoiceInk/Transcription/Cloud/CloudTranscriptionService.swift
+++ b/VoiceInk/Transcription/Cloud/CloudTranscriptionService.swift
@@ -15,21 +15,21 @@ enum CloudTranscriptionError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .unsupportedProvider:
-            return "The model provider is not supported by this service."
+            return String(localized: "The model provider is not supported by this service.")
         case .missingAPIKey:
-            return "API key for this service is missing. Please configure it in the settings."
+            return String(localized: "API key for this service is missing. Please configure it in the settings.")
         case .invalidAPIKey:
-            return "The provided API key is invalid."
+            return String(localized: "The provided API key is invalid.")
         case .audioFileNotFound:
-            return "The audio file to transcribe could not be found."
+            return String(localized: "The audio file to transcribe could not be found.")
         case .apiRequestFailed(let statusCode, let message):
-            return "The API request failed with status code \(statusCode): \(message)"
+            return String(format: String(localized: "The API request failed with status code %lld: %@"), Int64(statusCode), message)
         case .networkError(let error):
-            return "A network error occurred: \(error.localizedDescription)"
+            return String(format: String(localized: "A network error occurred: %@"), error.localizedDescription)
         case .noTranscriptionReturned:
-            return "The API returned an empty or invalid response."
+            return String(localized: "The API returned an empty or invalid response.")
         case .dataEncodingError:
-            return "Failed to encode the request body."
+            return String(localized: "Failed to encode the request body.")
         }
     }
 }

--- a/VoiceInk/Transcription/Cloud/CustomCloudModelManager.swift
+++ b/VoiceInk/Transcription/Cloud/CustomCloudModelManager.swift
@@ -56,7 +56,7 @@ class CustomCloudModelManager: ObservableObject {
         do {
             customModels = try JSONDecoder().decode([CustomCloudModel].self, from: data)
         } catch {
-            logger.error("Failed to decode custom models: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to decode custom models: \(error, privacy: .public)")
             customModels = []
         }
     }
@@ -66,7 +66,7 @@ class CustomCloudModelManager: ObservableObject {
             let data = try JSONEncoder().encode(customModels)
             userDefaults.set(data, forKey: customModelsKey)
         } catch {
-            logger.error("Failed to encode custom models: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to encode custom models: \(error, privacy: .public)")
         }
     }
     
@@ -76,25 +76,25 @@ class CustomCloudModelManager: ObservableObject {
         var errors: [String] = []
 
         if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            errors.append("Name cannot be empty")
+            errors.append(String(localized: "Name cannot be empty"))
         }
 
         if displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            errors.append("Display name cannot be empty")
+            errors.append(String(localized: "Display name cannot be empty"))
         }
 
         if apiEndpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            errors.append("API endpoint cannot be empty")
+            errors.append(String(localized: "API endpoint cannot be empty"))
         } else if !isValidURL(apiEndpoint) {
-            errors.append("API endpoint must be a valid URL")
+            errors.append(String(localized: "API endpoint must be a valid URL"))
         }
 
         if modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            errors.append("Model name cannot be empty")
+            errors.append(String(localized: "Model name cannot be empty"))
         }
 
         if customModels.contains(where: { $0.name == name && $0.id != excludingId }) {
-            errors.append("A model with this name already exists")
+            errors.append(String(localized: "A model with this name already exists"))
         }
 
         return errors

--- a/VoiceInk/Transcription/Engine/AudioFileProcessor.swift
+++ b/VoiceInk/Transcription/Engine/AudioFileProcessor.swift
@@ -21,15 +21,15 @@ class AudioProcessor {
         var errorDescription: String? {
             switch self {
             case .invalidAudioFile:
-                return "The audio file is invalid or corrupted"
+                return String(localized: "The audio file is invalid or corrupted")
             case .conversionFailed:
-                return "Failed to convert the audio format"
+                return String(localized: "Failed to convert the audio format")
             case .exportFailed:
-                return "Failed to export the processed audio"
+                return String(localized: "Failed to export the processed audio")
             case .unsupportedFormat:
-                return "The audio format is not supported"
+                return String(localized: "The audio format is not supported")
             case .sampleExtractionFailed:
-                return "Failed to extract audio samples"
+                return String(localized: "Failed to extract audio samples")
             }
         }
     }
@@ -183,4 +183,3 @@ class AudioProcessor {
         try audioFile.write(from: buffer)
     }
 } 
-

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -11,9 +11,9 @@ enum RecorderPanelStyle: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .notch:
-            return "Notch"
+            return String(localized: "Notch")
         case .mini:
-            return "Mini"
+            return String(localized: "Mini")
         }
     }
 

--- a/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
@@ -85,7 +85,7 @@ class TranscriptionModelManager: ObservableObject {
     func setDefaultTranscriptionModel(_ model: any TranscriptionModel) {
         guard isAvailableOnCurrentOS(model) else {
             NotificationManager.shared.showNotification(
-                title: "\(model.displayName) requires macOS 26 or later",
+                title: String(format: String(localized: "%@ requires macOS 26 or later"), model.displayName),
                 type: .error
             )
             return

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -89,7 +89,7 @@ class TranscriptionPipeline {
             do {
                 try modelContext.save()
             } catch {
-                logger.error("Failed to save canceled transcription: \(error.localizedDescription, privacy: .public)")
+                logger.error("Failed to save canceled transcription: \(error, privacy: .public)")
             }
         }
 
@@ -186,12 +186,12 @@ class TranscriptionPipeline {
                         finalText = enhancedText
                     } catch {
                         let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                        transcription.enhancedText = "Enhancement failed: \(errorDescription)"
+                        transcription.enhancedText = String(format: String(localized: "Enhancement failed: %@"), errorDescription)
                         responseError = errorDescription
                         let shortReason = String(errorDescription.prefix(80))
                         await MainActor.run {
                             NotificationManager.shared.showNotification(
-                                title: "Enhancement failed: \(shortReason)",
+                                title: String(format: String(localized: "Enhancement failed: %@"), shortReason),
                                 type: .warning
                             )
                         }
@@ -215,7 +215,7 @@ class TranscriptionPipeline {
                 }
             }
 
-            transcription.text = "Transcription Failed: \(errorDescription)"
+            transcription.text = String(format: String(localized: "Transcription Failed: %@"), errorDescription)
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
         }
 
@@ -228,7 +228,7 @@ class TranscriptionPipeline {
                         in: modelContext
                     )
                 } catch {
-                    logger.error("Failed to record session metric: \(error.localizedDescription, privacy: .public)")
+                    logger.error("Failed to record session metric: \(error, privacy: .public)")
                 }
             }
 
@@ -239,7 +239,7 @@ class TranscriptionPipeline {
                 }
                 NotificationCenter.default.post(name: .transcriptionCompleted, object: transcription)
             } catch {
-                logger.error("Failed to save transcription: \(error.localizedDescription, privacy: .public)")
+                logger.error("Failed to save transcription: \(error, privacy: .public)")
             }
         }
 

--- a/VoiceInk/Transcription/Engine/TranscriptionSession.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionSession.swift
@@ -125,7 +125,7 @@ final class StreamingTranscriptionSession: TranscriptionSession {
                 logger.notice("Streaming transcript received elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s chars=\(text.count, privacy: .public)")
                 return text
             } catch {
-                logger.error("❌ Streaming failed, falling back to batch: \(error.localizedDescription, privacy: .public)")
+                logger.error("❌ Streaming failed, falling back to batch: \(error, privacy: .public)")
                 streamingService.cancel()
             }
         } else {

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine+Assistant.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine+Assistant.swift
@@ -55,7 +55,7 @@ extension VoiceInkEngine {
             } catch {
                 let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
                 NotificationManager.shared.showNotification(
-                    title: "Assistant response was not saved: \(String(errorDescription.prefix(80)))",
+                    title: String(format: String(localized: "Assistant response was not saved: %@"), String(errorDescription.prefix(80))),
                     type: .warning
                 )
             }

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -91,7 +91,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
         do {
             try FileManager.default.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            logger.error("❌ Error creating recordings directory: \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ Error creating recordings directory: \(error, privacy: .public)")
         }
     }
 
@@ -213,7 +213,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             guard let transcriptionConfiguration = ModeRuntimeResolver.transcriptionConfiguration(
                                 transcriptionModelManager: self.transcriptionModelManager
                             ) else {
-                                NotificationManager.shared.showNotification(title: "No AI Model Selected", type: .error)
+                                NotificationManager.shared.showNotification(title: String(localized: "No AI Model Selected"), type: .error)
                                 await self.recorder.stopRecording()
                                 try? FileManager.default.removeItem(at: permanentURL)
                                 self.recordedFile = nil
@@ -275,7 +275,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                         do {
                                             try await self.whisperModelManager.loadModel(localWhisperModel)
                                         } catch {
-                                            self.logger.error("❌ Model loading failed: \(error.localizedDescription, privacy: .public)")
+                                            self.logger.error("❌ Model loading failed: \(error, privacy: .public)")
                                         }
                                     }
                                 } else if let fluidAudioModel = currentModel as? FluidAudioModel {
@@ -286,7 +286,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
                         } catch {
                             activeModeTask.cancel()
-                            self.logger.error("Recording failed to start: \(error.localizedDescription, privacy: .public)")
+                            self.logger.error("Recording failed to start: \(error, privacy: .public)")
                             await self.recorder.stopRecording()
                             self.cancelCurrentSession()
                             if let recordedFile = self.recordedFile {
@@ -297,7 +297,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             self.activeRecordingStartID = nil
                             self.clearActiveRecordingContext()
                             await self.cleanupResources()
-                            NotificationManager.shared.showNotification(title: "Recording failed to start", type: .error)
+                            NotificationManager.shared.showNotification(title: String(localized: "Recording failed to start"), type: .error)
                             await self.recorderUIManager?.dismissRecorderPanel()
                         }
                     }
@@ -337,7 +337,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
     ) async {
         guard let transcriptionConfiguration = currentSessionTranscriptionConfiguration ??
             ModeRuntimeResolver.transcriptionConfiguration(transcriptionModelManager: transcriptionModelManager) else {
-            transcription.text = "Transcription Failed: No model selected"
+            transcription.text = String(localized: "Transcription Failed: No model selected")
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
             try? modelContext.save()
             recordingState = .idle
@@ -526,7 +526,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
             try modelContext.save()
             NotificationCenter.default.post(name: .transcriptionCreated, object: transcription)
         } catch {
-            logger.error("Failed to save canceled recording: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to save canceled recording: \(error, privacy: .public)")
         }
     }
 

--- a/VoiceInk/Transcription/Engine/VoiceInkEngineError.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngineError.swift
@@ -14,30 +14,30 @@ extension VoiceInkEngineError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .modelLoadFailed:
-            return "Failed to load the transcription model."
+            return String(localized: "Failed to load the transcription model.")
         case .transcriptionFailed:
-            return "Failed to transcribe the audio."
+            return String(localized: "Failed to transcribe the audio.")
         case .whisperCoreFailed:
-            return "The core transcription engine failed."
+            return String(localized: "The core transcription engine failed.")
         case .unzipFailed:
-            return "Failed to unzip the downloaded Core ML model."
+            return String(localized: "Failed to unzip the downloaded Core ML model.")
         case .unknownError:
-            return "An unknown error occurred."
+            return String(localized: "An unknown error occurred.")
         }
     }
 
     var recoverySuggestion: String? {
         switch self {
         case .modelLoadFailed:
-            return "Try selecting a different model or redownloading the current model."
+            return String(localized: "Try selecting a different model or redownloading the current model.")
         case .transcriptionFailed:
-            return "Check the default model try again. If the problem persists, try a different model."
+            return String(localized: "Check the default model try again. If the problem persists, try a different model.")
         case .whisperCoreFailed:
-            return "This can happen due to an issue with the audio recording or insufficient system resources. Please try again, or restart the app."
+            return String(localized: "This can happen due to an issue with the audio recording or insufficient system resources. Please try again, or restart the app.")
         case .unzipFailed:
-            return "The downloaded Core ML model archive might be corrupted. Try deleting the model and downloading it again. Check available disk space."
+            return String(localized: "The downloaded Core ML model archive might be corrupted. Try deleting the model and downloading it again. Check available disk space.")
         case .unknownError:
-            return "Please restart the application. If the problem persists, contact support."
+            return String(localized: "Please restart the application. If the problem persists, contact support.")
         }
     }
 }

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioModelManager.swift
@@ -92,7 +92,7 @@ class FluidAudioModelManager: ObservableObject {
             )
             modelStateRevision += 1
         } catch {
-            logger.error("❌ FluidAudio download failed for \(modelName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.error("❌ FluidAudio download failed for \(modelName, privacy: .public): \(error, privacy: .public)")
         }
     }
 
@@ -152,17 +152,17 @@ class FluidAudioModelManager: ObservableObject {
     private static func statusMessage(for progress: DownloadUtils.DownloadProgress) -> String {
         switch progress.phase {
         case .listing:
-            return "Listing files from repository..."
+            return String(localized: "Listing files from repository...")
         case .downloading(let completedFiles, let totalFiles):
             guard totalFiles > 0 else {
-                return "Checking cached models..."
+                return String(localized: "Checking cached models...")
             }
-            return "Downloading models: \(completedFiles)/\(totalFiles) files"
+            return String(format: String(localized: "Downloading model files: %lld/%lld"), Int64(completedFiles), Int64(totalFiles))
         case .compiling(let modelName):
             guard !modelName.isEmpty else {
-                return "Finalizing models..."
+                return String(localized: "Finalizing models...")
             }
-            return "Compiling \(displayName(forModelComponent: modelName))"
+            return String(format: String(localized: "Compiling %@"), displayName(forModelComponent: modelName))
         }
     }
 

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -106,7 +106,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
                 do {
                     vadManager = try await VadManager(config: vadConfig)
                 } catch {
-                    logger.notice("VAD init failed; falling back to full audio: \(error.localizedDescription, privacy: .public)")
+                    logger.notice("VAD init failed; falling back to full audio: \(error, privacy: .public)")
                     vadManager = nil
                 }
             }
@@ -116,7 +116,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
                     let segments = try await vadManager.segmentSpeechAudio(audioSamples)
                     speechAudio = segments.isEmpty ? audioSamples : segments.flatMap { $0 }
                 } catch {
-                    logger.notice("VAD segmentation failed; using full audio: \(error.localizedDescription, privacy: .public)")
+                    logger.notice("VAD segmentation failed; using full audio: \(error, privacy: .public)")
                     speechAudio = audioSamples
                 }
             }

--- a/VoiceInk/Transcription/Native/NativeAppleSpeechAssetManager.swift
+++ b/VoiceInk/Transcription/Native/NativeAppleSpeechAssetManager.swift
@@ -55,7 +55,7 @@ enum NativeAppleSpeechAssetManager {
                 return .reservationLimitReached(reservedLocales)
             }
 
-            logger.error("Apple Speech asset download failed for '\(localeIdentifier, privacy: .public)': \(error.localizedDescription, privacy: .public).")
+            logger.error("Apple Speech asset download failed for '\(localeIdentifier, privacy: .public)': \(error, privacy: .public).")
             return .failed(error.localizedDescription)
         }
         #else
@@ -208,7 +208,7 @@ enum NativeAppleSpeechAssetManager {
             if isReservationLimitError(error) {
                 logger.warning("Apple Speech reservation limit reached for '\(context.localeIdentifier, privacy: .public)'. User must release a reserved language in settings. Status: \(String(describing: finalStatus), privacy: .public).")
             } else {
-                logger.warning("Apple Speech asset reservation failed for '\(context.localeIdentifier, privacy: .public)': \(error.localizedDescription, privacy: .public). Status: \(String(describing: finalStatus), privacy: .public).")
+                logger.warning("Apple Speech asset reservation failed for '\(context.localeIdentifier, privacy: .public)': \(error, privacy: .public). Status: \(String(describing: finalStatus), privacy: .public).")
             }
 
             return false

--- a/VoiceInk/Transcription/Native/NativeAppleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Native/NativeAppleTranscriptionService.swift
@@ -23,19 +23,19 @@ class NativeAppleTranscriptionService: TranscriptionService {
         var errorDescription: String? {
             switch self {
             case .unsupportedOS:
-                return "SpeechAnalyzer requires macOS 26 or later."
+                return String(localized: "SpeechAnalyzer requires macOS 26 or later.")
             case .transcriptionFailed:
-                return "Transcription failed using SpeechAnalyzer."
+                return String(localized: "Transcription failed using SpeechAnalyzer.")
             case .localeNotSupported:
-                return "The selected language is not supported by SpeechAnalyzer."
+                return String(localized: "The selected language is not supported by SpeechAnalyzer.")
             case .invalidModel:
-                return "Invalid model type provided for Native Apple transcription."
+                return String(localized: "Invalid model type provided for Native Apple transcription.")
             case .assetDownloadRequired(let displayName):
-                return "Download required for \(displayName)."
+                return String(format: String(localized: "Download required for %@."), displayName)
             case .assetReservationFailed(let displayName):
-                return "Apple Speech could not reserve language assets for \(displayName). Manage reserved Apple Speech languages in settings."
+                return String(format: String(localized: "Apple Speech could not reserve language assets for %@. Manage reserved Apple Speech languages in settings."), displayName)
             case .resultStreamTimedOut:
-                return "Apple Speech did not finish returning transcription results."
+                return String(localized: "Apple Speech did not finish returning transcription results.")
             }
         }
 
@@ -160,7 +160,7 @@ class NativeAppleTranscriptionService: TranscriptionService {
                 return result
             } catch {
                 group.cancelAll()
-                logger.error("Apple Speech result wait failed: \(error.localizedDescription, privacy: .public).")
+                logger.error("Apple Speech result wait failed: \(error, privacy: .public).")
                 throw error
             }
         }

--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -13,11 +13,11 @@ enum PunctuationCleanupMode: String, Codable, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .keep:
-            return "Keep"
+            return String(localized: "Keep")
         case .removeAll:
-            return "Remove all"
+            return String(localized: "Remove all")
         case .removeTrailingPeriod:
-            return "Remove trailing period"
+            return String(localized: "Remove trailing period")
         }
     }
 

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -204,7 +204,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
             }
 
         } catch {
-            logger.error("Transcription pass failed: \(error.localizedDescription, privacy: .public)")
+            logger.error("Transcription pass failed: \(error, privacy: .public)")
             eventsContinuation?.yield(.error(error))
         }
     }
@@ -246,7 +246,7 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
             guard !text.isEmpty else { return nil }
             return TextNormalizer.shared.normalizeSentence(text)
         } catch {
-            logger.error("Final transcription failed: \(error.localizedDescription, privacy: .public)")
+            logger.error("Final transcription failed: \(error, privacy: .public)")
             return nil
         }
     }

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift
@@ -19,15 +19,15 @@ enum StreamingTranscriptionError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .missingAPIKey:
-            return "API key not configured for streaming transcription"
+            return String(localized: "API key not configured for streaming transcription")
         case .connectionFailed(let message):
-            return "Streaming connection failed: \(message)"
+            return String(format: String(localized: "Streaming connection failed: %@"), message)
         case .timeout:
-            return "Streaming transcription timed out waiting for final result"
+            return String(localized: "Streaming transcription timed out waiting for final result")
         case .serverError(let message):
-            return "Streaming server error: \(message)"
+            return String(format: String(localized: "Streaming server error: %@"), message)
         case .notConnected:
-            return "Not connected to streaming transcription service"
+            return String(localized: "Not connected to streaming transcription service")
         }
     }
 }

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -174,7 +174,7 @@ class StreamingTranscriptionService {
         } catch {
             commitSignal?.finish()
             commitSignal = nil
-            logger.error("Failed to send commit: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to send commit: \(error, privacy: .public)")
             state = .failed
             await cleanupStreaming()
             throw error
@@ -317,7 +317,7 @@ class StreamingTranscriptionService {
                     break
                 case .error(let error):
                     await MainActor.run {
-                        self.logger.error("Streaming event error: \(error.localizedDescription, privacy: .public)")
+                        self.logger.error("Streaming event error: \(error, privacy: .public)")
                     }
                 }
             }  

--- a/VoiceInk/Transcription/Whisper/WhisperModelManager.swift
+++ b/VoiceInk/Transcription/Whisper/WhisperModelManager.swift
@@ -355,7 +355,7 @@ class WhisperModelManager: ObservableObject {
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             await NotificationManager.shared.showNotification(
-                title: "A model named \(baseName).bin already exists",
+                title: String(format: String(localized: "A model named %@.bin already exists"), baseName),
                 type: .warning,
                 duration: 4.0
             )
@@ -372,14 +372,14 @@ class WhisperModelManager: ObservableObject {
             onModelsChanged?()
 
             await NotificationManager.shared.showNotification(
-                title: "Imported \(destinationURL.lastPathComponent)",
+                title: String(format: String(localized: "Imported %@"), destinationURL.lastPathComponent),
                 type: .success,
                 duration: 3.0
             )
         } catch {
             logError("Failed to import local model", error)
             await NotificationManager.shared.showNotification(
-                title: "Failed to import model: \(error.localizedDescription)",
+                title: String(format: String(localized: "Failed to import model: %@"), error.localizedDescription),
                 type: .error,
                 duration: 5.0
             )
@@ -389,7 +389,7 @@ class WhisperModelManager: ObservableObject {
     // MARK: - Helpers
 
     private func logError(_ message: String, _ error: Error) {
-        logger.error("❌ \(message, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        logger.error("❌ \(message, privacy: .public): \(error, privacy: .public)")
     }
 }
 
@@ -428,13 +428,13 @@ struct DownloadProgressView: View {
 
     private var downloadPhase: String {
         if isOptimizing {
-            return "Optimizing model for your device"
+            return String(localized: "Optimizing model for your device")
         }
 
         if supportsCoreML && downloadProgress[modelName + "_coreml"] != nil {
-            return "Downloading Core ML Model for \(modelName)"
+            return String(format: String(localized: "Downloading Core ML Model for %@"), modelName)
         }
-        return "Downloading \(modelName) Model"
+        return String(format: String(localized: "Downloading %@ Model"), modelName)
     }
 
     var body: some View {

--- a/VoiceInk/Transcription/Whisper/WhisperModelWarmupCoordinator.swift
+++ b/VoiceInk/Transcription/Whisper/WhisperModelWarmupCoordinator.swift
@@ -26,7 +26,7 @@ final class WhisperModelWarmupCoordinator: ObservableObject {
                 try await runWarmup(for: model, whisperModelManager: whisperModelManager)
             } catch {
                 await MainActor.run {
-                    whisperModelManager.logger.error("❌ Warmup failed for \(model.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    whisperModelManager.logger.error("❌ Warmup failed for \(model.name, privacy: .public): \(error, privacy: .public)")
                 }
             }
 

--- a/VoiceInk/Transcription/Whisper/WhisperTranscriptionService.swift
+++ b/VoiceInk/Transcription/Whisper/WhisperTranscriptionService.swift
@@ -41,7 +41,7 @@ class WhisperTranscriptionService: TranscriptionService {
             do {
                 whisperContext = try await WhisperContext.createContext(path: modelURL.path)
             } catch {
-                logger.error("❌ Failed to load model: \(model.name, privacy: .public) - \(error.localizedDescription, privacy: .public)")
+                logger.error("❌ Failed to load model: \(model.name, privacy: .public) - \(error, privacy: .public)")
                 throw VoiceInkEngineError.modelLoadFailed
             }
         }

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -151,7 +151,7 @@ struct APIKeyManagementView: View {
                         }
                     } else {
                         HStack {
-                            Text("Server: \(ollamaBaseURL)")
+                            Text(String(format: String(localized: "Server: %@"), ollamaBaseURL))
                             Spacer()
                             Button("Edit") { isEditingURL = true }
                             Button(action: {
@@ -282,7 +282,7 @@ struct APIKeyManagementView: View {
                                 aiService.saveAPIKey(apiKey) { success, errorMessage in
                                     isVerifying = false
                                     if !success {
-                                        alertMessage = errorMessage ?? "Could not verify this API key. Check the key and try again."
+                                        alertMessage = errorMessage ?? String(localized: "Could not verify this API key. Check the key and try again.")
                                         showAlert = true
                                     }
                                     apiKey = ""

--- a/VoiceInk/Views/AI Models/CloudModelCardView.swift
+++ b/VoiceInk/Views/AI Models/CloudModelCardView.swift
@@ -169,7 +169,7 @@ struct CloudModelCardView: View {
                 .foregroundColor(Color(.labelColor))
             
             HStack(spacing: 8) {
-                SecureField("Enter your \(model.provider.rawValue) API key", text: $apiKey)
+                SecureField(String(format: String(localized: "Enter your %@ API key"), model.provider.rawValue), text: $apiKey)
                     .textFieldStyle(.roundedBorder)
                     .disabled(isVerifying)
                     .onChange(of: apiKey) { _, newValue in
@@ -191,7 +191,7 @@ struct CloudModelCardView: View {
                             Image(systemName: verificationStatus == .success ? "checkmark" : "checkmark.shield")
                                 .font(.system(size: 12, weight: .medium))
                         }
-                        Text(isVerifying ? "Verifying..." : "Verify")
+                        Text(isVerifying ? LocalizedStringKey("Verifying...") : LocalizedStringKey("Verify"))
                             .font(.system(size: 12, weight: .medium))
                     }
                     .foregroundColor(.white)
@@ -208,7 +208,7 @@ struct CloudModelCardView: View {
             
             if verificationStatus == .failure {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(verificationError ?? "Could not verify this API key. Check the key and try again.")
+                    Text(verificationError ?? String(localized: "Could not verify this API key. Check the key and try again."))
                         .font(.caption)
                         .fontWeight(.medium)
                         .foregroundColor(AppTheme.Status.error)
@@ -247,8 +247,8 @@ struct CloudModelCardView: View {
         guard let cloudProvider = CloudProviderRegistry.provider(for: model.provider) else {
             isVerifying = false
             verificationStatus = .failure
-            verificationError = "Could not verify this API key. Check the key and try again."
-            verificationErrorDetail = "Unsupported provider"
+            verificationError = String(localized: "Could not verify this API key. Check the key and try again.")
+            verificationErrorDetail = String(localized: "Unsupported provider")
             return
         }
 
@@ -268,7 +268,7 @@ struct CloudModelCardView: View {
                     }
                 } else {
                     verificationStatus = .failure
-                    verificationError = "Could not verify this API key. Check the key and try again."
+                    verificationError = String(localized: "Could not verify this API key. Check the key and try again.")
                     verificationErrorDetail = result.errorMessage
                 }
             }

--- a/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
+++ b/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
@@ -79,9 +79,9 @@ struct CustomProviderManagementView: View {
     }
 
     private func sectionHeader(
-        title: String,
-        subtitle: String,
-        addHelp: String,
+        title: LocalizedStringKey,
+        subtitle: LocalizedStringKey,
+        addHelp: LocalizedStringResource,
         onAdd: @escaping () -> Void
     ) -> some View {
         HStack(alignment: .top, spacing: 12) {
@@ -97,7 +97,7 @@ struct CustomProviderManagementView: View {
 
 private struct CustomProviderEmptyState: View {
     let systemImage: String
-    let title: String
+    let title: LocalizedStringKey
 
     var body: some View {
         VStack(spacing: 10) {
@@ -141,10 +141,17 @@ private struct CustomEnhancementModelRow: View {
                 Text(provider.name)
                     .font(.system(size: 13, weight: .semibold))
 
-                Text(provider.modelName.isEmpty ? "No model configured" : provider.modelName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                if provider.modelName.isEmpty {
+                    Text("No model configured")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                } else {
+                    Text(provider.modelName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
 
             Spacer()
@@ -191,10 +198,10 @@ struct CustomTranscriptionModelEditorPanel: View {
                 VStack(alignment: .leading, spacing: 18) {
                     CustomModelEditorSection(title: "Details") {
                         VStack(spacing: 10) {
-                            CustomModelTextField(label: "Display Name", placeholder: "My Custom Model", text: $displayName)
+                            CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Custom Model"), text: $displayName)
                             CustomModelTextField(label: "API Endpoint", placeholder: "https://api.openai.com/v1/audio/transcriptions", text: $apiEndpoint)
                             if !isEditing {
-                                CustomModelTextField(label: "API Key", placeholder: "Paste API key", text: $apiKey, isSecure: true)
+                                CustomModelTextField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey, isSecure: true)
                             }
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-4o-mini-transcribe", text: $modelName)
                             CustomModelToggleRow(title: "Multilingual Model", isOn: $isMultilingual)
@@ -262,7 +269,7 @@ struct CustomTranscriptionModelEditorPanel: View {
         )
 
         if !isEditing && trimmedKey.isEmpty {
-            validationErrors.append("API key cannot be empty")
+            validationErrors.append(String(localized: "API key cannot be empty"))
         }
 
         guard validationErrors.isEmpty else { return }
@@ -291,7 +298,7 @@ struct CustomTranscriptionModelEditorPanel: View {
             )
 
             guard customModelManager.addCustomModel(customModel, apiKey: trimmedKey) else {
-                validationErrors = ["Failed to save API key securely"]
+                validationErrors = [String(localized: "Failed to save API key securely")]
                 isSaving = false
                 return
             }
@@ -301,11 +308,11 @@ struct CustomTranscriptionModelEditorPanel: View {
         onSave()
     }
 
-    private func editorHeader(title: String) -> some View {
+    private func editorHeader(title: LocalizedStringKey) -> some View {
         CustomModelEditorHeader(title: title, onClose: onClose)
     }
 
-    private func editorFooter(primaryTitle: String, isPrimaryDisabled: Bool, primaryAction: @escaping () -> Void) -> some View {
+    private func editorFooter(primaryTitle: LocalizedStringKey, isPrimaryDisabled: Bool, primaryAction: @escaping () -> Void) -> some View {
         CustomModelEditorFooter(
             primaryTitle: primaryTitle,
             isPrimaryDisabled: isPrimaryDisabled,
@@ -344,10 +351,10 @@ struct CustomEnhancementModelEditorPanel: View {
                 VStack(alignment: .leading, spacing: 18) {
                     CustomModelEditorSection(title: "Details") {
                         VStack(spacing: 10) {
-                            CustomModelTextField(label: "Display Name", placeholder: "My Enhancement Model", text: $displayName)
+                            CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Enhancement Model"), text: $displayName)
                             CustomModelTextField(label: "Base URL", placeholder: "https://api.openai.com/v1/chat/completions", text: $baseURL)
                             if !isEditing {
-                                CustomModelTextField(label: "API Key", placeholder: "Paste API key", text: $apiKey, isSecure: true)
+                                CustomModelTextField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey, isSecure: true)
                             }
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-5.5", text: $modelName)
                         }
@@ -398,7 +405,7 @@ struct CustomEnhancementModelEditorPanel: View {
         isVerifying = false
     }
 
-    private var primaryButtonTitle: String {
+    private var primaryButtonTitle: LocalizedStringKey {
         if isVerifying {
             return "Verifying"
         }
@@ -424,7 +431,7 @@ struct CustomEnhancementModelEditorPanel: View {
         )
 
         if !isEditing && trimmedKey.isEmpty {
-            validationErrors.append("API key cannot be empty")
+            validationErrors.append(String(localized: "API key cannot be empty"))
         }
 
         guard validationErrors.isEmpty else {
@@ -450,13 +457,13 @@ struct CustomEnhancementModelEditorPanel: View {
             if didSave {
                 onSave()
             } else {
-                errorMessage = "Failed to save custom enhancement model"
+                errorMessage = String(localized: "Failed to save custom enhancement model")
             }
             return
         }
 
         guard let verificationURL = URL(string: trimmedURL) else {
-            errorMessage = "Base URL must be a valid URL"
+            errorMessage = String(localized: "Base URL must be a valid URL")
             return
         }
 
@@ -473,7 +480,7 @@ struct CustomEnhancementModelEditorPanel: View {
                 isVerifying = false
 
                 guard result.isValid else {
-                    errorMessage = result.errorMessage ?? "Could not verify this API key"
+                    errorMessage = result.errorMessage ?? String(localized: "Could not verify this API key")
                     return
                 }
 
@@ -484,7 +491,7 @@ struct CustomEnhancementModelEditorPanel: View {
                 if didSave {
                     onSave()
                 } else {
-                    errorMessage = "Failed to save API key securely"
+                    errorMessage = String(localized: "Failed to save API key securely")
                 }
             }
         }
@@ -497,10 +504,10 @@ private enum CustomModelEditorMetrics {
 }
 
 private struct CustomModelEditorSection<Content: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let content: () -> Content
 
-    init(title: String, @ViewBuilder content: @escaping () -> Content) {
+    init(title: LocalizedStringKey, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.content = content
     }
@@ -521,7 +528,7 @@ private struct CustomModelEditorSection<Content: View>: View {
 }
 
 private struct CustomModelTextField: View {
-    let label: String
+    let label: LocalizedStringKey
     let placeholder: String
     @Binding var text: String
     var isSecure = false
@@ -538,7 +545,7 @@ private struct CustomModelTextField: View {
                 if isSecure {
                     SecureField(placeholder, text: $text)
                 } else {
-                    TextField("", text: $text, prompt: Text(placeholder))
+                    TextField("", text: $text, prompt: Text(verbatim: placeholder))
                 }
             }
             .textFieldStyle(.roundedBorder)
@@ -550,7 +557,7 @@ private struct CustomModelTextField: View {
 }
 
 private struct CustomModelToggleRow: View {
-    let title: String
+    let title: LocalizedStringKey
     @Binding var isOn: Bool
 
     var body: some View {
@@ -588,7 +595,7 @@ private struct CustomModelErrorBox: View {
 }
 
 private struct CustomModelEditorHeader: View {
-    let title: String
+    let title: LocalizedStringKey
     let onClose: () -> Void
 
     var body: some View {
@@ -618,7 +625,7 @@ private struct CustomModelEditorHeader: View {
 }
 
 private struct CustomModelEditorFooter: View {
-    let primaryTitle: String
+    let primaryTitle: LocalizedStringKey
     let isPrimaryDisabled: Bool
     let onCancel: () -> Void
     let onPrimary: () -> Void
@@ -722,13 +729,13 @@ private struct CustomModelsSidePanelPreview: View {
         }
     }
 
-    private func customSectionHeader(title: String, subtitle: String, action: @escaping () -> Void) -> some View {
+    private func customSectionHeader(title: LocalizedStringKey, subtitle: LocalizedStringKey, action: @escaping () -> Void) -> some View {
         HStack(alignment: .top, spacing: 12) {
             ProviderSectionHeader(title: title, subtitle: subtitle)
 
             Spacer()
 
-            AddIconButton(helpText: "Add \(title)", action: action)
+            AddIconButton(helpText: "Add model", action: action)
         }
     }
 

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -215,7 +215,7 @@ struct LanguageSelectionView: View {
                         }
                     } label: {
                         HStack {
-                            Text("Language: \(currentLanguageDisplayName())")
+                            Text(String(format: String(localized: "Language: %@"), currentLanguageDisplayName()))
                             Image(systemName: "chevron.up.chevron.down")
                                 .font(.system(size: 10))
                         }

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -6,7 +6,19 @@ enum ModelFilter: String, CaseIterable, Identifiable {
     case local = "Local"
     case cloud = "Cloud"
     case custom = "Custom"
+
     var id: String { self.rawValue }
+
+    var title: LocalizedStringKey {
+        switch self {
+        case .local:
+            return "Local"
+        case .cloud:
+            return "Cloud"
+        case .custom:
+            return "Custom"
+        }
+    }
 }
 
 struct ModelManagementView: View {
@@ -202,7 +214,7 @@ struct ModelManagementView: View {
                     }
                     activePanel = nil
                 }) {
-                    Text(filter.rawValue)
+                    Text(filter.title)
                         .font(.system(size: 14, weight: selectedFilter == filter ? .semibold : .medium))
                         .foregroundColor(selectedFilter == filter ? .primary : .primary.opacity(0.7))
                         .padding(.horizontal, 16)
@@ -330,8 +342,11 @@ struct ModelManagementView: View {
             return
         }
 
-        alertTitle = "Delete Model"
-        alertMessage = "Are you sure you want to delete the model '\(downloadedModel.name)'?"
+        alertTitle = String(localized: "Delete Model")
+        alertMessage = String(
+            format: String(localized: "Are you sure you want to delete the model '%@'?"),
+            downloadedModel.name
+        )
         deleteActionClosure = {
             Task {
                 await whisperModelManager.deleteModel(downloadedModel)
@@ -341,8 +356,11 @@ struct ModelManagementView: View {
     }
 
     private func confirmDeleteCustomModel(_ model: CustomCloudModel) {
-        alertTitle = "Delete Custom Model"
-        alertMessage = "Are you sure you want to delete the custom model '\(model.displayName)'?"
+        alertTitle = String(localized: "Delete Custom Model")
+        alertMessage = String(
+            format: String(localized: "Are you sure you want to delete the custom model '%@'?"),
+            model.displayName
+        )
         deleteActionClosure = {
             customModelManager.removeCustomModel(withId: model.id)
             transcriptionModelManager.refreshAllAvailableModels()
@@ -351,8 +369,11 @@ struct ModelManagementView: View {
     }
 
     private func confirmDeleteCustomEnhancementModel(_ provider: CustomAIProviderConfig) {
-        alertTitle = "Delete Custom Enhancement Model"
-        alertMessage = "Are you sure you want to delete the custom enhancement model '\(provider.name)'?"
+        alertTitle = String(localized: "Delete Custom Enhancement Model")
+        alertMessage = String(
+            format: String(localized: "Are you sure you want to delete the custom enhancement model '%@'?"),
+            provider.name
+        )
         deleteActionClosure = {
             customAIProviderManager.deleteProvider(provider)
         }
@@ -365,7 +386,7 @@ struct ModelManagementView: View {
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.resolvesAliases = true
-        panel.title = "Select a Whisper ggml .bin model"
+        panel.title = String(localized: "Select a Whisper ggml .bin model")
         if panel.runModal() == .OK, let url = panel.url {
             Task { @MainActor in
                 await whisperModelManager.importWhisperModel(from: url)

--- a/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
+++ b/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
@@ -101,7 +101,7 @@ private struct EnhancementModelSettingsView: View {
                 ) {
                     Picker("Minimum words", selection: $shortEnhancementWordThreshold) {
                         ForEach(1...15, id: \.self) { count in
-                            Text(String.localizedStringWithFormat(String(localized: "%d words"), count)).tag(count)
+                            Text(String(localized: "\(count) words")).tag(count)
                         }
                     }
                 }

--- a/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
+++ b/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
@@ -50,7 +50,7 @@ private struct ModelSettingsTabBar: View {
                             .font(.system(size: 13, weight: .semibold))
                             .symbolRenderingMode(.hierarchical)
 
-                        Text(tab.rawValue)
+                        Text(LocalizedStringKey(tab.rawValue))
                             .font(.system(size: 14, weight: selection == tab ? .semibold : .medium))
                     }
                     .foregroundStyle(selection == tab ? Color.primary : Color.secondary)
@@ -101,7 +101,7 @@ private struct EnhancementModelSettingsView: View {
                 ) {
                     Picker("Minimum words", selection: $shortEnhancementWordThreshold) {
                         ForEach(1...15, id: \.self) { count in
-                            Text("\(count) \(count == 1 ? "word" : "words")").tag(count)
+                            Text(String.localizedStringWithFormat(String(localized: "%d words"), count)).tag(count)
                         }
                     }
                 }
@@ -113,7 +113,7 @@ private struct EnhancementModelSettingsView: View {
             Section {
                 Picker("Timeout duration", selection: $enhancementTimeoutSeconds) {
                     ForEach([3, 5, 7, 10, 15, 20, 30, 40, 50, 60], id: \.self) { seconds in
-                        Text("\(seconds) seconds").tag(seconds)
+                        Text(String(format: String(localized: "%d seconds"), seconds)).tag(seconds)
                     }
                 }
                 .pickerStyle(.menu)

--- a/VoiceInk/Views/AI Models/ProviderCloudManagementView.swift
+++ b/VoiceInk/Views/AI Models/ProviderCloudManagementView.swift
@@ -182,7 +182,7 @@ private struct ProviderListRow: View {
         APIKeyManager.shared.hasAPIKey(forProvider: descriptor.providerKey)
     }
 
-    private var statusText: String {
+    private var statusText: LocalizedStringKey {
         isConfigured ? "Connected" : "Not connected"
     }
 
@@ -201,19 +201,32 @@ private struct ProviderListRow: View {
 
         let transcriptionCount = descriptor.transcriptionModels.count
         if transcriptionCount > 0 {
-            parts.append(modelCountText(transcriptionCount, title: "Transcription"))
+            parts.append(
+                modelCountText(
+                    transcriptionCount,
+                    key: "%lld Transcription models"
+                )
+            )
         }
 
         if let provider = descriptor.aiProvider {
             let enhancementCount = aiService.availableModels(for: provider).count
-            parts.append(modelCountText(enhancementCount, title: "Enhancement"))
+            parts.append(
+                modelCountText(
+                    enhancementCount,
+                    key: "%lld Enhancement models"
+                )
+            )
         }
 
         return parts.joined(separator: " · ")
     }
 
-    private func modelCountText(_ count: Int, title: String) -> String {
-        "\(count) \(title) \(count == 1 ? "model" : "models")"
+    private func modelCountText(_ count: Int, key: String) -> String {
+        if key == "%lld Transcription models" {
+            return String.localizedStringWithFormat(String(localized: "%lld Transcription models"), Int64(count))
+        }
+        return String.localizedStringWithFormat(String(localized: "%lld Enhancement models"), Int64(count))
     }
 
     var body: some View {

--- a/VoiceInk/Views/AI Models/ProviderCloudManagementView.swift
+++ b/VoiceInk/Views/AI Models/ProviderCloudManagementView.swift
@@ -224,9 +224,9 @@ private struct ProviderListRow: View {
 
     private func modelCountText(_ count: Int, key: String) -> String {
         if key == "%lld Transcription models" {
-            return String.localizedStringWithFormat(String(localized: "%lld Transcription models"), Int64(count))
+            return String(localized: "\(count) Transcription models")
         }
-        return String.localizedStringWithFormat(String(localized: "%lld Enhancement models"), Int64(count))
+        return String(localized: "\(count) Enhancement models")
     }
 
     var body: some View {

--- a/VoiceInk/Views/AI Models/ProviderDetailPanel.swift
+++ b/VoiceInk/Views/AI Models/ProviderDetailPanel.swift
@@ -353,7 +353,7 @@ struct ProviderDetailPanel: View {
             return String(localized: "No models loaded.")
         }
 
-        return String.localizedStringWithFormat(String(localized: "%lld models available"), Int64(count))
+        return String(localized: "\(count) models available")
     }
 
     private func modelRow(title: String, subtitle: String?, trailing: String?, systemImage: String) -> some View {

--- a/VoiceInk/Views/AI Models/ProviderDetailPanel.swift
+++ b/VoiceInk/Views/AI Models/ProviderDetailPanel.swift
@@ -157,7 +157,7 @@ struct ProviderDetailPanel: View {
                 removeAPIKey()
             }
         } message: {
-            Text("This will remove your \(descriptor.displayName) API key. You can add it again later.")
+            Text(String(format: String(localized: "This will remove your %@ API key. You can add it again later."), descriptor.displayName))
         }
     }
 
@@ -194,7 +194,7 @@ struct ProviderDetailPanel: View {
                         } else {
                             Image(systemName: "checkmark.seal")
                         }
-                        Text(isVerifying ? "Verifying" : "Verify")
+                        Text(isVerifying ? LocalizedStringKey("Verifying") : LocalizedStringKey("Verify"))
                     }
                     .font(.system(size: 12, weight: .medium))
                 }
@@ -210,7 +210,7 @@ struct ProviderDetailPanel: View {
                         Image(systemName: "link")
                             .font(.system(size: 11, weight: .semibold))
 
-                        Text("Get \(descriptor.displayName) API Key")
+                        Text(String(format: String(localized: "Get %@ API Key"), descriptor.displayName))
                             .font(.system(size: 12, weight: .medium))
 
                         Image(systemName: "arrow.up.right.square")
@@ -224,7 +224,7 @@ struct ProviderDetailPanel: View {
                     .background(neutralLinkButtonBackground)
                 }
                 .buttonStyle(.plain)
-                .help("Open \(descriptor.displayName) API key page")
+                .help(String(format: String(localized: "Open %@ API key page"), descriptor.displayName))
             }
         }
         .padding(12)
@@ -306,7 +306,7 @@ struct ProviderDetailPanel: View {
                                 } else {
                                     Image(systemName: "arrow.clockwise")
                                 }
-                                Text(isRefreshingOpenRouterModels ? "Refreshing" : "Refresh")
+                                Text(isRefreshingOpenRouterModels ? LocalizedStringKey("Refreshing") : LocalizedStringKey("Refresh"))
                             }
                             .font(.system(size: 12, weight: .medium))
                         }
@@ -350,10 +350,10 @@ struct ProviderDetailPanel: View {
 
     private func openRouterModelAvailabilityText(for count: Int) -> String {
         if count == 0 {
-            return "No models loaded."
+            return String(localized: "No models loaded.")
         }
 
-        return "\(count) \(count == 1 ? "model" : "models") available"
+        return String.localizedStringWithFormat(String(localized: "%lld models available"), Int64(count))
     }
 
     private func modelRow(title: String, subtitle: String?, trailing: String?, systemImage: String) -> some View {
@@ -459,7 +459,7 @@ struct ProviderDetailPanel: View {
                     model: verificationModel(for: provider)
                 )
             } else {
-                result = (false, "Provider is not supported")
+                result = (false, String(localized: "Provider is not supported"))
             }
 
             await MainActor.run {
@@ -480,7 +480,7 @@ struct ProviderDetailPanel: View {
                     transcriptionModelManager.refreshAllAvailableModels()
                     NotificationCenter.default.post(name: .aiProviderKeyChanged, object: nil)
                 } else {
-                    verificationMessage = "Could not verify this API key. Check the key and try again."
+                    verificationMessage = String(localized: "Could not verify this API key. Check the key and try again.")
                     verificationDetailMessage = result.errorMessage
                 }
             }

--- a/VoiceInk/Views/AI Models/ProviderLocalManagementView.swift
+++ b/VoiceInk/Views/AI Models/ProviderLocalManagementView.swift
@@ -27,8 +27,8 @@ struct LocalEnhancementProviderManagementView: View {
 
             VStack(spacing: 0) {
                 LocalProviderDisclosureRow(
-                    title: "Ollama",
-                    subtitle: ollamaModelNames.isEmpty ? "Local server" : localModelCountLabel,
+                    title: Text(verbatim: "Ollama"),
+                    subtitle: ollamaModelNames.isEmpty ? Text("Local server") : Text(localModelCountLabel),
                     systemImage: "server.rack",
                     statusTitle: ollamaStatusTitle,
                     isExpanded: $isOllamaExpanded
@@ -40,10 +40,10 @@ struct LocalEnhancementProviderManagementView: View {
                     .padding(.leading, 58)
 
                 LocalProviderDisclosureRow(
-                    title: "Local CLI",
-                    subtitle: "Claude, Codex, scripts, or any command",
+                    title: Text("Local CLI"),
+                    subtitle: Text("Claude, Codex, scripts, or any command"),
                     systemImage: "terminal",
-                    statusTitle: isLocalCLIConfigured ? "Configured" : "Not configured",
+                    statusTitle: isLocalCLIConfigured ? Text("Configured") : Text("Not configured"),
                     isExpanded: $isLocalCLIExpanded
                 ) {
                     localCLIConfiguration
@@ -62,22 +62,23 @@ struct LocalEnhancementProviderManagementView: View {
     }
 
     private var localModelCountLabel: String {
-        "\(ollamaModelNames.count) \(ollamaModelNames.count == 1 ? "model" : "models")"
+        let count = ollamaModelNames.count
+        return String.localizedStringWithFormat(String(localized: "%lld models"), Int64(count))
     }
 
-    private var ollamaStatusTitle: String {
+    private var ollamaStatusTitle: Text {
         if aiService.isOllamaRefreshing {
-            return "Checking"
+            return Text("Checking")
         }
 
         if !aiService.connectedProviders.contains(.ollama) {
-            return "Disconnected"
+            return Text("Disconnected")
         }
 
-        return ollamaModelNames.isEmpty ? "No models" : localModelCountLabel
+        return ollamaModelNames.isEmpty ? Text("No models") : Text(localModelCountLabel)
     }
 
-    private var ollamaActionTitle: String {
+    private var ollamaActionTitle: LocalizedStringKey {
         aiService.connectedProviders.contains(.ollama) ? "Refresh" : "Connect"
     }
 
@@ -85,7 +86,7 @@ struct LocalEnhancementProviderManagementView: View {
         LocalProviderExpandedContent {
             LocalProviderFormRow(title: "Server") {
                 HStack(spacing: 8) {
-                    TextField("http://localhost:11434", text: $ollamaBaseURL)
+                    TextField("", text: $ollamaBaseURL, prompt: Text(verbatim: "http://localhost:11434"))
                         .textFieldStyle(.roundedBorder)
                         .frame(maxWidth: 320)
                         .disabled(aiService.isOllamaRefreshing)
@@ -243,18 +244,18 @@ private enum LocalProviderMetrics {
 }
 
 private struct LocalProviderDisclosureRow<Content: View>: View {
-    let title: String
-    let subtitle: String
+    let title: Text
+    let subtitle: Text
     let systemImage: String
-    let statusTitle: String
+    let statusTitle: Text
     @Binding var isExpanded: Bool
     let content: () -> Content
 
     init(
-        title: String,
-        subtitle: String,
+        title: Text,
+        subtitle: Text,
         systemImage: String,
-        statusTitle: String,
+        statusTitle: Text,
         isExpanded: Binding<Bool>,
         @ViewBuilder content: @escaping () -> Content
     ) {
@@ -289,11 +290,11 @@ private struct LocalProviderDisclosureRow<Content: View>: View {
                         )
 
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(title)
+                        title
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundStyle(.primary)
 
-                        Text(subtitle)
+                        subtitle
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -301,7 +302,7 @@ private struct LocalProviderDisclosureRow<Content: View>: View {
 
                     Spacer(minLength: 12)
 
-                    Text(statusTitle)
+                    statusTitle
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -347,10 +348,10 @@ private struct LocalProviderExpandedContent<Content: View>: View {
 }
 
 private struct LocalProviderFormRow<Content: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let content: () -> Content
 
-    init(title: String, @ViewBuilder content: @escaping () -> Content) {
+    init(title: LocalizedStringKey, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.content = content
     }

--- a/VoiceInk/Views/AI Models/ProviderLocalManagementView.swift
+++ b/VoiceInk/Views/AI Models/ProviderLocalManagementView.swift
@@ -63,7 +63,7 @@ struct LocalEnhancementProviderManagementView: View {
 
     private var localModelCountLabel: String {
         let count = ollamaModelNames.count
-        return String.localizedStringWithFormat(String(localized: "%lld models"), Int64(count))
+        return String(localized: "\(count) models")
     }
 
     private var ollamaStatusTitle: Text {

--- a/VoiceInk/Views/AI Models/ProviderSharedViews.swift
+++ b/VoiceInk/Views/AI Models/ProviderSharedViews.swift
@@ -52,8 +52,8 @@ struct ProviderBrandIcon: View {
 }
 
 struct ProviderSectionHeader: View {
-    let title: String
-    let subtitle: String
+    let title: LocalizedStringKey
+    let subtitle: LocalizedStringKey
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
@@ -68,10 +68,10 @@ struct ProviderSectionHeader: View {
 }
 
 struct ProviderConfigurationGroup<Content: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let content: () -> Content
 
-    init(title: String, @ViewBuilder content: @escaping () -> Content) {
+    init(title: LocalizedStringKey, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.content = content
     }
@@ -88,10 +88,10 @@ struct ProviderConfigurationGroup<Content: View>: View {
 }
 
 struct ProviderModelListSection<Content: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let content: () -> Content
 
-    init(title: String, @ViewBuilder content: @escaping () -> Content) {
+    init(title: LocalizedStringKey, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.content = content
     }
@@ -123,7 +123,7 @@ struct ProviderSurface: View {
 }
 
 struct ProviderStatusBadge: View {
-    let title: String
+    let title: LocalizedStringKey
     let color: Color
 
     var body: some View {

--- a/VoiceInk/Views/AudioFileRow.swift
+++ b/VoiceInk/Views/AudioFileRow.swift
@@ -81,7 +81,7 @@ struct AudioFileRow: View {
 
             Spacer()
 
-            Text(phase.rawValue)
+            Text(LocalizedStringKey(phase.rawValue))
                 .font(.caption)
                 .foregroundColor(AppTheme.Accent.primary)
         }
@@ -168,7 +168,7 @@ struct AudioFileRow: View {
         Button {
             selectedTab = tab
         } label: {
-            Text(tab.rawValue)
+            Text(LocalizedStringKey(tab.rawValue))
                 .font(.subheadline.weight(selectedTab == tab ? .semibold : .regular))
                 .foregroundColor(selectedTab == tab ? AppTheme.Accent.primary : .secondary)
                 .padding(.horizontal, 10)

--- a/VoiceInk/Views/AudioPlayerView.swift
+++ b/VoiceInk/Views/AudioPlayerView.swift
@@ -594,7 +594,7 @@ struct AudioPlayerView: View {
         guard let transcription = transcription else { return }
 
         guard let baseEnhancementConfiguration = currentEnhancementConfiguration else {
-            showErrorNotification("AI Enhancement is not enabled or configured")
+            showErrorNotification(String(localized: "AI Enhancement is not enabled or configured"))
             return
         }
 
@@ -619,12 +619,12 @@ struct AudioPlayerView: View {
                     try? modelContext.save()
 
                     isReEnhancing = false
-                    showSuccessFeedback(.reEnhanceSuccess, title: "Re-enhancement successful")
+                    showSuccessFeedback(.reEnhanceSuccess, title: String(localized: "Re-enhancement successful"))
                 }
             } catch {
                 await MainActor.run {
                     isReEnhancing = false
-                    showErrorNotification(error.localizedDescription.isEmpty ? "Re-enhancement failed" : error.localizedDescription)
+                    showErrorNotification(error.localizedDescription.isEmpty ? String(localized: "Re-enhancement failed") : error.localizedDescription)
                 }
             }
         }
@@ -632,7 +632,7 @@ struct AudioPlayerView: View {
 
     private func retranscribeAudio() {
         guard let selectedMode else {
-            showErrorNotification("No mode selected")
+            showErrorNotification(String(localized: "No mode selected"))
             return
         }
 
@@ -640,7 +640,7 @@ struct AudioPlayerView: View {
             mode: selectedMode,
             transcriptionModelManager: engine.transcriptionModelManager
         ) else {
-            showErrorNotification("No transcription model selected")
+            showErrorNotification(String(localized: "No transcription model selected"))
             return
         }
 
@@ -656,12 +656,12 @@ struct AudioPlayerView: View {
                 )
                 await MainActor.run {
                     isRetranscribing = false
-                    showSuccessFeedback(.retranscribeSuccess, title: "Retranscription successful")
+                    showSuccessFeedback(.retranscribeSuccess, title: String(localized: "Retranscription successful"))
                 }
             } catch {
                 await MainActor.run {
                     isRetranscribing = false
-                    showErrorNotification(error.localizedDescription.isEmpty ? "Retranscription failed" : error.localizedDescription)
+                    showErrorNotification(error.localizedDescription.isEmpty ? String(localized: "Retranscription failed") : error.localizedDescription)
                 }
             }
         }

--- a/VoiceInk/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Views/AudioTranscribeView.swift
@@ -145,7 +145,7 @@ struct AudioTranscribeView: View {
     private var topBar: some View {
         HStack(spacing: 10) {
             let count = transcriptionManager.queue.count
-            Text(String.localizedStringWithFormat(String(localized: "%d files"), count))
+            Text(String(localized: "\(count) files"))
             .font(.subheadline)
             .foregroundColor(.secondary)
 

--- a/VoiceInk/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Views/AudioTranscribeView.swift
@@ -144,9 +144,10 @@ struct AudioTranscribeView: View {
 
     private var topBar: some View {
         HStack(spacing: 10) {
-            Text("\(transcriptionManager.queue.count) file\(transcriptionManager.queue.count == 1 ? "" : "s")")
-                .font(.subheadline)
-                .foregroundColor(.secondary)
+            let count = transcriptionManager.queue.count
+            Text(String.localizedStringWithFormat(String(localized: "%d files"), count))
+            .font(.subheadline)
+            .foregroundColor(.secondary)
 
             Button {
                 selectFiles()

--- a/VoiceInk/Views/Common/AddIconButton.swift
+++ b/VoiceInk/Views/Common/AddIconButton.swift
@@ -1,7 +1,8 @@
 import SwiftUI
+import Foundation
 
 struct AddIconButton: View {
-    let helpText: String
+    let helpText: LocalizedStringResource
     var size: CGFloat = 18
     var isDisabled: Bool = false
     let action: () -> Void

--- a/VoiceInk/Views/Common/AppControls.swift
+++ b/VoiceInk/Views/Common/AppControls.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import Foundation
 
 struct AppIconButton: View {
     let systemName: String
-    let help: String
+    let help: LocalizedStringResource
     var size: CGFloat = 40
     var iconSize: CGFloat = 18
     var cornerRadius: CGFloat = AppTheme.Radius.pill
@@ -11,7 +12,7 @@ struct AppIconButton: View {
 
     init(
         systemName: String,
-        help: String,
+        help: LocalizedStringResource,
         size: CGFloat = 40,
         iconSize: CGFloat = 18,
         cornerRadius: CGFloat = AppTheme.Radius.pill,
@@ -45,7 +46,7 @@ struct AppIconButton: View {
 }
 
 struct AppPanelHeader: View {
-    let title: String
+    let title: LocalizedStringKey
     let onClose: () -> Void
 
     var body: some View {
@@ -74,8 +75,8 @@ struct AppPanelHeader: View {
 }
 
 struct AppScreenHeader<Trailing: View>: View {
-    let title: String
-    var infoMessage: String?
+    let title: LocalizedStringKey
+    var infoMessage: LocalizedStringKey?
     var infoURL: String?
     @ViewBuilder let trailing: () -> Trailing
 
@@ -108,7 +109,7 @@ struct AppScreenHeader<Trailing: View>: View {
 }
 
 extension AppScreenHeader where Trailing == EmptyView {
-    init(title: String, infoMessage: String? = nil, infoURL: String? = nil) {
+    init(title: LocalizedStringKey, infoMessage: LocalizedStringKey? = nil, infoURL: String? = nil) {
         self.title = title
         self.infoMessage = infoMessage
         self.infoURL = infoURL

--- a/VoiceInk/Views/Common/CompactHeroSection.swift
+++ b/VoiceInk/Views/Common/CompactHeroSection.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct CompactHeroSection: View {
     let icon: String
-    let title: String
-    let description: String
+    let title: LocalizedStringKey
+    let description: LocalizedStringKey
     var maxDescriptionWidth: CGFloat? = nil
 
     var body: some View {

--- a/VoiceInk/Views/Common/SaveIconButton.swift
+++ b/VoiceInk/Views/Common/SaveIconButton.swift
@@ -29,7 +29,7 @@ struct SaveIconButton: View {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [contentType]
         panel.nameFieldStringValue = "\(generateFileName()).\(fileExtension)"
-        panel.title = "Save Transcription"
+        panel.title = String(localized: "Save Transcription")
 
         if panel.runModal() == .OK {
             guard let url = panel.url else { return }

--- a/VoiceInk/Views/Common/TranscriptionInfoPanel.swift
+++ b/VoiceInk/Views/Common/TranscriptionInfoPanel.swift
@@ -137,7 +137,7 @@ struct TranscriptionInfoPanel: View {
         return parts.joined(separator: "\n\n")
     }
 
-    private func metadataRow(icon: String, label: String, value: String) -> some View {
+    private func metadataRow(icon: String, label: LocalizedStringKey, value: String) -> some View {
         HStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.system(size: 11, weight: .medium))

--- a/VoiceInk/Views/Components/ExpandableSettingsRow.swift
+++ b/VoiceInk/Views/Components/ExpandableSettingsRow.swift
@@ -4,8 +4,8 @@ struct ExpandableSettingsRow<Content: View>: View {
     @Binding private var isExpanded: Bool
 
     private let isEnabled: Binding<Bool>?
-    private let label: String
-    private let infoMessage: String?
+    private let label: LocalizedStringKey
+    private let infoMessage: LocalizedStringKey?
     private let infoURL: String?
     private let expandedContentTransition: AnyTransition
     private let content: () -> Content
@@ -15,8 +15,8 @@ struct ExpandableSettingsRow<Content: View>: View {
     init(
         isExpanded: Binding<Bool>,
         isEnabled: Binding<Bool>,
-        label: String,
-        infoMessage: String? = nil,
+        label: LocalizedStringKey,
+        infoMessage: LocalizedStringKey? = nil,
         infoURL: String? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) {
@@ -30,7 +30,7 @@ struct ExpandableSettingsRow<Content: View>: View {
     }
 
     init(
-        title: String,
+        title: LocalizedStringKey,
         isExpanded: Binding<Bool>,
         @ViewBuilder content: @escaping () -> Content
     ) {

--- a/VoiceInk/Views/Components/InfoTip.swift
+++ b/VoiceInk/Views/Components/InfoTip.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// A reusable info tip component that displays helpful information in a popover
 struct InfoTip: View {
     // Content configuration
-    var message: String
+    var message: LocalizedStringKey
     var learnMoreLink: URL?
 
     // Appearance customization
@@ -25,13 +25,14 @@ struct InfoTip: View {
             .popover(isPresented: $isShowingTip) {
                 VStack(alignment: .leading, spacing: 0) {
                     if let url = learnMoreLink {
-                        Text(message + " ")
+                        (
+                            Text(message)
+                                .foregroundColor(.secondary)
+                            + Text(" ")
+                            + Text("Learn more")
+                                .foregroundColor(AppTheme.Accent.primary)
+                        )
                             .font(.callout)
-                            .foregroundColor(.secondary)
-                        +
-                        Text("Learn more")
-                            .font(.callout)
-                            .foregroundColor(AppTheme.Accent.primary)
                     } else {
                         Text(message)
                             .font(.callout)
@@ -57,14 +58,26 @@ struct InfoTip: View {
 
 extension InfoTip {
     /// Creates an InfoTip with just a message
-    init(_ message: String) {
+    init(_ message: LocalizedStringKey) {
         self.message = message
         self.learnMoreLink = nil
     }
 
+    /// Creates an InfoTip with a dynamic string message
+    init(_ message: String) {
+        self.message = LocalizedStringKey(message)
+        self.learnMoreLink = nil
+    }
+
     /// Creates an InfoTip with a learn more link
-    init(_ message: String, learnMoreURL: String) {
+    init(_ message: LocalizedStringKey, learnMoreURL: String) {
         self.message = message
+        self.learnMoreLink = URL(string: learnMoreURL)
+    }
+
+    /// Creates an InfoTip with a dynamic string message and learn more link
+    init(_ message: String, learnMoreURL: String) {
+        self.message = LocalizedStringKey(message)
         self.learnMoreLink = URL(string: learnMoreURL)
     }
 }

--- a/VoiceInk/Views/Components/NativeAppleLanguageAssetControl.swift
+++ b/VoiceInk/Views/Components/NativeAppleLanguageAssetControl.swift
@@ -122,24 +122,27 @@ struct NativeAppleLanguageAssetControl: View {
     private var helpText: String {
         switch state {
         case .checking:
-            return "Checking whether this Apple Speech language is downloaded."
+            return String(localized: "Checking whether this Apple Speech language is downloaded.")
         case .downloaded:
-            return "Apple Speech language is downloaded."
+            return String(localized: "Apple Speech language is downloaded.")
         case .needsDownload:
-            return "Download this Apple Speech language."
+            return String(localized: "Download this Apple Speech language.")
         case .downloading:
-            return "Downloading assets for the selected Apple Speech language."
+            return String(localized: "Downloading assets for the selected Apple Speech language.")
         case .notSupported:
-            return "Apple Speech does not support this language."
+            return String(localized: "Apple Speech does not support this language.")
         case .assetManagementUnavailable:
-            return "Apple Speech language downloads are not available on this system."
+            return String(localized: "Apple Speech language downloads are not available on this system.")
         case .reservationLimitReached:
             if allowsReservationReplacement {
-                return "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language."
+                return String(localized: "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language.")
             }
-            return "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings."
+            return String(localized: "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings.")
         case .failed(let message):
-            return "Apple Speech language download failed: \(message)"
+            return String(
+                format: String(localized: "Apple Speech language download failed: %@"),
+                message
+            )
         }
     }
 
@@ -151,7 +154,7 @@ struct NativeAppleLanguageAssetControl: View {
                     .font(.subheadline)
                     .fontWeight(.semibold)
 
-                Text("Remove one reserved language to download \(selectedLanguageName).")
+                Text(String(format: String(localized: "Remove one reserved language to download %@."), selectedLanguageName))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -193,7 +196,7 @@ struct NativeAppleLanguageAssetControl: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("Remove \(languageDisplayName(for: identifier)) from reserved Apple Speech languages.")
+        .help(String(format: String(localized: "Remove %@ from reserved Apple Speech languages."), languageDisplayName(for: identifier)))
     }
 
     private var reservationLimitLocaleIdentifiers: [String] {
@@ -267,7 +270,12 @@ struct NativeAppleLanguageAssetControl: View {
             }
 
             guard released else {
-                state = .failed("Could not remove \(languageDisplayName(for: reservedLocaleIdentifier)) from reserved Apple Speech languages.")
+                state = .failed(
+                    String(
+                        format: String(localized: "Could not remove %@ from reserved Apple Speech languages."),
+                        languageDisplayName(for: reservedLocaleIdentifier)
+                    )
+                )
                 return
             }
 

--- a/VoiceInk/Views/Components/TrialMessageView.swift
+++ b/VoiceInk/Views/Components/TrialMessageView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct TrialMessageView: View {
-    let message: String
+    let message: Text
     let type: MessageType
     var onAddLicenseKey: (() -> Void)? = nil
     
@@ -21,7 +21,7 @@ struct TrialMessageView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.headline)
-                Text(message)
+                message
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
@@ -65,7 +65,7 @@ struct TrialMessageView: View {
         AppTheme.Text.secondary
     }
     
-    private var title: String {
+    private var title: LocalizedStringKey {
         switch type {
         case .licenseRequired: return "License Required"
         case .warning: return "Trial Ending Soon"

--- a/VoiceInk/Views/Dashboard/DashboardContent.swift
+++ b/VoiceInk/Views/Dashboard/DashboardContent.swift
@@ -221,7 +221,7 @@ struct DashboardContent: View {
             }
         } catch is CancellationError {
         } catch {
-            logger.error("Error loading dashboard stats: \(error.localizedDescription, privacy: .public)")
+            logger.error("Error loading dashboard stats: \(error, privacy: .public)")
         }
     }
 
@@ -260,19 +260,19 @@ struct DashboardContent: View {
         switch licenseState {
         case .unlicensed:
             TrialMessageView(
-                message: "Activate a license to continue using VoiceInk.",
+                message: Text("Activate a license to continue using VoiceInk."),
                 type: .licenseRequired,
                 onAddLicenseKey: onAddLicenseKey
             )
         case .trial(let daysRemaining):
             TrialMessageView(
-                message: "You have \(daysRemaining) days left in your trial",
+                message: Text(String.localizedStringWithFormat(String(localized: "You have %lld days left in your trial"), Int64(daysRemaining))),
                 type: daysRemaining <= 2 ? .warning : .info,
                 onAddLicenseKey: onAddLicenseKey
             )
         case .trialExpired:
             TrialMessageView(
-                message: "Your trial has expired. Upgrade to continue using VoiceInk",
+                message: Text("Your trial has expired. Upgrade to continue using VoiceInk"),
                 type: .expired,
                 onAddLicenseKey: onAddLicenseKey
             )
@@ -287,21 +287,16 @@ struct DashboardContent: View {
                 Spacer(minLength: 0)
 
                 if hasLoadedStatsSnapshot {
-                    (Text("You have saved ")
-                        .fontWeight(.bold)
-                        .foregroundColor(.white.opacity(0.85))
-                     +
-                     Text(formattedTimeSaved)
+                    let highlightedTime = Text(formattedTimeSaved)
                         .fontWeight(.black)
                         .font(.system(size: 36, design: .rounded))
-                        .foregroundStyle(.white)
-                     +
-                     Text(" with VoiceInk")
+                        .foregroundColor(.white)
+
+                    Text("You have saved \(highlightedTime) with VoiceInk")
                         .fontWeight(.bold)
                         .foregroundColor(.white.opacity(0.85))
-                    )
-                    .font(.system(size: 30))
-                    .multilineTextAlignment(.center)
+                        .font(.system(size: 30))
+                        .multilineTextAlignment(.center)
                 } else {
                     Text("VoiceInk Insights")
                         .font(.system(size: 32, weight: .black, design: .rounded))
@@ -395,7 +390,7 @@ struct DashboardContent: View {
     }
 
     @ViewBuilder
-    private func footerActionLabel(icon: String, title: String, color: Color) -> some View {
+    private func footerActionLabel(icon: String, title: LocalizedStringKey, color: Color) -> some View {
         HStack(alignment: .center, spacing: 8) {
             DashboardIconGlyph(systemName: icon, color: color, size: 13, frameSize: 16)
 
@@ -430,17 +425,19 @@ struct DashboardContent: View {
     
     private var heroSubtitle: String {
         guard hasLoadedStatsSnapshot else {
-            return "Your usage summary will appear here."
+            return String(localized: "Your usage summary will appear here.")
         }
 
         guard totalCount > 0 else {
-            return "Your VoiceInk journey starts with your first recording."
+            return String(localized: "Your VoiceInk journey starts with your first recording.")
         }
 
         let wordsText = Formatters.formattedNumber(totalWords)
-        let sessionText = totalCount == 1 ? "session" : "sessions"
+        let sessionText = totalCount == 1
+            ? String(localized: "session")
+            : String(localized: "sessions")
 
-        return "Dictated \(wordsText) words across \(totalCount) \(sessionText)."
+        return String(format: String(localized: "Dictated %@ words across %d %@."), wordsText, totalCount, sessionText)
     }
     
     private var heroGradient: LinearGradient {

--- a/VoiceInk/Views/Dashboard/DashboardContent.swift
+++ b/VoiceInk/Views/Dashboard/DashboardContent.swift
@@ -266,7 +266,7 @@ struct DashboardContent: View {
             )
         case .trial(let daysRemaining):
             TrialMessageView(
-                message: Text(String.localizedStringWithFormat(String(localized: "You have %lld days left in your trial"), Int64(daysRemaining))),
+                message: Text(String(localized: "You have \(daysRemaining) days left in your trial")),
                 type: daysRemaining <= 2 ? .warning : .info,
                 onAddLicenseKey: onAddLicenseKey
             )
@@ -433,11 +433,7 @@ struct DashboardContent: View {
         }
 
         let wordsText = Formatters.formattedNumber(totalWords)
-        return String.localizedStringWithFormat(
-            String(localized: "Dictated %1$@ words across %2$lld sessions."),
-            wordsText,
-            Int64(totalCount)
-        )
+        return String(localized: "Dictated \(wordsText) words across \(totalCount) sessions.")
     }
     
     private var heroGradient: LinearGradient {

--- a/VoiceInk/Views/Dashboard/DashboardContent.swift
+++ b/VoiceInk/Views/Dashboard/DashboardContent.swift
@@ -433,11 +433,11 @@ struct DashboardContent: View {
         }
 
         let wordsText = Formatters.formattedNumber(totalWords)
-        let sessionText = totalCount == 1
-            ? String(localized: "session")
-            : String(localized: "sessions")
-
-        return String(format: String(localized: "Dictated %@ words across %d %@."), wordsText, totalCount, sessionText)
+        return String.localizedStringWithFormat(
+            String(localized: "Dictated %1$@ words across %2$lld sessions."),
+            wordsText,
+            Int64(totalCount)
+        )
     }
     
     private var heroGradient: LinearGradient {

--- a/VoiceInk/Views/Dashboard/DashboardPromotionsSection.swift
+++ b/VoiceInk/Views/Dashboard/DashboardPromotionsSection.swift
@@ -88,12 +88,12 @@ struct DashboardPromotionsSection: View {
 }
 
 private struct DashboardPromotionCard: View {
-    let badge: String
-    let title: String
-    let message: String
+    let badge: LocalizedStringKey
+    let title: LocalizedStringKey
+    let message: LocalizedStringKey
     let accentSymbol: String
     let glowColor: Color
-    let actionTitle: String
+    let actionTitle: LocalizedStringKey
     let actionIcon: String
     let action: () -> Void
     var onDismiss: (() -> Void)? = nil
@@ -110,9 +110,10 @@ private struct DashboardPromotionCard: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(alignment: .leading, spacing: 14) {
-                Text(badge.uppercased())
+                Text(badge)
                     .font(.system(size: 11, weight: .heavy))
                     .tracking(0.8)
+                    .textCase(.uppercase)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                     .background(.white.opacity(0.2))

--- a/VoiceInk/Views/Dashboard/DashboardStatCard.swift
+++ b/VoiceInk/Views/Dashboard/DashboardStatCard.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 struct DashboardStatCard: View {
     let icon: String
-    let title: String
+    let title: LocalizedStringKey
     let value: String
-    let detail: String?
+    let detail: LocalizedStringKey?
     let color: Color
     
     var body: some View {
@@ -23,7 +23,7 @@ struct DashboardStatCard: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
             
-            if let detail, !detail.isEmpty {
+            if let detail {
                 Text(detail)
                     .font(.system(size: 11))
                     .foregroundColor(.secondary)

--- a/VoiceInk/Views/Dashboard/HelpAndResourcesSection.swift
+++ b/VoiceInk/Views/Dashboard/HelpAndResourcesSection.swift
@@ -43,7 +43,7 @@ struct HelpAndResourcesSection: View {
         .background(AppCardBackground(cornerRadius: 28))
     }
     
-    private func resourceLink(icon: String, title: String, color: Color, url: String? = nil, action: (() -> Void)? = nil) -> some View {
+    private func resourceLink(icon: String, title: LocalizedStringKey, color: Color, url: String? = nil, action: (() -> Void)? = nil) -> some View {
         Button(action: {
             if let action = action {
                 action()

--- a/VoiceInk/Views/Dashboard/ModelPerformancePanel.swift
+++ b/VoiceInk/Views/Dashboard/ModelPerformancePanel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SwiftData
 
 private func localizedSessionCount(_ count: Int) -> String {
-    String.localizedStringWithFormat(String(localized: "%d sessions"), count)
+    String(localized: "\(count) sessions")
 }
 
 // MARK: - Time filter

--- a/VoiceInk/Views/Dashboard/ModelPerformancePanel.swift
+++ b/VoiceInk/Views/Dashboard/ModelPerformancePanel.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import SwiftData
 
+private func localizedSessionCount(_ count: Int) -> String {
+    String.localizedStringWithFormat(String(localized: "%d sessions"), count)
+}
+
 // MARK: - Time filter
 
 enum TimeFilter: String, CaseIterable, Identifiable {
@@ -56,7 +60,7 @@ struct ModelPerformancePanel: View {
             Spacer()
             Picker("", selection: Binding(get: { filter }, set: { filterRaw = $0.rawValue })) {
                 ForEach(TimeFilter.allCases) { f in
-                    Text(f.rawValue).tag(f)
+                    Text(LocalizedStringKey(f.rawValue)).tag(f)
                 }
             }
             .pickerStyle(.menu)
@@ -170,7 +174,7 @@ private struct ModelPerformancePanelContent: View {
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
-                Text("\(stat.sessionCount) sessions")
+                Text(localizedSessionCount(stat.sessionCount))
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
             }
@@ -180,7 +184,7 @@ private struct ModelPerformancePanelContent: View {
                 Text(String(format: "%.1fx", stat.speedFactor))
                     .font(.system(size: 24, weight: .bold, design: .rounded))
                     .foregroundColor(AppTheme.Data.enhancement)
-                Text(stat.speedFactor >= 1.0 ? "Faster than Real-time" : "Slower than Real-time")
+                Text(stat.speedFactor >= 1.0 ? LocalizedStringKey("Faster than Real-time") : LocalizedStringKey("Slower than Real-time"))
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
             }
@@ -238,7 +242,7 @@ private struct ModelPerformancePanelContent: View {
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
-                Text("\(stat.sessionCount) sessions")
+                Text(localizedSessionCount(stat.sessionCount))
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
             }

--- a/VoiceInk/Views/Dashboard/PerformanceAnalysisPanelView.swift
+++ b/VoiceInk/Views/Dashboard/PerformanceAnalysisPanelView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 private func localizedTranscriptCount(_ count: Int) -> String {
-    String.localizedStringWithFormat(String(localized: "%d transcripts"), count)
+    String(localized: "\(count) transcripts")
 }
 
 /// Compact panel-optimized performance analysis view for side panels and sidebars.

--- a/VoiceInk/Views/Dashboard/PerformanceAnalysisPanelView.swift
+++ b/VoiceInk/Views/Dashboard/PerformanceAnalysisPanelView.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+private func localizedTranscriptCount(_ count: Int) -> String {
+    String.localizedStringWithFormat(String(localized: "%d transcripts"), count)
+}
+
 /// Compact panel-optimized performance analysis view for side panels and sidebars.
 struct PerformanceAnalysisPanelView: View {
     let transcriptions: [Transcription]
@@ -157,7 +161,7 @@ struct PerformanceAnalysisPanelView: View {
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
-                Text("\(modelStat.fileCount) transcripts")
+                Text(localizedTranscriptCount(modelStat.fileCount))
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
             }
@@ -230,7 +234,7 @@ struct PerformanceAnalysisPanelView: View {
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
-                Text("\(modelStat.fileCount) transcripts")
+                Text(localizedTranscriptCount(modelStat.fileCount))
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
             }

--- a/VoiceInk/Views/Dashboard/PerformanceAnalysisView.swift
+++ b/VoiceInk/Views/Dashboard/PerformanceAnalysisView.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+private func localizedTranscriptCount(_ count: Int) -> String {
+    String.localizedStringWithFormat(String(localized: "%d transcripts"), count)
+}
+
 // MARK: - Shared Analysis Logic
 
 enum PanelMode {
@@ -252,7 +256,7 @@ struct PerformanceAnalysisView: View {
 struct SummaryCard: View {
     let icon: String
     let value: String
-    let label: String
+    let label: LocalizedStringKey
     let color: Color
 
     var body: some View {
@@ -277,7 +281,7 @@ struct SummaryCard: View {
 }
 
 struct InfoRow: View {
-    let label: String
+    let label: LocalizedStringKey
     let value: String
 
     var body: some View {
@@ -294,7 +298,7 @@ struct InfoRow: View {
 }
 
 struct SystemInfoCard: View {
-    let label: String
+    let label: LocalizedStringKey
     let value: String
 
     var body: some View {
@@ -332,7 +336,7 @@ struct TranscriptionModelCard: View {
 
                 Spacer()
                 
-                Text("\(modelStat.fileCount) transcripts")
+                Text(localizedTranscriptCount(modelStat.fileCount))
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
@@ -397,7 +401,7 @@ struct EnhancementModelCard: View {
 
                 Spacer()
                 
-                Text("\(modelStat.fileCount) transcripts")
+                Text(localizedTranscriptCount(modelStat.fileCount))
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
@@ -421,7 +425,7 @@ struct EnhancementModelCard: View {
 }
 
 struct MetricDisplay: View {
-    let title: String
+    let title: LocalizedStringKey
     let value: String
     let color: Color
     

--- a/VoiceInk/Views/Dashboard/PerformanceAnalysisView.swift
+++ b/VoiceInk/Views/Dashboard/PerformanceAnalysisView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 private func localizedTranscriptCount(_ count: Int) -> String {
-    String.localizedStringWithFormat(String(localized: "%d transcripts"), count)
+    String(localized: "\(count) transcripts")
 }
 
 // MARK: - Shared Analysis Logic

--- a/VoiceInk/Views/Dictionary/DictionaryQuickAddPanel.swift
+++ b/VoiceInk/Views/Dictionary/DictionaryQuickAddPanel.swift
@@ -123,7 +123,7 @@ struct DictionaryQuickAddView: View {
     enum Mode: CaseIterable {
         case vocabulary, replacement
 
-        var label: String {
+        var label: LocalizedStringKey {
             switch self {
             case .vocabulary: return "Vocabulary"
             case .replacement: return "Word Replacement"
@@ -343,8 +343,8 @@ struct DictionaryQuickAddView: View {
 // MARK: - Key Hint
 
 private struct KeyHint: View {
-    let label: String
-    init(_ label: String) { self.label = label }
+    let label: LocalizedStringKey
+    init(_ label: LocalizedStringKey) { self.label = label }
 
     var body: some View {
         Text(label)

--- a/VoiceInk/Views/Dictionary/DictionarySettingsView.swift
+++ b/VoiceInk/Views/Dictionary/DictionarySettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct DictionarySettingsView: View {
     @State private var selectedSection: DictionarySection = .replacements
     @State private var isShowingSettings = false
-    private let dictionaryInfoMessage = "Word Replacements run after transcription. Vocabulary is used with AI enhancement to better understand names, technical terms, and unique spellings in your transcript."
+    private let dictionaryInfoMessage: LocalizedStringKey = "Word Replacements run after transcription. Vocabulary is used with AI enhancement to better understand names, technical terms, and unique spellings in your transcript."
     
     enum DictionarySection: String, CaseIterable, Hashable {
         case replacements = "Word Replacements"
@@ -12,9 +12,9 @@ struct DictionarySettingsView: View {
         var description: String {
             switch self {
             case .spellings:
-                return "Vocabulary is used only with AI enhancement to preserve important names, technical terms, and unique spellings in the final output."
+                return String(localized: "Vocabulary is used only with AI enhancement to preserve important names, technical terms, and unique spellings in the final output.")
             case .replacements:
-                return "Word Replacements run after transcription to replace misheard words, phrases, abbreviations, or boilerplate text."
+                return String(localized: "Word Replacements run after transcription to replace misheard words, phrases, abbreviations, or boilerplate text.")
             }
         }
 
@@ -142,7 +142,7 @@ private struct DictionarySectionButton: View {
     var body: some View {
         Button(action: action) {
             DictionarySectionButtonLabel(
-                title: section.rawValue,
+                title: LocalizedStringKey(section.rawValue),
                 icon: section.systemImage,
                 isSelected: isSelected
             )
@@ -153,7 +153,7 @@ private struct DictionarySectionButton: View {
 }
 
 private struct DictionarySectionButtonLabel: View {
-    let title: String
+    let title: LocalizedStringKey
     let icon: String
     let isSelected: Bool
 

--- a/VoiceInk/Views/Dictionary/EditReplacementSheet.swift
+++ b/VoiceInk/Views/Dictionary/EditReplacementSheet.swift
@@ -148,7 +148,7 @@ struct EditReplacementSheet: View {
 
                 for tokenPair in newTokensPairs {
                     if existingTokens.contains(tokenPair.lowercased) {
-                        alertMessage = "'\(tokenPair.original)' already exists in word replacements"
+                        alertMessage = String(format: String(localized: "'%@' already exists in word replacements"), tokenPair.original)
                         showAlert = true
                         return
                     }
@@ -164,7 +164,7 @@ struct EditReplacementSheet: View {
             try modelContext.save()
             dismiss()
         } catch {
-            alertMessage = "Failed to save changes: \(error.localizedDescription)"
+            alertMessage = String(format: String(localized: "Failed to save changes: %@"), error.localizedDescription)
             showAlert = true
         }
     }

--- a/VoiceInk/Views/Dictionary/VocabularyView.swift
+++ b/VoiceInk/Views/Dictionary/VocabularyView.swift
@@ -62,7 +62,7 @@ struct VocabularyView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     Button(action: toggleSort) {
                         HStack(spacing: 4) {
-                            Text(String.localizedStringWithFormat(String(localized: "Vocabulary Words (%lld)"), Int64(vocabularyWords.count)))
+                            Text(String(localized: "Vocabulary Words (\(vocabularyWords.count))"))
                                 .font(.system(size: 12, weight: .medium))
                                 .foregroundColor(.secondary)
 

--- a/VoiceInk/Views/Dictionary/VocabularyView.swift
+++ b/VoiceInk/Views/Dictionary/VocabularyView.swift
@@ -62,7 +62,7 @@ struct VocabularyView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     Button(action: toggleSort) {
                         HStack(spacing: 4) {
-                            Text("Vocabulary Words (\(vocabularyWords.count))")
+                            Text(String.localizedStringWithFormat(String(localized: "Vocabulary Words (%lld)"), Int64(vocabularyWords.count)))
                                 .font(.system(size: 12, weight: .medium))
                                 .foregroundColor(.secondary)
 
@@ -113,7 +113,7 @@ struct VocabularyView: View {
         } catch {
             // Rollback the delete to restore UI consistency
             modelContext.rollback()
-            alertMessage = "Failed to remove word: \(error.localizedDescription)"
+            alertMessage = String(format: String(localized: "Failed to remove word: %@"), error.localizedDescription)
             showAlert = true
         }
     }

--- a/VoiceInk/Views/Dictionary/WordReplacementView.swift
+++ b/VoiceInk/Views/Dictionary/WordReplacementView.swift
@@ -196,7 +196,7 @@ struct WordReplacementView: View {
         } catch {
             // Rollback the delete to restore UI consistency
             modelContext.rollback()
-            alertMessage = "Failed to remove replacement: \(error.localizedDescription)"
+            alertMessage = String(format: String(localized: "Failed to remove replacement: %@"), error.localizedDescription)
             showAlert = true
         }
     }
@@ -256,7 +256,7 @@ struct WordReplacementInfoPopover: View {
                         Text("Replacement:")
                             .font(.caption)
                             .foregroundColor(.secondary)
-                        Text("https://tryvoiceink.com")
+                        Text(verbatim: "https://tryvoiceink.com")
                             .font(.callout)
                     }
                 }

--- a/VoiceInk/Views/History/InlineHistoryView.swift
+++ b/VoiceInk/Views/History/InlineHistoryView.swift
@@ -111,7 +111,7 @@ struct InlineHistoryView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text(String.localizedStringWithFormat(String(localized: "This action cannot be undone. Are you sure you want to delete %lld items?"), Int64(selectedTranscriptions.count)))
+            Text(String(localized: "This action cannot be undone. Are you sure you want to delete \(selectedTranscriptions.count) items?"))
         }
         .onAppear {
             isViewCurrentlyVisible = true

--- a/VoiceInk/Views/History/InlineHistoryView.swift
+++ b/VoiceInk/Views/History/InlineHistoryView.swift
@@ -111,7 +111,7 @@ struct InlineHistoryView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This action cannot be undone. Are you sure you want to delete \(selectedTranscriptions.count) item\(selectedTranscriptions.count == 1 ? "" : "s")?")
+            Text(String.localizedStringWithFormat(String(localized: "This action cannot be undone. Are you sure you want to delete %lld items?"), Int64(selectedTranscriptions.count)))
         }
         .onAppear {
             isViewCurrentlyVisible = true
@@ -163,7 +163,7 @@ struct InlineHistoryView: View {
 
     private var selectionBar: some View {
         HStack(spacing: 16) {
-            Text("\(selectedTranscriptions.count) selected")
+            Text(String(format: String(localized: "%lld selected"), Int64(selectedTranscriptions.count)))
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.secondary)
 
@@ -526,7 +526,7 @@ private struct HistoryCardRow: View {
                                 selectedTab = tab
                             }
                         } label: {
-                            Text(tab.rawValue)
+                            Text(LocalizedStringKey(tab.rawValue))
                                 .font(.system(size: 11, weight: .medium))
                                 .foregroundColor(selectedTab == tab ? .primary : .secondary)
                                 .padding(.horizontal, 10)

--- a/VoiceInk/Views/History/TranscriptionDetailView.swift
+++ b/VoiceInk/Views/History/TranscriptionDetailView.swift
@@ -60,7 +60,7 @@ struct TranscriptionDetailView: View {
 }
 
 private struct MessageBubble: View {
-    let label: String
+    let label: LocalizedStringKey
     let text: String
     let isEnhanced: Bool
 

--- a/VoiceInk/Views/History/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/History/TranscriptionHistoryView.swift
@@ -114,7 +114,7 @@ struct TranscriptionHistoryView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             let count = selectedTranscriptions.count
-            Text(String.localizedStringWithFormat(String(localized: "This action cannot be undone. Are you sure you want to delete %lld items?"), Int64(count)))
+            Text(String(localized: "This action cannot be undone. Are you sure you want to delete \(count) items?"))
         }
         .sidePanel(isPresented: .init(
             get: { isRightSidebarVisible },

--- a/VoiceInk/Views/History/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/History/TranscriptionHistoryView.swift
@@ -113,7 +113,8 @@ struct TranscriptionHistoryView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This action cannot be undone. Are you sure you want to delete \(selectedTranscriptions.count) item\(selectedTranscriptions.count == 1 ? "" : "s")?")
+            let count = selectedTranscriptions.count
+            Text(String.localizedStringWithFormat(String(localized: "This action cannot be undone. Are you sure you want to delete %lld items?"), Int64(count)))
         }
         .sidePanel(isPresented: .init(
             get: { isRightSidebarVisible },
@@ -375,7 +376,7 @@ struct TranscriptionHistoryView: View {
             Spacer()
 
             if !selectedTranscriptions.isEmpty {
-                Text("\(selectedTranscriptions.count) selected")
+                Text(String(format: String(localized: "%lld selected"), Int64(selectedTranscriptions.count)))
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(.secondary)
             }

--- a/VoiceInk/Views/LicenseManagementView.swift
+++ b/VoiceInk/Views/LicenseManagementView.swift
@@ -195,7 +195,7 @@ struct LicenseManagementView: View {
     private var activeLicenseCard: some View {
         LicenseActiveSummaryCard(
             title: "VoiceInk Pro",
-            subtitle: "Version \(appVersion) (\(appBuild))",
+            subtitle: String(format: String(localized: "Version %@ (%@)"), appVersion, appBuild),
             licenseKey: licenseViewModel.licenseKey,
             didCopyLicenseKey: didCopyLicenseKey,
             onCopyLicenseKey: copyLicenseKey
@@ -247,13 +247,13 @@ struct LicenseManagementView: View {
     private var trialSummary: String {
         switch licenseViewModel.licenseState {
         case .unlicensed:
-            return "License required"
+            return String(localized: "License required")
         case .licensed:
-            return "Licensed"
+            return String(localized: "Licensed")
         case .trial(let daysRemaining):
-            return "\(daysRemaining) day\(daysRemaining == 1 ? "" : "s") left in trial"
+            return String.localizedStringWithFormat(String(localized: "%lld days left in trial"), Int64(daysRemaining))
         case .trialExpired:
-            return "Trial ended"
+            return String(localized: "Trial ended")
         }
     }
 
@@ -528,7 +528,7 @@ private struct ReportFeedbackBottomPanel: View {
 }
 
 private struct ReportPanelButton: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     let iconColor: Color
     let action: () -> Void
@@ -545,7 +545,7 @@ private struct ReportPanelButton: View {
 }
 
 private struct BenefitPill: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     let tint: Color
 
@@ -596,7 +596,7 @@ private struct CopiedStatePill: View {
 }
 
 private struct ResourceButton: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     var tint: Color = AppTheme.Text.secondary
     var foreground: Color = .primary
@@ -615,14 +615,14 @@ private struct ResourceButton: View {
 }
 
 private struct LicenseActionButton: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     let iconColor: Color
     var textColor: Color = .primary
     var fixedWidth: CGFloat?
     var fillsWidth = false
     var isLoading = false
-    var loadingTitle = "Loading"
+    var loadingTitle: LocalizedStringKey = "Loading"
     let action: () -> Void
 
     var body: some View {
@@ -670,7 +670,7 @@ private struct LicenseActionButtonStyle: ButtonStyle {
 }
 
 private struct LicenseActionLabel: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     let iconColor: Color
     var textColor: Color = .primary
@@ -689,7 +689,7 @@ private struct LicenseActionLabel: View {
 }
 
 private struct ActivatingLicenseLabel: View {
-    var title = "Activating"
+    var title: LocalizedStringKey = "Activating"
 
     var body: some View {
         HStack(spacing: 7) {

--- a/VoiceInk/Views/LicenseManagementView.swift
+++ b/VoiceInk/Views/LicenseManagementView.swift
@@ -251,7 +251,7 @@ struct LicenseManagementView: View {
         case .licensed:
             return String(localized: "Licensed")
         case .trial(let daysRemaining):
-            return String.localizedStringWithFormat(String(localized: "%lld days left in trial"), Int64(daysRemaining))
+            return String(localized: "\(daysRemaining) days left in trial")
         case .trialExpired:
             return String(localized: "Trial ended")
         }

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -77,7 +77,7 @@ struct MenuBarView: View {
                     Image(systemName: "sparkles.square.fill.on.square")
                         .font(.system(size: 11, weight: .medium))
                     let activeMode = modeManager.currentEffectiveConfiguration
-                    Text("Mode: \(activeMode?.name ?? "None")")
+                    Text(String(format: String(localized: "Mode: %@"), activeMode?.name ?? String(localized: "None")))
                     Image(systemName: "chevron.up.chevron.down")
                         .font(.system(size: 10))
                 }

--- a/VoiceInk/Views/Onboarding/AIProviderVerificationCard.swift
+++ b/VoiceInk/Views/Onboarding/AIProviderVerificationCard.swift
@@ -104,7 +104,7 @@ struct AIProviderVerificationCard: View {
     private var apiKeyField: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center) {
-                Text("\(selectedProvider.rawValue) API Key")
+                Text(String(format: String(localized: "%@ API Key"), selectedProvider.rawValue))
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(AppTheme.Text.primary)
 
@@ -155,7 +155,7 @@ struct AIProviderVerificationCard: View {
                             .controlSize(.small)
                     }
 
-                    Text(isVerifying ? "Testing..." : "Test connection")
+                    Text(isVerifying ? LocalizedStringKey("Testing...") : LocalizedStringKey("Test connection"))
                 }
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(canVerify ? AppTheme.Action.primaryForeground : AppTheme.Action.disabledForeground)
@@ -226,7 +226,7 @@ struct AIProviderVerificationCard: View {
     }
 
     private var apiKeyPlaceholder: String {
-        "Paste \(selectedProvider.rawValue) API key"
+        String(format: String(localized: "Paste %@ API key"), selectedProvider.rawValue)
     }
 
     private var apiKeyURL: URL? {
@@ -235,7 +235,9 @@ struct AIProviderVerificationCard: View {
 
     private func refreshVerificationState() {
         verificationSucceeded = isSelectedProviderConnected
-        verificationMessage = verificationSucceeded ? "\(selectedProvider.rawValue) connection verified." : nil
+        verificationMessage = verificationSucceeded
+            ? String(format: String(localized: "%@ connection verified."), selectedProvider.rawValue)
+            : nil
         verificationDetailMessage = nil
 
         if verificationSucceeded {
@@ -279,7 +281,7 @@ struct AIProviderVerificationCard: View {
                 if result.isValid {
                     guard APIKeyManager.shared.saveAPIKey(key, forProvider: provider.rawValue) else {
                         verificationSucceeded = false
-                        verificationMessage = "The key worked, but VoiceInk could not save it securely."
+                        verificationMessage = String(localized: "The key worked, but VoiceInk could not save it securely.")
                         verificationDetailMessage = nil
                         onVerificationChanged()
                         return
@@ -290,11 +292,11 @@ struct AIProviderVerificationCard: View {
                     aiService.apiKey = key
                     aiService.isAPIKeyValid = true
                     apiKey = ""
-                    verificationMessage = "\(provider.rawValue) connection verified."
+                    verificationMessage = String(format: String(localized: "%@ connection verified."), provider.rawValue)
                     verificationDetailMessage = nil
                     NotificationCenter.default.post(name: .aiProviderKeyChanged, object: nil)
                 } else {
-                    verificationMessage = "Could not verify this API key. Check the key and try again."
+                    verificationMessage = String(localized: "Could not verify this API key. Check the key and try again.")
                     verificationDetailMessage = result.errorMessage
                 }
 

--- a/VoiceInk/Views/Onboarding/OnboardingContextAwarenessScreen.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingContextAwarenessScreen.swift
@@ -146,7 +146,7 @@ private struct ContextAwarenessModePill: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(AppTheme.Text.secondary)
 
-            Text(model.title)
+            Text(LocalizedStringKey(model.title))
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(AppTheme.Text.primary)
                 .lineLimit(1)

--- a/VoiceInk/Views/Onboarding/OnboardingExperienceCard.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingExperienceCard.swift
@@ -45,7 +45,7 @@ struct OnboardingExperienceCard: View {
 
     private var sayPanel: some View {
         panelShell(kicker: step.sampleLabel) {
-            Text(step.sampleText)
+            Text(LocalizedStringKey(step.sampleText))
                 .font(.system(size: 17, weight: .medium))
                 .foregroundColor(AppTheme.Text.primary)
                 .lineSpacing(5)
@@ -113,7 +113,7 @@ struct OnboardingExperienceCard: View {
     private var notesTextArea: some View {
         ZStack(alignment: .topLeading) {
             if text.isEmpty {
-                Text(step.fieldPlaceholder)
+                Text(LocalizedStringKey(step.fieldPlaceholder))
                     .font(.system(size: 13))
                     .foregroundColor(AppTheme.Text.muted)
                     .padding(editorTextInset)
@@ -136,7 +136,7 @@ struct OnboardingExperienceCard: View {
 
     private var respondStage: some View {
         panelShell(kicker: step.sampleLabel, height: 150) {
-            Text(step.sampleText)
+            Text(LocalizedStringKey(step.sampleText))
                 .font(.system(size: 20, weight: .medium))
                 .foregroundColor(AppTheme.Text.primary)
                 .lineSpacing(5)
@@ -152,7 +152,7 @@ struct OnboardingExperienceCard: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(kicker)
+            Text(LocalizedStringKey(kicker))
                 .font(.system(size: 11, weight: .semibold))
                 .textCase(.uppercase)
                 .tracking(1.0)
@@ -233,7 +233,7 @@ private struct OnboardingExperienceInstruction: View {
     }
 
     private func instructionText(_ value: String) -> some View {
-        Text(value)
+        Text(LocalizedStringKey(value))
             .font(.system(size: 15, weight: .medium))
             .foregroundColor(AppTheme.Text.primary)
             .fixedSize(horizontal: false, vertical: true)

--- a/VoiceInk/Views/Onboarding/OnboardingLicenseCards.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingLicenseCards.swift
@@ -93,7 +93,7 @@ struct OnboardingVerifiedLicenseCard: View {
     var body: some View {
         LicenseActiveSummaryCard(
             title: "VoiceInk Pro",
-            subtitle: "License active on this Mac.",
+            subtitle: String(localized: "License active on this Mac."),
             licenseKey: licenseKey,
             didCopyLicenseKey: didCopyLicenseKey,
             onCopyLicenseKey: copyLicenseKey
@@ -140,13 +140,13 @@ private struct OnboardingLicenseActionRow: View {
                 .frame(width: 34, height: 34)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
+                    Text(LocalizedStringKey(title))
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(AppTheme.Text.primary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.88)
 
-                    Text(subtitle)
+                    Text(LocalizedStringKey(subtitle))
                         .font(.system(size: 11))
                         .foregroundColor(AppTheme.Text.muted)
                         .lineLimit(2)
@@ -194,7 +194,7 @@ private struct OnboardingLicenseActionRow: View {
 }
 
 private struct OnboardingLicensePrimaryButton: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     let isLoading: Bool
     let isEnabled: Bool
@@ -211,7 +211,7 @@ private struct OnboardingLicensePrimaryButton: View {
                         .font(.system(size: 12, weight: .semibold))
                 }
 
-                Text(isLoading ? "Activating" : title)
+                Text(isLoading ? LocalizedStringKey("Activating") : title)
                     .font(.system(size: 13, weight: .semibold))
             }
             .foregroundColor(isEnabled ? AppTheme.Text.primary : AppTheme.Text.disabled)

--- a/VoiceInk/Views/Onboarding/OnboardingPermissionController.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingPermissionController.swift
@@ -76,14 +76,14 @@ final class OnboardingPermissionController {
         let permissionStatus = status(for: permission)
 
         if permissionStatus.isGranted {
-            return "Done"
+            return String(localized: "Done")
         }
 
         switch permission {
         case .microphone:
-            return permissionStatus.requiresSettings ? "Open Settings" : "Allow"
+            return permissionStatus.requiresSettings ? String(localized: "Open Settings") : String(localized: "Allow")
         case .accessibility, .screenRecording:
-            return "Allow"
+            return String(localized: "Allow")
         }
     }
 

--- a/VoiceInk/Views/Onboarding/OnboardingPermissionModels.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingPermissionModels.swift
@@ -55,42 +55,42 @@ enum OnboardingStage: String, CaseIterable {
     var title: String {
         switch self {
         case .permissions:
-            return "Allow Permissions"
+            return String(localized: "Allow Permissions")
         case .microphone:
-            return "Choose Microphone"
+            return String(localized: "Choose Microphone")
         case .model:
-            return "Download Transcription Model"
+            return String(localized: "Download Transcription Model")
         case .api:
-            return "Verify API Key"
+            return String(localized: "Verify API Key")
         case .experience:
-            return "Experience VoiceInk"
+            return String(localized: "Experience VoiceInk")
         case .contextAwareness:
-            return "VoiceInk is Context-Aware"
+            return String(localized: "VoiceInk is Context-Aware")
         case .trust:
-            return "VoiceInk is Open Source"
+            return String(localized: "VoiceInk is Open Source")
         case .license:
-            return "Buy VoiceInk License"
+            return String(localized: "Buy VoiceInk License")
         }
     }
 
     var subtitle: String {
         switch self {
         case .permissions:
-            return "Allow VoiceInk to work across all your apps."
+            return String(localized: "Allow VoiceInk to work across all your apps.")
         case .microphone:
-            return "Pick the microphone VoiceInk should use for recordings."
+            return String(localized: "Pick the microphone VoiceInk should use for recordings.")
         case .model:
-            return "VoiceInk will download NVIDIA's Parakeet model to set up fast local transcription."
+            return String(localized: "VoiceInk will download NVIDIA's Parakeet model to set up fast local transcription.")
         case .api:
-            return "VoiceInk uses LLMs to enhance transcripts and perform AI actions. Set up an API key before continuing."
+            return String(localized: "VoiceInk uses LLMs to enhance transcripts and perform AI actions. Set up an API key before continuing.")
         case .experience:
-            return "Try a few short samples and see how VoiceInk works before you start."
+            return String(localized: "Try a few short samples and see how VoiceInk works before you start.")
         case .contextAwareness:
-            return "VoiceInk can select the right mode from the app you are using and the rules you configure."
+            return String(localized: "VoiceInk can select the right mode from the app you are using and the rules you configure.")
         case .trust:
-            return "VoiceInk is private by default. No data leaves your device unless you opt in."
+            return String(localized: "VoiceInk is private by default. No data leaves your device unless you opt in.")
         case .license:
-            return "Activate an existing key, purchase a license, or start a 7-day free trial."
+            return String(localized: "Activate an existing key, purchase a license, or start a 7-day free trial.")
         }
     }
 
@@ -119,19 +119,19 @@ enum OnboardingPermissionKind: String, CaseIterable, Identifiable {
         case .microphone:
             return OnboardingPermissionDescriptor(
                 title: "Microphone",
-                subtitle: "VoiceInk uses your microphone to capture your voice."
+                subtitle: String(localized: "VoiceInk uses your microphone to capture your voice.")
             )
 
         case .accessibility:
             return OnboardingPermissionDescriptor(
-                title: "Accessibility",
-                subtitle: "VoiceInk uses Accessibility to type transcriptions directly into any app."
+                title: String(localized: "Accessibility"),
+                subtitle: String(localized: "VoiceInk uses Accessibility to type transcriptions directly into any app.")
             )
 
         case .screenRecording:
             return OnboardingPermissionDescriptor(
-                title: "Screen Recording",
-                subtitle: "VoiceInk reads visible screen content to improve the accuracy of transcripts."
+                title: String(localized: "Screen Recording"),
+                subtitle: String(localized: "VoiceInk reads visible screen content to improve the accuracy of transcripts.")
             )
         }
     }
@@ -160,15 +160,15 @@ enum OnboardingPermissionStatus: Equatable {
     var label: String {
         switch self {
         case .granted:
-            return "Granted"
+            return String(localized: "Granted")
         case .needsAccess:
-            return "Needs access"
+            return String(localized: "Needs access")
         case .denied:
-            return "Denied"
+            return String(localized: "Denied")
         case .restricted:
-            return "Restricted"
+            return String(localized: "Restricted")
         case .unknown:
-            return "Unknown"
+            return String(localized: "Unknown")
         }
     }
 

--- a/VoiceInk/Views/Onboarding/OnboardingSections.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingSections.swift
@@ -34,14 +34,14 @@ struct OnboardingHeroHeader: View {
                 )
 
             VStack(spacing: 8) {
-                Text(title)
+                Text(LocalizedStringKey(title))
                     .font(.system(size: 30, weight: .bold))
                     .foregroundColor(AppTheme.Text.primary)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Text(subtitle)
+                Text(LocalizedStringKey(subtitle))
                     .font(.system(size: 14))
                     .foregroundColor(AppTheme.Text.muted)
                     .multilineTextAlignment(.center)
@@ -111,7 +111,7 @@ struct OnboardingBottomBar: View {
     private var leadingSlot: some View {
         if let leadingTitle, let onLeading {
             Button(action: onLeading) {
-                Text(leadingTitle)
+                Text(LocalizedStringKey(leadingTitle))
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(AppTheme.Action.secondaryForeground)
                     .frame(width: Metrics.controlButtonWidth, height: Metrics.buttonHeight)
@@ -127,7 +127,7 @@ struct OnboardingBottomBar: View {
 
     private var primaryButton: some View {
         Button(action: onPrimary) {
-            Text(primaryTitle)
+            Text(LocalizedStringKey(primaryTitle))
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(isPrimaryEnabled ? AppTheme.Action.primaryForeground : AppTheme.Action.disabledForeground)
                 .padding(.horizontal, Metrics.primaryButtonHorizontalPadding)

--- a/VoiceInk/Views/Onboarding/OnboardingTrustScreen.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingTrustScreen.swift
@@ -157,7 +157,7 @@ private struct TrustPill: View {
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(AppTheme.Text.secondary)
 
-            Text(title)
+            Text(LocalizedStringKey(title))
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(AppTheme.Text.primary)
                 .lineLimit(1)

--- a/VoiceInk/Views/Onboarding/PermissionStepRow.swift
+++ b/VoiceInk/Views/Onboarding/PermissionStepRow.swift
@@ -18,11 +18,11 @@ struct PermissionStepRow: View {
                 stepNumberView
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(descriptor.title)
+                    Text(LocalizedStringKey(descriptor.title))
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(AppTheme.Text.primary)
 
-                    Text(descriptor.subtitle)
+                    Text(LocalizedStringKey(descriptor.subtitle))
                         .font(.system(size: 12))
                         .foregroundColor(AppTheme.Text.muted)
                         .fixedSize(horizontal: false, vertical: true)
@@ -77,7 +77,7 @@ struct PermissionStepRow: View {
 
     private var actionButton: some View {
         Button(action: onAction) {
-            Text(actionTitle)
+            Text(LocalizedStringKey(actionTitle))
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(AppTheme.Action.primaryForeground)
                 .frame(minWidth: 94)
@@ -92,7 +92,7 @@ struct PermissionStepRow: View {
     }
 
     private var statusBadge: some View {
-        Text(isLocked ? "Locked" : status.label)
+        Text(isLocked ? LocalizedStringKey("Locked") : LocalizedStringKey(status.label))
             .font(.system(size: 12, weight: .semibold))
             .foregroundColor(isLocked ? AppTheme.Text.muted : statusTone)
             .padding(.horizontal, 10)

--- a/VoiceInk/Views/Onboarding/TranscriptionModelDownloadCard.swift
+++ b/VoiceInk/Views/Onboarding/TranscriptionModelDownloadCard.swift
@@ -64,18 +64,27 @@ struct TranscriptionModelDownloadCard: View {
             .scaledToFit()
             .frame(width: 34, height: 28)
             .frame(width: 38, height: 38)
-            .accessibilityLabel("NVIDIA")
+            .accessibilityLabel(Text(verbatim: "NVIDIA"))
     }
 
     private var modelMetadata: some View {
         HStack(spacing: 6) {
             metadataPill(model.size)
-            metadataPill("25+ languages")
-            metadataPill("Local")
+            localizedMetadataPill("25+ languages")
+            localizedMetadataPill("Local")
         }
     }
 
     private func metadataPill(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(AppTheme.Text.secondary)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(Capsule().fill(AppTheme.Surface.subtle))
+    }
+
+    private func localizedMetadataPill(_ text: LocalizedStringKey) -> some View {
         Text(text)
             .font(.system(size: 11, weight: .medium))
             .foregroundColor(AppTheme.Text.secondary)
@@ -137,7 +146,7 @@ struct TranscriptionModelDownloadCard: View {
             .background(Capsule().fill(AppTheme.Surface.controlActive))
     }
 
-    private var downloadButtonTitle: String {
+    private var downloadButtonTitle: LocalizedStringKey {
         if isDownloading {
             return "Downloading..."
         }

--- a/VoiceInk/Views/PromptEditorView.swift
+++ b/VoiceInk/Views/PromptEditorView.swift
@@ -27,15 +27,15 @@ struct PromptEditorView: View {
     @State private var useSystemInstructions: Bool
     @State private var showDeleteConfirmation = false
 
-    private var saveButtonTitle: String {
+    private var saveButtonTitle: LocalizedStringKey {
         mode == .add ? "Create & Select" : "Save & Select"
     }
 
-    private var panelTitle: String {
+    private var panelTitle: LocalizedStringKey {
         mode == .add ? "New Prompt" : "Edit Prompt"
     }
 
-    private var promptKindLabel: String {
+    private var promptKindLabel: LocalizedStringKey {
         "Prompt"
     }
 
@@ -111,7 +111,7 @@ struct PromptEditorView: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Are you sure you want to delete '\(title)'? This action cannot be undone.")
+            Text(String(format: String(localized: "Are you sure you want to delete '%@'? This action cannot be undone."), title))
         }
     }
 

--- a/VoiceInk/Views/Recorder/AudioVisualizerView.swift
+++ b/VoiceInk/Views/Recorder/AudioVisualizerView.swift
@@ -75,7 +75,7 @@ struct ProcessingStatusDisplay: View {
     let mode: Mode
     let color: Color
 
-    private var label: String {
+    private var label: LocalizedStringKey {
         switch mode {
         case .transcribing: return "Transcribing"
         case .enhancing:    return "Enhancing"

--- a/VoiceInk/Views/Recorder/RecorderComponents.swift
+++ b/VoiceInk/Views/Recorder/RecorderComponents.swift
@@ -126,17 +126,17 @@ struct RecorderRecordButton: View {
     private var accessibilityLabel: String {
         switch recordingState {
         case .idle:
-            return "Start recording"
+            return String(localized: "Start recording")
         case .starting:
-            return "Starting recording"
+            return String(localized: "Starting recording")
         case .recording:
-            return "Stop recording"
+            return String(localized: "Stop recording")
         case .transcribing:
-            return "Transcribing recording"
+            return String(localized: "Transcribing recording")
         case .enhancing:
-            return "Enhancing recording"
+            return String(localized: "Enhancing recording")
         case .busy:
-            return "Recorder unavailable"
+            return String(localized: "Recorder unavailable")
         }
     }
 
@@ -384,7 +384,7 @@ struct AssistantPanelView: View {
     private var statusText: String? {
         switch session.phase {
         case .responding, .sendingFollowUp:
-            return "Thinking"
+            return String(localized: "Thinking")
         case .failed(let message):
             return message
         case .inactive, .ready:

--- a/VoiceInk/Views/Settings/AudioCleanupSettingsView.swift
+++ b/VoiceInk/Views/Settings/AudioCleanupSettingsView.swift
@@ -56,7 +56,7 @@ struct AudioCleanupSettingsView: View {
                     Button("Cancel", role: .cancel) { }
 
                     if cleanupInfo.fileCount > 0 {
-                        Button("Delete \(cleanupInfo.fileCount) Files", role: .destructive) {
+                        Button(String.localizedStringWithFormat(String(localized: "Delete %lld Files"), Int64(cleanupInfo.fileCount)), role: .destructive) {
                             Task {
                                 await MainActor.run { isPerformingCleanup = true }
                                 let result = await AudioCleanupManager.shared.runCleanupForTranscriptions(
@@ -73,18 +73,18 @@ struct AudioCleanupSettingsView: View {
                     }
                 } message: {
                     if cleanupInfo.fileCount > 0 {
-                        Text("This will delete \(cleanupInfo.fileCount) audio files (\(AudioCleanupManager.shared.formatFileSize(cleanupInfo.totalSize))).")
+                        Text(String.localizedStringWithFormat(String(localized: "This will delete %lld audio files (%@)."), Int64(cleanupInfo.fileCount), AudioCleanupManager.shared.formatFileSize(cleanupInfo.totalSize)))
                     } else {
-                        Text("No audio files found older than \(audioRetentionPeriod) day\(audioRetentionPeriod > 1 ? "s" : "").")
+                        Text(String.localizedStringWithFormat(String(localized: "No audio files found older than %lld days."), Int64(audioRetentionPeriod)))
                     }
                 }
                 .alert("Cleanup Complete", isPresented: $showResultAlert) {
                     Button("OK", role: .cancel) { }
                 } message: {
                     if cleanupResult.errorCount > 0 {
-                        Text("Deleted \(cleanupResult.deletedCount) files. Failed: \(cleanupResult.errorCount).")
+                        Text(String(format: String(localized: "Deleted files: %lld. Failed: %lld."), Int64(cleanupResult.deletedCount), Int64(cleanupResult.errorCount)))
                     } else {
-                        Text("Deleted \(cleanupResult.deletedCount) audio files.")
+                        Text(String.localizedStringWithFormat(String(localized: "Deleted %lld audio files."), Int64(cleanupResult.deletedCount)))
                     }
                 }
             }

--- a/VoiceInk/Views/Settings/AudioCleanupSettingsView.swift
+++ b/VoiceInk/Views/Settings/AudioCleanupSettingsView.swift
@@ -56,7 +56,7 @@ struct AudioCleanupSettingsView: View {
                     Button("Cancel", role: .cancel) { }
 
                     if cleanupInfo.fileCount > 0 {
-                        Button(String.localizedStringWithFormat(String(localized: "Delete %lld Files"), Int64(cleanupInfo.fileCount)), role: .destructive) {
+                        Button(String(localized: "Delete \(cleanupInfo.fileCount) Files"), role: .destructive) {
                             Task {
                                 await MainActor.run { isPerformingCleanup = true }
                                 let result = await AudioCleanupManager.shared.runCleanupForTranscriptions(
@@ -73,9 +73,9 @@ struct AudioCleanupSettingsView: View {
                     }
                 } message: {
                     if cleanupInfo.fileCount > 0 {
-                        Text(String.localizedStringWithFormat(String(localized: "This will delete %lld audio files (%@)."), Int64(cleanupInfo.fileCount), AudioCleanupManager.shared.formatFileSize(cleanupInfo.totalSize)))
+                        Text(String(localized: "This will delete \(cleanupInfo.fileCount) audio files (\(AudioCleanupManager.shared.formatFileSize(cleanupInfo.totalSize)))."))
                     } else {
-                        Text(String.localizedStringWithFormat(String(localized: "No audio files found older than %lld days."), Int64(audioRetentionPeriod)))
+                        Text(String(localized: "No audio files found older than \(audioRetentionPeriod) days."))
                     }
                 }
                 .alert("Cleanup Complete", isPresented: $showResultAlert) {
@@ -84,7 +84,7 @@ struct AudioCleanupSettingsView: View {
                     if cleanupResult.errorCount > 0 {
                         Text(String(format: String(localized: "Deleted files: %lld. Failed: %lld."), Int64(cleanupResult.deletedCount), Int64(cleanupResult.errorCount)))
                     } else {
-                        Text(String.localizedStringWithFormat(String(localized: "Deleted %lld audio files."), Int64(cleanupResult.deletedCount)))
+                        Text(String(localized: "Deleted \(cleanupResult.deletedCount) audio files."))
                     }
                 }
             }

--- a/VoiceInk/Views/Settings/AudioSetupView.swift
+++ b/VoiceInk/Views/Settings/AudioSetupView.swift
@@ -252,9 +252,9 @@ struct AudioSetupView: View {
 
     private var systemDefaultSourceTitle: String {
         guard let name = audioDeviceManager.getSystemDefaultDeviceName() else {
-            return "System Default"
+            return String(localized: "System Default")
         }
-        return "System Default (\(name))"
+        return String(format: String(localized: "System Default (%@)"), name)
     }
 
     private func refreshMicrophones() {

--- a/VoiceInk/Views/Settings/CustomSoundSettingsView.swift
+++ b/VoiceInk/Views/Settings/CustomSoundSettingsView.swift
@@ -46,7 +46,7 @@ struct CustomSoundSettingsView: View {
                 }
 
                 if isCustom || fileName != nil {
-                    Text("Custom: \(fileName ?? "Custom")").tag(SoundMenuSelection.custom)
+                    Text(String(format: String(localized: "Custom: %@"), fileName ?? String(localized: "Custom"))).tag(SoundMenuSelection.custom)
                 }
             }
             .labelsHidden()
@@ -119,8 +119,8 @@ struct CustomSoundSettingsView: View {
 
     private func selectSound(for type: CustomSoundManager.SoundType) {
         let panel = NSOpenPanel()
-        panel.title = "Choose \(type.rawValue.capitalized) Sound"
-        panel.message = "Select an audio file"
+        panel.title = String(format: String(localized: "Choose %@ Sound"), type.rawValue.capitalized)
+        panel.message = String(localized: "Select an audio file")
         panel.allowedContentTypes = [
             UTType.audio,
             UTType.mp3,

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -160,7 +160,7 @@ struct SettingsView: View {
 
                 Picker(selection: $pasteMethodRawValue) {
                     ForEach(PasteMethod.allCases) { method in
-                        Text(LocalizedStringKey(method.displayName)).tag(method.rawValue)
+                        Text(method.displayName).tag(method.rawValue)
                     }
                 } label: {
                     HStack(spacing: 4) {
@@ -181,7 +181,7 @@ struct SettingsView: View {
             Section("Interface") {
                 Picker("Recorder Style", selection: $recorderUIManager.recorderPanelStyle) {
                     ForEach(RecorderPanelStyle.allCases) { style in
-                        Text(LocalizedStringKey(style.displayName)).tag(style)
+                        Text(style.displayName).tag(style)
                     }
                 }
                 .pickerStyle(.segmented)
@@ -289,7 +289,7 @@ struct SettingsView: View {
     private func shortcutModePicker(binding: Binding<RecordingShortcutManager.Mode>) -> some View {
         Picker("", selection: binding) {
             ForEach(RecordingShortcutManager.Mode.allCases, id: \.self) { mode in
-                Text(LocalizedStringKey(mode.displayName)).tag(mode)
+                Text(mode.displayName).tag(mode)
             }
         }
         .labelsHidden()

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -160,7 +160,7 @@ struct SettingsView: View {
 
                 Picker(selection: $pasteMethodRawValue) {
                     ForEach(PasteMethod.allCases) { method in
-                        Text(method.displayName).tag(method.rawValue)
+                        Text(LocalizedStringKey(method.displayName)).tag(method.rawValue)
                     }
                 } label: {
                     HStack(spacing: 4) {
@@ -181,7 +181,7 @@ struct SettingsView: View {
             Section("Interface") {
                 Picker("Recorder Style", selection: $recorderUIManager.recorderPanelStyle) {
                     ForEach(RecorderPanelStyle.allCases) { style in
-                        Text(style.displayName).tag(style)
+                        Text(LocalizedStringKey(style.displayName)).tag(style)
                     }
                 }
                 .pickerStyle(.segmented)
@@ -289,7 +289,7 @@ struct SettingsView: View {
     private func shortcutModePicker(binding: Binding<RecordingShortcutManager.Mode>) -> some View {
         Picker("", selection: binding) {
             ForEach(RecordingShortcutManager.Mode.allCases, id: \.self) { mode in
-                Text(mode.displayName).tag(mode)
+                Text(LocalizedStringKey(mode.displayName)).tag(mode)
             }
         }
         .labelsHidden()

--- a/VoiceInk/Views/Sidebar/AppSidebar.swift
+++ b/VoiceInk/Views/Sidebar/AppSidebar.swift
@@ -57,12 +57,12 @@ struct AppSidebar: View {
 }
 
 private extension ViewType {
-    var title: String {
+    var title: LocalizedStringKey {
         switch self {
         case .transcribeAudio:
             return "Transcribe"
         default:
-            return rawValue
+            return LocalizedStringKey(rawValue)
         }
     }
 

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -64,10 +64,10 @@ struct VoiceInkApp: App {
 
                 DispatchQueue.main.async {
                     let alert = NSAlert()
-                    alert.messageText = "Storage Warning"
-                    alert.informativeText = "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions."
+                    alert.messageText = String(localized: "Storage Warning")
+                    alert.informativeText = String(localized: "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions.")
                     alert.alertStyle = .warning
-                    alert.addButton(withTitle: "OK")
+                    alert.addButton(withTitle: String(localized: "OK"))
                     alert.runModal()
                 }
             } catch let memoryError {
@@ -372,10 +372,10 @@ struct VoiceInkApp: App {
         guard !AXIsProcessTrusted() else { return }
 
         NotificationManager.shared.showNotification(
-            title: "Accessibility permission is not provided",
+            title: String(localized: "Accessibility permission is not provided"),
             type: .warning,
             duration: 7.0,
-            actionButton: ("Open Settings", Self.openAccessibilitySettings)
+            actionButton: (String(localized: "Open Settings"), Self.openAccessibilitySettings)
         )
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds full German localization and migrates all user-facing text to `.xcstrings` with safe formatting and correct sentence-level plurals. Also fixes count labels across the app, simplifies localized props, and makes logs/system info locale-stable.

- **New Features**
  - Added `Localizable.xcstrings` and `InfoPlist.xcstrings` with German translations.
  - Enabled German (`de`) in project `knownRegions`.
  - Localized alerts, menus, shortcuts, notifications, panels, error messages, and intent dialogs.

- **Refactors**
  - Replaced string literals with `String(localized:)`/`LocalizedStringKey`/`LocalizedStringResource`, removed double-localization, and updated shared components to accept localized props; use `Text(displayName)` directly when already localized.
  - Fixed pluralization across the app (sessions, transcripts, files, apps/websites, models) using sentence-level variants in `.xcstrings`; removed manual singular branches and unused helpers.
  - Standardized logging to log error objects (not `localizedDescription`) and made system info output locale-stable (POSIX timestamps and explicit GB/bytes formatting).

<sup>Written for commit 18c91386759a596581adac88635f1a4af415c588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

