### PR TITLE
Add custom command output mode to run shell scripts on transcription

### DIFF
--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -1842,6 +1842,16 @@
         }
       }
     },
+    "Append to Journal" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An Journal anhängen"
+          }
+        }
+      }
+    },
     "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language." : {
       "localizations" : {
         "de" : {
@@ -3001,6 +3011,86 @@
         }
       }
     },
+    "Custom Command" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl"
+          }
+        }
+      }
+    },
+    "Custom command cannot be empty." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl darf nicht leer sein."
+          }
+        }
+      }
+    },
+    "Custom command could not start: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl konnte nicht gestartet werden: %@"
+          }
+        }
+      }
+    },
+    "Custom command exited with status %d: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl wurde mit Status %d beendet: %@"
+          }
+        }
+      }
+    },
+    "Custom command exited with status %d." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl wurde mit Status %d beendet."
+          }
+        }
+      }
+    },
+    "Custom command failed: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Custom command is empty." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl ist leer."
+          }
+        }
+      }
+    },
+    "Custom command timed out after %.0f seconds." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Befehl hat nach %.0f Sekunden das Zeitlimit überschritten."
+          }
+        }
+      }
+    },
     "Custom Device" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3271,6 +3361,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ausgewählte Elemente löschen?"
+          }
+        }
+      }
+    },
+    "Paste and Press Tab" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einfügen und Tab drücken"
           }
         }
       }
@@ -6458,6 +6558,16 @@
         }
       }
     },
+    "No transcription text was available for the custom command." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Für den benutzerdefinierten Befehl war kein Transkriptionstext verfügbar."
+          }
+        }
+      }
+    },
     "No transcriptions" : {
       "localizations" : {
         "de" : {
@@ -7927,6 +8037,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbesserung mit Ollama auf diesem Mac ausführen oder an einen CLI-Befehl senden."
+          }
+        }
+      }
+    },
+    "Search Web" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web durchsuchen"
+          }
+        }
+      }
+    },
+    "Runs locally with your user permissions. The final transcript is sent on stdin and exposed as VOICEINK_TRANSCRIPT." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird lokal mit Ihren Benutzerberechtigungen ausgeführt. Das finale Transkript wird über stdin gesendet und als VOICEINK_TRANSCRIPT bereitgestellt."
           }
         }
       }

--- a/VoiceInk/Modes/CustomCommandTemplate.swift
+++ b/VoiceInk/Modes/CustomCommandTemplate.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum CustomCommandTemplate: String, CaseIterable, Identifiable {
+    case pasteAndPressTab
+    case appendToJournal
+    case searchWeb
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .pasteAndPressTab:
+            return String(localized: "Paste and Press Tab")
+        case .appendToJournal:
+            return String(localized: "Append to Journal")
+        case .searchWeb:
+            return String(localized: "Search Web")
+        }
+    }
+
+    var command: String {
+        switch self {
+        case .pasteAndPressTab:
+            return """
+            printf "%s" "$VOICEINK_TRANSCRIPT" | pbcopy
+            osascript <<'APPLESCRIPT'
+            tell application "System Events"
+                keystroke "v" using command down
+                delay 1
+                key code 48
+            end tell
+            APPLESCRIPT
+            """
+        case .appendToJournal:
+            return """
+            mkdir -p "$HOME/Documents/VoiceInk"
+            journal="$HOME/Documents/VoiceInk/journal.md"
+            timestamp=$(date "+%Y-%m-%d %H:%M")
+            printf -- "- **%s** %s\\n" "$timestamp" "$VOICEINK_TRANSCRIPT" >> "$journal"
+            """
+        case .searchWeb:
+            return """
+            query=$(printf "%s" "$VOICEINK_TRANSCRIPT" | LC_ALL=C od -An -tx1 -v | tr -d ' \\n' | sed 's/../%&/g')
+            open "https://www.google.com/search?q=$query"
+            """
+        }
+    }
+}

--- a/VoiceInk/Modes/ModeConfig.swift
+++ b/VoiceInk/Modes/ModeConfig.swift
@@ -23,11 +23,13 @@ enum AutoSendKey: String, Codable, CaseIterable {
 enum ModeOutputMode: String, Codable, CaseIterable {
     case paste
     case respond
+    case customCommand
 
     var displayName: String {
         switch self {
         case .paste: return String(localized: "Paste")
         case .respond: return String(localized: "Respond")
+        case .customCommand: return String(localized: "Custom Command")
         }
     }
 
@@ -35,6 +37,7 @@ enum ModeOutputMode: String, Codable, CaseIterable {
         switch self {
         case .paste: return "doc.on.clipboard"
         case .respond: return "text.bubble"
+        case .customCommand: return "terminal"
         }
     }
 
@@ -43,7 +46,20 @@ enum ModeOutputMode: String, Codable, CaseIterable {
     }
 
     static func choices(canRespond: Bool) -> [ModeOutputMode] {
-        canRespond ? [.paste, .respond] : [.paste]
+        canRespond ? [.paste, .respond, .customCommand] : [.paste, .customCommand]
+    }
+}
+
+struct ModeCustomCommand: Codable, Equatable {
+    var command: String
+
+    init(command: String = "") {
+        self.command = command
+    }
+
+    var trimmedCommand: String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 
@@ -69,11 +85,12 @@ struct ModeConfig: Codable, Identifiable, Equatable {
     var selectedAIModel: String?
     var outputMode: ModeOutputMode = .paste
     var autoSendKey: AutoSendKey = .none
+    var customCommand: ModeCustomCommand?
     var isEnabled: Bool = true
     var isDefault: Bool = false
         
     enum CodingKeys: String, CodingKey {
-        case id, name, icon, appConfigs, urlConfigs, triggerGroups, isAIEnhancementEnabled, selectedPrompt, isRealtimeTranscriptionEnabled, selectedLanguage, isTextFormattingEnabled, punctuationCleanupMode, removePunctuation, lowercaseTranscription, useClipboardContext, useSelectedTextContext, useScreenCapture, selectedAIProvider, selectedAIModel, outputMode, isAutoSendEnabled, autoSendKey, isEnabled, isDefault
+        case id, name, icon, appConfigs, urlConfigs, triggerGroups, isAIEnhancementEnabled, selectedPrompt, isRealtimeTranscriptionEnabled, selectedLanguage, isTextFormattingEnabled, punctuationCleanupMode, removePunctuation, lowercaseTranscription, useClipboardContext, useSelectedTextContext, useScreenCapture, selectedAIProvider, selectedAIModel, outputMode, isAutoSendEnabled, autoSendKey, customCommand, isEnabled, isDefault
         case legacyEmoji = "emoji"
         case selectedWhisperModel
         case selectedTranscriptionModelName
@@ -83,7 +100,7 @@ struct ModeConfig: Codable, Identifiable, Equatable {
          urlConfigs: [URLConfig]? = nil, triggerGroups: [ModeTriggerGroup]? = nil, isAIEnhancementEnabled: Bool, selectedPrompt: String? = nil,
          selectedTranscriptionModelName: String? = nil, isRealtimeTranscriptionEnabled: Bool = true, selectedLanguage: String? = nil, useClipboardContext: Bool = false, useSelectedTextContext: Bool = true, useScreenCapture: Bool = false,
          isTextFormattingEnabled: Bool = false, punctuationCleanupMode: PunctuationCleanupMode = .keep, lowercaseTranscription: Bool = false,
-         selectedAIProvider: String? = nil, selectedAIModel: String? = nil, outputMode: ModeOutputMode = .paste, autoSendKey: AutoSendKey = .none, isEnabled: Bool = true, isDefault: Bool = false) {
+         selectedAIProvider: String? = nil, selectedAIModel: String? = nil, outputMode: ModeOutputMode = .paste, autoSendKey: AutoSendKey = .none, customCommand: ModeCustomCommand? = nil, isEnabled: Bool = true, isDefault: Bool = false) {
         self.id = id
         self.name = name
         self.icon = icon
@@ -97,6 +114,7 @@ struct ModeConfig: Codable, Identifiable, Equatable {
         self.useScreenCapture = useScreenCapture
         self.autoSendKey = autoSendKey
         self.outputMode = outputMode
+        self.customCommand = customCommand
         self.selectedAIProvider = selectedAIProvider
         self.selectedAIModel = selectedAIModel
         self.selectedTranscriptionModelName = selectedTranscriptionModelName
@@ -148,6 +166,7 @@ struct ModeConfig: Codable, Identifiable, Equatable {
         selectedAIProvider = try container.decodeIfPresent(String.self, forKey: .selectedAIProvider)
         selectedAIModel = try container.decodeIfPresent(String.self, forKey: .selectedAIModel)
         outputMode = try container.decodeIfPresent(ModeOutputMode.self, forKey: .outputMode) ?? .paste
+        customCommand = try container.decodeIfPresent(ModeCustomCommand.self, forKey: .customCommand)
         // Migrate from old isAutoSendEnabled bool to new autoSendKey enum
         if let rawValue = try container.decodeIfPresent(String.self, forKey: .autoSendKey),
            let newKey = AutoSendKey(rawValue: rawValue) {
@@ -192,6 +211,7 @@ struct ModeConfig: Codable, Identifiable, Equatable {
         try container.encodeIfPresent(selectedAIModel, forKey: .selectedAIModel)
         try container.encode(outputMode, forKey: .outputMode)
         try container.encode(autoSendKey, forKey: .autoSendKey)
+        try container.encodeIfPresent(customCommand, forKey: .customCommand)
         try container.encodeIfPresent(selectedTranscriptionModelName, forKey: .selectedTranscriptionModelName)
         try container.encode(isEnabled, forKey: .isEnabled)
         try container.encode(isDefault, forKey: .isDefault)

--- a/VoiceInk/Modes/ModeConfigDraft.swift
+++ b/VoiceInk/Modes/ModeConfigDraft.swift
@@ -22,6 +22,7 @@ struct ModeConfigDraft {
     var selectedAIModel: String?
     var outputMode: ModeOutputMode
     var autoSendKey: AutoSendKey
+    var customCommand: String
     var isDefault: Bool
     var isTranscriptionFormattingExpanded: Bool
 
@@ -53,6 +54,7 @@ struct ModeConfigDraft {
             selectedAIModel = inheritedConfig?.selectedAIModel
             outputMode = .paste
             autoSendKey = .none
+            customCommand = inheritedConfig?.customCommand?.command ?? ""
             isDefault = false
             isTranscriptionFormattingExpanded = false
             sourceConfig = nil
@@ -80,6 +82,7 @@ struct ModeConfigDraft {
             selectedAIModel = latestConfig.selectedAIModel
             outputMode = latestConfig.outputMode
             autoSendKey = latestConfig.autoSendKey
+            customCommand = latestConfig.customCommand?.command ?? ""
             isDefault = latestConfig.isDefault
             isTranscriptionFormattingExpanded = false
             sourceConfig = latestConfig
@@ -156,6 +159,7 @@ struct ModeConfigDraft {
     func makeConfig(mode: ConfigurationMode) -> ModeConfig {
         let savedAutoSendKey: AutoSendKey = outputMode.usesPasteOptions ? autoSendKey : .none
         let savedIsDefault = outputMode.usesPasteOptions ? isDefault : false
+        let savedCustomCommand = makeCustomCommand()
 
         switch mode {
         case .add:
@@ -181,6 +185,7 @@ struct ModeConfigDraft {
                 selectedAIModel: selectedAIModel,
                 outputMode: outputMode,
                 autoSendKey: savedAutoSendKey,
+                customCommand: savedCustomCommand,
                 isDefault: savedIsDefault
             )
 
@@ -206,8 +211,14 @@ struct ModeConfigDraft {
             updatedConfig.selectedAIModel = selectedAIModel
             updatedConfig.outputMode = outputMode
             updatedConfig.autoSendKey = savedAutoSendKey
+            updatedConfig.customCommand = savedCustomCommand
             updatedConfig.isDefault = savedIsDefault
             return updatedConfig
         }
+    }
+
+    private func makeCustomCommand() -> ModeCustomCommand? {
+        let command = ModeCustomCommand(command: customCommand)
+        return command.trimmedCommand == nil ? nil : command
     }
 }

--- a/VoiceInk/Modes/ModeConfigFormView.swift
+++ b/VoiceInk/Modes/ModeConfigFormView.swift
@@ -530,16 +530,14 @@ struct ModeConfigFormView: View {
 
     private var advancedSection: some View {
         Section("Advanced") {
-            if canRespond {
-                Picker("Output", selection: $draft.outputMode) {
-                    ForEach(outputChoices, id: \.self) { outputMode in
-                        Label(outputMode.displayName, systemImage: outputMode.iconName)
-                            .tag(outputMode)
-                    }
+            Picker("Output", selection: $draft.outputMode) {
+                ForEach(outputChoices, id: \.self) { outputMode in
+                    Label(outputMode.displayName, systemImage: outputMode.iconName)
+                        .tag(outputMode)
                 }
-                .onChange(of: draft.outputMode) { _, _ in
-                    applyOutputRules()
-                }
+            }
+            .onChange(of: draft.outputMode) { _, _ in
+                applyOutputRules()
             }
 
             if draft.outputMode.usesPasteOptions {
@@ -561,6 +559,45 @@ struct ModeConfigFormView: View {
                     }
                 }
             }
+
+            if draft.outputMode == .customCommand {
+                customCommandControls
+            }
+        }
+    }
+
+    private var customCommandControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Text("Command")
+                InfoTip(LocalizedStringKey("Runs locally with your user permissions. The final transcript is sent on stdin and exposed as VOICEINK_TRANSCRIPT."))
+                Spacer()
+                Menu {
+                    ForEach(CustomCommandTemplate.allCases) { template in
+                        Button(template.displayName) {
+                            draft.customCommand = template.command
+                        }
+                    }
+                } label: {
+                    Label("Template", systemImage: "doc.on.doc")
+                }
+                .menuStyle(.button)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            TextEditor(text: $draft.customCommand)
+                .font(.system(size: 12, design: .monospaced))
+                .frame(minHeight: 96)
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .background(AppTheme.Surface.control)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(AppTheme.Border.control.opacity(0.4), lineWidth: 1)
+                )
+
         }
     }
 

--- a/VoiceInk/Modes/ModeRuntimeConfiguration.swift
+++ b/VoiceInk/Modes/ModeRuntimeConfiguration.swift
@@ -56,6 +56,7 @@ struct OutputRuntimeConfiguration {
     let mode: ModeConfig?
     let outputMode: ModeOutputMode
     let autoSendKey: AutoSendKey
+    let customCommand: ModeCustomCommand?
 }
 
 @MainActor
@@ -135,7 +136,8 @@ enum ModeRuntimeResolver {
         return OutputRuntimeConfiguration(
             mode: mode,
             outputMode: mode?.outputMode ?? .paste,
-            autoSendKey: mode?.autoSendKey ?? .none
+            autoSendKey: mode?.autoSendKey ?? .none,
+            customCommand: mode?.customCommand
         )
     }
 

--- a/VoiceInk/Modes/ModeValidator.swift
+++ b/VoiceInk/Modes/ModeValidator.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 enum ModeValidationError: Error, Identifiable {
     case emptyName
+    case emptyCustomCommand
     case duplicateName(String)
     case duplicateAppTrigger(String, String) // (app name, existing mode name)
     case duplicateWebsiteTrigger(String, String) // (website, existing mode name)
@@ -10,6 +11,7 @@ enum ModeValidationError: Error, Identifiable {
     var id: String {
         switch self {
         case .emptyName: return "emptyName"
+        case .emptyCustomCommand: return "emptyCustomCommand"
         case .duplicateName: return "duplicateName"
         case .duplicateAppTrigger: return "duplicateAppTrigger"
         case .duplicateWebsiteTrigger: return "duplicateWebsiteTrigger"
@@ -20,6 +22,8 @@ enum ModeValidationError: Error, Identifiable {
         switch self {
         case .emptyName:
             return String(localized: "Mode name cannot be empty.")
+        case .emptyCustomCommand:
+            return String(localized: "Custom command cannot be empty.")
         case .duplicateName(let name):
             return String(
                 format: String(localized: "A mode with the name '%@' already exists."),
@@ -53,6 +57,11 @@ struct ModeValidator {
 
         if config.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             errors.append(.emptyName)
+        }
+
+        if config.outputMode == .customCommand,
+           config.customCommand?.trimmedCommand == nil {
+            errors.append(.emptyCustomCommand)
         }
 
         let isDuplicateName = modeManager.configurations.contains { existingConfig in

--- a/VoiceInk/Modes/ModeViewComponents.swift
+++ b/VoiceInk/Modes/ModeViewComponents.swift
@@ -140,7 +140,7 @@ struct ConfigurationRow: View {
         (selectedModel.map { $0 != "Default" } ?? false) ||
         (selectedLanguage.map { $0 != "Default" } ?? false) ||
         config.isAIEnhancementEnabled ||
-        config.outputMode == .respond ||
+        config.outputMode != .paste ||
         config.autoSendKey.isEnabled
     }
     
@@ -287,7 +287,7 @@ struct ConfigurationRow: View {
                         )
                     }
                     
-                    if config.outputMode == .respond {
+                    if config.outputMode != .paste {
                         HStack(spacing: 4) {
                             Image(systemName: config.outputMode.iconName)
                                 .font(.system(size: 10))

--- a/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
+++ b/VoiceInk/Services/AIEnhancement/LocalCLIService.swift
@@ -36,8 +36,6 @@ final class LocalCLIService {
     static let selectedTemplateKey = "localCLISelectedTemplate"
     static let timeoutSecondsKey = "localCLITimeoutSeconds"
     static let defaultTimeoutSeconds: Double = 45
-    private static let shellPathQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.localcli.path")
-    private static var cachedInteractiveLoginPATH: String?
 
     var commandTemplate: String {
         didSet {
@@ -124,7 +122,7 @@ final class LocalCLIService {
                 process.arguments = ["-lc", commandTemplate]
 
                 var environment = ProcessInfo.processInfo.environment
-                environment["PATH"] = Self.preferredPATH(fallback: environment["PATH"])
+                environment["PATH"] = ShellCommandEnvironment.preferredPATH(fallback: environment["PATH"])
                 environment["VOICEINK_SYSTEM_PROMPT"] = systemPrompt
                 environment["VOICEINK_USER_PROMPT"] = userPrompt
                 environment["VOICEINK_FULL_PROMPT"] = fullPrompt
@@ -189,74 +187,6 @@ final class LocalCLIService {
                 continuation.resume(returning: stdout)
             }
         }
-    }
-
-    private static func preferredPATH(fallback: String?) -> String {
-        shellPathQueue.sync {
-            if let cachedInteractiveLoginPATH {
-                return cachedInteractiveLoginPATH
-            }
-
-            if let discovered = discoverPATHFromInteractiveLoginShell() {
-                cachedInteractiveLoginPATH = discovered
-                return discovered
-            }
-
-            return fallback?.isEmpty == false ? fallback! : "/usr/bin:/bin:/usr/sbin:/sbin"
-        }
-    }
-
-    private static func discoverPATHFromInteractiveLoginShell() -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = [
-            "-ilc",
-            "echo __VOICEINK_PATH_START__; print -r -- $PATH; echo __VOICEINK_PATH_END__"
-        ]
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        let semaphore = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in semaphore.signal() }
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        let waitResult = semaphore.wait(timeout: .now() + 3)
-        if waitResult == .timedOut {
-            if process.isRunning {
-                process.terminate()
-            }
-            return nil
-        }
-
-        guard process.terminationStatus == 0 else {
-            return nil
-        }
-
-        let output = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let startMarker = "__VOICEINK_PATH_START__"
-        let endMarker = "__VOICEINK_PATH_END__"
-
-        guard let startRange = output.range(of: startMarker),
-              let endRange = output.range(of: endMarker, range: startRange.upperBound..<output.endIndex)
-        else {
-            return nil
-        }
-
-        let pathSection = output[startRange.upperBound..<endRange.lowerBound]
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !pathSection.isEmpty else {
-            return nil
-        }
-
-        return pathSection
     }
 
     private static func cleanOutput(_ value: String) -> String {

--- a/VoiceInk/Services/ShellCommandEnvironment.swift
+++ b/VoiceInk/Services/ShellCommandEnvironment.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+enum ShellCommandEnvironment {
+    private static let shellPathQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.shell.path")
+    private static var cachedPreferredPATH: String?
+    private static let inheritedEnvironmentKeys = [
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE"
+    ]
+
+    static func preferredPATH(fallback: String?) -> String {
+        shellPathQueue.sync {
+            if let cachedPreferredPATH {
+                return cachedPreferredPATH
+            }
+
+            let fallbackPATH = fallback?.isEmpty == false ? fallback! : defaultPATH
+            let loginShellPATH = discoverPATHFromShell(arguments: ["-lc", pathDiscoveryCommand])
+            if let loginShellPATH,
+               loginShellPATH != fallbackPATH || fallbackPATH != defaultPATH {
+                cachedPreferredPATH = loginShellPATH
+                return loginShellPATH
+            }
+
+            if let interactiveLoginShellPATH = discoverPATHFromShell(arguments: ["-ilc", pathDiscoveryCommand]) {
+                cachedPreferredPATH = interactiveLoginShellPATH
+                return interactiveLoginShellPATH
+            }
+
+            if let loginShellPATH {
+                cachedPreferredPATH = loginShellPATH
+                return loginShellPATH
+            }
+
+            return fallbackPATH
+        }
+    }
+
+    static func commandEnvironment(
+        inheritedEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalEnvironment: [String: String] = [:]
+    ) -> [String: String] {
+        var environment = inheritedEnvironmentKeys.reduce(into: [String: String]()) { result, key in
+            if let value = inheritedEnvironment[key], !value.isEmpty {
+                result[key] = value
+            }
+        }
+
+        environment["PATH"] = preferredPATH(fallback: inheritedEnvironment["PATH"])
+        setDefault("HOME", NSHomeDirectory(), in: &environment)
+        setDefault("USER", NSUserName(), in: &environment)
+        setDefault("LOGNAME", NSUserName(), in: &environment)
+        setDefault("SHELL", "/bin/zsh", in: &environment)
+        setDefault("TMPDIR", NSTemporaryDirectory(), in: &environment)
+
+        additionalEnvironment.forEach { key, value in
+            environment[key] = value
+        }
+
+        return environment
+    }
+
+    private static func setDefault(_ key: String, _ value: String, in environment: inout [String: String]) {
+        guard environment[key]?.isEmpty ?? true else { return }
+        environment[key] = value
+    }
+
+    private static let defaultPATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+    private static let pathDiscoveryCommand = "echo __VOICEINK_PATH_START__; print -r -- $PATH; echo __VOICEINK_PATH_END__"
+
+    private static func discoverPATHFromShell(arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = arguments
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in semaphore.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let waitResult = semaphore.wait(timeout: .now() + 3)
+        if waitResult == .timedOut {
+            if process.isRunning {
+                process.terminate()
+            }
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let output = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let startMarker = "__VOICEINK_PATH_START__"
+        let endMarker = "__VOICEINK_PATH_END__"
+
+        guard let startRange = output.range(of: startMarker),
+              let endRange = output.range(of: endMarker, range: startRange.upperBound..<output.endIndex) else {
+            return nil
+        }
+
+        let pathSection = output[startRange.upperBound..<endRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return pathSection.isEmpty ? nil : pathSection
+    }
+}

--- a/VoiceInk/Services/ShellCommandEnvironment.swift
+++ b/VoiceInk/Services/ShellCommandEnvironment.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 enum ShellCommandEnvironment {
@@ -93,19 +94,25 @@ enum ShellCommandEnvironment {
             return nil
         }
 
+        let stdoutBuffer = ShellCommandDataBuffer()
+        let drainGroup = DispatchGroup()
+        drain(stdoutPipe.fileHandleForReading, into: stdoutBuffer, group: drainGroup)
+        drain(stderrPipe.fileHandleForReading, into: nil, group: drainGroup)
+
         let waitResult = semaphore.wait(timeout: .now() + 3)
         if waitResult == .timedOut {
-            if process.isRunning {
-                process.terminate()
-            }
+            terminate(process, semaphore: semaphore)
+            _ = drainGroup.wait(timeout: .now() + 1)
             return nil
         }
 
         guard process.terminationStatus == 0 else {
+            _ = drainGroup.wait(timeout: .now() + 1)
             return nil
         }
 
-        let output = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        _ = drainGroup.wait(timeout: .now() + 1)
+        let output = stdoutBuffer.stringValue()
         let startMarker = "__VOICEINK_PATH_START__"
         let endMarker = "__VOICEINK_PATH_END__"
 
@@ -118,5 +125,50 @@ enum ShellCommandEnvironment {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return pathSection.isEmpty ? nil : pathSection
+    }
+
+    private static func drain(_ handle: FileHandle, into buffer: ShellCommandDataBuffer?, group: DispatchGroup) {
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer {
+                try? handle.close()
+                group.leave()
+            }
+
+            let data = handle.readDataToEndOfFile()
+            buffer?.append(data)
+        }
+    }
+
+    private static func terminate(_ process: Process, semaphore: DispatchSemaphore) {
+        guard process.isRunning else { return }
+
+        process.terminate()
+        if semaphore.wait(timeout: .now() + 1) == .success {
+            return
+        }
+
+        guard process.isRunning else { return }
+        _ = kill(process.processIdentifier, SIGKILL)
+        _ = semaphore.wait(timeout: .now() + 1)
+    }
+}
+
+private final class ShellCommandDataBuffer {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ newData: Data) {
+        guard !newData.isEmpty else { return }
+        lock.lock()
+        data.append(newData)
+        lock.unlock()
+    }
+
+    func stringValue() -> String {
+        lock.lock()
+        let value = data
+        lock.unlock()
+        return String(data: value, encoding: .utf8) ?? ""
     }
 }

--- a/VoiceInk/Transcription/Engine/CustomCommandDeliveryRunner.swift
+++ b/VoiceInk/Transcription/Engine/CustomCommandDeliveryRunner.swift
@@ -1,0 +1,250 @@
+import Darwin
+import Foundation
+import os
+
+struct CustomCommandDeliveryContext {
+    let transcript: String
+
+    var standardInput: String {
+        transcript
+    }
+
+    var environment: [String: String] {
+        [
+            "VOICEINK_TRANSCRIPT": transcript
+        ]
+    }
+}
+
+struct CustomCommandDeliveryResult {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+}
+
+enum CustomCommandDeliveryError: Error, LocalizedError {
+    case commandNotConfigured
+    case noTextToDeliver
+    case launchFailed(String)
+    case timeout(seconds: Double)
+    case nonZeroExit(status: Int32, stderr: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandNotConfigured:
+            return String(localized: "Custom command is empty.")
+        case .noTextToDeliver:
+            return String(localized: "No transcription text was available for the custom command.")
+        case .launchFailed(let message):
+            return String(format: String(localized: "Custom command could not start: %@"), message)
+        case .timeout(let seconds):
+            return String(format: String(localized: "Custom command timed out after %.0f seconds."), seconds)
+        case .nonZeroExit(let status, let stderr):
+            let details = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            if details.isEmpty {
+                return String(format: String(localized: "Custom command exited with status %d."), status)
+            }
+            return String(format: String(localized: "Custom command exited with status %d: %@"), status, String(details.prefix(300)))
+        }
+    }
+}
+
+enum CustomCommandDeliveryRunner {
+    private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "CustomCommandDeliveryRunner")
+
+    static func run(
+        command: String,
+        timeout: TimeInterval,
+        context: CustomCommandDeliveryContext
+    ) async throws -> CustomCommandDeliveryResult {
+        let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCommand.isEmpty else {
+            throw CustomCommandDeliveryError.commandNotConfigured
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                execute(
+                    command: trimmedCommand,
+                    timeout: timeout,
+                    context: context,
+                    continuation: continuation
+                )
+            }
+        }
+    }
+
+    private static func execute(
+        command: String,
+        timeout: TimeInterval,
+        context: CustomCommandDeliveryContext,
+        continuation: CheckedContinuation<CustomCommandDeliveryResult, Error>
+    ) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", command]
+        process.environment = ShellCommandEnvironment.commandEnvironment(
+            additionalEnvironment: context.environment
+        )
+
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardInput = inputPipe
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        let outputBuffer = LockedDataBuffer()
+        let errorBuffer = LockedDataBuffer()
+        let outputDrain = PipeDrainTracker()
+        let errorDrain = PipeDrainTracker()
+        outputPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                outputDrain.finish()
+            } else {
+                outputBuffer.append(data)
+            }
+        }
+        errorPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                errorDrain.finish()
+            } else {
+                errorBuffer.append(data)
+            }
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in semaphore.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            clearHandlers(outputPipe: outputPipe, errorPipe: errorPipe)
+            continuation.resume(throwing: CustomCommandDeliveryError.launchFailed(error.localizedDescription))
+            return
+        }
+
+        writeStandardInput(context.standardInput, to: inputPipe.fileHandleForWriting)
+
+        let waitResult = semaphore.wait(timeout: .now() + timeout)
+        if waitResult == .timedOut {
+            terminate(process, semaphore: semaphore)
+            waitForPipeDrains(outputDrain, errorDrain)
+            clearHandlers(outputPipe: outputPipe, errorPipe: errorPipe)
+            continuation.resume(throwing: CustomCommandDeliveryError.timeout(seconds: timeout))
+            return
+        }
+
+        waitForPipeDrains(outputDrain, errorDrain)
+        clearHandlers(outputPipe: outputPipe, errorPipe: errorPipe)
+
+        let stdout = outputBuffer.stringValue()
+        let stderr = errorBuffer.stringValue()
+
+        guard process.terminationStatus == 0 else {
+            continuation.resume(
+                throwing: CustomCommandDeliveryError.nonZeroExit(
+                    status: process.terminationStatus,
+                    stderr: stderr
+                )
+            )
+            return
+        }
+
+        continuation.resume(
+            returning: CustomCommandDeliveryResult(
+                status: process.terminationStatus,
+                stdout: stdout,
+                stderr: stderr
+            )
+        )
+    }
+
+    private static func writeStandardInput(_ input: String, to handle: FileHandle) {
+        defer { try? handle.close() }
+
+        guard let inputData = input.data(using: .utf8),
+              !inputData.isEmpty else {
+            return
+        }
+
+        do {
+            try handle.write(contentsOf: inputData)
+        } catch {
+            // The command may exit before reading stdin; its exit status is handled separately.
+        }
+    }
+
+    private static func terminate(_ process: Process, semaphore: DispatchSemaphore) {
+        guard process.isRunning else { return }
+
+        process.terminate()
+        if semaphore.wait(timeout: .now() + 2) == .success {
+            return
+        }
+
+        guard process.isRunning else { return }
+        if kill(process.processIdentifier, SIGKILL) != 0 {
+            logger.error("Failed to SIGKILL custom command process \(process.processIdentifier, privacy: .public): errno \(errno, privacy: .public)")
+            return
+        }
+
+        if semaphore.wait(timeout: .now() + 1) == .timedOut {
+            logger.error("Custom command process \(process.processIdentifier, privacy: .public) did not exit after SIGKILL")
+        }
+    }
+
+    private static func clearHandlers(outputPipe: Pipe, errorPipe: Pipe) {
+        outputPipe.fileHandleForReading.readabilityHandler = nil
+        errorPipe.fileHandleForReading.readabilityHandler = nil
+    }
+
+    private static func waitForPipeDrains(_ drains: PipeDrainTracker...) {
+        let deadline = DispatchTime.now() + .milliseconds(500)
+        drains.forEach { $0.wait(until: deadline) }
+    }
+}
+
+private final class LockedDataBuffer {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ newData: Data) {
+        guard !newData.isEmpty else { return }
+        lock.lock()
+        data.append(newData)
+        lock.unlock()
+    }
+
+    func stringValue() -> String {
+        lock.lock()
+        let value = data
+        lock.unlock()
+        return String(data: value, encoding: .utf8) ?? ""
+    }
+}
+
+private final class PipeDrainTracker {
+    private let lock = NSLock()
+    private let group = DispatchGroup()
+    private var didFinish = false
+
+    init() {
+        group.enter()
+    }
+
+    func finish() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !didFinish else { return }
+        didFinish = true
+        group.leave()
+    }
+
+    func wait(until deadline: DispatchTime) {
+        _ = group.wait(timeout: deadline)
+    }
+}

--- a/VoiceInk/Transcription/Engine/CustomCommandDeliveryRunner.swift
+++ b/VoiceInk/Transcription/Engine/CustomCommandDeliveryRunner.swift
@@ -94,9 +94,9 @@ enum CustomCommandDeliveryRunner {
         process.standardOutput = outputPipe
         process.standardError = errorPipe
 
-        let outputBuffer = LockedDataBuffer()
-        let errorBuffer = LockedDataBuffer()
-        let outputDrainGroup = DispatchGroup()
+        let outputCollector = PipeOutputCollector(handle: outputPipe.fileHandleForReading)
+        let errorCollector = PipeOutputCollector(handle: errorPipe.fileHandleForReading)
+        let outputCollectors = [outputCollector, errorCollector]
         let inputWriteGroup = DispatchGroup()
 
         let semaphore = DispatchSemaphore(value: 0)
@@ -105,34 +105,32 @@ enum CustomCommandDeliveryRunner {
         do {
             try process.run()
         } catch {
+            try? inputPipe.fileHandleForWriting.close()
+            outputCollectors.forEach { $0.stop() }
             continuation.resume(throwing: CustomCommandDeliveryError.launchFailed(error.localizedDescription))
             return
         }
 
         let timeoutDeadline = DispatchTime.now() + timeout
-        startDraining(outputPipe.fileHandleForReading, into: outputBuffer, group: outputDrainGroup)
-        startDraining(errorPipe.fileHandleForReading, into: errorBuffer, group: outputDrainGroup)
         startWritingStandardInput(context.standardInput, to: inputPipe.fileHandleForWriting, group: inputWriteGroup)
 
         let waitResult = semaphore.wait(timeout: timeoutDeadline)
         if waitResult == .timedOut {
             terminate(process, semaphore: semaphore)
-            closePipeHandles(inputPipe: inputPipe, outputPipe: outputPipe, errorPipe: errorPipe)
-            _ = waitForGroup(outputDrainGroup, timeout: 2)
+            try? inputPipe.fileHandleForWriting.close()
+            _ = waitForCollectors(outputCollectors, timeout: 1)
+            outputCollectors.forEach { $0.stop() }
             _ = waitForGroup(inputWriteGroup, timeout: 1)
             continuation.resume(throwing: CustomCommandDeliveryError.timeout(seconds: timeout))
             return
         }
 
-        if !waitForGroup(outputDrainGroup, timeout: 5) {
-            logger.error("Custom command output drains did not finish before the grace period elapsed")
-            closePipeHandles(inputPipe: inputPipe, outputPipe: outputPipe, errorPipe: errorPipe)
-            _ = waitForGroup(outputDrainGroup, timeout: 1)
-        }
+        _ = waitForCollectors(outputCollectors, timeout: 2)
+        outputCollectors.forEach { $0.stop() }
         _ = waitForGroup(inputWriteGroup, timeout: 1)
 
-        let stdout = outputBuffer.stringValue()
-        let stderr = errorBuffer.stringValue()
+        let stdout = outputCollector.stringValue()
+        let stderr = errorCollector.stringValue()
 
         guard process.terminationStatus == 0 else {
             continuation.resume(
@@ -151,18 +149,6 @@ enum CustomCommandDeliveryRunner {
                 stderr: stderr
             )
         )
-    }
-
-    private static func startDraining(_ handle: FileHandle, into buffer: LockedDataBuffer, group: DispatchGroup) {
-        group.enter()
-        DispatchQueue.global(qos: .utility).async {
-            defer {
-                try? handle.close()
-                group.leave()
-            }
-
-            buffer.append(handle.readDataToEndOfFile())
-        }
     }
 
     private static func startWritingStandardInput(_ input: String, to handle: FileHandle, group: DispatchGroup) {
@@ -247,39 +233,106 @@ enum CustomCommandDeliveryRunner {
         process.arguments = ["-P", "\(parentPID)"]
 
         let outputPipe = Pipe()
-        let outputBuffer = LockedDataBuffer()
-        let outputDrainGroup = DispatchGroup()
         process.standardOutput = outputPipe
         process.standardError = Pipe()
+        let outputCollector = PipeOutputCollector(handle: outputPipe.fileHandleForReading)
 
         do {
             try process.run()
         } catch {
+            outputCollector.stop()
             return []
         }
 
-        startDraining(outputPipe.fileHandleForReading, into: outputBuffer, group: outputDrainGroup)
         process.waitUntilExit()
-        _ = waitForGroup(outputDrainGroup, timeout: 1)
+        _ = waitForCollectors([outputCollector], timeout: 0.5)
+        outputCollector.stop()
 
         guard process.terminationStatus == 0 else {
             return []
         }
 
-        let output = outputBuffer.stringValue()
+        let output = outputCollector.stringValue()
         return output
             .split(whereSeparator: \.isNewline)
             .compactMap { Int32(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
     }
 
-    private static func closePipeHandles(inputPipe: Pipe, outputPipe: Pipe, errorPipe: Pipe) {
-        try? inputPipe.fileHandleForWriting.close()
-        try? outputPipe.fileHandleForReading.close()
-        try? errorPipe.fileHandleForReading.close()
-    }
-
     private static func waitForGroup(_ group: DispatchGroup, timeout: TimeInterval) -> Bool {
         group.wait(timeout: .now() + timeout) == .success
+    }
+
+    private static func waitForCollectors(_ collectors: [PipeOutputCollector], timeout: TimeInterval) -> Bool {
+        let deadline = DispatchTime.now() + timeout
+        return collectors.allSatisfy { $0.wait(until: deadline) }
+    }
+}
+
+private final class PipeOutputCollector {
+    private let handle: FileHandle
+    private let buffer = LockedDataBuffer()
+    private let drainTracker = PipeDrainTracker()
+    private let stopLock = NSLock()
+    private var stopped = false
+
+    init(handle: FileHandle) {
+        self.handle = handle
+        handle.readabilityHandler = { [weak self] handle in
+            self?.readAvailableData(from: handle)
+        }
+    }
+
+    func stop() {
+        stopLock.lock()
+        guard !stopped else {
+            stopLock.unlock()
+            return
+        }
+        stopped = true
+        stopLock.unlock()
+
+        handle.readabilityHandler = nil
+        drainTracker.finish()
+    }
+
+    func wait(until deadline: DispatchTime) -> Bool {
+        drainTracker.wait(until: deadline)
+    }
+
+    func stringValue() -> String {
+        buffer.stringValue()
+    }
+
+    private func readAvailableData(from handle: FileHandle) {
+        let data = handle.availableData
+        if data.isEmpty {
+            drainTracker.finish()
+        } else {
+            buffer.append(data)
+        }
+    }
+}
+
+private final class PipeDrainTracker {
+    private let lock = NSLock()
+    private let group = DispatchGroup()
+    private var didFinish = false
+
+    init() {
+        group.enter()
+    }
+
+    func finish() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !didFinish else { return }
+        didFinish = true
+        group.leave()
+    }
+
+    func wait(until deadline: DispatchTime) -> Bool {
+        group.wait(timeout: deadline) == .success
     }
 }
 

--- a/VoiceInk/Transcription/Engine/CustomCommandDeliveryRunner.swift
+++ b/VoiceInk/Transcription/Engine/CustomCommandDeliveryRunner.swift
@@ -96,24 +96,8 @@ enum CustomCommandDeliveryRunner {
 
         let outputBuffer = LockedDataBuffer()
         let errorBuffer = LockedDataBuffer()
-        let outputDrain = PipeDrainTracker()
-        let errorDrain = PipeDrainTracker()
-        outputPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if data.isEmpty {
-                outputDrain.finish()
-            } else {
-                outputBuffer.append(data)
-            }
-        }
-        errorPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if data.isEmpty {
-                errorDrain.finish()
-            } else {
-                errorBuffer.append(data)
-            }
-        }
+        let outputDrainGroup = DispatchGroup()
+        let inputWriteGroup = DispatchGroup()
 
         let semaphore = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in semaphore.signal() }
@@ -121,24 +105,31 @@ enum CustomCommandDeliveryRunner {
         do {
             try process.run()
         } catch {
-            clearHandlers(outputPipe: outputPipe, errorPipe: errorPipe)
             continuation.resume(throwing: CustomCommandDeliveryError.launchFailed(error.localizedDescription))
             return
         }
 
-        writeStandardInput(context.standardInput, to: inputPipe.fileHandleForWriting)
+        let timeoutDeadline = DispatchTime.now() + timeout
+        startDraining(outputPipe.fileHandleForReading, into: outputBuffer, group: outputDrainGroup)
+        startDraining(errorPipe.fileHandleForReading, into: errorBuffer, group: outputDrainGroup)
+        startWritingStandardInput(context.standardInput, to: inputPipe.fileHandleForWriting, group: inputWriteGroup)
 
-        let waitResult = semaphore.wait(timeout: .now() + timeout)
+        let waitResult = semaphore.wait(timeout: timeoutDeadline)
         if waitResult == .timedOut {
             terminate(process, semaphore: semaphore)
-            waitForPipeDrains(outputDrain, errorDrain)
-            clearHandlers(outputPipe: outputPipe, errorPipe: errorPipe)
+            closePipeHandles(inputPipe: inputPipe, outputPipe: outputPipe, errorPipe: errorPipe)
+            _ = waitForGroup(outputDrainGroup, timeout: 2)
+            _ = waitForGroup(inputWriteGroup, timeout: 1)
             continuation.resume(throwing: CustomCommandDeliveryError.timeout(seconds: timeout))
             return
         }
 
-        waitForPipeDrains(outputDrain, errorDrain)
-        clearHandlers(outputPipe: outputPipe, errorPipe: errorPipe)
+        if !waitForGroup(outputDrainGroup, timeout: 5) {
+            logger.error("Custom command output drains did not finish before the grace period elapsed")
+            closePipeHandles(inputPipe: inputPipe, outputPipe: outputPipe, errorPipe: errorPipe)
+            _ = waitForGroup(outputDrainGroup, timeout: 1)
+        }
+        _ = waitForGroup(inputWriteGroup, timeout: 1)
 
         let stdout = outputBuffer.stringValue()
         let stderr = errorBuffer.stringValue()
@@ -162,48 +153,133 @@ enum CustomCommandDeliveryRunner {
         )
     }
 
-    private static func writeStandardInput(_ input: String, to handle: FileHandle) {
-        defer { try? handle.close() }
+    private static func startDraining(_ handle: FileHandle, into buffer: LockedDataBuffer, group: DispatchGroup) {
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer {
+                try? handle.close()
+                group.leave()
+            }
 
-        guard let inputData = input.data(using: .utf8),
-              !inputData.isEmpty else {
-            return
+            buffer.append(handle.readDataToEndOfFile())
         }
+    }
 
-        do {
-            try handle.write(contentsOf: inputData)
-        } catch {
-            // The command may exit before reading stdin; its exit status is handled separately.
+    private static func startWritingStandardInput(_ input: String, to handle: FileHandle, group: DispatchGroup) {
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer {
+                try? handle.close()
+                group.leave()
+            }
+
+            guard let inputData = input.data(using: .utf8),
+                  !inputData.isEmpty else {
+                return
+            }
+
+            do {
+                try handle.write(contentsOf: inputData)
+            } catch {
+                // The command may exit before reading stdin; its exit status is handled separately.
+            }
         }
     }
 
     private static func terminate(_ process: Process, semaphore: DispatchSemaphore) {
         guard process.isRunning else { return }
 
-        process.terminate()
-        if semaphore.wait(timeout: .now() + 2) == .success {
-            return
+        let targets = processTreeTargets(rootPID: process.processIdentifier)
+        signalTargets(targets, signal: SIGTERM)
+        let didExitAfterTerminate = semaphore.wait(timeout: .now() + 2) == .success
+
+        let remainingTargets = targets.filter(isProcessRunning)
+        if !remainingTargets.isEmpty {
+            signalTargets(remainingTargets, signal: SIGKILL)
         }
 
-        guard process.isRunning else { return }
-        if kill(process.processIdentifier, SIGKILL) != 0 {
-            logger.error("Failed to SIGKILL custom command process \(process.processIdentifier, privacy: .public): errno \(errno, privacy: .public)")
-            return
-        }
-
-        if semaphore.wait(timeout: .now() + 1) == .timedOut {
+        if !didExitAfterTerminate,
+           semaphore.wait(timeout: .now() + 1) == .timedOut {
             logger.error("Custom command process \(process.processIdentifier, privacy: .public) did not exit after SIGKILL")
         }
     }
 
-    private static func clearHandlers(outputPipe: Pipe, errorPipe: Pipe) {
-        outputPipe.fileHandleForReading.readabilityHandler = nil
-        errorPipe.fileHandleForReading.readabilityHandler = nil
+    private static func processTreeTargets(rootPID: pid_t) -> [pid_t] {
+        Array(descendants(of: rootPID).reversed()) + [rootPID]
     }
 
-    private static func waitForPipeDrains(_ drains: PipeDrainTracker...) {
-        let deadline = DispatchTime.now() + .milliseconds(500)
-        drains.forEach { $0.wait(until: deadline) }
+    private static func signalTargets(_ pids: [pid_t], signal: Int32) {
+        for pid in pids {
+            if kill(pid, signal) != 0 && errno != ESRCH {
+                logger.error("Failed to signal custom command process \(pid, privacy: .public): errno \(errno, privacy: .public)")
+            }
+        }
+    }
+
+    private static func isProcessRunning(_ pid: pid_t) -> Bool {
+        errno = 0
+        if kill(pid, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+
+    private static func descendants(of rootPID: pid_t) -> [pid_t] {
+        var result: [pid_t] = []
+        var queue = [rootPID]
+        var visited = Set<pid_t>()
+
+        while let parentPID = queue.first {
+            queue.removeFirst()
+            guard visited.insert(parentPID).inserted else { continue }
+
+            let childPIDs = children(of: parentPID)
+            result.append(contentsOf: childPIDs)
+            queue.append(contentsOf: childPIDs)
+        }
+
+        return result
+    }
+
+    private static func children(of parentPID: pid_t) -> [pid_t] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-P", "\(parentPID)"]
+
+        let outputPipe = Pipe()
+        let outputBuffer = LockedDataBuffer()
+        let outputDrainGroup = DispatchGroup()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+
+        startDraining(outputPipe.fileHandleForReading, into: outputBuffer, group: outputDrainGroup)
+        process.waitUntilExit()
+        _ = waitForGroup(outputDrainGroup, timeout: 1)
+
+        guard process.terminationStatus == 0 else {
+            return []
+        }
+
+        let output = outputBuffer.stringValue()
+        return output
+            .split(whereSeparator: \.isNewline)
+            .compactMap { Int32(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
+    }
+
+    private static func closePipeHandles(inputPipe: Pipe, outputPipe: Pipe, errorPipe: Pipe) {
+        try? inputPipe.fileHandleForWriting.close()
+        try? outputPipe.fileHandleForReading.close()
+        try? errorPipe.fileHandleForReading.close()
+    }
+
+    private static func waitForGroup(_ group: DispatchGroup, timeout: TimeInterval) -> Bool {
+        group.wait(timeout: .now() + timeout) == .success
     }
 }
 
@@ -223,28 +299,5 @@ private final class LockedDataBuffer {
         let value = data
         lock.unlock()
         return String(data: value, encoding: .utf8) ?? ""
-    }
-}
-
-private final class PipeDrainTracker {
-    private let lock = NSLock()
-    private let group = DispatchGroup()
-    private var didFinish = false
-
-    init() {
-        group.enter()
-    }
-
-    func finish() {
-        lock.lock()
-        defer { lock.unlock() }
-
-        guard !didFinish else { return }
-        didFinish = true
-        group.leave()
-    }
-
-    func wait(until deadline: DispatchTime) {
-        _ = group.wait(timeout: deadline)
     }
 }

--- a/VoiceInk/Transcription/Engine/TranscriptionDelivery.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionDelivery.swift
@@ -102,6 +102,9 @@ final class TranscriptionDelivery {
     }
 
     private func runCustomCommand(command: String, commandText: String) async {
+        let startTime = Date()
+        logger.notice("Custom command started")
+
         do {
             let result = try await CustomCommandDeliveryRunner.run(
                 command: command,
@@ -109,25 +112,39 @@ final class TranscriptionDelivery {
                 context: CustomCommandDeliveryContext(transcript: commandText)
             )
 
+            let duration = Date().timeIntervalSince(startTime)
+            let stdoutBytes = result.stdout.utf8.count
+            let stderrBytes = result.stderr.utf8.count
+
             if !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                logger.debug("Custom command stdout: \(result.stdout, privacy: .public)")
+                logger.notice("Custom command stdout bytes=\(stdoutBytes, privacy: .public): \(result.stdout, privacy: .public)")
             }
 
             if !result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                logger.warning("Custom command stderr: \(result.stderr, privacy: .public)")
+                logger.notice(
+                    "Custom command succeeded with stderr duration=\(Self.formattedDuration(duration), privacy: .public)s stdoutBytes=\(stdoutBytes, privacy: .public) stderrBytes=\(stderrBytes, privacy: .public): \(result.stderr, privacy: .public)"
+                )
+            } else {
+                logger.notice(
+                    "Custom command succeeded duration=\(Self.formattedDuration(duration), privacy: .public)s stdoutBytes=\(stdoutBytes, privacy: .public) stderrBytes=\(stderrBytes, privacy: .public)"
+                )
             }
         } catch {
-            notifyCustomCommandFailure(error)
+            notifyCustomCommandFailure(error, duration: Date().timeIntervalSince(startTime))
         }
     }
 
-    private func notifyCustomCommandFailure(_ error: Error) {
+    private func notifyCustomCommandFailure(_ error: Error, duration: TimeInterval? = nil) {
         let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-        logger.error("Custom command failed: \(message, privacy: .public)")
-        NotificationManager.shared.showNotification(
-            title: String(format: String(localized: "Custom command failed: %@"), String(message.prefix(120))),
-            type: .warning
-        )
+        if let duration {
+            logger.error("Custom command failed duration=\(Self.formattedDuration(duration), privacy: .public)s: \(message, privacy: .public)")
+        } else {
+            logger.error("Custom command failed: \(message, privacy: .public)")
+        }
+    }
+
+    private static func formattedDuration(_ duration: TimeInterval) -> String {
+        String(format: "%.3f", duration)
     }
 
     private func paste(_ text: String, output: OutputRuntimeConfiguration, actions: Actions) async {

--- a/VoiceInk/Transcription/Engine/TranscriptionDelivery.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionDelivery.swift
@@ -1,7 +1,10 @@
 import Foundation
+import os
 
 @MainActor
 final class TranscriptionDelivery {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionDelivery")
+
     struct Request {
         let transcription: Transcription
         let text: String?
@@ -33,6 +36,11 @@ final class TranscriptionDelivery {
         if request.output.outputMode == .respond,
            request.responseConfig != nil || request.responseError != nil {
             await deliverResponse(request, actions: actions)
+            return
+        }
+
+        if request.output.outputMode == .customCommand {
+            await deliverCustomCommand(request, actions: actions)
             return
         }
 
@@ -68,28 +76,89 @@ final class TranscriptionDelivery {
         }
     }
 
-    private func paste(_ text: String, output: OutputRuntimeConfiguration, actions: Actions) async {
-        var textToPaste = text
-        if let restrictionMessage = LicenseViewModel().usageRestrictionMessage {
-            textToPaste = """
-                \(restrictionMessage)
-                \n\(textToPaste)
-                """
+    private func deliverCustomCommand(_ item: Request, actions: Actions) async {
+        guard let text = item.text else {
+            notifyCustomCommandFailure(CustomCommandDeliveryError.noTextToDeliver)
+            SoundManager.shared.playStopSound()
+            await actions.dismiss()
+            return
         }
 
+        guard let customCommand = item.output.customCommand,
+              let command = customCommand.trimmedCommand else {
+            notifyCustomCommandFailure(CustomCommandDeliveryError.commandNotConfigured)
+            SoundManager.shared.playStopSound()
+            await actions.dismiss()
+            return
+        }
+
+        let commandText = deliverableText(from: text)
+        SoundManager.shared.playStopSound()
+        await actions.dismiss()
+
+        Task {
+            await runCustomCommand(command: command, commandText: commandText)
+        }
+    }
+
+    private func runCustomCommand(command: String, commandText: String) async {
+        do {
+            let result = try await CustomCommandDeliveryRunner.run(
+                command: command,
+                timeout: 10,
+                context: CustomCommandDeliveryContext(transcript: commandText)
+            )
+
+            if !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                logger.debug("Custom command stdout: \(result.stdout, privacy: .public)")
+            }
+
+            if !result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                logger.warning("Custom command stderr: \(result.stderr, privacy: .public)")
+            }
+        } catch {
+            notifyCustomCommandFailure(error)
+        }
+    }
+
+    private func notifyCustomCommandFailure(_ error: Error) {
+        let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        logger.error("Custom command failed: \(message, privacy: .public)")
+        NotificationManager.shared.showNotification(
+            title: String(format: String(localized: "Custom command failed: %@"), String(message.prefix(120))),
+            type: .warning
+        )
+    }
+
+    private func paste(_ text: String, output: OutputRuntimeConfiguration, actions: Actions) async {
+        let textToPaste = deliverableText(from: text)
         let appendSpace = UserDefaults.standard.bool(forKey: "AppendTrailingSpace")
         let pastedText = textToPaste + (appendSpace ? " " : "")
-        _ = await CursorPaster.startPasteAtCursor(pastedText).value
         SoundManager.shared.playStopSound()
+        await actions.dismiss()
+
+        let pasteTask = CursorPaster.startPasteAtCursor(pastedText)
 
         let autoSendKey = output.outputMode == .paste ? output.autoSendKey : .none
-        if autoSendKey.isEnabled {
-            Task { @MainActor in
+        Task { @MainActor in
+            _ = await pasteTask.value
+
+            if autoSendKey.isEnabled {
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 CursorPaster.performAutoSend(autoSendKey)
             }
         }
+    }
 
-        await actions.dismiss()
+    private func deliverableText(from text: String) -> String {
+        var textToDeliver = text
+        if let restrictionMessage = LicenseViewModel().usageRestrictionMessage {
+            textToDeliver = """
+                \(restrictionMessage)
+                \n\(textToDeliver)
+                """
+        }
+
+        return textToDeliver
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Custom Command output mode to run a local shell script after transcription. Passes the final transcript via stdin and `VOICEINK_TRANSCRIPT`, and hardens execution with timeouts, process-tree cleanup, non-blocking pipe collectors, and structured logs.

- **New Features**
  - Output mode: Custom Command in the Output picker.
  - Editor with Template menu (Paste and Press Tab, Append to Journal, Search Web).
  - Stores command in config; validates non-empty; localized strings (incl. German).
  - Runs via zsh `-lc` with a 10s timeout; safe env and PATH; captures stdout/stderr; detailed logs on success/failure.

- **Refactors**
  - Added `ShellCommandEnvironment` for PATH discovery and minimal env; used by the runner and `LocalCLIService`.
  - Delivery routes through the new runner; on timeout kills the process tree (SIGTERM → SIGKILL); structured logging; UI badges show non-paste modes consistently.
  - Uses non-blocking pipe output collectors to reliably drain stdout/stderr and avoid deadlocks.

<sup>Written for commit 04c6d543e9366e1d0f21f796d087a30efd31e87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

