### PR TITLE
Add trigger words

### DIFF
--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -5,22 +5,26 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
     let id: UUID
     let title: String
     let promptText: String
+    let triggerWords: [String]
     let useSystemInstructions: Bool
     
     init(
         id: UUID = UUID(),
         title: String,
         promptText: String,
+        triggerWords: [String] = [],
         useSystemInstructions: Bool = true
     ) {
         self.id = id
         self.title = title
         self.promptText = promptText
+        self.triggerWords = Self.normalizedTriggerWords(triggerWords)
         self.useSystemInstructions = useSystemInstructions
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, title, promptText, useSystemInstructions
+        case id, title, promptText, triggerWords, useSystemInstructions
+        case legacyTriggerWord = "triggerWord"
     }
 
     init(from decoder: Decoder) throws {
@@ -28,7 +32,35 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
         id = try container.decode(UUID.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
         promptText = try container.decode(String.self, forKey: .promptText)
+        let decodedTriggerWords = try container.decodeIfPresent([String].self, forKey: .triggerWords)
+        let legacyTriggerWord = try container.decodeIfPresent(String.self, forKey: .legacyTriggerWord)
+        triggerWords = Self.normalizedTriggerWords(
+            decodedTriggerWords ?? legacyTriggerWord.map { [$0] } ?? []
+        )
         useSystemInstructions = try container.decodeIfPresent(Bool.self, forKey: .useSystemInstructions) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(promptText, forKey: .promptText)
+        if !triggerWords.isEmpty {
+            try container.encode(triggerWords, forKey: .triggerWords)
+        }
+        try container.encode(useSystemInstructions, forKey: .useSystemInstructions)
+    }
+
+    private static func normalizedTriggerWords(_ words: [String]) -> [String] {
+        var seen = Set<String>()
+        return words.compactMap { word in
+            let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+
+            let key = trimmed.lowercased()
+            guard seen.insert(key).inserted else { return nil }
+            return trimmed
+        }
     }
     
     var finalPromptText: String {
@@ -43,20 +75,29 @@ struct CustomPrompt: Identifiable, Codable, Equatable {
 // MARK: - UI Extensions
 extension CustomPrompt {
     func promptIcon(isSelected: Bool, onTap: @escaping () -> Void, onEdit: ((CustomPrompt) -> Void)? = nil, onDelete: ((CustomPrompt) -> Void)? = nil) -> some View {
-        Text(title)
-            .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(isSelected ? Color.white : Color.primary)
-            .lineLimit(1)
-            .frame(maxWidth: .infinity, minHeight: 30)
-            .padding(.horizontal, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 7)
-                    .fill(isSelected ? AppTheme.Accent.primary : AppTheme.Surface.control)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 7)
-                    .stroke(AppTheme.Border.control, lineWidth: isSelected ? 0 : 0.5)
-            )
+        HStack(spacing: 6) {
+            Text(title)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            if !triggerWords.isEmpty {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .accessibilityLabel("Has trigger words")
+            }
+        }
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(isSelected ? Color.white : Color.primary)
+        .frame(maxWidth: .infinity, minHeight: 30)
+        .padding(.horizontal, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(isSelected ? AppTheme.Accent.primary : AppTheme.Surface.control)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(AppTheme.Border.control, lineWidth: isSelected ? 0 : 0.5)
+        )
         .contentShape(Rectangle())
         .onTapGesture(count: 2) {
             if let onEdit = onEdit {

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -435,8 +435,18 @@ class AIEnhancementService: ObservableObject {
     }
 
     @discardableResult
-    func addPrompt(title: String, promptText: String, useSystemInstructions: Bool = true) -> CustomPrompt {
-        let newPrompt = CustomPrompt(title: title, promptText: promptText, useSystemInstructions: useSystemInstructions)
+    func addPrompt(
+        title: String,
+        promptText: String,
+        triggerWords: [String] = [],
+        useSystemInstructions: Bool = true
+    ) -> CustomPrompt {
+        let newPrompt = CustomPrompt(
+            title: title,
+            promptText: promptText,
+            triggerWords: triggerWords,
+            useSystemInstructions: useSystemInstructions
+        )
         customPrompts.append(newPrompt)
         return newPrompt
     }

--- a/VoiceInk/Services/PromptDetectionService.swift
+++ b/VoiceInk/Services/PromptDetectionService.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+final class PromptDetectionService {
+    struct Detection {
+        let prompt: CustomPrompt
+        let processedText: String
+    }
+
+    func detectPrompt(in text: String, prompts: [CustomPrompt]) -> Detection? {
+        for candidate in triggerCandidates(from: prompts) {
+            if let processedText = detectAndStripTriggerWord(from: text, triggerWord: candidate.triggerWord) {
+                return Detection(prompt: candidate.prompt, processedText: processedText)
+            }
+        }
+
+        return nil
+    }
+
+    private struct TriggerCandidate {
+        let prompt: CustomPrompt
+        let triggerWord: String
+        let promptIndex: Int
+        let triggerIndex: Int
+    }
+
+    private func triggerCandidates(from prompts: [CustomPrompt]) -> [TriggerCandidate] {
+        prompts.enumerated()
+            .flatMap { promptIndex, prompt in
+                prompt.triggerWords.enumerated().compactMap { triggerIndex, triggerWord -> TriggerCandidate? in
+                    let trimmed = triggerWord.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return nil }
+                    return TriggerCandidate(
+                        prompt: prompt,
+                        triggerWord: trimmed,
+                        promptIndex: promptIndex,
+                        triggerIndex: triggerIndex
+                    )
+                }
+            }
+            .sorted { lhs, rhs in
+                if lhs.triggerWord.count != rhs.triggerWord.count {
+                    return lhs.triggerWord.count > rhs.triggerWord.count
+                }
+                if lhs.promptIndex != rhs.promptIndex {
+                    return lhs.promptIndex < rhs.promptIndex
+                }
+                return lhs.triggerIndex < rhs.triggerIndex
+            }
+    }
+
+    private func detectAndStripTriggerWord(from text: String, triggerWord: String) -> String? {
+        if let afterTrailing = stripTrailingTriggerWord(from: text, triggerWord: triggerWord) {
+            if let afterBoth = stripLeadingTriggerWord(from: afterTrailing, triggerWord: triggerWord) {
+                return afterBoth
+            }
+            return afterTrailing
+        }
+
+        if let afterLeading = stripLeadingTriggerWord(from: text, triggerWord: triggerWord) {
+            if let afterBoth = stripTrailingTriggerWord(from: afterLeading, triggerWord: triggerWord) {
+                return afterBoth
+            }
+            return afterLeading
+        }
+
+        return nil
+    }
+
+    private func stripLeadingTriggerWord(from text: String, triggerWord: String) -> String? {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTrigger = triggerWord.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let triggerRange = trimmedText.range(of: trimmedTrigger, options: [.caseInsensitive]),
+              triggerRange.lowerBound == trimmedText.startIndex else {
+            return nil
+        }
+
+        let triggerEndIndex = triggerRange.upperBound
+
+        if triggerEndIndex < trimmedText.endIndex {
+            let charAfterTrigger = trimmedText[triggerEndIndex]
+            if charAfterTrigger.isLetter || charAfterTrigger.isNumber {
+                return nil
+            }
+        }
+
+        if triggerEndIndex >= trimmedText.endIndex {
+            return ""
+        }
+
+        var remainingText = String(trimmedText[triggerEndIndex...])
+        remainingText = remainingText.replacingOccurrences(
+            of: "^[,\\.!\\?;:\\s]+",
+            with: "",
+            options: .regularExpression
+        )
+        remainingText = remainingText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !remainingText.isEmpty {
+            remainingText = remainingText.prefix(1).uppercased() + remainingText.dropFirst()
+        }
+
+        return remainingText
+    }
+
+    private func stripTrailingTriggerWord(from text: String, triggerWord: String) -> String? {
+        var trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTrigger = triggerWord.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let punctuationSet = CharacterSet(charactersIn: ",.!?;:")
+        while let scalar = trimmedText.unicodeScalars.last, punctuationSet.contains(scalar) {
+            trimmedText.removeLast()
+        }
+
+        guard let triggerRange = trimmedText.range(of: trimmedTrigger, options: [.caseInsensitive, .backwards]),
+              triggerRange.upperBound == trimmedText.endIndex else {
+            return nil
+        }
+
+        let triggerStartIndex = triggerRange.lowerBound
+        if triggerStartIndex > trimmedText.startIndex {
+            let charBeforeTrigger = trimmedText[trimmedText.index(before: triggerStartIndex)]
+            if charBeforeTrigger.isLetter || charBeforeTrigger.isNumber {
+                return nil
+            }
+        }
+
+        var remainingText = String(trimmedText[..<triggerStartIndex])
+        remainingText = remainingText.replacingOccurrences(
+            of: "[,\\.!\\?;:\\s]+$",
+            with: "",
+            options: .regularExpression
+        )
+        remainingText = remainingText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !remainingText.isEmpty {
+            remainingText = remainingText.prefix(1).uppercased() + remainingText.dropFirst()
+        }
+
+        return remainingText
+    }
+}

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -25,6 +25,7 @@ class TranscriptionPipeline {
     private let modelContext: ModelContext
     private let serviceRegistry: TranscriptionServiceRegistry
     private let enhancementService: AIEnhancementService?
+    private let promptDetectionService = PromptDetectionService()
     private let delivery = TranscriptionDelivery()
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionPipeline")
 
@@ -141,7 +142,17 @@ class TranscriptionPipeline {
             finalText = cleanedText
 
             if !assistant.isFollowUp {
-                let resolvedEnhancementConfiguration = enhancementConfiguration()
+                var resolvedEnhancementConfiguration = enhancementConfiguration()
+                var promptDetection: PromptDetectionService.Detection?
+
+                if let enhancementService,
+                   let currentConfiguration = resolvedEnhancementConfiguration,
+                   currentConfiguration.provider != nil,
+                   let detection = promptDetectionService.detectPrompt(in: text, prompts: enhancementService.allPrompts) {
+                    resolvedEnhancementConfiguration = currentConfiguration.replacingPrompt(detection.prompt)
+                    promptDetection = detection
+                }
+
                 let resolvedOutputConfiguration = outputConfiguration()
                 let shouldRespondInRecorder = resolvedOutputConfiguration.outputMode == .respond &&
                     resolvedEnhancementConfiguration?.isEnabled == true &&
@@ -156,7 +167,8 @@ class TranscriptionPipeline {
                 let shortEnhancementWordThreshold = savedThreshold > 0 ? savedThreshold : 3
                 let shouldSkipEnhancement = !shouldRespondInRecorder &&
                     isSkipShortEnhancementEnabled &&
-                    WordCounter.count(in: text) <= shortEnhancementWordThreshold
+                    WordCounter.count(in: text) <= shortEnhancementWordThreshold &&
+                    promptDetection == nil
 
                 if let enhancementService,
                    let resolvedEnhancementConfiguration,
@@ -166,14 +178,15 @@ class TranscriptionPipeline {
                     if shouldCancel() { await finishCanceledTranscription(); return }
 
                     onStateChange(.enhancing)
+                    let textForAI = promptDetection?.processedText ?? text
                     if shouldRespondInRecorder {
-                        await assistant.startResponse(cleanedText, resolvedEnhancementConfiguration)
+                        await assistant.startResponse(textForAI, resolvedEnhancementConfiguration)
                     }
 
                     do {
                         let contextSnapshot = await recordingContextSnapshot()
                         let (enhancedText, enhancementDuration, promptName) = try await enhancementService.enhance(
-                            text,
+                            textForAI,
                             configuration: resolvedEnhancementConfiguration,
                             contextSnapshot: contextSnapshot
                         )

--- a/VoiceInk/Views/PromptEditorView.swift
+++ b/VoiceInk/Views/PromptEditorView.swift
@@ -24,19 +24,13 @@ struct PromptEditorView: View {
     let onDelete: ((CustomPrompt) -> Void)?
     @State private var title: String
     @State private var promptText: String
+    @State private var triggerWords: [String]
+    @State private var newTriggerWord = ""
     @State private var useSystemInstructions: Bool
     @State private var showDeleteConfirmation = false
 
     private var saveButtonTitle: LocalizedStringKey {
         mode == .add ? "Create & Select" : "Save & Select"
-    }
-
-    private var panelTitle: LocalizedStringKey {
-        mode == .add ? "New Prompt" : "Edit Prompt"
-    }
-
-    private var promptKindLabel: LocalizedStringKey {
-        "Prompt"
     }
 
     private var editingPrompt: CustomPrompt? {
@@ -69,10 +63,12 @@ struct PromptEditorView: View {
         case .add:
             _title = State(initialValue: "")
             _promptText = State(initialValue: "")
+            _triggerWords = State(initialValue: [])
             _useSystemInstructions = State(initialValue: true)
         case .edit(let prompt):
             _title = State(initialValue: prompt.title)
             _promptText = State(initialValue: prompt.promptText)
+            _triggerWords = State(initialValue: prompt.triggerWords)
             _useSystemInstructions = State(initialValue: prompt.useSystemInstructions)
         }
     }
@@ -87,13 +83,12 @@ struct PromptEditorView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    identitySection
-
                     if case .add = mode {
                         templateMenu
                     }
 
                     instructionsEditor
+                    triggerWordsEditor
                     systemTemplateToggle
                 }
                 .padding(20)
@@ -131,16 +126,9 @@ struct PromptEditorView: View {
             .keyboardShortcut(.escape, modifiers: [])
             .help("Back")
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(panelTitle)
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-
-                Text(promptKindLabel)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+            TextField("Prompt name", text: $title)
+                .textFieldStyle(.plain)
+                .font(.system(size: 16, weight: .semibold))
 
             Spacer()
         }
@@ -184,16 +172,6 @@ struct PromptEditorView: View {
         .help("Start with a template")
     }
 
-    private var identitySection: some View {
-        TextField("Prompt name", text: $title)
-            .textFieldStyle(.plain)
-            .font(.system(size: 15, weight: .medium))
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
-            .background(AppCardBackground(cornerRadius: 7))
-            .clipShape(RoundedRectangle(cornerRadius: 7))
-    }
-
     private var instructionsEditor: some View {
         ZStack(alignment: .topLeading) {
             TextEditor(text: $promptText)
@@ -211,6 +189,46 @@ struct PromptEditorView: View {
                     .padding(.horizontal, 14)
                     .padding(.top, 10)
                     .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private var triggerWordsEditor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 4) {
+                Text("Trigger Words")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.secondary)
+
+                InfoTip("Say a trigger word at the beginning or end of a transcription to use this prompt for that request. The trigger word is removed before enhancement.")
+            }
+
+            HStack(spacing: 8) {
+                TextField("Add trigger word", text: $newTriggerWord)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(AppCardBackground(cornerRadius: 7))
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+                    .onSubmit(addTriggerWord)
+
+                AddIconButton(
+                    helpText: "Add trigger word",
+                    isDisabled: normalizedNewTriggerWord == nil,
+                    action: addTriggerWord
+                )
+            }
+
+            if !triggerWords.isEmpty {
+                FlowLayout(spacing: 6) {
+                    ForEach(triggerWords, id: \.self) { word in
+                        TriggerWordChip(word: word) {
+                            triggerWords.removeAll { $0 == word }
+                        }
+                    }
+                }
+                .padding(.top, 2)
             }
         }
     }
@@ -268,6 +286,7 @@ struct PromptEditorView: View {
             return enhancementService.addPrompt(
                 title: title,
                 promptText: promptText,
+                triggerWords: triggerWords,
                 useSystemInstructions: useSystemInstructions
             )
         case .edit(let prompt):
@@ -275,10 +294,57 @@ struct PromptEditorView: View {
                 id: prompt.id,
                 title: title,
                 promptText: promptText,
+                triggerWords: triggerWords,
                 useSystemInstructions: useSystemInstructions
             )
             enhancementService.updatePrompt(updatedPrompt)
             return updatedPrompt
         }
+    }
+
+    private var normalizedNewTriggerWord: String? {
+        let trimmed = newTriggerWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard !triggerWords.contains(where: { $0.localizedCaseInsensitiveCompare(trimmed) == .orderedSame }) else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private func addTriggerWord() {
+        guard let word = normalizedNewTriggerWord else { return }
+        triggerWords.append(word)
+        newTriggerWord = ""
+    }
+}
+
+private struct TriggerWordChip: View {
+    let word: String
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "mic.fill")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Text(word)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 140, alignment: .leading)
+
+            Button(action: onDelete) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14, height: 14)
+            }
+            .buttonStyle(.plain)
+            .help("Remove trigger word")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(AppCardBackground(cornerRadius: 7))
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add trigger words that auto-select a prompt when spoken at the start or end of a transcription. The trigger word is removed before enhancement, and you can add/manage them in the prompt editor.

- **New Features**
  - CustomPrompt: added `triggerWords` with trim, lowercase-dedupe, and backward-compatible decoding of legacy `triggerWord`.
  - PromptDetectionService: detects trigger words (case-insensitive) at beginning or end, strips them and nearby punctuation, and capitalizes the remaining text; prioritizes longer matches.
  - TranscriptionPipeline: auto-selects the detected prompt, uses the stripped text for enhancement/response, and bypasses the short-text skip when a trigger is used.
  - PromptEditorView: new Trigger Words section with add/remove chips; shows a mic icon on prompts that have triggers; streamlined header with inline name field.
  - AIEnhancementService: `addPrompt` now accepts `triggerWords` (default empty), so existing calls continue to work.

<sup>Written for commit 4edeb9aeae9922950daf5e09b91ea133d73c8c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

