### PR TITLE
Fix German localization coverage to 100% and resolve stale string ent…

### DIFF
--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -1,130 +1,149 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+  "sourceLanguage": "en",
+  "strings": {
+    "": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         }
       }
     },
-    " " : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " "
+    " ": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " "
           }
         }
       }
     },
-    " (drag to reorder)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " (zum Neuordnen ziehen)"
+    " (drag to reorder)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (zum Neuordnen ziehen)"
           }
         }
       }
     },
-    "'%@' already exists in word replacements" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' existiert bereits in den Wortersetzungen"
+    "'%@' already exists in word replacements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' existiert bereits in den Wortersetzungen"
           }
         }
       }
     },
-    "'%@' is already in the vocabulary" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' ist bereits im Vokabular enthalten"
+    "'%@' is already in the vocabulary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' ist bereits im Vokabular enthalten"
           }
         }
       }
     },
-    "%@ API Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ API-Schlüssel"
+    "%@ API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API-Schlüssel"
           }
         }
       }
     },
-    "%@ connection verified." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-Verbindung verifiziert."
+    "%@ connection verified.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Verbindung verifiziert."
           }
         }
       }
     },
-    "%@ Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-Modus"
+    "%@ Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Modus"
           }
         }
       }
     },
-    "%@ requires macOS 26 or later" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ erfordert macOS 26 oder neuer"
+    "%@ requires macOS 26 or later": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ erfordert macOS 26 oder neuer"
           }
         }
       }
     },
-    "%d Apps" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d App"
+    "%d seconds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d Sekunden"
+          }
+        }
+      }
+    },
+    "%lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
+          }
+        }
+      }
+    },
+    "%lld apps": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d Apps"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d App"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d Apps"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps"
                 }
               }
             }
@@ -132,50 +151,39 @@
         }
       }
     },
-    "%d seconds" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d Sekunden"
-          }
-        }
-      }
-    },
-    "%d Websites" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d Website"
+    "%lld Apps": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d Websites"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d Website"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%d Websites"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps"
                 }
               }
             }
@@ -183,49 +191,39 @@
         }
       }
     },
-    "%lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
-          }
-        }
-      }
-    },
-    "%lld apps" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld App"
+    "%lld days left in trial": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Noch %lld Tag in der Testphase"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Apps"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Noch %lld Tage in der Testphase"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld app"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld day left in trial"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld apps"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld days left in trial"
                 }
               }
             }
@@ -233,79 +231,39 @@
         }
       }
     },
-    "%lld Apps" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld App"
+    "%lld Enhancement models": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Verbesserungsmodell"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Apps"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld App"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Apps"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%lld days left in trial" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Noch %lld Tag in der Testphase"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Noch %lld Tage in der Testphase"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Verbesserungsmodelle"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld day left in trial"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Enhancement model"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld days left in trial"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Enhancement models"
                 }
               }
             }
@@ -313,79 +271,39 @@
         }
       }
     },
-    "%lld Enhancement models" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Verbesserungsmodell"
+    "%lld files": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Datei"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Verbesserungsmodelle"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Enhancement model"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Enhancement models"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%lld files" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Datei"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Dateien"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Dateien"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld file"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld file"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld files"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld files"
                 }
               }
             }
@@ -393,79 +311,39 @@
         }
       }
     },
-    "%lld models" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Modell"
+    "%lld models": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modell"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Modelle"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld model"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld models"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%lld models available" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Modell verfügbar"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Modelle verfügbar"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modelle"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld model available"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld model"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld models available"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld models"
                 }
               }
             }
@@ -473,60 +351,39 @@
         }
       }
     },
-    "%lld seconds" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Sekunden"
-          }
-        }
-      }
-    },
-    "%lld selected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld ausgewählt"
-          }
-        }
-      }
-    },
-    "%lld sessions" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Sitzung"
+    "%lld models available": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modell verfügbar"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Sitzungen"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Modelle verfügbar"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld session"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld model available"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sessions"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld models available"
                 }
               }
             }
@@ -534,79 +391,60 @@
         }
       }
     },
-    "%lld Transcription models" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Transkriptionsmodell"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Transkriptionsmodelle"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Transcription model"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Transcription models"
-                }
-              }
-            }
+    "%lld seconds": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Sekunden"
           }
         }
       }
     },
-    "%lld transcripts" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Transkription"
+    "%lld selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ausgewählt"
+          }
+        }
+      }
+    },
+    "%lld sessions": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Sitzung"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Transkriptionen"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Sitzungen"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld transcript"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld session"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld transcripts"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld sessions"
                 }
               }
             }
@@ -614,79 +452,39 @@
         }
       }
     },
-    "%lld websites" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Website"
+    "%lld Transcription models": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkriptionsmodell"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Websites"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld website"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld websites"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%lld Websites" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Website"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Websites"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkriptionsmodelle"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Website"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transcription model"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Websites"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transcription models"
                 }
               }
             }
@@ -694,2595 +492,39 @@
         }
       }
     },
-    "%lld words" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Wort"
+    "%lld transcripts": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkription"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Wörter"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld word"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld words"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "%lld%%" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld %%"
-          }
-        }
-      }
-    },
-    "••••••••" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "••••••••"
-          }
-        }
-      }
-    },
-    "↵" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "↵"
-          }
-        }
-      }
-    },
-    "+" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "+"
-          }
-        }
-      }
-    },
-    "+%lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "+%lld"
-          }
-        }
-      }
-    },
-    "0s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0 s"
-          }
-        }
-      }
-    },
-    "1 day" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Tag"
-          }
-        }
-      }
-    },
-    "1 hour" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Stunde"
-          }
-        }
-      }
-    },
-    "1.5×" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1,5×"
-          }
-        }
-      }
-    },
-    "1×" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1×"
-          }
-        }
-      }
-    },
-    "1s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 s"
-          }
-        }
-      }
-    },
-    "2×" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2×"
-          }
-        }
-      }
-    },
-    "2s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2 s"
-          }
-        }
-      }
-    },
-    "3 days" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3 Tage"
-          }
-        }
-      }
-    },
-    "3s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3 s"
-          }
-        }
-      }
-    },
-    "4s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4 s"
-          }
-        }
-      }
-    },
-    "5s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5 s"
-          }
-        }
-      }
-    },
-    "7 days" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7 Tage"
-          }
-        }
-      }
-    },
-    "14 days" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "14 Tage"
-          }
-        }
-      }
-    },
-    "15s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "15 s"
-          }
-        }
-      }
-    },
-    "25+ languages" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "25+ Sprachen"
-          }
-        }
-      }
-    },
-    "30 days" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 Tage"
-          }
-        }
-      }
-    },
-    "30% OFF" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30% RABATT"
-          }
-        }
-      }
-    },
-    "30s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 s"
-          }
-        }
-      }
-    },
-    "45s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "45 s"
-          }
-        }
-      }
-    },
-    "60s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "60 s"
-          }
-        }
-      }
-    },
-    "90s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "90 s"
-          }
-        }
-      }
-    },
-    "120s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "120 s"
-          }
-        }
-      }
-    },
-    "180s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "180 s"
-          }
-        }
-      }
-    },
-    "250ms" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "250 ms"
-          }
-        }
-      }
-    },
-    "300s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "300 s"
-          }
-        }
-      }
-    },
-    "500ms" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "500 ms"
-          }
-        }
-      }
-    },
-    "A custom enhancement model with this display name already exists" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein benutzerdefiniertes Verbesserungsmodell mit diesem Anzeigenamen existiert bereits"
-          }
-        }
-      }
-    },
-    "A custom enhancement model with this model name already exists" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein benutzerdefiniertes Verbesserungsmodell mit diesem Modellnamen existiert bereits"
-          }
-        }
-      }
-    },
-    "A mode with the name '%@' already exists." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein Modus mit dem Namen '%@' existiert bereits."
-          }
-        }
-      }
-    },
-    "A model named %@.bin already exists" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein Modell namens %@.bin existiert bereits"
-          }
-        }
-      }
-    },
-    "A model with this name already exists" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein Modell mit diesem Namen existiert bereits"
-          }
-        }
-      }
-    },
-    "A network error occurred: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein Netzwerkfehler ist aufgetreten: %@"
-          }
-        }
-      }
-    },
-    "Accessibility" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bedienungshilfen"
-          }
-        }
-      }
-    },
-    "Accessibility permission is not provided" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein Zugriff auf Bedienungshilfen"
-          }
-        }
-      }
-    },
-    "Accuracy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Genauigkeit"
-          }
-        }
-      }
-    },
-    "Activate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren"
-          }
-        }
-      }
-    },
-    "Activate a license to continue using VoiceInk." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren Sie eine Lizenz, um VoiceInk weiter zu verwenden."
-          }
-        }
-      }
-    },
-    "Activate an existing key, purchase a license, or start a 7-day free trial." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren Sie einen vorhandenen Schlüssel, kaufen Sie eine Lizenz oder starten Sie eine 7-tägige kostenlose Testversion."
-          }
-        }
-      }
-    },
-    "Activate License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz aktivieren"
-          }
-        }
-      }
-    },
-    "Activating" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird aktiviert"
-          }
-        }
-      }
-    },
-    "Activation Delay" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivierungsverzögerung"
-          }
-        }
-      }
-    },
-    "Active" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiv"
-          }
-        }
-      }
-    },
-    "Add" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzufügen"
-          }
-        }
-      }
-    },
-    "Add %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ hinzufügen"
-          }
-        }
-      }
-    },
-    "Add a custom fine-tuned whisper model to use with VoiceInk. Select the downloaded .bin file." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein benutzerdefiniertes, feinjustiertes Whisper-Modell für VoiceInk hinzufügen. Wählen Sie die heruntergeladene .bin-Datei aus."
-          }
-        }
-      }
-    },
-    "Add a new mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuen Modus hinzufügen"
-          }
-        }
-      }
-    },
-    "Add a trailing space after pasted transcription output." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein abschließendes Leerzeichen nach der eingefügten Transkription hinzufügen."
-          }
-        }
-      }
-    },
-    "Add app or website..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App oder Website hinzufügen..."
-          }
-        }
-      }
-    },
-    "Add custom emoji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Emoji hinzufügen"
-          }
-        }
-      }
-    },
-    "Add Custom Enhancement Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Verbesserungsmodell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add custom model" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eigenes Modell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add Custom Transcription Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Transkriptionsmodell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add customized modes for different contexts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Modi für verschiedene Kontexte hinzufügen"
-          }
-        }
-      }
-    },
-    "Add enhancement model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserungsmodell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add files" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateien hinzufügen"
-          }
-        }
-      }
-    },
-    "Add filler word" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Füllwort hinzufügen"
-          }
-        }
-      }
-    },
-    "Add Filler Word" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Füllwort hinzufügen"
-          }
-        }
-      }
-    },
-    "Add microphones in the order VoiceInk should try them." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofone in der Reihenfolge hinzufügen, in der VoiceInk sie verwenden soll."
-          }
-        }
-      }
-    },
-    "Add model" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add New" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neu hinzufügen"
-          }
-        }
-      }
-    },
-    "Add New Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuen Modus hinzufügen"
-          }
-        }
-      }
-    },
-    "Add new prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuen Prompt hinzufügen"
-          }
-        }
-      }
-    },
-    "Add prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt hinzufügen"
-          }
-        }
-      }
-    },
-    "Add Second Shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zweites Tastenkürzel hinzufügen"
-          }
-        }
-      }
-    },
-    "Add Space After Paste" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leerzeichen nach dem Einfügen hinzufügen"
-          }
-        }
-      }
-    },
-    "Add transcription model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsmodell hinzufügen"
-          }
-        }
-      }
-    },
-    "Add trigger" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auslöser hinzufügen"
-          }
-        }
-      }
-    },
-    "Add trigger word" : {
-      "comment" : "A button that adds a new trigger word.",
-      "isCommentAutoGenerated" : true
-    },
-    "Add website" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website hinzufügen"
-          }
-        }
-      }
-    },
-    "Add word" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wort hinzufügen"
-          }
-        }
-      }
-    },
-    "Add word replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wortersetzung hinzufügen"
-          }
-        }
-      }
-    },
-    "Add word to vocabulary" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wort zum Vokabular hinzufügen"
-          }
-        }
-      }
-    },
-    "Additional Shortcuts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weitere Tastaturkürzel"
-          }
-        }
-      }
-    },
-    "Advanced" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erweitert"
-          }
-        }
-      }
-    },
-    "Affiliate" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partnerprogramm"
-          }
-        }
-      }
-    },
-    "AFFILIATE 30%" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AFFILIATE 30%"
-          }
-        }
-      }
-    },
-    "AI Enhancement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Verbesserung"
-          }
-        }
-      }
-    },
-    "AI enhancement failed to process the text." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die KI-Verbesserung konnte den Text nicht verarbeiten."
-          }
-        }
-      }
-    },
-    "AI Enhancement is not enabled or configured" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Verbesserung ist nicht aktiviert oder konfiguriert"
-          }
-        }
-      }
-    },
-    "AI Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Modell"
-          }
-        }
-      }
-    },
-    "AI Models" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Modelle"
-          }
-        }
-      }
-    },
-    "AI Provider" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Anbieter"
-          }
-        }
-      }
-    },
-    "AI Provider Integration" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Anbieter-Integration"
-          }
-        }
-      }
-    },
-    "AI provider not configured. Please check your API key." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Anbieter nicht konfiguriert. Bitte überprüfen Sie Ihren API-Schlüssel."
-          }
-        }
-      }
-    },
-    "AI Request" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Anfrage"
-          }
-        }
-      }
-    },
-    "All settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Einstellungen"
-          }
-        }
-      }
-    },
-    "All Time" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gesamt"
-          }
-        }
-      }
-    },
-    "Allow" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlauben"
-          }
-        }
-      }
-    },
-    "Allow Permissions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berechtigungen erlauben"
-          }
-        }
-      }
-    },
-    "Allow VoiceInk to work across all your apps." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlauben Sie VoiceInk, app-übergreifend zu funktionieren."
-          }
-        }
-      }
-    },
-    "An unexpected error occurred. Please try again or contact support at %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support unter %@"
-          }
-        }
-      }
-    },
-    "An unknown error occurred." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein unbekannter Fehler ist aufgetreten."
-          }
-        }
-      }
-    },
-    "Analyzable" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysierbar"
-          }
-        }
-      }
-    },
-    "Analyze" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysieren"
-          }
-        }
-      }
-    },
-    "Analyzing..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird analysiert..."
-          }
-        }
-      }
-    },
-    "API Endpoint" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Endpunkt"
-          }
-        }
-      }
-    },
-    "API endpoint cannot be empty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Endpunkt darf nicht leer sein"
-          }
-        }
-      }
-    },
-    "API endpoint must be a valid URL" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Endpunkt muss eine gültige URL sein"
-          }
-        }
-      }
-    },
-    "API key" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel"
-          }
-        }
-      }
-    },
-    "API Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel"
-          }
-        }
-      }
-    },
-    "API key cannot be empty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel darf nicht leer sein"
-          }
-        }
-      }
-    },
-    "API Key Configuration" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel-Konfiguration"
-          }
-        }
-      }
-    },
-    "API key for this service is missing. Please configure it in the settings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der API-Schlüssel für diesen Dienst fehlt. Bitte konfigurieren Sie ihn in den Einstellungen."
-          }
-        }
-      }
-    },
-    "API key not configured for streaming transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel für Streaming-Transkription ist nicht konfiguriert"
-          }
-        }
-      }
-    },
-    "Append to Journal" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An Journal anhängen"
-          }
-        }
-      }
-    },
-    "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech kann bis zu 5 Sprachen reservieren. Wählen Sie eine Sprache zum Entfernen aus, bevor Sie die ausgewählte Sprache herunterladen."
-          }
-        }
-      }
-    },
-    "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech kann bis zu 5 Sprachen reservieren. Verwalten Sie reservierte Sprachen in den Moduseinstellungen."
-          }
-        }
-      }
-    },
-    "Apple Speech could not reserve language assets for %@. Manage reserved Apple Speech languages in settings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech konnte die Sprachressourcen für %@ nicht reservieren. Verwalten Sie reservierte Apple-Speech-Sprachen in den Einstellungen."
-          }
-        }
-      }
-    },
-    "Apple Speech did not finish returning transcription results." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech hat die Rückgabe der Transkriptionsergebnisse nicht abgeschlossen."
-          }
-        }
-      }
-    },
-    "Apple Speech does not support this language." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech unterstützt diese Sprache nicht."
-          }
-        }
-      }
-    },
-    "Apple Speech language download failed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download der Apple-Speech-Sprache fehlgeschlagen: %@"
-          }
-        }
-      }
-    },
-    "Apple Speech language downloads are not available on this system." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloads für Apple-Speech-Sprachen sind auf diesem System nicht verfügbar."
-          }
-        }
-      }
-    },
-    "Apple Speech language is downloaded." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Apple-Speech-Sprache wurde heruntergeladen."
-          }
-        }
-      }
-    },
-    "AppleScript" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AppleScript"
-          }
-        }
-      }
-    },
-    "Apply intelligent text formatting to break large block of text into paragraphs." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intelligente Textformatierung anwenden, um große Textblöcke in Absätze zu unterteilen."
-          }
-        }
-      }
-    },
-    "Are you sure you want to delete '%@' prompt? This action cannot be undone." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soll der Prompt „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
-          }
-        }
-      }
-    },
-    "Are you sure you want to delete '%@'? This action cannot be undone." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soll „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
-          }
-        }
-      }
-    },
-    "Are you sure you want to delete the custom enhancement model '%@'?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchten Sie das benutzerdefinierte Verbesserungsmodell '%@' wirklich löschen?"
-          }
-        }
-      }
-    },
-    "Are you sure you want to delete the custom model '%@'?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchten Sie das benutzerdefinierte Modell '%@' wirklich löschen?"
-          }
-        }
-      }
-    },
-    "Are you sure you want to delete the model '%@'?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchten Sie das Modell '%@' wirklich löschen?"
-          }
-        }
-      }
-    },
-    "Arrow" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfeil"
-          }
-        }
-      }
-    },
-    "Ask" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fragen"
-          }
-        }
-      }
-    },
-    "Assistant" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assistent"
-          }
-        }
-      }
-    },
-    "Assistant response was not saved: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assistentenantwort wurde nicht gespeichert: %@"
-          }
-        }
-      }
-    },
-    "Audio" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio"
-          }
-        }
-      }
-    },
-    "Audio Cleanup" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio-Bereinigung"
-          }
-        }
-      }
-    },
-    "Audio device is no longer available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiogerät ist nicht mehr verfügbar"
-          }
-        }
-      }
-    },
-    "Audio file is %.1f seconds long. Please use an audio file that is %.0f seconds or shorter for start and stop sounds." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Audiodatei ist %.1f Sekunden lang. Bitte verwenden Sie für Start- und Stopptöne eine Audiodatei, die %.0f Sekunden oder kürzer ist."
-          }
-        }
-      }
-    },
-    "Audio file not found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiodatei nicht gefunden"
-          }
-        }
-      }
-    },
-    "Audio Input" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audioeingabe"
-          }
-        }
-      }
-    },
-    "AudioUnit not initialized" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AudioUnit nicht initialisiert"
-          }
-        }
-      }
-    },
-    "Auto Send" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch senden"
-          }
-        }
-      }
-    },
-    "Auto-check Updates" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updates automatisch prüfen"
-          }
-        }
-      }
-    },
-    "Auto-delete Audio Files" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiodateien automatisch löschen"
-          }
-        }
-      }
-    },
-    "Auto-delete Transcripts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionen automatisch löschen"
-          }
-        }
-      }
-    },
-    "Autodetected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch erkannt"
-          }
-        }
-      }
-    },
-    "Automatically delete audio recordings while keeping text transcripts intact." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audioaufnahmen automatisch löschen, während Texttranskriptionen erhalten bleiben."
-          }
-        }
-      }
-    },
-    "Automatically delete transcript history based on the retention period you set." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionshistorie automatisch basierend auf dem festgelegten Aufbewahrungszeitraum löschen."
-          }
-        }
-      }
-    },
-    "Automatically presses a key combination after pasting text. Useful for chat applications or forms that use different send shortcuts." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drückt nach dem Einfügen automatisch eine Tastenkombination. Nützlich für Chat-Apps oder Formulare mit abweichenden Sendekürzeln."
-          }
-        }
-      }
-    },
-    "Automatically remove configured filler words like 'uh', 'um', or 'hmm' from transcriptions. If no filler words are configured, this cleanup is skipped." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurierte Füllwörter wie „ähm“, „äh“ oder „hmm“ automatisch aus Transkriptionen entfernen. Wenn keine Füllwörter konfiguriert sind, wird diese Bereinigung übersprungen."
-          }
-        }
-      }
-    },
-    "Automatically skip AI enhancement when the transcription has very few words. Short phrases like \"yes\", \"thank you\", or quick commands don't benefit from enhancement." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Verbesserung automatisch überspringen, wenn die Transkription sehr wenige Wörter enthält. Kurze Phrasen wie „ja“, „danke“ oder schnelle Befehle profitieren nicht von der Verbesserung."
-          }
-        }
-      }
-    },
-    "Available Enhancement Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verfügbare Verbesserungsmodelle"
-          }
-        }
-      }
-    },
-    "Available Microphones" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verfügbare Mikrofone"
-          }
-        }
-      }
-    },
-    "Available Transcription Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verfügbare Transkriptionsmodelle"
-          }
-        }
-      }
-    },
-    "Avg. Audio" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ø Audio"
-          }
-        }
-      }
-    },
-    "Avg. Enhancement Time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ø Verbesserungszeit"
-          }
-        }
-      }
-    },
-    "Avg. Process Time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ø Verarbeitungszeit"
-          }
-        }
-      }
-    },
-    "Avg. Processing" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ø Verarbeitungszeit"
-          }
-        }
-      }
-    },
-    "Back" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurück"
-          }
-        }
-      }
-    },
-    "Backup" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sicherung"
-          }
-        }
-      }
-    },
-    "Base URL" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basis-URL"
-          }
-        }
-      }
-    },
-    "Base URL cannot be empty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basis-URL darf nicht leer sein"
-          }
-        }
-      }
-    },
-    "Base URL must be a valid URL" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basis-URL muss eine gültige URL sein"
-          }
-        }
-      }
-    },
-    "Buy License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz kaufen"
-          }
-        }
-      }
-    },
-    "Buy VoiceInk License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Lizenz kaufen"
-          }
-        }
-      }
-    },
-    "Cancel" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
-          }
-        }
-      }
-    },
-    "Cancel Recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme abbrechen"
-          }
-        }
-      }
-    },
-    "Cancel transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription abbrechen"
-          }
-        }
-      }
-    },
-    "Cannot retry: Audio file not found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederholung nicht möglich: Audiodatei nicht gefunden"
-          }
-        }
-      }
-    },
-    "Cannot Save Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus kann nicht gespeichert werden"
-          }
-        }
-      }
-    },
-    "Changelog" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Änderungsprotokoll"
-          }
-        }
-      }
-    },
-    "Check for Updates" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Updates suchen"
-          }
-        }
-      }
-    },
-    "Check for Updates…" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Updates suchen …"
-          }
-        }
-      }
-    },
-    "Check the default model try again. If the problem persists, try a different model." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie das Standardmodell und versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wählen Sie ein anderes Modell."
-          }
-        }
-      }
-    },
-    "Checking" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird geprüft"
-          }
-        }
-      }
-    },
-    "Checking cached models..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischengespeicherte Modelle werden geprüft..."
-          }
-        }
-      }
-    },
-    "Checking whether this Apple Speech language is downloaded." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wird geprüft, ob diese Apple-Speech-Sprache heruntergeladen ist."
-          }
-        }
-      }
-    },
-    "Choose" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auswählen"
-          }
-        }
-      }
-    },
-    "Choose %@ Sound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-Klang auswählen"
-          }
-        }
-      }
-    },
-    "Choose a Language to Remove" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache zum Entfernen auswählen"
-          }
-        }
-      }
-    },
-    "Choose a location to save your settings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie einen Speicherort für Ihre Einstellungen."
-          }
-        }
-      }
-    },
-    "Choose a settings backup, then select what you want to import." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie ein Einstellungs-Backup und dann aus, was importiert werden soll."
-          }
-        }
-      }
-    },
-    "Choose Files" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateien auswählen"
-          }
-        }
-      }
-    },
-    "Choose Microphone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon auswählen"
-          }
-        }
-      }
-    },
-    "Choose what to import from this backup." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie aus, was aus diesem Backup importiert werden soll."
-          }
-        }
-      }
-    },
-    "Claude, Codex, scripts, or any command" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claude, Codex, Skripte oder beliebige Befehle"
-          }
-        }
-      }
-    },
-    "Cleanup Complete" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bereinigung abgeschlossen"
-          }
-        }
-      }
-    },
-    "Cleanup complete." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bereinigung abgeschlossen."
-          }
-        }
-      }
-    },
-    "Clear" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leeren"
-          }
-        }
-      }
-    },
-    "Clear all items" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Elemente löschen"
-          }
-        }
-      }
-    },
-    "Clipboard" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischenablage"
-          }
-        }
-      }
-    },
-    "Close" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen"
-          }
-        }
-      }
-    },
-    "Cloud" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud"
-          }
-        }
-      }
-    },
-    "Cloud Providers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud-Anbieter"
-          }
-        }
-      }
-    },
-    "Command" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehl"
-          }
-        }
-      }
-    },
-    "Command + Return (⌘⏎)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehlstaste + Eingabe (⌘⏎)"
-          }
-        }
-      }
-    },
-    "Compiling %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ wird kompiliert"
-          }
-        }
-      }
-    },
-    "Complete Onboarding" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung abschließen"
-          }
-        }
-      }
-    },
-    "Configure" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurieren"
-          }
-        }
-      }
-    },
-    "Configure API Keys" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel konfigurieren"
-          }
-        }
-      }
-    },
-    "Configured" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguriert"
-          }
-        }
-      }
-    },
-    "Connect" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden"
-          }
-        }
-      }
-    },
-    "Connect a microphone or allow microphone access, then refresh." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen Sie ein Mikrofon an oder erlauben Sie den Mikrofonzugriff und aktualisieren Sie dann."
-          }
-        }
-      }
-    },
-    "Connect providers here, then choose models inside Modes." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anbieter hier verbinden, dann Modelle in Modi auswählen."
-          }
-        }
-      }
-    },
-    "Connected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbunden"
-          }
-        }
-      }
-    },
-    "Connection" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung"
-          }
-        }
-      }
-    },
-    "Connection verified." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung verifiziert."
-          }
-        }
-      }
-    },
-    "Context Awareness" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontexterkennung"
-          }
-        }
-      }
-    },
-    "Continue" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter"
-          }
-        }
-      }
-    },
-    "Control how VoiceInk handles your transcription data and audio recordings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steuern Sie, wie VoiceInk Ihre Transkriptionsdaten und Audioaufnahmen verwaltet."
-          }
-        }
-      }
-    },
-    "Convert transcription output to lowercase." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsausgabe in Kleinbuchstaben umwandeln."
-          }
-        }
-      }
-    },
-    "Copied" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiert"
-          }
-        }
-      }
-    },
-    "Copied to clipboard" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In Zwischenablage kopiert"
-          }
-        }
-      }
-    },
-    "Copied!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiert!"
-          }
-        }
-      }
-    },
-    "Copy Last Transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte Transkription kopieren"
-          }
-        }
-      }
-    },
-    "Copy License Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzschlüssel kopieren"
-          }
-        }
-      }
-    },
-    "Copy System Info" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systeminfo kopieren"
-          }
-        }
-      }
-    },
-    "Could not add emoji." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji konnte nicht hinzugefügt werden."
-          }
-        }
-      }
-    },
-    "Could not encode settings to JSON: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen konnten nicht als JSON kodiert werden: %@"
-          }
-        }
-      }
-    },
-    "Could not get the file URL from the open panel." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Datei-URL konnte nicht aus dem Öffnen-Dialog ermittelt werden."
-          }
-        }
-      }
-    },
-    "Could not reach the server. Please check your internet connection and try again." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Server konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."
-          }
-        }
-      }
-    },
-    "Could not remove %@ from reserved Apple Speech languages." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ konnte nicht aus den reservierten Apple-Speech-Sprachen entfernt werden."
-          }
-        }
-      }
-    },
-    "Could not save settings to file: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen konnten nicht in der Datei gespeichert werden: %@"
-          }
-        }
-      }
-    },
-    "Could not verify this API key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieser API-Schlüssel konnte nicht verifiziert werden"
-          }
-        }
-      }
-    },
-    "Could not verify this API key. Check the key and try again." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieser API-Schlüssel konnte nicht verifiziert werden. Überprüfen Sie den Schlüssel und versuchen Sie es erneut."
-          }
-        }
-      }
-    },
-    "Create & Select" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen & auswählen"
-          }
-        }
-      }
-    },
-    "Create first mode to automate your VoiceInk workflow based on apps/website you are using" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen Sie Ihren ersten Modus, um Ihren VoiceInk-Workflow basierend auf verwendeten Apps und Websites zu automatisieren"
-          }
-        }
-      }
-    },
-    "Created" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellt"
-          }
-        }
-      }
-    },
-    "Custom" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniert"
-          }
-        }
-      }
-    },
-    "Custom Command" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl"
-          }
-        }
-      }
-    },
-    "Custom command cannot be empty." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl darf nicht leer sein."
-          }
-        }
-      }
-    },
-    "Custom command could not start: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl konnte nicht gestartet werden: %@"
-          }
-        }
-      }
-    },
-    "Custom command exited with status %d: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl wurde mit Status %d beendet: %@"
-          }
-        }
-      }
-    },
-    "Custom command exited with status %d." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl wurde mit Status %d beendet."
-          }
-        }
-      }
-    },
-    "Custom command failed: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl fehlgeschlagen: %@"
-          }
-        }
-      }
-    },
-    "Custom command is empty." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl ist leer."
-          }
-        }
-      }
-    },
-    "Custom command timed out after %.0f seconds." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierter Befehl hat nach %.0f Sekunden das Zeitlimit überschritten."
-          }
-        }
-      }
-    },
-    "Custom Device" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Gerät"
-          }
-        }
-      }
-    },
-    "Custom Enhancement Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Verbesserungsmodelle"
-          }
-        }
-      }
-    },
-    "Custom Model Definitions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Modelldefinitionen"
-          }
-        }
-      }
-    },
-    "Custom Prompts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Prompts"
-          }
-        }
-      }
-    },
-    "Custom Transcription Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Transkriptionsmodelle"
-          }
-        }
-      }
-    },
-    "Custom: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniert: %@"
-          }
-        }
-      }
-    },
-    "Dashboard" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dashboard"
-          }
-        }
-      }
-    },
-    "Date" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum"
-          }
-        }
-      }
-    },
-    "Deactivate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deaktivieren"
-          }
-        }
-      }
-    },
-    "Deactivate License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz deaktivieren"
-          }
-        }
-      }
-    },
-    "Deactivate License?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz deaktivieren?"
-          }
-        }
-      }
-    },
-    "Default" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standard"
-          }
-        }
-      }
-    },
-    "Default mode is used when no app or website matches" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt"
-          }
-        }
-      }
-    },
-    "Default mode is used when no specific app or website matches are found." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt."
-          }
-        }
-      }
-    },
-    "Default uses simulated Cmd+V key events. AppleScript can help when custom keyboard layouts do not paste correctly." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standard verwendet simulierte Cmd+V-Ereignisse. AppleScript kann helfen, wenn benutzerdefinierte Tastaturlayouts nicht korrekt einfügen."
-          }
-        }
-      }
-    },
-    "Delete" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
-          }
-        }
-      }
-    },
-    "Delete %lld Files" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Datei löschen"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Dateien löschen"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Transkriptionen"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Delete %lld File"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld transcript"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Delete %lld Files"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld transcripts"
                 }
               }
             }
@@ -3290,120 +532,39 @@
         }
       }
     },
-    "Delete After" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen nach"
-          }
-        }
-      }
-    },
-    "Delete Custom Enhancement Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Verbesserungsmodell löschen"
-          }
-        }
-      }
-    },
-    "Delete Custom Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Modell löschen"
-          }
-        }
-      }
-    },
-    "Delete Mode?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus löschen?"
-          }
-        }
-      }
-    },
-    "Delete Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell löschen"
-          }
-        }
-      }
-    },
-    "Delete Prompt?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt löschen?"
-          }
-        }
-      }
-    },
-    "Delete Selected Items?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählte Elemente löschen?"
-          }
-        }
-      }
-    },
-    "Deleted" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gelöscht"
-          }
-        }
-      }
-    },
-    "Deleted %lld audio files." : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Audiodatei gelöscht."
+    "%lld websites": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Website"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Audiodateien gelöscht."
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Websites"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Deleted %lld audio file."
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld website"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Deleted %lld audio files."
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld websites"
                 }
               }
             }
@@ -3411,111 +572,39 @@
         }
       }
     },
-    "Deleted files: %lld. Failed: %lld." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gelöschte Dateien: %lld. Fehlgeschlagen: %lld."
-          }
-        }
-      }
-    },
-    "Denied" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verweigert"
-          }
-        }
-      }
-    },
-    "Deselect All" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle abwählen"
-          }
-        }
-      }
-    },
-    "Details" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details"
-          }
-        }
-      }
-    },
-    "Detect speech segments and filter out silence to improve accuracy of local models." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachsegmente erkennen und Stille herausfiltern, um die Genauigkeit lokaler Modelle zu verbessern."
-          }
-        }
-      }
-    },
-    "Device" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerät"
-          }
-        }
-      }
-    },
-    "Diagnostics" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnose"
-          }
-        }
-      }
-    },
-    "Dictated %@ words across %lld sessions." : {
-      "comment" : "Hero subtitle showing word count and session count",
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Sie haben %1$@ Wörter in %2$lld Sitzung diktiert."
+    "%lld Websites": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Website"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Sie haben %1$@ Wörter in %2$lld Sitzungen diktiert."
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Websites"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Dictated %1$@ words across %2$lld session."
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Website"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Dictated %1$@ words across %2$lld sessions."
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Websites"
                 }
               }
             }
@@ -3523,2719 +612,39 @@
         }
       }
     },
-    "Dictation" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diktat"
-          }
-        }
-      }
-    },
-    "Dictionary" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wörterbuch"
-          }
-        }
-      }
-    },
-    "Dictionary Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wörterbuch-Einstellungen"
-          }
-        }
-      }
-    },
-    "Disabled" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deaktiviert"
-          }
-        }
-      }
-    },
-    "Disconnected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Getrennt"
-          }
-        }
-      }
-    },
-    "Dismiss" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen"
-          }
-        }
-      }
-    },
-    "Dismiss Recorder" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme schließen"
-          }
-        }
-      }
-    },
-    "Dismiss shortcut tip" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel-Hinweis schließen"
-          }
-        }
-      }
-    },
-    "Dismiss the VoiceInk recorder and cancel any active recording." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahme schließen und aktive Aufnahme abbrechen."
-          }
-        }
-      }
-    },
-    "Dismiss this promotion" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Angebot ausblenden"
-          }
-        }
-      }
-    },
-    "Dismiss VoiceInk Recorder" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahme schließen"
-          }
-        }
-      }
-    },
-    "Display Name" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anzeigename"
-          }
-        }
-      }
-    },
-    "Display name cannot be empty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anzeigename darf nicht leer sein"
-          }
-        }
-      }
-    },
-    "Docs" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dokumentation"
-          }
-        }
-      }
-    },
-    "Documentation" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dokumentation"
-          }
-        }
-      }
-    },
-    "Done" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fertig"
-          }
-        }
-      }
-    },
-    "Double-click to edit • Right-click for more options" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doppelklick zum Bearbeiten • Rechtsklick für weitere Optionen"
-          }
-        }
-      }
-    },
-    "Download" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herunterladen"
-          }
-        }
-      }
-    },
-    "Download Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell herunterladen"
-          }
-        }
-      }
-    },
-    "Download required for %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download für %@ erforderlich."
-          }
-        }
-      }
-    },
-    "Download this Apple Speech language." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Apple-Speech-Sprache herunterladen."
-          }
-        }
-      }
-    },
-    "Download Transcription Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsmodell herunterladen"
-          }
-        }
-      }
-    },
-    "Downloaded" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heruntergeladen"
-          }
-        }
-      }
-    },
-    "Downloading %@ Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-Modell wird heruntergeladen"
-          }
-        }
-      }
-    },
-    "Downloading assets for the selected Apple Speech language." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ressourcen für die ausgewählte Apple-Speech-Sprache werden heruntergeladen."
-          }
-        }
-      }
-    },
-    "Downloading Core ML Model for %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Core-ML-Modell für %@ wird heruntergeladen"
-          }
-        }
-      }
-    },
-    "Downloading model files: %lld/%lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelldateien werden heruntergeladen: %lld/%lld"
-          }
-        }
-      }
-    },
-    "Downloading..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird heruntergeladen..."
-          }
-        }
-      }
-    },
-    "Drop audio or video files here" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio- oder Videodateien hier ablegen"
-          }
-        }
-      }
-    },
-    "Drop files anywhere to add more" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateien irgendwo ablegen, um weitere hinzuzufügen"
-          }
-        }
-      }
-    },
-    "Drop to add files" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ablegen zum Hinzufügen"
-          }
-        }
-      }
-    },
-    "Duration" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dauer"
-          }
-        }
-      }
-    },
-    "During recording, press Option + 1-9 to switch modes quickly." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drücken Sie während der Aufnahme Option + 1-9, um schnell den Modus zu wechseln."
-          }
-        }
-      }
-    },
-    "e.g. my email, my mail" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "z. B. meine E-Mail, meine Mail"
-          }
-        }
-      }
-    },
-    "e.g. Prakash, VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "z. B. Prakash, VoiceInk"
-          }
-        }
-      }
-    },
-    "e.g. support@tryvoiceink.com" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "z. B. support@tryvoiceink.com"
-          }
-        }
-      }
-    },
-    "Earn With The VoiceInk Affiliate Program" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit dem VoiceInk-Partnerprogramm Geld verdienen"
-          }
-        }
-      }
-    },
-    "Edit" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit Custom Enhancement Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Verbesserungsmodell bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit Custom Transcription Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Transkriptionsmodell bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit Prompt" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzung bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit the apps and websites in this group." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps und Websites in dieser Gruppe bearbeiten."
-          }
-        }
-      }
-    },
-    "Edit trigger group" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auslösergruppe bearbeiten"
-          }
-        }
-      }
-    },
-    "Edit Word Replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wortersetzung bearbeiten"
-          }
-        }
-      }
-    },
-    "Email" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-Mail"
-          }
-        }
-      }
-    },
-    "Email Support" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-Mail-Support"
-          }
-        }
-      }
-    },
-    "Emoji already exists." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji existiert bereits."
-          }
-        }
-      }
-    },
-    "Emoji cannot be empty." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji darf nicht leer sein."
-          }
-        }
-      }
-    },
-    "Enable Accessibility Access" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bedienungshilfen aktivieren"
-          }
-        }
-      }
-    },
-    "Enabled" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiviert"
-          }
-        }
-      }
-    },
-    "Enhance" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbessern"
-          }
-        }
-      }
-    },
-    "Enhanced" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbessert"
-          }
-        }
-      }
-    },
-    "Enhancement" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserung"
-          }
-        }
-      }
-    },
-    "Enhancement failed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserung fehlgeschlagen: %@"
-          }
-        }
-      }
-    },
-    "Enhancement Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserungsmodell"
-          }
-        }
-      }
-    },
-    "Enhancement Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserungsmodelle"
-          }
-        }
-      }
-    },
-    "Enhancement modes and AI actions will stay off. You can always set it up later in the app." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserungsmodi und KI-Aktionen bleiben deaktiviert. Sie können dies später einrichten."
-          }
-        }
-      }
-    },
-    "Enhancement request timed out. Check your connection or increase the timeout duration." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeitüberschreitung bei der Verbesserungsanfrage. Überprüfen Sie Ihre Verbindung oder verlängern Sie die maximale Wartezeit."
-          }
-        }
-      }
-    },
-    "Enhancement Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserungseinstellungen"
-          }
-        }
-      }
-    },
-    "Enhancement Time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserungszeit"
-          }
-        }
-      }
-    },
-    "Enhancing" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird verbessert"
-          }
-        }
-      }
-    },
-    "Enhancing recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme wird verbessert"
-          }
-        }
-      }
-    },
-    "Enhancing..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird verbessert..."
-          }
-        }
-      }
-    },
-    "Enter License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz eingeben"
-          }
-        }
-      }
-    },
-    "Enter License Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzschlüssel eingeben"
-          }
-        }
-      }
-    },
-    "Enter word or phrase to replace (use commas for multiple)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wort oder Ausdruck eingeben (mehrere mit Komma trennen)"
-          }
-        }
-      }
-    },
-    "Enter your" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geben Sie Ihren"
-          }
-        }
-      }
-    },
-    "Enter your %@ API key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ API-Schlüssel eingeben"
-          }
-        }
-      }
-    },
-    "Environment variables available: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk also writes VOICEINK_FULL_PROMPT to stdin for every command." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verfügbare Umgebungsvariablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk schreibt außerdem VOICEINK_FULL_PROMPT für jeden Befehl nach stdin."
-          }
-        }
-      }
-    },
-    "Error" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler"
-          }
-        }
-      }
-    },
-    "Error importing settings: %@. The file might be corrupted or not in the correct format." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Importieren der Einstellungen: %@. Die Datei könnte beschädigt oder im falschen Format sein."
-          }
-        }
-      }
-    },
-    "esc" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esc"
-          }
-        }
-      }
-    },
-    "Examples" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beispiele"
-          }
-        }
-      }
-    },
-    "Experience VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk erleben"
-          }
-        }
-      }
-    },
-    "Experimental" : {
-      "comment" : "A label displayed next to a model that is in experimental use.",
-      "isCommentAutoGenerated" : true
-    },
-    "Explore Affiliate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partnerprogramm erkunden"
-          }
-        }
-      }
-    },
-    "Export" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportieren"
-          }
-        }
-      }
-    },
-    "Export all settings, or choose specific categories when importing a backup." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Einstellungen exportieren oder beim Importieren bestimmte Kategorien wählen."
-          }
-        }
-      }
-    },
-    "Export Canceled" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export abgebrochen"
-          }
-        }
-      }
-    },
-    "Export Error" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportfehler"
-          }
-        }
-      }
-    },
-    "Export Failed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export fehlgeschlagen"
-          }
-        }
-      }
-    },
-    "Export Logs" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protokolle exportieren"
-          }
-        }
-      }
-    },
-    "Export Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen exportieren"
-          }
-        }
-      }
-    },
-    "Export Successful" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export erfolgreich"
-          }
-        }
-      }
-    },
-    "Export VoiceInk Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Einstellungen exportieren"
-          }
-        }
-      }
-    },
-    "Fail immediately" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sofort abbrechen"
-          }
-        }
-      }
-    },
-    "Failed to add '%@': %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' konnte nicht hinzugefügt werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to add replacement: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzung konnte nicht hinzugefügt werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to convert the audio format" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audioformat konnte nicht konvertiert werden"
-          }
-        }
-      }
-    },
-    "Failed to copy audio file" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiodatei konnte nicht kopiert werden"
-          }
-        }
-      }
-    },
-    "Failed to copy transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription konnte nicht kopiert werden"
-          }
-        }
-      }
-    },
-    "Failed to create audio file: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiodatei konnte nicht erstellt werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to create AudioUnit: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AudioUnit konnte nicht erstellt werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to create custom sounds directory" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordner für benutzerdefinierte Töne konnte nicht erstellt werden"
-          }
-        }
-      }
-    },
-    "Failed to disable output: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabe konnte nicht deaktiviert werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to enable input: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingabe konnte nicht aktiviert werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to encode the request body." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anfragetext konnte nicht codiert werden."
-          }
-        }
-      }
-    },
-    "Failed to execute Local CLI command: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler CLI-Befehl konnte nicht ausgeführt werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to export the processed audio" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verarbeitete Audiodatei konnte nicht exportiert werden"
-          }
-        }
-      }
-    },
-    "Failed to extract audio samples" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiosamples konnten nicht extrahiert werden"
-          }
-        }
-      }
-    },
-    "Failed to get device format: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geräteformat konnte nicht gelesen werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to import model: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell konnte nicht importiert werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to initialize AudioUnit: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AudioUnit konnte nicht initialisiert werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to load the transcription model." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsmodell konnte nicht geladen werden."
-          }
-        }
-      }
-    },
-    "Failed to remove replacement: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzung konnte nicht entfernt werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to remove word: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wort konnte nicht entfernt werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to save API key securely" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel konnte nicht sicher gespeichert werden"
-          }
-        }
-      }
-    },
-    "Failed to save changes: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Änderungen konnten nicht gespeichert werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to save custom enhancement model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniertes Verbesserungsmodell konnte nicht gespeichert werden"
-          }
-        }
-      }
-    },
-    "Failed to save imported %@: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importiertes %@ konnte nicht gespeichert werden: %@"
-          }
-        }
-      }
-    },
-    "Failed to set audio format: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audioformat konnte nicht gesetzt werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to set file format: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateiformat konnte nicht gesetzt werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to set input callback: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingabe-Callback konnte nicht gesetzt werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to set input device: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingabegerät konnte nicht gesetzt werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to start AudioUnit: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AudioUnit konnte nicht gestartet werden: %lld"
-          }
-        }
-      }
-    },
-    "Failed to transcribe the audio." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio konnte nicht transkribiert werden."
-          }
-        }
-      }
-    },
-    "Failed to unzip the downloaded Core ML model." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heruntergeladenes Core-ML-Modell konnte nicht entpackt werden."
-          }
-        }
-      }
-    },
-    "Fast multilingual transcription that runs locally on Mac." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schnelle mehrsprachige Transkription, die lokal auf dem Mac läuft."
-          }
-        }
-      }
-    },
-    "Faster than Real-time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schneller als Echtzeit"
-          }
-        }
-      }
-    },
-    "Feedback or Issues?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feedback oder Probleme?"
-          }
-        }
-      }
-    },
-    "fewer keystrokes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "weniger Tastenanschläge"
-          }
-        }
-      }
-    },
-    "Filler word" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Füllwort"
-          }
-        }
-      }
-    },
-    "Finalizing models..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelle werden fertiggestellt..."
-          }
-        }
-      }
-    },
-    "Finish Onboarding" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung abschließen"
-          }
-        }
-      }
-    },
-    "Free updates" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kostenlose Updates"
-          }
-        }
-      }
-    },
-    "General" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemein"
-          }
-        }
-      }
-    },
-    "General Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemeine Einstellungen"
-          }
-        }
-      }
-    },
-    "Get %@ API Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-API-Schlüssel abrufen"
-          }
-        }
-      }
-    },
-    "Get API key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel abrufen"
-          }
-        }
-      }
-    },
-    "Get API Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel abrufen"
-          }
-        }
-      }
-    },
-    "Granted" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gewährt"
-          }
-        }
-      }
-    },
-    "HAL Output AudioUnit not found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HAL Output AudioUnit nicht gefunden"
-          }
-        }
-      }
-    },
-    "Has trigger words" : {
-      "comment" : "A tooltip that describes a custom prompt that has trigger words.",
-      "isCommentAutoGenerated" : true
-    },
-    "Have a license key?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haben Sie einen Lizenzschlüssel?"
-          }
-        }
-      }
-    },
-    "Have feedback, a bug report, or something that feels off? Send a note with system information by email, or join Discord for community discussion. Every report helps make VoiceInk more reliable and easier to use." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haben Sie Feedback, einen Fehlerbericht oder ist etwas nicht stimmig? Senden Sie eine E-Mail mit Systeminformationen oder treten Sie dem Discord für eine Diskussion mit der Community bei. Jeder Bericht hilft dabei, VoiceInk zuverlässiger und einfacher nutzbar zu machen."
-          }
-        }
-      }
-    },
-    "Help & Resources" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hilfe & Ressourcen"
-          }
-        }
-      }
-    },
-    "Hide Dock Icon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dock-Symbol ausblenden"
-          }
-        }
-      }
-    },
-    "History" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verlauf"
-          }
-        }
-      }
-    },
-    "How to use Word Replacements" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwendung von Wortersetzungen"
-          }
-        }
-      }
-    },
-    "Hybrid" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hybrid"
-          }
-        }
-      }
-    },
-    "Immediately" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sofort"
-          }
-        }
-      }
-    },
-    "Import" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importieren"
-          }
-        }
-      }
-    },
-    "Import Canceled" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import abgebrochen"
-          }
-        }
-      }
-    },
-    "Import Error" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importfehler"
-          }
-        }
-      }
-    },
-    "Import Local Model…" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokales Modell importieren…"
-          }
-        }
-      }
-    },
-    "Import Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen importieren"
-          }
-        }
-      }
-    },
-    "Import Successful" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import erfolgreich"
-          }
-        }
-      }
-    },
-    "Import VoiceInk Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Einstellungen importieren"
-          }
-        }
-      }
-    },
-    "IMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the AI Models section." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WICHTIG: Falls Sie KI-Verbesserungsfunktionen verwendet haben, konfigurieren Sie bitte Ihre API-Schlüssel im Bereich KI-Modelle neu."
-          }
-        }
-      }
-    },
-    "Imported %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ importiert"
-          }
-        }
-      }
-    },
-    "Imported local model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokales Modell importiert"
-          }
-        }
-      }
-    },
-    "Info" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
-          }
-        }
-      }
-    },
-    "Interface" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oberfläche"
-          }
-        }
-      }
-    },
-    "Invalid Audio File" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültige Audiodatei"
-          }
-        }
-      }
-    },
-    "Invalid audio file format" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiges Audiodateiformat"
-          }
-        }
-      }
-    },
-    "Invalid emoji." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiges Emoji."
-          }
-        }
-      }
-    },
-    "Invalid model type provided for Native Apple transcription." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiger Modelltyp für native Apple-Transkription angegeben."
-          }
-        }
-      }
-    },
-    "Invalid Ollama server URL" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültige Ollama-Server-URL"
-          }
-        }
-      }
-    },
-    "Invalid response from AI provider." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültige Antwort vom KI-Anbieter."
-          }
-        }
-      }
-    },
-    "Invalid response from Ollama server" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültige Antwort vom Ollama-Server"
-          }
-        }
-      }
-    },
-    "It is recommended that you complete the onboarding." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wird empfohlen, die Einführung abzuschließen."
-          }
-        }
-      }
-    },
-    "It is recommended to restart VoiceInk for all changes to take full effect." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wird empfohlen, VoiceInk neu zu starten, damit alle Änderungen vollständig wirksam werden."
-          }
-        }
-      }
-    },
-    "Join Discord" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discord beitreten"
-          }
-        }
-      }
-    },
-    "Keep" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beibehalten"
-          }
-        }
-      }
-    },
-    "Keep Audio For" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio aufbewahren für"
-          }
-        }
-      }
-    },
-    "Keep Clipboard Content" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischenablage-Inhalt beibehalten"
-          }
-        }
-      }
-    },
-    "Keep preserves punctuation as transcribed. Remove all strips punctuation marks from the transcribed text. Remove trailing period only removes a final period from the transcribed text." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "„Behalten“ bewahrt die Zeichensetzung wie transkribiert. „Alle entfernen“ entfernt alle Satzzeichen. „Nur abschließenden Punkt“ entfernt nur den letzten Punkt des Textes."
-          }
-        }
-      }
-    },
-    "Key verified" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schlüssel verifiziert"
-          }
-        }
-      }
-    },
-    "Keyboard Shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturkürzel"
-          }
-        }
-      }
-    },
-    "Keystrokes Saved" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenanschläge gespart"
-          }
-        }
-      }
-    },
-    "Language" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache"
-          }
-        }
-      }
-    },
-    "Language: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache: %@"
-          }
-        }
-      }
-    },
-    "Language: Autodetected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache: Automatisch erkannt"
-          }
-        }
-      }
-    },
-    "Language: English" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache: Englisch"
-          }
-        }
-      }
-    },
-    "Language: English (only)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache: Nur Englisch"
-          }
-        }
-      }
-    },
-    "Last 7 Days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte 7 Tage"
-          }
-        }
-      }
-    },
-    "Last 30 Days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte 30 Tage"
-          }
-        }
-      }
-    },
-    "Last transcription copied" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte Transkription kopiert"
-          }
-        }
-      }
-    },
-    "Launch at Login" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bei Anmeldung starten"
-          }
-        }
-      }
-    },
-    "Learn more" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehr erfahren"
-          }
-        }
-      }
-    },
-    "License activated successfully!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz erfolgreich aktiviert!"
-          }
-        }
-      }
-    },
-    "License active on this Mac." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz auf diesem Mac aktiv."
-          }
-        }
-      }
-    },
-    "License key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzschlüssel"
-          }
-        }
-      }
-    },
-    "License Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzschlüssel"
-          }
-        }
-      }
-    },
-    "License key not found. Please double-check your key and try again." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzschlüssel nicht gefunden. Bitte überprüfen Sie Ihren Schlüssel und versuchen Sie es erneut."
-          }
-        }
-      }
-    },
-    "License Management" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzverwaltung"
-          }
-        }
-      }
-    },
-    "License required" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz erforderlich"
-          }
-        }
-      }
-    },
-    "License Required" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz erforderlich"
-          }
-        }
-      }
-    },
-    "License validated successfully!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz erfolgreich validiert!"
-          }
-        }
-      }
-    },
-    "Licensed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenziert"
-          }
-        }
-      }
-    },
-    "Licensed (Pro)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenziert (Pro)"
-          }
-        }
-      }
-    },
-    "Lifetime access" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lebenslanger Zugang"
-          }
-        }
-      }
-    },
-    "Lifetime access." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lebenslanger Zugang."
-          }
-        }
-      }
-    },
-    "Listing files from repository..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateien aus dem Repository werden aufgelistet..."
-          }
-        }
-      }
-    },
-    "Load a template or enter a command to enable Local CLI enhancement." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laden Sie eine Vorlage oder geben Sie einen Befehl ein, um die lokale CLI-Verbesserung zu aktivieren."
-          }
-        }
-      }
-    },
-    "Load More" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehr laden"
-          }
-        }
-      }
-    },
-    "Load Template" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorlage laden"
-          }
-        }
-      }
-    },
-    "Loading" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird geladen"
-          }
-        }
-      }
-    },
-    "Loading apps" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps werden geladen"
-          }
-        }
-      }
-    },
-    "Loading model..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell wird geladen..."
-          }
-        }
-      }
-    },
-    "Loading..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird geladen …"
-          }
-        }
-      }
-    },
-    "Local" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal"
-          }
-        }
-      }
-    },
-    "Local & CLI Providers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokale & CLI-Anbieter"
-          }
-        }
-      }
-    },
-    "Local CLI" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokale CLI"
-          }
-        }
-      }
-    },
-    "Local CLI command failed with exit code %lld: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen: %@"
-          }
-        }
-      }
-    },
-    "Local CLI command failed with exit code %lld." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen."
-          }
-        }
-      }
-    },
-    "Local CLI command is not configured. Load a template or enter a command first." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler CLI-Befehl ist nicht konfiguriert. Laden Sie eine Vorlage oder geben Sie zuerst einen Befehl ein."
-          }
-        }
-      }
-    },
-    "Local CLI command returned empty output." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler CLI-Befehl hat eine leere Ausgabe zurückgegeben."
-          }
-        }
-      }
-    },
-    "Local CLI command timed out after %lld seconds." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeitüberschreitung des lokalen CLI-Befehls nach %lld Sekunden."
-          }
-        }
-      }
-    },
-    "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler CLI-Befehl wurde nicht gefunden. Verwenden Sie einen absoluten Pfad oder korrigieren Sie Ihren Shell-PATH. Details: %@"
-          }
-        }
-      }
-    },
-    "Local models don't work reliably on Intel Macs" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokale Modelle funktionieren auf Intel-Macs nicht zuverlässig"
-          }
-        }
-      }
-    },
-    "Local server" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler Server"
-          }
-        }
-      }
-    },
-    "Local Storage" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler Speicher"
-          }
-        }
-      }
-    },
-    "Locked" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gesperrt"
-          }
-        }
-      }
-    },
-    "Lost Key?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schlüssel verloren?"
-          }
-        }
-      }
-    },
-    "Lowercase output" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabe in Kleinbuchstaben"
-          }
-        }
-      }
-    },
-    "macOS 26+" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOS 26+"
-          }
-        }
-      }
-    },
-    "Manage custom enhancement models in the Custom tab." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefinierte Verbesserungsmodelle im Tab „Benutzerdefiniert“ verwalten."
-          }
-        }
-      }
-    },
-    "Manage License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz verwalten"
-          }
-        }
-      }
-    },
-    "Manage Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelle verwalten"
-          }
-        }
-      }
-    },
-    "Manage Modes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modi verwalten"
-          }
-        }
-      }
-    },
-    "Memory" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arbeitsspeicher"
-          }
-        }
-      }
-    },
-    "Microphone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon"
-          }
-        }
-      }
-    },
-    "Microphone Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon-Modus"
-          }
-        }
-      }
-    },
-    "Middle-Click Recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mittelklick-Aufnahme"
-          }
-        }
-      }
-    },
-    "Mini" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mini"
-          }
-        }
-      }
-    },
-    "Minimum words" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mindestwörter"
-          }
-        }
-      }
-    },
-    "Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus"
-          }
-        }
-      }
-    },
-    "Mode name" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modusname"
-          }
-        }
-      }
-    },
-    "Mode name cannot be empty." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modusname darf nicht leer sein."
-          }
-        }
-      }
-    },
-    "Mode shortcuts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus-Tastenkürzel"
-          }
-        }
-      }
-    },
-    "Mode:" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus:"
-          }
-        }
-      }
-    },
-    "Mode: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus: %@"
-          }
-        }
-      }
-    },
-    "model" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell"
-          }
-        }
-      }
-    },
-    "Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell"
-          }
-        }
-      }
-    },
-    "Model Catalog" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modellkatalog"
-          }
-        }
-      }
-    },
-    "Model Name" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modellname"
-          }
-        }
-      }
-    },
-    "Model name cannot be empty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modellname darf nicht leer sein"
-          }
-        }
-      }
-    },
-    "Model Performance" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell-Leistung"
-          }
-        }
-      }
-    },
-    "Model Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelleinstellungen"
-          }
-        }
-      }
-    },
-    "models" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelle"
-          }
-        }
-      }
-    },
-    "models available" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelle verfügbar"
-          }
-        }
-      }
-    },
-    "Modes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modi"
-          }
-        }
-      }
-    },
-    "Modes help you set up VoiceInk for different writing tasks, workflows, and scenarios." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modi helfen Ihnen, VoiceInk für verschiedene Schreibaufgaben, Arbeitsabläufe und Szenarien einzurichten."
-          }
-        }
-      }
-    },
-    "Modes Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modi-Einstellungen"
-          }
-        }
-      }
-    },
-    "More enhancement models available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weitere Verbesserungsmodelle verfügbar"
-          }
-        }
-      }
-    },
-    "More transcription models available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weitere Transkriptionsmodelle verfügbar"
-          }
-        }
-      }
-    },
-    "Move down" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach unten"
-          }
-        }
-      }
-    },
-    "Move up" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach oben"
-          }
-        }
-      }
-    },
-    "ms" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ms"
-          }
-        }
-      }
-    },
-    "Multilingual Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehrsprachiges Modell"
-          }
-        }
-      }
-    },
-    "Mute Audio While Recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio während Aufnahme stummschalten"
-          }
-        }
-      }
-    },
-    "My Custom Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mein benutzerdefiniertes Modell"
-          }
-        }
-      }
-    },
-    "My Enhancement Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mein Verbesserungsmodell"
-          }
-        }
-      }
-    },
-    "my website link" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mein Website-Link"
-          }
-        }
-      }
-    },
-    "Name cannot be empty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name darf nicht leer sein"
-          }
-        }
-      }
-    },
-    "Native Apple" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Natives Apple"
-          }
-        }
-      }
-    },
-    "Needs access" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff erforderlich"
-          }
-        }
-      }
-    },
-    "Network connection failed. Check your internet." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerkverbindung fehlgeschlagen. Überprüfen Sie Ihre Internetverbindung."
-          }
-        }
-      }
-    },
-    "New Prompt" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuer Prompt"
-          }
-        }
-      }
-    },
-    "No AI Model Selected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein KI-Modell ausgewählt"
-          }
-        }
-      }
-    },
-    "No Apps" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Apps"
-          }
-        }
-      }
-    },
-    "No apps found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Apps gefunden"
-          }
-        }
-      }
-    },
-    "No audio files found older than %lld days." : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Keine Audiodateien gefunden, die älter als %lld Tag sind."
+    "%lld words": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Wort"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Keine Audiodateien gefunden, die älter als %lld Tage sind."
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Wörter"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "No audio files found older than %lld day."
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld word"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "No audio files found older than %lld days."
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld words"
                 }
               }
             }
@@ -6243,3093 +652,2552 @@
         }
       }
     },
-    "No automatic triggers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine automatischen Auslöser"
+    "%lld%%": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld %%"
           }
         }
       }
     },
-    "No Custom Enhancement Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine benutzerdefinierten Verbesserungsmodelle"
+    "••••••••": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "••••••••"
           }
         }
       }
     },
-    "No Custom Transcription Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine benutzerdefinierten Transkriptionsmodelle"
+    "↵": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "↵"
           }
         }
       }
     },
-    "No data for this period" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Daten für diesen Zeitraum"
+    "+": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+"
           }
         }
       }
     },
-    "No devices available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Geräte verfügbar"
+    "+%lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld"
           }
         }
       }
     },
-    "No matching apps" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine passenden Apps"
+    "0s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0 s"
           }
         }
       }
     },
-    "No Metadata" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Metadaten"
+    "1 day": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Tag"
           }
         }
       }
     },
-    "No microphones found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Mikrofone gefunden"
+    "1 hour": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Stunde"
           }
         }
       }
     },
-    "No mode selected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein Modus ausgewählt"
+    "1.5×": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1,5×"
           }
         }
       }
     },
-    "No model configured" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein Modell konfiguriert"
+    "1×": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1×"
           }
         }
       }
     },
-    "No model selected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein Modell ausgewählt"
+    "1s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 s"
           }
         }
       }
     },
-    "No models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modelle"
+    "2×": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2×"
           }
         }
       }
     },
-    "No models available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modelle verfügbar"
+    "2s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 s"
           }
         }
       }
     },
-    "No models listed." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modelle aufgelistet."
+    "3 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Tage"
           }
         }
       }
     },
-    "No models loaded" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modelle geladen"
+    "3s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 s"
           }
         }
       }
     },
-    "No models loaded." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modelle geladen."
+    "4s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4 s"
           }
         }
       }
     },
-    "No Modes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modi"
+    "5s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 s"
           }
         }
       }
     },
-    "No modes available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modi verfügbar"
+    "7 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 Tage"
           }
         }
       }
     },
-    "No Modes Available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Modi verfügbar"
+    "14 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "14 Tage"
           }
         }
       }
     },
-    "No Modes Yet" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Noch keine Modi"
+    "15s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 s"
           }
         }
       }
     },
-    "No prompts available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Prompts verfügbar"
+    "25+ languages": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25+ Sprachen"
           }
         }
       }
     },
-    "No Prompts Available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Prompts verfügbar"
+    "30 days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 Tage"
           }
         }
       }
     },
-    "No providers connected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Anbieter verbunden"
+    "30% OFF": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30% RABATT"
           }
         }
       }
     },
-    "No Recorder Sessions Yet" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Noch keine Aufnahmesitzungen"
+    "30s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 s"
           }
         }
       }
     },
-    "No removable language reservations were found." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine entfernbaren Sprachreservierungen gefunden."
+    "45s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "45 s"
           }
         }
       }
     },
-    "No results found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Ergebnisse gefunden"
+    "60s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "60 s"
           }
         }
       }
     },
-    "No Selection" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Auswahl"
+    "90s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 s"
           }
         }
       }
     },
-    "No settings were imported." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wurden keine Einstellungen importiert."
+    "120s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "120 s"
           }
         }
       }
     },
-    "No transcription available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Transkription verfügbar"
+    "180s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "180 s"
           }
         }
       }
     },
-    "No transcription model selected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein Transkriptionsmodell ausgewählt"
+    "250ms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "250 ms"
           }
         }
       }
     },
-    "No transcription models available. Please connect to a cloud service or download a local model in the AI Models tab." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Transkriptionsmodelle verfügbar. Bitte verbinden Sie sich mit einem Cloud-Dienst oder laden Sie im Tab „KI-Modelle“ ein lokales Modell herunter."
+    "300s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "300 s"
           }
         }
       }
     },
-    "No transcription text was available for the custom command." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Für den benutzerdefinierten Befehl war kein Transkriptionstext verfügbar."
+    "500ms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "500 ms"
           }
         }
       }
     },
-    "No transcriptions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Transkriptionen"
+    "A custom enhancement model with this display name already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein benutzerdefiniertes Verbesserungsmodell mit diesem Anzeigenamen existiert bereits"
           }
         }
       }
     },
-    "No transcriptions yet" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Noch keine Transkriptionen"
+    "A custom enhancement model with this model name already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein benutzerdefiniertes Verbesserungsmodell mit diesem Modellnamen existiert bereits"
           }
         }
       }
     },
-    "No triggers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Auslöser"
+    "A mode with the name '%@' already exists.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Modus mit dem Namen '%@' existiert bereits."
           }
         }
       }
     },
-    "No triggers in this group" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Auslöser in dieser Gruppe"
+    "A model named %@.bin already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Modell namens %@.bin existiert bereits"
           }
         }
       }
     },
-    "No Websites" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Websites"
+    "A model with this name already exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Modell mit diesem Namen existiert bereits"
           }
         }
       }
     },
-    "None" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein"
+    "A network error occurred: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Netzwerkfehler ist aufgetreten: %@"
           }
         }
       }
     },
-    "None detected" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nichts erkannt"
+    "Accessibility": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen"
           }
         }
       }
     },
-    "None selected" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nichts ausgewählt"
+    "Accessibility permission is not provided": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Zugriff auf Bedienungshilfen"
           }
         }
       }
     },
-    "Not configured" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht konfiguriert"
+    "Accuracy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genauigkeit"
           }
         }
       }
     },
-    "Not connected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht verbunden"
+    "Activate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren"
           }
         }
       }
     },
-    "Not connected to streaming transcription service" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht mit dem Streaming-Transkriptionsdienst verbunden"
+    "Activate a license to continue using VoiceInk.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie eine Lizenz, um VoiceInk weiter zu verwenden."
           }
         }
       }
     },
-    "Not Determined" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht festgelegt"
+    "Activate an existing key, purchase a license, or start a 7-day free trial.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie einen vorhandenen Schlüssel, kaufen Sie eine Lizenz oder starten Sie eine 7-tägige kostenlose Testversion."
           }
         }
       }
     },
-    "Not Granted" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht gewährt"
+    "Activate License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz aktivieren"
           }
         }
       }
     },
-    "Not Licensed" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht lizenziert"
+    "Activating": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aktiviert"
           }
         }
       }
     },
-    "Notch" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notch"
+    "Activation Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivierungsverzögerung"
           }
         }
       }
     },
-    "Note: Press Option 1-9 during recording to switch modes manually." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinweis: Drücken Sie Option 1-9 während der Aufnahme, um manuell den Modus zu wechseln."
+    "Active": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiv"
           }
         }
       }
     },
-    "Notes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notizen"
+    "Add": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
           }
         }
       }
     },
-    "OK" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "Add %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hinzufügen"
           }
         }
       }
     },
-    "Ollama request timed out" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeitüberschreitung bei der Ollama-Anfrage"
+    "Add a custom fine-tuned whisper model to use with VoiceInk. Select the downloaded .bin file.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein benutzerdefiniertes, feinjustiertes Whisper-Modell für VoiceInk hinzufügen. Wählen Sie die heruntergeladene .bin-Datei aus."
           }
         }
       }
     },
-    "Ollama server error" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ollama-Serverfehler"
+    "Add a new mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Modus hinzufügen"
           }
         }
       }
     },
-    "Ollama service is not available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ollama-Dienst ist nicht verfügbar"
+    "Add a trailing space after pasted transcription output.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein abschließendes Leerzeichen nach der eingefügten Transkription hinzufügen."
           }
         }
       }
     },
-    "On timeout" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bei Timeout"
+    "Add app or website...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App oder Website hinzufügen..."
           }
         }
       }
     },
-    "On-Device" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auf dem Gerät"
+    "Add custom emoji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Emoji hinzufügen"
           }
         }
       }
     },
-    "Open %@ API key page" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ API-Schlüssel-Seite öffnen"
+    "Add Custom Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell hinzufügen"
           }
         }
       }
     },
-    "Open Accessibility settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen für Bedienungshilfen öffnen"
+    "Add custom model": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigenes Modell hinzufügen"
           }
         }
       }
     },
-    "Open history from anywhere with a global shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verlauf von überall mit einem globalen Tastenkürzel öffnen"
+    "Add Custom Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Transkriptionsmodell hinzufügen"
           }
         }
       }
     },
-    "Open History Window" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verlaufsfenster öffnen"
+    "Add customized modes for different contexts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Modi für verschiedene Kontexte hinzufügen"
           }
         }
       }
     },
-    "Open Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen öffnen"
+    "Add enhancement model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodell hinzufügen"
           }
         }
       }
     },
-    "Open Source" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Source"
+    "Add files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien hinzufügen"
           }
         }
       }
     },
-    "OpenAI Compatible" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OpenAI-kompatibel"
+    "Add filler word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwort hinzufügen"
           }
         }
       }
     },
-    "Optimizing model for your device" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell wird für Ihr Gerät optimiert"
+    "Add Filler Word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwort hinzufügen"
           }
         }
       }
     },
-    "or" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "oder"
+    "Add microphones in the order VoiceInk should try them.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofone in der Reihenfolge hinzufügen, in der VoiceInk sie verwenden soll."
           }
         }
       }
     },
-    "Original" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Original"
+    "Add model": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell hinzufügen"
           }
         }
       }
     },
-    "Original Text" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Originaltext"
+    "Add Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell hinzufügen"
           }
         }
       }
     },
-    "Original text (use commas for multiple)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Originaltext (mehrere mit Komma trennen)"
+    "Add New": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neu hinzufügen"
           }
         }
       }
     },
-    "Original:" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Original:"
+    "Add New Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Modus hinzufügen"
           }
         }
       }
     },
-    "Output" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabe"
+    "Add new prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Prompt hinzufügen"
           }
         }
       }
     },
-    "Paragraph breaks" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Absatzumbrüche"
+    "Add prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt hinzufügen"
           }
         }
       }
     },
-    "Paste" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einfügen"
+    "Add Second Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zweites Tastenkürzel hinzufügen"
           }
         }
       }
     },
-    "Paste %@ API key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-API-Schlüssel einfügen"
+    "Add Space After Paste": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leerzeichen nach dem Einfügen hinzufügen"
           }
         }
       }
     },
-    "Paste and Press Tab" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einfügen und Tab drücken"
+    "Add transcription model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell hinzufügen"
           }
         }
       }
     },
-    "Paste API key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel einfügen"
+    "Add trigger": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser hinzufügen"
           }
         }
       }
     },
-    "Paste Last Enhanced Transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte verbesserte Transkription einfügen"
+    "Add trigger word": {
+      "comment": "A button that adds a new trigger word.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöserwort hinzufügen"
           }
         }
       }
     },
-    "Paste Last Transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte Transkription einfügen"
+    "Add website": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website hinzufügen"
           }
         }
       }
     },
-    "Paste Last Transcription (Enhanced)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte Transkription einfügen (Verbessert)"
+    "Add word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort hinzufügen"
           }
         }
       }
     },
-    "Paste Last Transcription (Original)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte Transkription einfügen (Original)"
+    "Add word replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzung hinzufügen"
           }
         }
       }
     },
-    "Paste Method" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einfügemethode"
+    "Add word to vocabulary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort zum Vokabular hinzufügen"
           }
         }
       }
     },
-    "Pasting" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einfügen"
+    "Additional Shortcuts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Tastaturkürzel"
           }
         }
       }
     },
-    "Pause Media While Recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medien während Aufnahme pausieren"
+    "Advanced": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erweitert"
           }
         }
       }
     },
-    "Performance Analysis" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leistungsanalyse"
+    "Affiliate": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partnerprogramm"
           }
         }
       }
     },
-    "Pick the microphone VoiceInk should use for recordings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie das Mikrofon aus, das VoiceInk für Aufnahmen verwenden soll."
+    "AFFILIATE 30%": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AFFILIATE 30%"
           }
         }
       }
     },
-    "Playback speed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiedergabegeschwindigkeit"
+    "AI Enhancement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verbesserung"
           }
         }
       }
     },
-    "Please enter a license key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte geben Sie einen Lizenzschlüssel ein"
+    "AI enhancement failed to process the text.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die KI-Verbesserung konnte den Text nicht verarbeiten."
           }
         }
       }
     },
-    "Please fix the validation errors before saving." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte beheben Sie die Validierungsfehler vor dem Speichern."
+    "AI Enhancement is not enabled or configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verbesserung ist nicht aktiviert oder konfiguriert"
           }
         }
       }
     },
-    "Please restart the application. If the problem persists, contact support." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte starten Sie die Anwendung neu. Wenn das Problem weiterhin besteht, kontaktieren Sie den Support."
+    "AI Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Modell"
           }
         }
       }
     },
-    "Premium Features Activated" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Premium-Funktionen aktiviert"
+    "AI Models": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Modelle"
           }
         }
       }
     },
-    "Press Esc again to cancel" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esc erneut drücken, um abzubrechen"
+    "AI Provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter"
           }
         }
       }
     },
-    "Press shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel drücken"
+    "AI Provider Integration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter-Integration"
           }
         }
       }
     },
-    "Prewarm model (Experimental)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell vorwärmen (Experimentell)"
+    "AI provider not configured. Please check your API key.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter nicht konfiguriert. Bitte überprüfen Sie Ihren API-Schlüssel."
           }
         }
       }
     },
-    "Primary Shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primäres Tastenkürzel"
+    "AI Request": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anfrage"
           }
         }
       }
     },
-    "Prioritized" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Priorisiert"
+    "All settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Einstellungen"
           }
         }
       }
     },
-    "Priority Order" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prioritätsreihenfolge"
+    "All Time": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesamt"
           }
         }
       }
     },
-    "Priority support" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bevorzugter Support"
+    "Allow": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlauben"
           }
         }
       }
     },
-    "Privacy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutz"
+    "Allow Permissions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigungen erlauben"
           }
         }
       }
     },
-    "Privacy Starts Here" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutz beginnt hier"
+    "Allow VoiceInk to work across all your apps.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlauben Sie VoiceInk, app-übergreifend zu funktionieren."
           }
         }
       }
     },
-    "PRO" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRO"
+    "An unexpected error occurred. Please try again or contact support at %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support unter %@"
           }
         }
       }
     },
-    "Processing audio..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio wird verarbeitet..."
+    "An unknown error occurred.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein unbekannter Fehler ist aufgetreten."
           }
         }
       }
     },
-    "Processor" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prozessor"
+    "Analyzable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysierbar"
           }
         }
       }
     },
-    "Prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt"
+    "Analyze": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysieren"
           }
         }
       }
     },
-    "Prompt name" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt-Name"
+    "Analyzing...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird analysiert..."
           }
         }
       }
     },
-    "Provider" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anbieter"
+    "API Endpoint": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Endpunkt"
           }
         }
       }
     },
-    "Provider is not supported" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anbieter wird nicht unterstützt"
+    "API endpoint cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Endpunkt darf nicht leer sein"
           }
         }
       }
     },
-    "Punctuation" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeichensetzung"
+    "API endpoint must be a valid URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Endpunkt muss eine gültige URL sein"
           }
         }
       }
     },
-    "Purchase License" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz kaufen"
+    "API key": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
           }
         }
       }
     },
-    "Push to Talk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push-to-Talk"
+    "API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
           }
         }
       }
     },
-    "Quick Access" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schnellzugriff"
+    "API key cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel darf nicht leer sein"
           }
         }
       }
     },
-    "Quick Add to Dictionary" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schnell zum Wörterbuch hinzufügen"
+    "API Key Configuration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel-Konfiguration"
           }
         }
       }
     },
-    "Quit" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beenden"
+    "API key for this service is missing. Please configure it in the settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der API-Schlüssel für diesen Dienst fehlt. Bitte konfigurieren Sie ihn in den Einstellungen."
           }
         }
       }
     },
-    "Quit VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk beenden"
+    "API key not configured for streaming transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel für Streaming-Transkription ist nicht konfiguriert"
           }
         }
       }
     },
-    "Rate limit exceeded. Please try again later." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ratenlimit überschritten. Bitte versuchen Sie es später erneut."
+    "Append to Journal": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An Journal anhängen"
           }
         }
       }
     },
-    "Re-enhance with selected prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit ausgewähltem Prompt neu verbessern"
+    "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech kann bis zu 5 Sprachen reservieren. Wählen Sie eine Sprache zum Entfernen aus, bevor Sie die ausgewählte Sprache herunterladen."
           }
         }
       }
     },
-    "Re-enhancement failed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneute Verbesserung fehlgeschlagen"
+    "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech kann bis zu 5 Sprachen reservieren. Verwalten Sie reservierte Sprachen in den Moduseinstellungen."
           }
         }
       }
     },
-    "Re-enhancement successful" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneute Verbesserung erfolgreich"
+    "Apple Speech could not reserve language assets for %@. Manage reserved Apple Speech languages in settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech konnte die Sprachressourcen für %@ nicht reservieren. Verwalten Sie reservierte Apple-Speech-Sprachen in den Einstellungen."
           }
         }
       }
     },
-    "REACH OUT" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KONTAKT"
+    "Apple Speech did not finish returning transcription results.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech hat die Rückgabe der Transkriptionsergebnisse nicht abgeschlossen."
           }
         }
       }
     },
-    "Read more about custom local models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehr über benutzerdefinierte lokale Modelle erfahren"
+    "Apple Speech does not support this language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech unterstützt diese Sprache nicht."
           }
         }
       }
     },
-    "Real-time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echtzeit"
+    "Apple Speech language download failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download der Apple-Speech-Sprache fehlgeschlagen: %@"
           }
         }
       }
     },
-    "Recheck" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneut prüfen"
+    "Apple Speech language downloads are not available on this system.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads für Apple-Speech-Sprachen sind auf diesem System nicht verfügbar."
           }
         }
       }
     },
-    "Recommended" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empfohlen"
+    "Apple Speech language is downloaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Apple-Speech-Sprache wurde heruntergeladen."
           }
         }
       }
     },
-    "Recommended Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empfohlene Modelle"
+    "AppleScript": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppleScript"
           }
         }
       }
     },
-    "Record" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnehmen"
+    "Apply intelligent text formatting to break large block of text into paragraphs.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intelligente Textformatierung anwenden, um große Textblöcke in Absätze zu unterteilen."
           }
         }
       }
     },
-    "Record shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel aufnehmen"
+    "Are you sure you want to delete '%@' prompt? This action cannot be undone.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soll der Prompt „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
           }
         }
       }
     },
-    "Recorder Cancel" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme abbrechen"
+    "Are you sure you want to delete '%@'? This action cannot be undone.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soll „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
           }
         }
       }
     },
-    "Recorder Style" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recorder-Stil"
+    "Are you sure you want to delete the custom enhancement model '%@'?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie das benutzerdefinierte Verbesserungsmodell '%@' wirklich löschen?"
           }
         }
       }
     },
-    "Recorder unavailable" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme nicht verfügbar"
+    "Are you sure you want to delete the custom model '%@'?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie das benutzerdefinierte Modell '%@' wirklich löschen?"
           }
         }
       }
     },
-    "Recording Behavior" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmeverhalten"
+    "Are you sure you want to delete the model '%@'?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie das Modell '%@' wirklich löschen?"
           }
         }
       }
     },
-    "Recording failed to start" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme konnte nicht gestartet werden"
+    "Arrow": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfeil"
           }
         }
       }
     },
-    "Recording Failed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme fehlgeschlagen: %@"
+    "Ask": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fragen"
           }
         }
       }
     },
-    "Recording Sounds" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmesounds"
+    "Assistant": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistent"
           }
         }
       }
     },
-    "Refresh" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualisieren"
+    "Assistant response was not saved: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistentenantwort wurde nicht gespeichert: %@"
           }
         }
       }
     },
-    "Refresh Microphones" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofone aktualisieren"
+    "Audio": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio"
           }
         }
       }
     },
-    "Refresh models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelle aktualisieren"
+    "Audio Cleanup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-Bereinigung"
           }
         }
       }
     },
-    "Refresh Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelle aktualisieren"
+    "Audio device is no longer available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiogerät ist nicht mehr verfügbar"
           }
         }
       }
     },
-    "Refreshing" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird aktualisiert"
+    "Audio file is %.1f seconds long. Please use an audio file that is %.0f seconds or shorter for start and stop sounds.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Audiodatei ist %.1f Sekunden lang. Bitte verwenden Sie für Start- und Stopptöne eine Audiodatei, die %.0f Sekunden oder kürzer ist."
           }
         }
       }
     },
-    "Remove" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entfernen"
+    "Audio file not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei nicht gefunden"
           }
         }
       }
     },
-    "Remove %@ from reserved Apple Speech languages." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ aus reservierten Apple-Speech-Sprachen entfernen."
+    "Audio Input": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioeingabe"
           }
         }
       }
     },
-    "Remove all" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle entfernen"
+    "AudioUnit not initialized": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit nicht initialisiert"
           }
         }
       }
     },
-    "Remove API key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel entfernen"
+    "Auto Send": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch senden"
           }
         }
       }
     },
-    "Remove API Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel entfernen"
+    "Auto-check Updates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates automatisch prüfen"
           }
         }
       }
     },
-    "Remove API Key?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel entfernen?"
+    "Auto-delete Audio Files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodateien automatisch löschen"
           }
         }
       }
     },
-    "Remove Filler Words" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Füllwörter entfernen"
+    "Auto-delete Transcripts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen automatisch löschen"
           }
         }
       }
     },
-    "Remove License" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenz entfernen"
+    "Autodetected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch erkannt"
           }
         }
       }
     },
-    "Remove one reserved language to download %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine reservierte Sprache entfernen, um %@ herunterzuladen."
+    "Automatically delete audio recordings while keeping text transcripts intact.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioaufnahmen automatisch löschen, während Texttranskriptionen erhalten bleiben."
           }
         }
       }
     },
-    "Remove replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzung entfernen"
+    "Automatically delete transcript history based on the retention period you set.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionshistorie automatisch basierend auf dem festgelegten Aufbewahrungszeitraum löschen."
           }
         }
       }
     },
-    "Remove trailing period" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schlusspunkt entfernen"
+    "Automatically presses a key combination after pasting text. Useful for chat applications or forms that use different send shortcuts.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drückt nach dem Einfügen automatisch eine Tastenkombination. Nützlich für Chat-Apps oder Formulare mit abweichenden Sendekürzeln."
           }
         }
       }
     },
-    "Remove trigger" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auslöser entfernen"
+    "Automatically remove configured filler words like 'uh', 'um', or 'hmm' from transcriptions. If no filler words are configured, this cleanup is skipped.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurierte Füllwörter wie „ähm“, „äh“ oder „hmm“ automatisch aus Transkriptionen entfernen. Wenn keine Füllwörter konfiguriert sind, wird diese Bereinigung übersprungen."
           }
         }
       }
     },
-    "Remove trigger word" : {
-      "comment" : "A button that removes a trigger word.",
-      "isCommentAutoGenerated" : true
-    },
-    "Remove website" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website entfernen"
-          }
-        }
-      }
-    },
-    "Remove word" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wort entfernen"
-          }
-        }
-      }
-    },
-    "Reorder Modes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modi neu anordnen"
-          }
-        }
-      }
-    },
-    "Replace" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzen"
-          }
-        }
-      }
-    },
-    "Replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzung"
-          }
-        }
-      }
-    },
-    "Replacement text" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersatztext"
-          }
-        }
-      }
-    },
-    "Replacement Text" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersatztext"
-          }
-        }
-      }
-    },
-    "Replacement:" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ersetzung:"
-          }
-        }
-      }
-    },
-    "Report or Feedback" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bericht oder Feedback"
-          }
-        }
-      }
-    },
-    "Request Timeout" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anfrage-Timeout"
-          }
-        }
-      }
-    },
-    "Required" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erforderlich"
-          }
-        }
-      }
-    },
-    "Required for VoiceInk shortcuts and app-wide controls to work properly." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erforderlich für VoiceInk-Tastaturkürzel und app-weite Steuerung."
-          }
-        }
-      }
-    },
-    "Reset" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurücksetzen"
-          }
-        }
-      }
-    },
-    "Reset Onboarding" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung zurücksetzen"
-          }
-        }
-      }
-    },
-    "Reset to default" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auf Standard zurücksetzen"
-          }
-        }
-      }
-    },
-    "Respond" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Antworten"
-          }
-        }
-      }
-    },
-    "Restart VoiceInk after enabling Screen Recording." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk nach dem Aktivieren der Bildschirmaufnahme neu starten."
-          }
-        }
-      }
-    },
-    "Restore Delay" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederherstellungsverzögerung"
-          }
-        }
-      }
-    },
-    "Restricted" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingeschränkt"
-          }
-        }
-      }
-    },
-    "Resume Delay" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederaufnahmeverzögerung"
-          }
-        }
-      }
-    },
-    "Resume Download" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download fortsetzen"
-          }
-        }
-      }
-    },
-    "Retranscribe this audio" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Audio neu transkribieren"
-          }
-        }
-      }
-    },
-    "Retranscription failed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneute Transkription fehlgeschlagen"
-          }
-        }
-      }
-    },
-    "Retranscription successful" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneute Transkription erfolgreich"
-          }
-        }
-      }
-    },
-    "Retry" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederholen"
-          }
-        }
-      }
-    },
-    "Retry failed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederholung fehlgeschlagen: %@"
-          }
-        }
-      }
-    },
-    "Retry Last Transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letzte Transkription wiederholen"
-          }
-        }
-      }
-    },
-    "Return (⏎)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingabe (⏎)"
-          }
-        }
-      }
-    },
-    "Review how VoiceInk handles your data before choosing a license." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie, wie VoiceInk Ihre Daten handhabt, bevor Sie eine Lizenz auswählen."
-          }
-        }
-      }
-    },
-    "Rewrite" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umschreiben"
-          }
-        }
-      }
-    },
-    "Run Cleanup Now" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bereinigung jetzt ausführen"
-          }
-        }
-      }
-    },
-    "Run enhancement with Ollama on this Mac, or send it to any CLI command." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbesserung mit Ollama auf diesem Mac ausführen oder an einen CLI-Befehl senden."
-          }
-        }
-      }
-    },
-    "Runs locally with your user permissions. The final transcript is sent on stdin and exposed as VOICEINK_TRANSCRIPT." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird lokal mit Ihren Benutzerberechtigungen ausgeführt. Das finale Transkript wird über stdin gesendet und als VOICEINK_TRANSCRIPT bereitgestellt."
-          }
-        }
-      }
-    },
-    "Save" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speichern"
-          }
-        }
-      }
-    },
-    "Save & Select" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speichern & auswählen"
-          }
-        }
-      }
-    },
-    "Save as MD" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als MD speichern"
-          }
-        }
-      }
-    },
-    "Save as TXT" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als TXT speichern"
-          }
-        }
-      }
-    },
-    "Save Changes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Änderungen speichern"
-          }
-        }
-      }
-    },
-    "Save this prompt and select it." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diesen Prompt speichern und auswählen."
-          }
-        }
-      }
-    },
-    "Save to file" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In Datei speichern"
-          }
-        }
-      }
-    },
-    "Save Transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription speichern"
-          }
-        }
-      }
-    },
-    "Saving" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird gespeichert"
-          }
-        }
-      }
-    },
-    "Screen" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirm"
-          }
-        }
-      }
-    },
-    "Screen Recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirmaufnahme"
-          }
-        }
-      }
-    },
-    "Search apps or enter website..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps suchen oder Website eingeben..."
-          }
-        }
-      }
-    },
-    "Search transcriptions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionen suchen"
-          }
-        }
-      }
-    },
-    "Search transcriptions..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionen suchen..."
-          }
-        }
-      }
-    },
-    "Search Web" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web durchsuchen"
-          }
-        }
-      }
-    },
-    "Secondary Shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sekundäres Tastenkürzel"
-          }
-        }
-      }
-    },
-    "seconds" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sekunden"
-          }
-        }
-      }
-    },
-    "Select a transcription to view details" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription auswählen, um Details anzuzeigen"
-          }
-        }
-      }
-    },
-    "Select a Whisper ggml .bin model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisper-ggml-.bin-Modell auswählen"
-          }
-        }
-      }
-    },
-    "Select All" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle auswählen"
-          }
-        }
-      }
-    },
-    "Select an audio file" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiodatei auswählen"
-          }
-        }
-      }
-    },
-    "Select an enabled mode to start" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivierten Modus zum Starten auswählen"
+    "Automatically skip AI enhancement when the transcription has very few words. Short phrases like \"yes\", \"thank you\", or quick commands don't benefit from enhancement.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verbesserung automatisch überspringen, wenn die Transkription sehr wenige Wörter enthält. Kurze Phrasen wie „ja“, „danke“ oder schnelle Befehle profitieren nicht von der Verbesserung."
           }
         }
       }
     },
-    "Select at least one category to import." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie mindestens eine Kategorie zum Importieren aus."
+    "Available Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Verbesserungsmodelle"
           }
         }
       }
     },
-    "Select Language" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache auswählen"
+    "Available Microphones": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Mikrofone"
           }
         }
       }
     },
-    "Select mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus auswählen"
+    "Available Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Transkriptionsmodelle"
           }
         }
       }
     },
-    "Select Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus auswählen"
+    "Avg. Audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Audio"
           }
         }
       }
     },
-    "Select Mode %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modus %@ auswählen"
+    "Avg. Enhancement Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Verbesserungszeit"
           }
         }
       }
     },
-    "Select Prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt auswählen"
+    "Avg. Process Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Verarbeitungszeit"
           }
         }
       }
     },
-    "Select sound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klang auswählen"
+    "Avg. Processing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ø Verarbeitungszeit"
           }
         }
       }
     },
-    "selected" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ausgewählt"
+    "Back": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück"
           }
         }
       }
     },
-    "Selected Microphone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewähltes Mikrofon"
+    "Backup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sicherung"
           }
         }
       }
     },
-    "Selected model not found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewähltes Modell nicht gefunden"
+    "Base URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basis-URL"
           }
         }
       }
     },
-    "Selected Text" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählter Text"
+    "Base URL cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basis-URL darf nicht leer sein"
           }
         }
       }
     },
-    "Send follow up" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Folgenachricht senden"
+    "Base URL must be a valid URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basis-URL muss eine gültige URL sein"
           }
         }
       }
     },
-    "Separate multiple originals with commas:" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehrere Originale mit Komma trennen:"
+    "Buy License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz kaufen"
           }
         }
       }
     },
-    "Server" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server"
+    "Buy VoiceInk License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Lizenz kaufen"
           }
         }
       }
     },
-    "Server error (%d). Please try again later or contact support." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Serverfehler (%d). Bitte versuchen Sie es später erneut oder kontaktieren Sie den Support."
+    "Cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         }
       }
     },
-    "Server:" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server:"
+    "Cancel Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme abbrechen"
           }
         }
       }
     },
-    "Server: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server: %@"
+    "Cancel transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription abbrechen"
           }
         }
       }
     },
-    "Sessions Recorded" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufgenommene Sitzungen"
+    "Cannot retry: Audio file not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholung nicht möglich: Audiodatei nicht gefunden"
           }
         }
       }
     },
-    "Set as default" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als Standard festlegen"
+    "Cannot Save Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus kann nicht gespeichert werden"
           }
         }
       }
     },
-    "Set how long to wait for the AI provider to respond. If no response is received within this duration, you can either fail immediately and paste the original transcription, or retry the request up to 3 attempts." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legen Sie fest, wie lange auf eine Antwort des KI-Anbieters gewartet werden soll. Wenn innerhalb dieser Dauer keine Antwort eingeht, können Sie entweder sofort abbrechen und die ursprüngliche Transkription einfügen oder die Anfrage bis zu 3-mal wiederholen."
+    "Changelog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungsprotokoll"
           }
         }
       }
     },
-    "Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+    "Check for Updates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen"
           }
         }
       }
     },
-    "Settings imported successfully from %@.\n\nImported: %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen erfolgreich aus %@ importiert.\n\nImportiert: %@."
+    "Check for Updates…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen …"
           }
         }
       }
     },
-    "Share & Unlock" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teilen & freischalten"
+    "Check the default model try again. If the problem persists, try a different model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie das Standardmodell und versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wählen Sie ein anderes Modell."
           }
         }
       }
     },
-    "Share VoiceInk on your socials, and instantly unlock a 30% discount on VoiceInk Pro." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teilen Sie VoiceInk in Ihren sozialen Netzwerken und schalten Sie sofort 30 % Rabatt auf VoiceInk Pro frei."
+    "Checking": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft"
           }
         }
       }
     },
-    "Share VoiceInk with friends or your audience and receive 30% on every referral that upgrades." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empfehlen Sie VoiceInk Freunden oder Ihrem Publikum und erhalten Sie 30 % für jede geworbene Person, die ein Upgrade durchführt."
+    "Checking cached models...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischengespeicherte Modelle werden geprüft..."
           }
         }
       }
     },
-    "Shift + Return (⇧⏎)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umschalttaste + Eingabe (⇧⏎)"
+    "Checking whether this Apple Speech language is downloaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wird geprüft, ob diese Apple-Speech-Sprache heruntergeladen ist."
           }
         }
       }
     },
-    "Shortcut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel"
+    "Choose": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswählen"
           }
         }
       }
     },
-    "Shortcut already used by %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel wird bereits von %@ verwendet"
+    "Choose %@ Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Klang auswählen"
           }
         }
       }
     },
-    "Shortcut not allowed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel nicht erlaubt: %@"
+    "Choose a Language to Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache zum Entfernen auswählen"
           }
         }
       }
     },
-    "Shortcut reserved by macOS: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenkürzel von macOS reserviert: %@"
+    "Choose a location to save your settings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie einen Speicherort für Ihre Einstellungen."
           }
         }
       }
     },
-    "Shortcuts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturkürzel"
+    "Choose a settings backup, then select what you want to import.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie ein Einstellungs-Backup und dann aus, was importiert werden soll."
           }
         }
       }
     },
-    "Show Announcements" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ankündigungen anzeigen"
+    "Choose Files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien auswählen"
           }
         }
       }
     },
-    "Show Dock Icon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dock-Symbol anzeigen"
+    "Choose Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon auswählen"
           }
         }
       }
     },
-    "Show in Finder" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Im Finder zeigen"
+    "Choose what to import from this backup.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie aus, was aus diesem Backup importiert werden soll."
           }
         }
       }
     },
-    "Skip" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überspringen"
+    "Claude, Codex, scripts, or any command": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude, Codex, Skripte oder beliebige Befehle"
           }
         }
       }
     },
-    "Skip API setup" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Einrichtung überspringen"
+    "Cleanup Complete": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigung abgeschlossen"
           }
         }
       }
     },
-    "Skip API Setup" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Einrichtung überspringen"
+    "Cleanup complete.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigung abgeschlossen."
           }
         }
       }
     },
-    "Skip API setup?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Einrichtung überspringen?"
+    "Clear": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeren"
           }
         }
       }
     },
-    "Skip onboarding" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung überspringen"
+    "Clear all items": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Elemente löschen"
           }
         }
       }
     },
-    "Skip Onboarding" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung überspringen"
+    "Clipboard": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischenablage"
           }
         }
       }
     },
-    "Skip onboarding?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung überspringen?"
+    "Close": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
           }
         }
       }
     },
-    "Skip short transcriptions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kurze Transkriptionen überspringen"
+    "Cloud": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud"
           }
         }
       }
     },
-    "Slower than Real-time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langsamer als Echtzeit"
+    "Cloud Providers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-Anbieter"
           }
         }
       }
     },
-    "Sort alphabetically" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alphabetisch sortieren"
+    "Command": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehl"
           }
         }
       }
     },
-    "Sort by original" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Original sortieren"
+    "Command + Return (⌘⏎)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehlstaste + Eingabe (⌘⏎)"
           }
         }
       }
     },
-    "Sort by replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Ersatz sortieren"
+    "Compiling %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird kompiliert"
           }
         }
       }
     },
-    "Sound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klang"
+    "Complete Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung abschließen"
           }
         }
       }
     },
-    "SpeechAnalyzer requires macOS 26 or later." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SpeechAnalyzer erfordert macOS 26 oder neuer."
+    "Configure": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurieren"
           }
         }
       }
     },
-    "Speed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geschwindigkeit"
+    "Configure API Keys": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel konfigurieren"
           }
         }
       }
     },
-    "Start" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten"
+    "Configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguriert"
           }
         }
       }
     },
-    "Start 7-day Trial" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7-tägige Testversion starten"
+    "Connect": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
           }
         }
       }
     },
-    "Start or stop the VoiceInk recorder for voice transcription." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahme für Sprachtranskription starten oder stoppen."
+    "Connect a microphone or allow microphone access, then refresh.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen Sie ein Mikrofon an oder erlauben Sie den Mikrofonzugriff und aktualisieren Sie dann."
           }
         }
       }
     },
-    "Start recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme starten"
+    "Connect providers here, then choose models inside Modes.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter hier verbinden, dann Modelle in Modi auswählen."
           }
         }
       }
     },
-    "Start Sound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Startklang"
+    "Connected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
           }
         }
       }
     },
-    "Start transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription starten"
+    "Connection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung"
           }
         }
       }
     },
-    "Start with a template" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit einer Vorlage beginnen"
+    "Connection verified.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung verifiziert."
           }
         }
       }
     },
-    "Start your first recording to unlock value insights." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten Sie Ihre erste Aufnahme, um wertvolle Einblicke zu erhalten."
+    "Context Awareness": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontexterkennung"
           }
         }
       }
     },
-    "Starting recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme wird gestartet"
+    "Continue": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
           }
         }
       }
     },
-    "Stop recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme stoppen"
+    "Control how VoiceInk handles your transcription data and audio recordings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steuern Sie, wie VoiceInk Ihre Transkriptionsdaten und Audioaufnahmen verwaltet."
           }
         }
       }
     },
-    "Stop Sound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stoppklang"
+    "Convert transcription output to lowercase.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsausgabe in Kleinbuchstaben umwandeln."
           }
         }
       }
     },
-    "Storage Warning" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherwarnung"
+    "Copied": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert"
           }
         }
       }
     },
-    "Streaming connection failed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Streaming-Verbindung fehlgeschlagen: %@"
+    "Copied to clipboard": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Zwischenablage kopiert"
           }
         }
       }
     },
-    "Streaming server error: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Streaming-Serverfehler: %@"
+    "Copied!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert!"
           }
         }
       }
     },
-    "Streaming transcription timed out waiting for final result" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeitüberschreitung der Streaming-Transkription beim Warten auf das Endergebnis"
+    "Copy Last Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription kopieren"
           }
         }
       }
     },
-    "Suggested" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgeschlagen"
+    "Copy License Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel kopieren"
           }
         }
       }
     },
-    "Summarize" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zusammenfassen"
+    "Copy System Info": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeminfo kopieren"
           }
         }
       }
     },
-    "Supports any provider that uses the same API format as OpenAI chat completion." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Chat Completion verwendet."
+    "Could not add emoji.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji konnte nicht hinzugefügt werden."
           }
         }
       }
     },
-    "Supports any provider that uses the same API format as OpenAI transcription." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Transcription verwendet."
+    "Could not encode settings to JSON: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen konnten nicht als JSON kodiert werden: %@"
           }
         }
       }
     },
-    "Supports WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstützt WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP"
+    "Could not get the file URL from the open panel.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datei-URL konnte nicht aus dem Öffnen-Dialog ermittelt werden."
           }
         }
       }
     },
-    "Switch AI provider" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KI-Anbieter wechseln"
+    "Could not reach the server. Please check your internet connection and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Server konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."
           }
         }
       }
     },
-    "Switched to: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gewechselt zu: %@"
+    "Could not remove %@ from reserved Apple Speech languages.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte nicht aus den reservierten Apple-Speech-Sprachen entfernt werden."
           }
         }
       }
     },
-    "System Default" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemstandard"
+    "Could not save settings to file: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen konnten nicht in der Datei gespeichert werden: %@"
           }
         }
       }
     },
-    "System Default (%@)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemstandard (%@)"
+    "Could not verify this API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser API-Schlüssel konnte nicht verifiziert werden"
           }
         }
       }
     },
-    "System Information" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systeminformationen"
+    "Could not verify this API key. Check the key and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser API-Schlüssel konnte nicht verifiziert werden. Überprüfen Sie den Schlüssel und versuchen Sie es erneut."
           }
         }
       }
     },
-    "System Prompt" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemprompt"
+    "Create & Select": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen & auswählen"
           }
         }
       }
     },
-    "System prompt is required" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemprompt ist erforderlich"
+    "Create first mode to automate your VoiceInk workflow based on apps/website you are using": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen Sie Ihren ersten Modus, um Ihren VoiceInk-Workflow basierend auf verwendeten Apps und Websites zu automatisieren"
           }
         }
       }
     },
-    "Template" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorlage"
+    "Created": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellt"
           }
         }
       }
     },
-    "Test" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testen"
+    "Custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
           }
         }
       }
     },
-    "Test connection" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung testen"
+    "Custom Command": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl"
           }
         }
       }
     },
-    "Test the connection to continue." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung testen, um fortzufahren."
+    "Custom command cannot be empty.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl darf nicht leer sein."
           }
         }
       }
     },
-    "Testing..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird getestet..."
+    "Custom command could not start: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl konnte nicht gestartet werden: %@"
           }
         }
       }
     },
-    "Thank you for using VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danke, dass Sie VoiceInk verwenden"
+    "Custom command exited with status %d: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl wurde mit Status %d beendet: %@"
           }
         }
       }
     },
-    "The AI provider's server encountered an error. Please try again later." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beim Server des KI-Anbieters ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut."
+    "Custom command exited with status %d.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl wurde mit Status %d beendet."
           }
         }
       }
     },
-    "The API request failed with status code %lld: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die API-Anfrage ist mit Statuscode %lld fehlgeschlagen: %@"
+    "Custom command is empty.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl ist leer."
           }
         }
       }
     },
-    "The API returned an empty or invalid response." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die API hat eine leere oder ungültige Antwort zurückgegeben."
+    "Custom command timed out after %.0f seconds.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierter Befehl hat nach %.0f Sekunden das Zeitlimit überschritten."
           }
         }
       }
     },
-    "The app '%@' is already configured in the '%@' mode." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die App '%@' ist bereits im Modus '%@' konfiguriert."
+    "Custom Device": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Gerät"
           }
         }
       }
     },
-    "The audio file is invalid or corrupted" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Audiodatei ist ungültig oder beschädigt"
+    "Custom Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Verbesserungsmodelle"
           }
         }
       }
     },
-    "The audio file to transcribe could not be found." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die zu transkribierende Audiodatei konnte nicht gefunden werden."
+    "Custom Model Definitions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Modelldefinitionen"
           }
         }
       }
     },
-    "The audio format is not supported" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Audioformat wird nicht unterstützt"
+    "Custom Prompts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Prompts"
           }
         }
       }
     },
-    "The core transcription engine failed." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Kern-Transkriptionsengine ist fehlgeschlagen."
+    "Custom Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Transkriptionsmodelle"
           }
         }
       }
     },
-    "The downloaded Core ML model archive might be corrupted. Try deleting the model and downloading it again. Check available disk space." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das heruntergeladene Core-ML-Modellarchiv ist möglicherweise beschädigt. Löschen Sie das Modell und laden Sie es erneut herunter. Prüfen Sie den verfügbaren Speicherplatz."
+    "Custom: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert: %@"
           }
         }
       }
     },
-    "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die importierte Einstellungsdatei (Version %@) stammt aus einer anderen Version als Ihre Anwendung (Version %@). Der Import wird fortgesetzt, mögliche Inkompatibilitäten sind jedoch zu beachten."
+    "Dashboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dashboard"
           }
         }
       }
     },
-    "The key worked, but VoiceInk could not save it securely." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Schlüssel funktioniert, aber VoiceInk konnte ihn nicht sicher speichern."
+    "Date": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum"
           }
         }
       }
     },
-    "The model provider is not supported by this service." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Modellanbieter wird von diesem Dienst nicht unterstützt."
+    "Deactivate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktivieren"
           }
         }
       }
     },
-    "The provided API key is invalid." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der angegebene API-Schlüssel ist ungültig."
+    "Deactivate License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz deaktivieren"
           }
         }
       }
     },
-    "The selected language is not supported by SpeechAnalyzer." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die ausgewählte Sprache wird von SpeechAnalyzer nicht unterstützt."
+    "Deactivate License?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz deaktivieren?"
           }
         }
       }
     },
-    "The settings export operation was canceled." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Einstellungsexport wurde abgebrochen."
+    "Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
           }
         }
       }
     },
-    "The settings import operation was canceled." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Einstellungsimport wurde abgebrochen."
+    "Default mode is used when no app or website matches": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt"
           }
         }
       }
     },
-    "The transcription language is automatically detected by the model." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Transkriptionssprache wird vom Modell automatisch erkannt."
+    "Default mode is used when no specific app or website matches are found.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt."
           }
         }
       }
     },
-    "The website '%@' is already configured in the '%@' mode." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Website '%@' ist bereits im Modus '%@' konfiguriert."
+    "Default uses simulated Cmd+V key events. AppleScript can help when custom keyboard layouts do not paste correctly.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard verwendet simulierte Cmd+V-Ereignisse. AppleScript kann helfen, wenn benutzerdefinierte Tastaturlayouts nicht korrekt einfügen."
           }
         }
       }
     },
-    "Thinking" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird verarbeitet"
+    "Delete": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
           }
         }
       }
     },
-    "This action cannot be undone. Are you sure you want to delete %lld items?" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Diese Aktion kann nicht rückgängig gemacht werden. Soll wirklich %lld Element gelöscht werden?"
+    "Delete %lld Files": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Datei löschen"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Diese Aktion kann nicht rückgängig gemacht werden. Sollen wirklich %lld Elemente gelöscht werden?"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Dateien löschen"
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This action cannot be undone. Are you sure you want to delete %lld item?"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Delete %lld File"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This action cannot be undone. Are you sure you want to delete %lld items?"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Delete %lld Files"
                 }
               }
             }
@@ -9337,816 +3205,120 @@
         }
       }
     },
-    "This can happen due to an issue with the audio recording or insufficient system resources. Please try again, or restart the app." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dies kann durch ein Problem mit der Audioaufnahme oder durch unzureichende Systemressourcen auftreten. Bitte versuchen Sie es erneut oder starten Sie die App neu."
+    "Delete After": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen nach"
           }
         }
       }
     },
-    "This filler word already exists." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Füllwort existiert bereits."
+    "Delete Custom Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell löschen"
           }
         }
       }
     },
-    "This is an English-optimized model and only supports English transcription." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Modell ist für Englisch optimiert und unterstützt nur Transkription auf Englisch."
+    "Delete Custom Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Modell löschen"
           }
         }
       }
     },
-    "This license has been revoked or disabled. Please contact support." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Lizenz wurde widerrufen oder deaktiviert. Bitte kontaktieren Sie den Support."
+    "Delete Mode?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus löschen?"
           }
         }
       }
     },
-    "This license has reached its device limit. Visit the License Management Portal to deactivate other devices." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Lizenz hat ihr Gerätelimit erreicht. Besuchen Sie das Lizenzverwaltungsportal, um andere Geräte zu deaktivieren."
+    "Delete Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell löschen"
           }
         }
       }
     },
-    "This model supports multiple languages. Select a specific language or auto-detect(if available)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Modell unterstützt mehrere Sprachen. Wählen Sie eine bestimmte Sprache oder die automatische Erkennung (falls verfügbar)."
+    "Delete Prompt?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt löschen?"
           }
         }
       }
     },
-    "This removes the license from this Mac. You can activate it again later." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dadurch wird die Lizenz von diesem Mac entfernt. Sie können sie später wieder aktivieren."
+    "Delete Selected Items?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Elemente löschen?"
           }
         }
       }
     },
-    "This will delete %lld audio files (%@)." : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Audiodatei (%@) wird gelöscht."
+    "Deleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelöscht"
+          }
+        }
+      }
+    },
+    "Deleted %lld audio files.": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodatei gelöscht."
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Audiodateien (%@) werden gelöscht."
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will delete %lld audio file (%@)."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will delete %lld audio files (%@)."
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "This will remove your" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dadurch wird Ihr"
-          }
-        }
-      }
-    },
-    "This will remove your %@ API key. You can add it again later." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihr %@ API-Schlüssel wird entfernt. Sie können ihn später wieder hinzufügen."
-          }
-        }
-      }
-    },
-    "This Year" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Jahr"
-          }
-        }
-      }
-    },
-    "Timeout" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timeout"
-          }
-        }
-      }
-    },
-    "Timeout duration" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timeout-Dauer"
-          }
-        }
-      }
-    },
-    "Toggle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umschalten"
-          }
-        }
-      }
-    },
-    "Toggle Inspector" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inspektor ein-/ausblenden"
-          }
-        }
-      }
-    },
-    "Toggle Menu Bar Only" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur-Menüleistenmodus umschalten"
-          }
-        }
-      }
-    },
-    "Toggle Recorder" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme umschalten"
-          }
-        }
-      }
-    },
-    "Toggle Sidebar" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seitenleiste ein-/ausblenden"
-          }
-        }
-      }
-    },
-    "Toggle VoiceInk Recorder" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahme umschalten"
-          }
-        }
-      }
-    },
-    "Total Transcripts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionen gesamt"
-          }
-        }
-      }
-    },
-    "Transcribe" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkribieren"
-          }
-        }
-      }
-    },
-    "Transcribing" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird transkribiert"
-          }
-        }
-      }
-    },
-    "Transcribing recording" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme wird transkribiert"
-          }
-        }
-      }
-    },
-    "Transcribing..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird transkribiert..."
-          }
-        }
-      }
-    },
-    "Transcript Cleanup" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptions-Bereinigung"
-          }
-        }
-      }
-    },
-    "Transcription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription"
-          }
-        }
-      }
-    },
-    "Transcription failed using SpeechAnalyzer." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription mit SpeechAnalyzer fehlgeschlagen."
-          }
-        }
-      }
-    },
-    "Transcription Failed: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription fehlgeschlagen: %@"
-          }
-        }
-      }
-    },
-    "Transcription Failed: No model selected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription fehlgeschlagen: Kein Modell ausgewählt"
-          }
-        }
-      }
-    },
-    "Transcription Formatting" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsformatierung"
-          }
-        }
-      }
-    },
-    "Transcription Language" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionssprache"
-          }
-        }
-      }
-    },
-    "Transcription Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsmodell"
-          }
-        }
-      }
-    },
-    "Transcription Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionsmodelle"
-          }
-        }
-      }
-    },
-    "Transcription Time" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionszeit"
-          }
-        }
-      }
-    },
-    "Transcription was cancelled" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkription wurde abgebrochen"
-          }
-        }
-      }
-    },
-    "Translate" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Übersetzen"
-          }
-        }
-      }
-    },
-    "Trial Active" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testversion aktiv"
-          }
-        }
-      }
-    },
-    "Trial ended" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testphase beendet"
-          }
-        }
-      }
-    },
-    "Trial Ending Soon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testversion endet bald"
-          }
-        }
-      }
-    },
-    "Trial Expired" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testversion abgelaufen"
-          }
-        }
-      }
-    },
-    "Trigger Words" : {
-      "comment" : "A label displayed above the user's trigger words.",
-      "isCommentAutoGenerated" : true
-    },
-    "Triggers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auslöser"
-          }
-        }
-      }
-    },
-    "Try a different search term" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anderen Suchbegriff versuchen"
-          }
-        }
-      }
-    },
-    "Try a few short samples and see how VoiceInk works before you start." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Probieren Sie ein paar kurze Beispiele aus und sehen Sie, wie VoiceInk funktioniert, bevor Sie beginnen."
-          }
-        }
-      }
-    },
-    "Try selecting a different model or redownloading the current model." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie ein anderes Modell aus oder laden Sie das aktuelle Modell erneut herunter."
-          }
-        }
-      }
-    },
-    "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren Sie diese Option, wenn Transkriptionen mit lokalen Modellen länger als erwartet dauern. Führt beim App-Start und Aufwachen im Hintergrund stille Transkriptionen aus, um die Optimierung anzustoßen."
-          }
-        }
-      }
-    },
-    "Unavailable" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht verfügbar"
-          }
-        }
-      }
-    },
-    "Unknown" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannt"
-          }
-        }
-      }
-    },
-    "Unlock VoiceInk Pro For Less" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk Pro günstiger freischalten"
-          }
-        }
-      }
-    },
-    "Unsupported provider" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht unterstützter Anbieter"
-          }
-        }
-      }
-    },
-    "Update the word or phrase that should be automatically replaced." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Wort oder den Ausdruck aktualisieren, der automatisch ersetzt werden soll."
-          }
-        }
-      }
-    },
-    "Use captured on-screen text as context for this mode." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erfassten Bildschirmtext als Kontext für diesen Modus verwenden."
-          }
-        }
-      }
-    },
-    "Use clipboard text as context for this mode." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text aus der Zwischenablage als Kontext für diesen Modus verwenden."
-          }
-        }
-      }
-    },
-    "Use Cloud" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud verwenden"
-          }
-        }
-      }
-    },
-    "Use selected text from the active app as context for this mode." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählten Text der aktiven App als Kontext für diesen Modus verwenden."
-          }
-        }
-      }
-    },
-    "Use System Template" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemvorlage verwenden"
-          }
-        }
-      }
-    },
-    "Use VoiceInk now." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk jetzt nutzen."
-          }
-        }
-      }
-    },
-    "User Message" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzernachricht"
-          }
-        }
-      }
-    },
-    "Using: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwendet: %@"
-          }
-        }
-      }
-    },
-    "Variables: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT"
-          }
-        }
-      }
-    },
-    "Verification Successful" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfung erfolgreich"
-          }
-        }
-      }
-    },
-    "Verified" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifiziert"
-          }
-        }
-      }
-    },
-    "Verify" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen"
-          }
-        }
-      }
-    },
-    "Verify and Save" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen und speichern"
-          }
-        }
-      }
-    },
-    "Verify API Key" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API-Schlüssel überprüfen"
-          }
-        }
-      }
-    },
-    "Verifying" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird überprüft"
-          }
-        }
-      }
-    },
-    "Verifying..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird überprüft..."
-          }
-        }
-      }
-    },
-    "Version %@ (%@)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@ (%@)"
-          }
-        }
-      }
-    },
-    "Version Mismatch" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versionskonflikt"
-          }
-        }
-      }
-    },
-    "View details" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details anzeigen"
-          }
-        }
-      }
-    },
-    "View transcription and enhancement model performance" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptions- und Verbesserungsmodell-Leistung anzeigen"
-          }
-        }
-      }
-    },
-    "Vocabulary" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vokabular"
-          }
-        }
-      }
-    },
-    "Vocabulary is used only with AI enhancement to preserve important names, technical terms, and unique spellings in the final output." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vokabular wird nur mit KI-Verbesserung verwendet, um wichtige Namen, Fachbegriffe und besondere Schreibweisen in der finalen Ausgabe beizubehalten."
-          }
-        }
-      }
-    },
-    "Vocabulary Words" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vokabular-Wörter"
-          }
-        }
-      }
-    },
-    "Vocabulary Words (%lld)" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Vokabular-Wort (%lld)"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Vokabular-Wörter (%lld)"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodateien gelöscht."
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Vocabulary Word (%lld)"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Deleted %lld audio file."
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Vocabulary Words (%lld)"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Deleted %lld audio files."
                 }
               }
             }
@@ -10154,484 +3326,111 @@
         }
       }
     },
-    "Voice Activity Detection (VAD)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachaktivitätserkennung (VAD)"
+    "Deleted files: %lld. Failed: %lld.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelöschte Dateien: %lld. Fehlgeschlagen: %lld."
           }
         }
       }
     },
-    "VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk"
+    "Denied": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verweigert"
           }
         }
       }
     },
-    "VoiceInk app is not available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-App ist nicht verfügbar"
+    "Deselect All": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle abwählen"
           }
         }
       }
     },
-    "VoiceInk automatically understands what you are working with and selects your preferred setup. You can always configure this by editing or creating new modes." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk erkennt automatisch, woran Sie arbeiten, und wählt Ihre bevorzugte Konfiguration aus. Sie können dies jederzeit konfigurieren, indem Sie Modi bearbeiten oder neue Modi erstellen."
+    "Details": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details"
           }
         }
       }
     },
-    "VoiceInk can select the right mode from the app you are using and the rules you configure." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk kann anhand der verwendeten App und der konfigurierten Regeln den passenden Modus auswählen."
+    "Detect speech segments and filter out silence to improve accuracy of local models.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachsegmente erkennen und Stille herausfiltern, um die Genauigkeit lokaler Modelle zu verbessern."
           }
         }
       }
     },
-    "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk konnte nicht auf den Speicherort zugreifen. Ihre Transkriptionen werden nicht zwischen Sitzungen gespeichert."
+    "Device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerät"
           }
         }
       }
     },
-    "VoiceInk Insights" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Einblicke"
+    "Diagnostics": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose"
           }
         }
       }
     },
-    "VoiceInk is also open source, so you can inspect every single line of code." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk ist auch Open Source, sodass Sie jede Codezeile einsehen können."
-          }
-        }
-      }
-    },
-    "VoiceInk is Context-Aware" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk erkennt den Kontext"
-          }
-        }
-      }
-    },
-    "VoiceInk is context-aware." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk erkennt den Kontext."
-          }
-        }
-      }
-    },
-    "VoiceInk is Open Source" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk ist Open Source"
-          }
-        }
-      }
-    },
-    "VoiceInk is private by default" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk ist standardmäßig privat"
-          }
-        }
-      }
-    },
-    "VoiceInk is private by default. No data leaves your device unless you opt in." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk ist standardmäßig privat. Keine Daten verlassen Ihr Gerät, sofern Sie dem nicht zustimmen."
-          }
-        }
-      }
-    },
-    "VoiceInk Modes" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Modi"
-          }
-        }
-      }
-    },
-    "VoiceInk modes include Dictation, Enhance, Email, Assistant, Rewrite, Ask, Summarize, and Translate." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Modi umfassen Diktat, Verbesserung, E-Mail, Assistent, Umschreiben, Fragen, Zusammenfassen und Übersetzen."
-          }
-        }
-      }
-    },
-    "VoiceInk Pro" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk Pro"
-          }
-        }
-      }
-    },
-    "VoiceInk reads visible screen content to improve the accuracy of transcripts." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk liest sichtbare Bildschirminhalte, um die Genauigkeit der Transkripte zu verbessern."
-          }
-        }
-      }
-    },
-    "VoiceInk recorder dismissed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahme geschlossen"
-          }
-        }
-      }
-    },
-    "VoiceInk recorder toggled" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahme umgeschaltet"
-          }
-        }
-      }
-    },
-    "VoiceInk recording service is not available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Aufnahmedienst ist nicht verfügbar"
-          }
-        }
-      }
-    },
-    "VoiceInk sessions completed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk-Sitzungen abgeschlossen"
-          }
-        }
-      }
-    },
-    "VoiceInk temporarily uses the clipboard to paste transcription. When enabled, it restores your previous clipboard content after the selected delay. When disabled, the pasted transcription stays on your clipboard." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk nutzt die Zwischenablage vorübergehend zum Einfügen der Transkription. Wenn aktiviert, wird der frühere Inhalt der Zwischenablage nach der gewählten Verzögerung wiederhergestellt. Wenn deaktiviert, bleibt die Transkription in der Zwischenablage."
-          }
-        }
-      }
-    },
-    "VoiceInk uses Accessibility to type transcriptions directly into any app." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk verwendet Bedienungshilfen, um Transkriptionen direkt in jede App einzugeben."
-          }
-        }
-      }
-    },
-    "VoiceInk uses LLMs to enhance transcripts and perform AI actions. Set up an API key before continuing." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk verwendet LLMs, um Transkripte zu verbessern und KI-Aktionen auszuführen. Richten Sie einen API-Schlüssel ein, bevor Sie fortfahren."
-          }
-        }
-      }
-    },
-    "VoiceInk uses your microphone to capture your voice." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk verwendet Ihr Mikrofon, um Ihre Stimme aufzunehmen."
-          }
-        }
-      }
-    },
-    "VoiceInk vs. typing by hand" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk vs. Tippen von Hand"
-          }
-        }
-      }
-    },
-    "VoiceInk will download NVIDIA's Parakeet model to set up fast local transcription." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VoiceInk lädt das Parakeet-Modell von NVIDIA herunter, um schnelle lokale Transkription einzurichten."
-          }
-        }
-      }
-    },
-    "Voicing, Voice ink" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voicing, Voice ink"
-          }
-        }
-      }
-    },
-    "Voicing, Voice ink, Voiceing" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voicing, Voice ink, Voiceing"
-          }
-        }
-      }
-    },
-    "Waiting" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wartet"
-          }
-        }
-      }
-    },
-    "With" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit"
-          }
-        }
-      }
-    },
-    "word" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wort"
-          }
-        }
-      }
-    },
-    "Word Replacement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wortersetzung"
-          }
-        }
-      }
-    },
-    "Word replacement examples" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beispiele für Wortersetzungen"
-          }
-        }
-      }
-    },
-    "Word Replacements" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wortersetzungen"
-          }
-        }
-      }
-    },
-    "Word Replacements run after transcription to replace misheard words, phrases, abbreviations, or boilerplate text." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wortersetzungen werden nach der Transkription ausgeführt, um falsch erkannte Wörter, Ausdrücke, Abkürzungen oder Textbausteine zu ersetzen."
-          }
-        }
-      }
-    },
-    "Word Replacements run after transcription. Vocabulary is used with AI enhancement to better understand names, technical terms, and unique spellings in your transcript." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wortersetzungen werden nach der Transkription angewendet. Das Vokabular wird mit KI-Verbesserung verwendet, um Namen, Fachbegriffe und besondere Schreibweisen in Ihrer Transkription besser zu verstehen."
-          }
-        }
-      }
-    },
-    "words" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wörter"
-          }
-        }
-      }
-    },
-    "Words" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wörter"
-          }
-        }
-      }
-    },
-    "Words Dictated" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diktierte Wörter"
-          }
-        }
-      }
-    },
-    "words generated" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wörter generiert"
-          }
-        }
-      }
-    },
-    "Words Per Minute" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wörter pro Minute"
-          }
-        }
-      }
-    },
-    "Write prompt instructions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prompt-Anweisungen schreiben"
-          }
-        }
-      }
-    },
-    "You Control It" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie haben die Kontrolle"
-          }
-        }
-      }
-    },
-    "You have %lld days left in your trial" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Ihre Testphase läuft noch %lld Tag"
+    "Dictated %@ words across %lld sessions.": {
+      "comment": "Hero subtitle showing word count and session count",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Sie haben %1$@ Wörter in %2$lld Sitzung diktiert."
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Ihre Testphase läuft noch %lld Tage"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Sie haben %1$@ Wörter in %2$lld Sitzungen diktiert."
                 }
               }
             }
           }
         },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "You have %lld day left in your trial"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Dictated %1$@ words across %2$lld session."
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "You have %lld days left in your trial"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Dictated %1$@ words across %2$lld sessions."
                 }
               }
             }
@@ -10639,117 +3438,7243 @@
         }
       }
     },
-    "You have saved %@ with VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie haben %@ mit VoiceInk gespart"
+    "Dictation": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktat"
           }
         }
       }
     },
-    "You'll see the introduction screens again the next time you launch the app." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beim nächsten App-Start werden die Einführungsbildschirme erneut angezeigt."
+    "Dictionary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörterbuch"
           }
         }
       }
     },
-    "Your data never has to leave your device." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre Daten müssen Ihr Gerät nie verlassen."
+    "Dictionary Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörterbuch-Einstellungen"
           }
         }
       }
     },
-    "Your license key is verified. VoiceInk is ready to use on this Mac." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihr Lizenzschlüssel wurde verifiziert. VoiceInk ist auf diesem Mac einsatzbereit."
+    "Disabled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktiviert"
           }
         }
       }
     },
-    "Your settings have been successfully exported to %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre Einstellungen wurden erfolgreich in %@ exportiert."
+    "Disconnected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Getrennt"
           }
         }
       }
     },
-    "Your transcription history will appear here" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre Transkriptionshistorie wird hier angezeigt"
+    "Dismiss": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
           }
         }
       }
     },
-    "Your trial has ended. Upgrade to VoiceInk Pro at %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre Testversion ist beendet. Upgraden Sie auf VoiceInk Pro unter %@"
+    "Dismiss Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme schließen"
           }
         }
       }
     },
-    "Your trial has expired. Upgrade to continue using VoiceInk" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre Testversion ist abgelaufen. Upgraden Sie, um VoiceInk weiter zu verwenden."
+    "Dismiss shortcut tip": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel-Hinweis schließen"
           }
         }
       }
     },
-    "Your usage summary will appear here." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre Nutzungsübersicht wird hier angezeigt."
+    "Dismiss the VoiceInk recorder and cancel any active recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme schließen und aktive Aufnahme abbrechen."
           }
         }
       }
     },
-    "Your VoiceInk journey starts with your first recording." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihre VoiceInk-Reise beginnt mit der ersten Aufnahme."
+    "Dismiss this promotion": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Angebot ausblenden"
           }
         }
       }
     },
-    "YouTube Videos & Guides" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube-Videos & Anleitungen"
+    "Dismiss VoiceInk Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme schließen"
+          }
+        }
+      }
+    },
+    "Display Name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigename"
+          }
+        }
+      }
+    },
+    "Display name cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigename darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Docs": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokumentation"
+          }
+        }
+      }
+    },
+    "Documentation": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokumentation"
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        }
+      }
+    },
+    "Double-click to edit • Right-click for more options": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doppelklick zum Bearbeiten • Rechtsklick für weitere Optionen"
+          }
+        }
+      }
+    },
+    "Download": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herunterladen"
+          }
+        }
+      }
+    },
+    "Download Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell herunterladen"
+          }
+        }
+      }
+    },
+    "Download required for %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download für %@ erforderlich."
+          }
+        }
+      }
+    },
+    "Download this Apple Speech language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Apple-Speech-Sprache herunterladen."
+          }
+        }
+      }
+    },
+    "Download Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell herunterladen"
+          }
+        }
+      }
+    },
+    "Downloaded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading %@ Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Modell wird heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading assets for the selected Apple Speech language.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ressourcen für die ausgewählte Apple-Speech-Sprache werden heruntergeladen."
+          }
+        }
+      }
+    },
+    "Downloading Core ML Model for %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Core-ML-Modell für %@ wird heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading model files: %lld/%lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelldateien werden heruntergeladen: %lld/%lld"
+          }
+        }
+      }
+    },
+    "Downloading...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird heruntergeladen..."
+          }
+        }
+      }
+    },
+    "Drop audio or video files here": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio- oder Videodateien hier ablegen"
+          }
+        }
+      }
+    },
+    "Drop files anywhere to add more": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien irgendwo ablegen, um weitere hinzuzufügen"
+          }
+        }
+      }
+    },
+    "Drop to add files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ablegen zum Hinzufügen"
+          }
+        }
+      }
+    },
+    "Duration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dauer"
+          }
+        }
+      }
+    },
+    "During recording, press Option + 1-9 to switch modes quickly.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drücken Sie während der Aufnahme Option + 1-9, um schnell den Modus zu wechseln."
+          }
+        }
+      }
+    },
+    "e.g. my email, my mail": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. meine E-Mail, meine Mail"
+          }
+        }
+      }
+    },
+    "e.g. Prakash, VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. Prakash, VoiceInk"
+          }
+        }
+      }
+    },
+    "e.g. support@tryvoiceink.com": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. support@tryvoiceink.com"
+          }
+        }
+      }
+    },
+    "Earn With The VoiceInk Affiliate Program": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit dem VoiceInk-Partnerprogramm Geld verdienen"
+          }
+        }
+      }
+    },
+    "Edit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Custom Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Custom Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Transkriptionsmodell bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit the apps and websites in this group.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps und Websites in dieser Gruppe bearbeiten."
+          }
+        }
+      }
+    },
+    "Edit trigger group": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslösergruppe bearbeiten"
+          }
+        }
+      }
+    },
+    "Edit Word Replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzung bearbeiten"
+          }
+        }
+      }
+    },
+    "Email": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E-Mail"
+          }
+        }
+      }
+    },
+    "Email Support": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E-Mail-Support"
+          }
+        }
+      }
+    },
+    "Emoji already exists.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji existiert bereits."
+          }
+        }
+      }
+    },
+    "Emoji cannot be empty.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji darf nicht leer sein."
+          }
+        }
+      }
+    },
+    "Enable Accessibility Access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen aktivieren"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert"
+          }
+        }
+      }
+    },
+    "Enhance": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbessern"
+          }
+        }
+      }
+    },
+    "Enhanced": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbessert"
+          }
+        }
+      }
+    },
+    "Enhancement": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserung"
+          }
+        }
+      }
+    },
+    "Enhancement failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserung fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodell"
+          }
+        }
+      }
+    },
+    "Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodelle"
+          }
+        }
+      }
+    },
+    "Enhancement modes and AI actions will stay off. You can always set it up later in the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungsmodi und KI-Aktionen bleiben deaktiviert. Sie können dies später einrichten."
+          }
+        }
+      }
+    },
+    "Enhancement request timed out. Check your connection or increase the timeout duration.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung bei der Verbesserungsanfrage. Überprüfen Sie Ihre Verbindung oder verlängern Sie die maximale Wartezeit."
+          }
+        }
+      }
+    },
+    "Enhancement Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungseinstellungen"
+          }
+        }
+      }
+    },
+    "Enhancement Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserungszeit"
+          }
+        }
+      }
+    },
+    "Enhancing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verbessert"
+          }
+        }
+      }
+    },
+    "Enhancing recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme wird verbessert"
+          }
+        }
+      }
+    },
+    "Enhancing...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verbessert..."
+          }
+        }
+      }
+    },
+    "Enter License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz eingeben"
+          }
+        }
+      }
+    },
+    "Enter License Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel eingeben"
+          }
+        }
+      }
+    },
+    "Enter word or phrase to replace (use commas for multiple)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort oder Ausdruck eingeben (mehrere mit Komma trennen)"
+          }
+        }
+      }
+    },
+    "Enter your": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie Ihren"
+          }
+        }
+      }
+    },
+    "Enter your %@ API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API-Schlüssel eingeben"
+          }
+        }
+      }
+    },
+    "Environment variables available: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk also writes VOICEINK_FULL_PROMPT to stdin for every command.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbare Umgebungsvariablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk schreibt außerdem VOICEINK_FULL_PROMPT für jeden Befehl nach stdin."
+          }
+        }
+      }
+    },
+    "Error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
+          }
+        }
+      }
+    },
+    "Error importing settings: %@. The file might be corrupted or not in the correct format.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Importieren der Einstellungen: %@. Die Datei könnte beschädigt oder im falschen Format sein."
+          }
+        }
+      }
+    },
+    "esc": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esc"
+          }
+        }
+      }
+    },
+    "Examples": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispiele"
+          }
+        }
+      }
+    },
+    "Experience VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erleben"
+          }
+        }
+      }
+    },
+    "Experimental": {
+      "comment": "A label displayed next to a model that is in experimental use.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimentell"
+          }
+        }
+      }
+    },
+    "Explore Affiliate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partnerprogramm erkunden"
+          }
+        }
+      }
+    },
+    "Export": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportieren"
+          }
+        }
+      }
+    },
+    "Export all settings, or choose specific categories when importing a backup.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Einstellungen exportieren oder beim Importieren bestimmte Kategorien wählen."
+          }
+        }
+      }
+    },
+    "Export Canceled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export abgebrochen"
+          }
+        }
+      }
+    },
+    "Export Error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportfehler"
+          }
+        }
+      }
+    },
+    "Export Failed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Export Logs": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolle exportieren"
+          }
+        }
+      }
+    },
+    "Export Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen exportieren"
+          }
+        }
+      }
+    },
+    "Export Successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export erfolgreich"
+          }
+        }
+      }
+    },
+    "Export VoiceInk Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Einstellungen exportieren"
+          }
+        }
+      }
+    },
+    "Fail immediately": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sofort abbrechen"
+          }
+        }
+      }
+    },
+    "Failed to add '%@': %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' konnte nicht hinzugefügt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to add replacement: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung konnte nicht hinzugefügt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to convert the audio format": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioformat konnte nicht konvertiert werden"
+          }
+        }
+      }
+    },
+    "Failed to copy audio file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei konnte nicht kopiert werden"
+          }
+        }
+      }
+    },
+    "Failed to copy transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription konnte nicht kopiert werden"
+          }
+        }
+      }
+    },
+    "Failed to create audio file: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei konnte nicht erstellt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to create AudioUnit: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit konnte nicht erstellt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to create custom sounds directory": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordner für benutzerdefinierte Töne konnte nicht erstellt werden"
+          }
+        }
+      }
+    },
+    "Failed to disable output: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe konnte nicht deaktiviert werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to enable input: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe konnte nicht aktiviert werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to encode the request body.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfragetext konnte nicht codiert werden."
+          }
+        }
+      }
+    },
+    "Failed to execute Local CLI command: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl konnte nicht ausgeführt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to export the processed audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verarbeitete Audiodatei konnte nicht exportiert werden"
+          }
+        }
+      }
+    },
+    "Failed to extract audio samples": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiosamples konnten nicht extrahiert werden"
+          }
+        }
+      }
+    },
+    "Failed to get device format: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geräteformat konnte nicht gelesen werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to import model: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell konnte nicht importiert werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to initialize AudioUnit: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit konnte nicht initialisiert werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to load the transcription model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell konnte nicht geladen werden."
+          }
+        }
+      }
+    },
+    "Failed to remove replacement: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung konnte nicht entfernt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to remove word: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort konnte nicht entfernt werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to save API key securely": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel konnte nicht sicher gespeichert werden"
+          }
+        }
+      }
+    },
+    "Failed to save changes: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen konnten nicht gespeichert werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to save custom enhancement model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniertes Verbesserungsmodell konnte nicht gespeichert werden"
+          }
+        }
+      }
+    },
+    "Failed to save imported %@: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importiertes %@ konnte nicht gespeichert werden: %@"
+          }
+        }
+      }
+    },
+    "Failed to set audio format: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioformat konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to set file format: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateiformat konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to set input callback: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe-Callback konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to set input device: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabegerät konnte nicht gesetzt werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to start AudioUnit: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit konnte nicht gestartet werden: %lld"
+          }
+        }
+      }
+    },
+    "Failed to transcribe the audio.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio konnte nicht transkribiert werden."
+          }
+        }
+      }
+    },
+    "Failed to unzip the downloaded Core ML model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heruntergeladenes Core-ML-Modell konnte nicht entpackt werden."
+          }
+        }
+      }
+    },
+    "Fast multilingual transcription that runs locally on Mac.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnelle mehrsprachige Transkription, die lokal auf dem Mac läuft."
+          }
+        }
+      }
+    },
+    "Faster than Real-time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schneller als Echtzeit"
+          }
+        }
+      }
+    },
+    "Feedback or Issues?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback oder Probleme?"
+          }
+        }
+      }
+    },
+    "fewer keystrokes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "weniger Tastenanschläge"
+          }
+        }
+      }
+    },
+    "Filler word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwort"
+          }
+        }
+      }
+    },
+    "Finalizing models...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle werden fertiggestellt..."
+          }
+        }
+      }
+    },
+    "Finish Onboarding": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung abschließen"
+          }
+        }
+      }
+    },
+    "Free updates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kostenlose Updates"
+          }
+        }
+      }
+    },
+    "General": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
+          }
+        }
+      }
+    },
+    "General Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemeine Einstellungen"
+          }
+        }
+      }
+    },
+    "Get %@ API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-API-Schlüssel abrufen"
+          }
+        }
+      }
+    },
+    "Get API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel abrufen"
+          }
+        }
+      }
+    },
+    "Get API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel abrufen"
+          }
+        }
+      }
+    },
+    "Granted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gewährt"
+          }
+        }
+      }
+    },
+    "HAL Output AudioUnit not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HAL Output AudioUnit nicht gefunden"
+          }
+        }
+      }
+    },
+    "Has trigger words": {
+      "comment": "A tooltip that describes a custom prompt that has trigger words.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hat Auslöserwörter"
+          }
+        }
+      }
+    },
+    "Have a license key?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haben Sie einen Lizenzschlüssel?"
+          }
+        }
+      }
+    },
+    "Have feedback, a bug report, or something that feels off? Send a note with system information by email, or join Discord for community discussion. Every report helps make VoiceInk more reliable and easier to use.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haben Sie Feedback, einen Fehlerbericht oder ist etwas nicht stimmig? Senden Sie eine E-Mail mit Systeminformationen oder treten Sie dem Discord für eine Diskussion mit der Community bei. Jeder Bericht hilft dabei, VoiceInk zuverlässiger und einfacher nutzbar zu machen."
+          }
+        }
+      }
+    },
+    "Help & Resources": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilfe & Ressourcen"
+          }
+        }
+      }
+    },
+    "Hide Dock Icon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock-Symbol ausblenden"
+          }
+        }
+      }
+    },
+    "History": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf"
+          }
+        }
+      }
+    },
+    "How to use Word Replacements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendung von Wortersetzungen"
+          }
+        }
+      }
+    },
+    "Hybrid": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hybrid"
+          }
+        }
+      }
+    },
+    "Immediately": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sofort"
+          }
+        }
+      }
+    },
+    "Import": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importieren"
+          }
+        }
+      }
+    },
+    "Import Canceled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import abgebrochen"
+          }
+        }
+      }
+    },
+    "Import Error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importfehler"
+          }
+        }
+      }
+    },
+    "Import Local Model…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokales Modell importieren…"
+          }
+        }
+      }
+    },
+    "Import Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen importieren"
+          }
+        }
+      }
+    },
+    "Import Successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import erfolgreich"
+          }
+        }
+      }
+    },
+    "Import VoiceInk Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Einstellungen importieren"
+          }
+        }
+      }
+    },
+    "IMPORTANT: If you were using AI enhancement features, please make sure to reconfigure your API keys in the AI Models section.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WICHTIG: Falls Sie KI-Verbesserungsfunktionen verwendet haben, konfigurieren Sie bitte Ihre API-Schlüssel im Bereich KI-Modelle neu."
+          }
+        }
+      }
+    },
+    "Imported %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ importiert"
+          }
+        }
+      }
+    },
+    "Imported local model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokales Modell importiert"
+          }
+        }
+      }
+    },
+    "Info": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        }
+      }
+    },
+    "Interface": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche"
+          }
+        }
+      }
+    },
+    "Invalid Audio File": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Audiodatei"
+          }
+        }
+      }
+    },
+    "Invalid audio file format": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Audiodateiformat"
+          }
+        }
+      }
+    },
+    "Invalid emoji.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Emoji."
+          }
+        }
+      }
+    },
+    "Invalid model type provided for Native Apple transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Modelltyp für native Apple-Transkription angegeben."
+          }
+        }
+      }
+    },
+    "Invalid Ollama server URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Ollama-Server-URL"
+          }
+        }
+      }
+    },
+    "Invalid response from AI provider.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Antwort vom KI-Anbieter."
+          }
+        }
+      }
+    },
+    "Invalid response from Ollama server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Antwort vom Ollama-Server"
+          }
+        }
+      }
+    },
+    "It is recommended that you complete the onboarding.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wird empfohlen, die Einführung abzuschließen."
+          }
+        }
+      }
+    },
+    "It is recommended to restart VoiceInk for all changes to take full effect.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wird empfohlen, VoiceInk neu zu starten, damit alle Änderungen vollständig wirksam werden."
+          }
+        }
+      }
+    },
+    "Join Discord": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord beitreten"
+          }
+        }
+      }
+    },
+    "Keep": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beibehalten"
+          }
+        }
+      }
+    },
+    "Keep Audio For": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio aufbewahren für"
+          }
+        }
+      }
+    },
+    "Keep Clipboard Content": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischenablage-Inhalt beibehalten"
+          }
+        }
+      }
+    },
+    "Keep preserves punctuation as transcribed. Remove all strips punctuation marks from the transcribed text. Remove trailing period only removes a final period from the transcribed text.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„Behalten“ bewahrt die Zeichensetzung wie transkribiert. „Alle entfernen“ entfernt alle Satzzeichen. „Nur abschließenden Punkt“ entfernt nur den letzten Punkt des Textes."
+          }
+        }
+      }
+    },
+    "Key verified": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel verifiziert"
+          }
+        }
+      }
+    },
+    "Keyboard Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturkürzel"
+          }
+        }
+      }
+    },
+    "Keystrokes Saved": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenanschläge gespart"
+          }
+        }
+      }
+    },
+    "Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache"
+          }
+        }
+      }
+    },
+    "Language: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: %@"
+          }
+        }
+      }
+    },
+    "Language: Autodetected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: Automatisch erkannt"
+          }
+        }
+      }
+    },
+    "Language: English": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: Englisch"
+          }
+        }
+      }
+    },
+    "Language: English (only)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: Nur Englisch"
+          }
+        }
+      }
+    },
+    "Last 7 Days": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte 7 Tage"
+          }
+        }
+      }
+    },
+    "Last 30 Days": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte 30 Tage"
+          }
+        }
+      }
+    },
+    "Last transcription copied": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription kopiert"
+          }
+        }
+      }
+    },
+    "Launch at Login": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Anmeldung starten"
+          }
+        }
+      }
+    },
+    "Learn more": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr erfahren"
+          }
+        }
+      }
+    },
+    "License activated successfully!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erfolgreich aktiviert!"
+          }
+        }
+      }
+    },
+    "License active on this Mac.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz auf diesem Mac aktiv."
+          }
+        }
+      }
+    },
+    "License key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel"
+          }
+        }
+      }
+    },
+    "License Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel"
+          }
+        }
+      }
+    },
+    "License key not found. Please double-check your key and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel nicht gefunden. Bitte überprüfen Sie Ihren Schlüssel und versuchen Sie es erneut."
+          }
+        }
+      }
+    },
+    "License Management": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzverwaltung"
+          }
+        }
+      }
+    },
+    "License required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erforderlich"
+          }
+        }
+      }
+    },
+    "License Required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erforderlich"
+          }
+        }
+      }
+    },
+    "License validated successfully!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz erfolgreich validiert!"
+          }
+        }
+      }
+    },
+    "Licensed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenziert"
+          }
+        }
+      }
+    },
+    "Licensed (Pro)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenziert (Pro)"
+          }
+        }
+      }
+    },
+    "Lifetime access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lebenslanger Zugang"
+          }
+        }
+      }
+    },
+    "Lifetime access.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lebenslanger Zugang."
+          }
+        }
+      }
+    },
+    "Listing files from repository...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien aus dem Repository werden aufgelistet..."
+          }
+        }
+      }
+    },
+    "Load a template or enter a command to enable Local CLI enhancement.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laden Sie eine Vorlage oder geben Sie einen Befehl ein, um die lokale CLI-Verbesserung zu aktivieren."
+          }
+        }
+      }
+    },
+    "Load More": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr laden"
+          }
+        }
+      }
+    },
+    "Load Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlage laden"
+          }
+        }
+      }
+    },
+    "Loading": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen"
+          }
+        }
+      }
+    },
+    "Loading apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps werden geladen"
+          }
+        }
+      }
+    },
+    "Loading model...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell wird geladen..."
+          }
+        }
+      }
+    },
+    "Loading...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen …"
+          }
+        }
+      }
+    },
+    "Local": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokal"
+          }
+        }
+      }
+    },
+    "Local & CLI Providers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale & CLI-Anbieter"
+          }
+        }
+      }
+    },
+    "Local CLI": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale CLI"
+          }
+        }
+      }
+    },
+    "Local CLI command failed with exit code %lld: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Local CLI command failed with exit code %lld.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen."
+          }
+        }
+      }
+    },
+    "Local CLI command is not configured. Load a template or enter a command first.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl ist nicht konfiguriert. Laden Sie eine Vorlage oder geben Sie zuerst einen Befehl ein."
+          }
+        }
+      }
+    },
+    "Local CLI command returned empty output.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl hat eine leere Ausgabe zurückgegeben."
+          }
+        }
+      }
+    },
+    "Local CLI command timed out after %lld seconds.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung des lokalen CLI-Befehls nach %lld Sekunden."
+          }
+        }
+      }
+    },
+    "Local CLI command was not found. Use an absolute path or fix your shell PATH. Details: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler CLI-Befehl wurde nicht gefunden. Verwenden Sie einen absoluten Pfad oder korrigieren Sie Ihren Shell-PATH. Details: %@"
+          }
+        }
+      }
+    },
+    "Local models don't work reliably on Intel Macs": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Modelle funktionieren auf Intel-Macs nicht zuverlässig"
+          }
+        }
+      }
+    },
+    "Local server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler Server"
+          }
+        }
+      }
+    },
+    "Local Storage": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler Speicher"
+          }
+        }
+      }
+    },
+    "Locked": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesperrt"
+          }
+        }
+      }
+    },
+    "Lost Key?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel verloren?"
+          }
+        }
+      }
+    },
+    "Lowercase output": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe in Kleinbuchstaben"
+          }
+        }
+      }
+    },
+    "macOS 26+": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 26+"
+          }
+        }
+      }
+    },
+    "Manage custom enhancement models in the Custom tab.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte Verbesserungsmodelle im Tab „Benutzerdefiniert“ verwalten."
+          }
+        }
+      }
+    },
+    "Manage License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz verwalten"
+          }
+        }
+      }
+    },
+    "Manage Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle verwalten"
+          }
+        }
+      }
+    },
+    "Manage Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi verwalten"
+          }
+        }
+      }
+    },
+    "Memory": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsspeicher"
+          }
+        }
+      }
+    },
+    "Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon"
+          }
+        }
+      }
+    },
+    "Microphone Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon-Modus"
+          }
+        }
+      }
+    },
+    "Middle-Click Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittelklick-Aufnahme"
+          }
+        }
+      }
+    },
+    "Mini": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mini"
+          }
+        }
+      }
+    },
+    "Minimum words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestwörter"
+          }
+        }
+      }
+    },
+    "Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus"
+          }
+        }
+      }
+    },
+    "Mode name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modusname"
+          }
+        }
+      }
+    },
+    "Mode name cannot be empty.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modusname darf nicht leer sein."
+          }
+        }
+      }
+    },
+    "Mode shortcuts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus-Tastenkürzel"
+          }
+        }
+      }
+    },
+    "Mode:": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus:"
+          }
+        }
+      }
+    },
+    "Mode: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus: %@"
+          }
+        }
+      }
+    },
+    "model": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        }
+      }
+    },
+    "Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        }
+      }
+    },
+    "Model Catalog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellkatalog"
+          }
+        }
+      }
+    },
+    "Model Name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellname"
+          }
+        }
+      }
+    },
+    "Model name cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellname darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Model Performance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell-Leistung"
+          }
+        }
+      }
+    },
+    "Model Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelleinstellungen"
+          }
+        }
+      }
+    },
+    "models": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle"
+          }
+        }
+      }
+    },
+    "models available": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle verfügbar"
+          }
+        }
+      }
+    },
+    "Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi"
+          }
+        }
+      }
+    },
+    "Modes help you set up VoiceInk for different writing tasks, workflows, and scenarios.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi helfen Ihnen, VoiceInk für verschiedene Schreibaufgaben, Arbeitsabläufe und Szenarien einzurichten."
+          }
+        }
+      }
+    },
+    "Modes Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi-Einstellungen"
+          }
+        }
+      }
+    },
+    "More enhancement models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Verbesserungsmodelle verfügbar"
+          }
+        }
+      }
+    },
+    "More transcription models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Transkriptionsmodelle verfügbar"
+          }
+        }
+      }
+    },
+    "Move down": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach unten"
+          }
+        }
+      }
+    },
+    "Move up": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach oben"
+          }
+        }
+      }
+    },
+    "ms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ms"
+          }
+        }
+      }
+    },
+    "Multilingual Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehrsprachiges Modell"
+          }
+        }
+      }
+    },
+    "Mute Audio While Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio während Aufnahme stummschalten"
+          }
+        }
+      }
+    },
+    "My Custom Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mein benutzerdefiniertes Modell"
+          }
+        }
+      }
+    },
+    "My Enhancement Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mein Verbesserungsmodell"
+          }
+        }
+      }
+    },
+    "my website link": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mein Website-Link"
+          }
+        }
+      }
+    },
+    "Name cannot be empty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name darf nicht leer sein"
+          }
+        }
+      }
+    },
+    "Native Apple": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Natives Apple"
+          }
+        }
+      }
+    },
+    "Needs access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff erforderlich"
+          }
+        }
+      }
+    },
+    "Network connection failed. Check your internet.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerkverbindung fehlgeschlagen. Überprüfen Sie Ihre Internetverbindung."
+          }
+        }
+      }
+    },
+    "No AI Model Selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein KI-Modell ausgewählt"
+          }
+        }
+      }
+    },
+    "No Apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Apps"
+          }
+        }
+      }
+    },
+    "No apps found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Apps gefunden"
+          }
+        }
+      }
+    },
+    "No audio files found older than %lld days.": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Keine Audiodateien gefunden, die älter als %lld Tag sind."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Keine Audiodateien gefunden, die älter als %lld Tage sind."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No audio files found older than %lld day."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No audio files found older than %lld days."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "No automatic triggers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine automatischen Auslöser"
+          }
+        }
+      }
+    },
+    "No Custom Enhancement Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine benutzerdefinierten Verbesserungsmodelle"
+          }
+        }
+      }
+    },
+    "No Custom Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine benutzerdefinierten Transkriptionsmodelle"
+          }
+        }
+      }
+    },
+    "No data for this period": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Daten für diesen Zeitraum"
+          }
+        }
+      }
+    },
+    "No devices available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Geräte verfügbar"
+          }
+        }
+      }
+    },
+    "No matching apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Apps"
+          }
+        }
+      }
+    },
+    "No Metadata": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Metadaten"
+          }
+        }
+      }
+    },
+    "No microphones found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Mikrofone gefunden"
+          }
+        }
+      }
+    },
+    "No mode selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modus ausgewählt"
+          }
+        }
+      }
+    },
+    "No model configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modell konfiguriert"
+          }
+        }
+      }
+    },
+    "No model selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modell ausgewählt"
+          }
+        }
+      }
+    },
+    "No models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle"
+          }
+        }
+      }
+    },
+    "No models available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle verfügbar"
+          }
+        }
+      }
+    },
+    "No models listed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle aufgelistet."
+          }
+        }
+      }
+    },
+    "No models loaded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle geladen"
+          }
+        }
+      }
+    },
+    "No models loaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle geladen."
+          }
+        }
+      }
+    },
+    "No Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modi"
+          }
+        }
+      }
+    },
+    "No modes available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modi verfügbar"
+          }
+        }
+      }
+    },
+    "No Modes Available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modi verfügbar"
+          }
+        }
+      }
+    },
+    "No Modes Yet": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Modi"
+          }
+        }
+      }
+    },
+    "No prompts available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Prompts verfügbar"
+          }
+        }
+      }
+    },
+    "No Prompts Available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Prompts verfügbar"
+          }
+        }
+      }
+    },
+    "No providers connected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Anbieter verbunden"
+          }
+        }
+      }
+    },
+    "No Recorder Sessions Yet": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Aufnahmesitzungen"
+          }
+        }
+      }
+    },
+    "No removable language reservations were found.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine entfernbaren Sprachreservierungen gefunden."
+          }
+        }
+      }
+    },
+    "No results found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Ergebnisse gefunden"
+          }
+        }
+      }
+    },
+    "No Selection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auswahl"
+          }
+        }
+      }
+    },
+    "No settings were imported.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurden keine Einstellungen importiert."
+          }
+        }
+      }
+    },
+    "No transcription available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Transkription verfügbar"
+          }
+        }
+      }
+    },
+    "No transcription model selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Transkriptionsmodell ausgewählt"
+          }
+        }
+      }
+    },
+    "No transcription models available. Please connect to a cloud service or download a local model in the AI Models tab.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Transkriptionsmodelle verfügbar. Bitte verbinden Sie sich mit einem Cloud-Dienst oder laden Sie im Tab „KI-Modelle“ ein lokales Modell herunter."
+          }
+        }
+      }
+    },
+    "No transcription text was available for the custom command.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für den benutzerdefinierten Befehl war kein Transkriptionstext verfügbar."
+          }
+        }
+      }
+    },
+    "No transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Transkriptionen"
+          }
+        }
+      }
+    },
+    "No transcriptions yet": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Transkriptionen"
+          }
+        }
+      }
+    },
+    "No triggers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auslöser"
+          }
+        }
+      }
+    },
+    "No triggers in this group": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auslöser in dieser Gruppe"
+          }
+        }
+      }
+    },
+    "No Websites": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Websites"
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein"
+          }
+        }
+      }
+    },
+    "None detected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts erkannt"
+          }
+        }
+      }
+    },
+    "None selected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts ausgewählt"
+          }
+        }
+      }
+    },
+    "Not configured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht konfiguriert"
+          }
+        }
+      }
+    },
+    "Not connected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verbunden"
+          }
+        }
+      }
+    },
+    "Not connected to streaming transcription service": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht mit dem Streaming-Transkriptionsdienst verbunden"
+          }
+        }
+      }
+    },
+    "Not Determined": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht festgelegt"
+          }
+        }
+      }
+    },
+    "Not Granted": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht gewährt"
+          }
+        }
+      }
+    },
+    "Not Licensed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht lizenziert"
+          }
+        }
+      }
+    },
+    "Notch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notch"
+          }
+        }
+      }
+    },
+    "Note: Press Option 1-9 during recording to switch modes manually.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis: Drücken Sie Option 1-9 während der Aufnahme, um manuell den Modus zu wechseln."
+          }
+        }
+      }
+    },
+    "Notes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notizen"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Ollama request timed out": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung bei der Ollama-Anfrage"
+          }
+        }
+      }
+    },
+    "Ollama server error": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama-Serverfehler"
+          }
+        }
+      }
+    },
+    "Ollama service is not available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama-Dienst ist nicht verfügbar"
+          }
+        }
+      }
+    },
+    "On timeout": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Timeout"
+          }
+        }
+      }
+    },
+    "On-Device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf dem Gerät"
+          }
+        }
+      }
+    },
+    "Open %@ API key page": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API-Schlüssel-Seite öffnen"
+          }
+        }
+      }
+    },
+    "Open Accessibility settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen für Bedienungshilfen öffnen"
+          }
+        }
+      }
+    },
+    "Open history from anywhere with a global shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf von überall mit einem globalen Tastenkürzel öffnen"
+          }
+        }
+      }
+    },
+    "Open History Window": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlaufsfenster öffnen"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
+          }
+        }
+      }
+    },
+    "Open Source": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Source"
+          }
+        }
+      }
+    },
+    "OpenAI Compatible": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI-kompatibel"
+          }
+        }
+      }
+    },
+    "Optimizing model for your device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell wird für Ihr Gerät optimiert"
+          }
+        }
+      }
+    },
+    "or": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "oder"
+          }
+        }
+      }
+    },
+    "Original": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original"
+          }
+        }
+      }
+    },
+    "Original Text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Originaltext"
+          }
+        }
+      }
+    },
+    "Original text (use commas for multiple)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Originaltext (mehrere mit Komma trennen)"
+          }
+        }
+      }
+    },
+    "Original:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original:"
+          }
+        }
+      }
+    },
+    "Output": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe"
+          }
+        }
+      }
+    },
+    "Paragraph breaks": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Absatzumbrüche"
+          }
+        }
+      }
+    },
+    "Paste": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügen"
+          }
+        }
+      }
+    },
+    "Paste %@ API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-API-Schlüssel einfügen"
+          }
+        }
+      }
+    },
+    "Paste and Press Tab": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügen und Tab drücken"
+          }
+        }
+      }
+    },
+    "Paste API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel einfügen"
+          }
+        }
+      }
+    },
+    "Paste Last Enhanced Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte verbesserte Transkription einfügen"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription einfügen"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription (Enhanced)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription einfügen (Verbessert)"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription (Original)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription einfügen (Original)"
+          }
+        }
+      }
+    },
+    "Paste Method": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügemethode"
+          }
+        }
+      }
+    },
+    "Pasting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfügen"
+          }
+        }
+      }
+    },
+    "Pause Media While Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medien während Aufnahme pausieren"
+          }
+        }
+      }
+    },
+    "Performance Analysis": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leistungsanalyse"
+          }
+        }
+      }
+    },
+    "Pick the microphone VoiceInk should use for recordings.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie das Mikrofon aus, das VoiceInk für Aufnahmen verwenden soll."
+          }
+        }
+      }
+    },
+    "Playback speed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiedergabegeschwindigkeit"
+          }
+        }
+      }
+    },
+    "Please enter a license key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte geben Sie einen Lizenzschlüssel ein"
+          }
+        }
+      }
+    },
+    "Please fix the validation errors before saving.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte beheben Sie die Validierungsfehler vor dem Speichern."
+          }
+        }
+      }
+    },
+    "Please restart the application. If the problem persists, contact support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte starten Sie die Anwendung neu. Wenn das Problem weiterhin besteht, kontaktieren Sie den Support."
+          }
+        }
+      }
+    },
+    "Premium Features Activated": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premium-Funktionen aktiviert"
+          }
+        }
+      }
+    },
+    "Press Esc again to cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esc erneut drücken, um abzubrechen"
+          }
+        }
+      }
+    },
+    "Press shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel drücken"
+          }
+        }
+      }
+    },
+    "Prewarm model (Experimental)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell vorwärmen (Experimentell)"
+          }
+        }
+      }
+    },
+    "Primary Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primäres Tastenkürzel"
+          }
+        }
+      }
+    },
+    "Prioritized": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Priorisiert"
+          }
+        }
+      }
+    },
+    "Priority Order": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prioritätsreihenfolge"
+          }
+        }
+      }
+    },
+    "Priority support": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bevorzugter Support"
+          }
+        }
+      }
+    },
+    "Privacy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz"
+          }
+        }
+      }
+    },
+    "Privacy Starts Here": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz beginnt hier"
+          }
+        }
+      }
+    },
+    "PRO": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRO"
+          }
+        }
+      }
+    },
+    "Processing audio...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio wird verarbeitet..."
+          }
+        }
+      }
+    },
+    "Processor": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozessor"
+          }
+        }
+      }
+    },
+    "Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
+          }
+        }
+      }
+    },
+    "Prompt name": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt-Name"
+          }
+        }
+      }
+    },
+    "Provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter"
+          }
+        }
+      }
+    },
+    "Provider is not supported": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter wird nicht unterstützt"
+          }
+        }
+      }
+    },
+    "Punctuation": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeichensetzung"
+          }
+        }
+      }
+    },
+    "Purchase License": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz kaufen"
+          }
+        }
+      }
+    },
+    "Push to Talk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push-to-Talk"
+          }
+        }
+      }
+    },
+    "Quick Access": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnellzugriff"
+          }
+        }
+      }
+    },
+    "Quick Add to Dictionary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnell zum Wörterbuch hinzufügen"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
+          }
+        }
+      }
+    },
+    "Quit VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk beenden"
+          }
+        }
+      }
+    },
+    "Rate limit exceeded. Please try again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ratenlimit überschritten. Bitte versuchen Sie es später erneut."
+          }
+        }
+      }
+    },
+    "Re-enhance with selected prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit ausgewähltem Prompt neu verbessern"
+          }
+        }
+      }
+    },
+    "Re-enhancement failed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Verbesserung fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Re-enhancement successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Verbesserung erfolgreich"
+          }
+        }
+      }
+    },
+    "REACH OUT": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KONTAKT"
+          }
+        }
+      }
+    },
+    "Read more about custom local models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr über benutzerdefinierte lokale Modelle erfahren"
+          }
+        }
+      }
+    },
+    "Real-time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echtzeit"
+          }
+        }
+      }
+    },
+    "Recheck": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut prüfen"
+          }
+        }
+      }
+    },
+    "Recommended": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlen"
+          }
+        }
+      }
+    },
+    "Recommended Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlene Modelle"
+          }
+        }
+      }
+    },
+    "Record": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnehmen"
+          }
+        }
+      }
+    },
+    "Record shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel aufnehmen"
+          }
+        }
+      }
+    },
+    "Recorder Cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme abbrechen"
+          }
+        }
+      }
+    },
+    "Recorder Style": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorder-Stil"
+          }
+        }
+      }
+    },
+    "Recorder unavailable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme nicht verfügbar"
+          }
+        }
+      }
+    },
+    "Recording Behavior": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmeverhalten"
+          }
+        }
+      }
+    },
+    "Recording failed to start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme konnte nicht gestartet werden"
+          }
+        }
+      }
+    },
+    "Recording Failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Recording Sounds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmesounds"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        }
+      }
+    },
+    "Refresh Microphones": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofone aktualisieren"
+          }
+        }
+      }
+    },
+    "Refresh models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle aktualisieren"
+          }
+        }
+      }
+    },
+    "Refresh Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle aktualisieren"
+          }
+        }
+      }
+    },
+    "Refreshing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aktualisiert"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        }
+      }
+    },
+    "Remove %@ from reserved Apple Speech languages.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aus reservierten Apple-Speech-Sprachen entfernen."
+          }
+        }
+      }
+    },
+    "Remove all": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle entfernen"
+          }
+        }
+      }
+    },
+    "Remove API key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen"
+          }
+        }
+      }
+    },
+    "Remove API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen"
+          }
+        }
+      }
+    },
+    "Remove API Key?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen?"
+          }
+        }
+      }
+    },
+    "Remove Filler Words": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwörter entfernen"
+          }
+        }
+      }
+    },
+    "Remove License": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz entfernen"
+          }
+        }
+      }
+    },
+    "Remove one reserved language to download %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine reservierte Sprache entfernen, um %@ herunterzuladen."
+          }
+        }
+      }
+    },
+    "Remove replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung entfernen"
+          }
+        }
+      }
+    },
+    "Remove trailing period": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlusspunkt entfernen"
+          }
+        }
+      }
+    },
+    "Remove trigger": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser entfernen"
+          }
+        }
+      }
+    },
+    "Remove trigger word": {
+      "comment": "A button that removes a trigger word.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöserwort entfernen"
+          }
+        }
+      }
+    },
+    "Remove website": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website entfernen"
+          }
+        }
+      }
+    },
+    "Remove word": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort entfernen"
+          }
+        }
+      }
+    },
+    "Reorder Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modi neu anordnen"
+          }
+        }
+      }
+    },
+    "Replace": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzen"
+          }
+        }
+      }
+    },
+    "Replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung"
+          }
+        }
+      }
+    },
+    "Replacement text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersatztext"
+          }
+        }
+      }
+    },
+    "Replacement Text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersatztext"
+          }
+        }
+      }
+    },
+    "Replacement:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersetzung:"
+          }
+        }
+      }
+    },
+    "Report or Feedback": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bericht oder Feedback"
+          }
+        }
+      }
+    },
+    "Request Timeout": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfrage-Timeout"
+          }
+        }
+      }
+    },
+    "Required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderlich"
+          }
+        }
+      }
+    },
+    "Required for VoiceInk shortcuts and app-wide controls to work properly.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderlich für VoiceInk-Tastaturkürzel und app-weite Steuerung."
+          }
+        }
+      }
+    },
+    "Reset": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        }
+      }
+    },
+    "Reset Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung zurücksetzen"
+          }
+        }
+      }
+    },
+    "Reset to default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf Standard zurücksetzen"
+          }
+        }
+      }
+    },
+    "Respond": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antworten"
+          }
+        }
+      }
+    },
+    "Restart VoiceInk after enabling Screen Recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk nach dem Aktivieren der Bildschirmaufnahme neu starten."
+          }
+        }
+      }
+    },
+    "Restore Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederherstellungsverzögerung"
+          }
+        }
+      }
+    },
+    "Restricted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschränkt"
+          }
+        }
+      }
+    },
+    "Resume Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederaufnahmeverzögerung"
+          }
+        }
+      }
+    },
+    "Resume Download": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download fortsetzen"
+          }
+        }
+      }
+    },
+    "Retranscribe this audio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Audio neu transkribieren"
+          }
+        }
+      }
+    },
+    "Retranscription failed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Transkription fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Retranscription successful": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Transkription erfolgreich"
+          }
+        }
+      }
+    },
+    "Retry": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholen"
+          }
+        }
+      }
+    },
+    "Retry failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholung fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Retry Last Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Transkription wiederholen"
+          }
+        }
+      }
+    },
+    "Return (⏎)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe (⏎)"
+          }
+        }
+      }
+    },
+    "Review how VoiceInk handles your data before choosing a license.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie, wie VoiceInk Ihre Daten handhabt, bevor Sie eine Lizenz auswählen."
+          }
+        }
+      }
+    },
+    "Rewrite": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschreiben"
+          }
+        }
+      }
+    },
+    "Run Cleanup Now": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigung jetzt ausführen"
+          }
+        }
+      }
+    },
+    "Run enhancement with Ollama on this Mac, or send it to any CLI command.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbesserung mit Ollama auf diesem Mac ausführen oder an einen CLI-Befehl senden."
+          }
+        }
+      }
+    },
+    "Runs locally with your user permissions. The final transcript is sent on stdin and exposed as VOICEINK_TRANSCRIPT.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird lokal mit Ihren Benutzerberechtigungen ausgeführt. Das finale Transkript wird über stdin gesendet und als VOICEINK_TRANSCRIPT bereitgestellt."
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        }
+      }
+    },
+    "Save & Select": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern & auswählen"
+          }
+        }
+      }
+    },
+    "Save as MD": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als MD speichern"
+          }
+        }
+      }
+    },
+    "Save as TXT": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als TXT speichern"
+          }
+        }
+      }
+    },
+    "Save Changes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen speichern"
+          }
+        }
+      }
+    },
+    "Save this prompt and select it.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diesen Prompt speichern und auswählen."
+          }
+        }
+      }
+    },
+    "Save to file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Datei speichern"
+          }
+        }
+      }
+    },
+    "Save Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription speichern"
+          }
+        }
+      }
+    },
+    "Saving": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird gespeichert"
+          }
+        }
+      }
+    },
+    "Screen": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirm"
+          }
+        }
+      }
+    },
+    "Screen Recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmaufnahme"
+          }
+        }
+      }
+    },
+    "Search apps or enter website...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps suchen oder Website eingeben..."
+          }
+        }
+      }
+    },
+    "Search transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen suchen"
+          }
+        }
+      }
+    },
+    "Search transcriptions...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen suchen..."
+          }
+        }
+      }
+    },
+    "Search Web": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web durchsuchen"
+          }
+        }
+      }
+    },
+    "Secondary Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekundäres Tastenkürzel"
+          }
+        }
+      }
+    },
+    "seconds": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekunden"
+          }
+        }
+      }
+    },
+    "Select a transcription to view details": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription auswählen, um Details anzuzeigen"
+          }
+        }
+      }
+    },
+    "Select a Whisper ggml .bin model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisper-ggml-.bin-Modell auswählen"
+          }
+        }
+      }
+    },
+    "Select All": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle auswählen"
+          }
+        }
+      }
+    },
+    "Select an audio file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei auswählen"
+          }
+        }
+      }
+    },
+    "Select an enabled mode to start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivierten Modus zum Starten auswählen"
+          }
+        }
+      }
+    },
+    "Select at least one category to import.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie mindestens eine Kategorie zum Importieren aus."
+          }
+        }
+      }
+    },
+    "Select Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache auswählen"
+          }
+        }
+      }
+    },
+    "Select mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus auswählen"
+          }
+        }
+      }
+    },
+    "Select Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus auswählen"
+          }
+        }
+      }
+    },
+    "Select Mode %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modus %@ auswählen"
+          }
+        }
+      }
+    },
+    "Select Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt auswählen"
+          }
+        }
+      }
+    },
+    "Select sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klang auswählen"
+          }
+        }
+      }
+    },
+    "selected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ausgewählt"
+          }
+        }
+      }
+    },
+    "Selected Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewähltes Mikrofon"
+          }
+        }
+      }
+    },
+    "Selected model not found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewähltes Modell nicht gefunden"
+          }
+        }
+      }
+    },
+    "Selected Text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählter Text"
+          }
+        }
+      }
+    },
+    "Send follow up": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folgenachricht senden"
+          }
+        }
+      }
+    },
+    "Separate multiple originals with commas:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehrere Originale mit Komma trennen:"
+          }
+        }
+      }
+    },
+    "Server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server"
+          }
+        }
+      }
+    },
+    "Server error (%d). Please try again later or contact support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serverfehler (%d). Bitte versuchen Sie es später erneut oder kontaktieren Sie den Support."
+          }
+        }
+      }
+    },
+    "Server:": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server:"
+          }
+        }
+      }
+    },
+    "Server: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server: %@"
+          }
+        }
+      }
+    },
+    "Sessions Recorded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgenommene Sitzungen"
+          }
+        }
+      }
+    },
+    "Set as default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als Standard festlegen"
+          }
+        }
+      }
+    },
+    "Set how long to wait for the AI provider to respond. If no response is received within this duration, you can either fail immediately and paste the original transcription, or retry the request up to 3 attempts.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legen Sie fest, wie lange auf eine Antwort des KI-Anbieters gewartet werden soll. Wenn innerhalb dieser Dauer keine Antwort eingeht, können Sie entweder sofort abbrechen und die ursprüngliche Transkription einfügen oder die Anfrage bis zu 3-mal wiederholen."
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
+          }
+        }
+      }
+    },
+    "Settings imported successfully from %@.\n\nImported: %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen erfolgreich aus %@ importiert.\n\nImportiert: %@."
+          }
+        }
+      }
+    },
+    "Share & Unlock": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilen & freischalten"
+          }
+        }
+      }
+    },
+    "Share VoiceInk on your socials, and instantly unlock a 30% discount on VoiceInk Pro.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilen Sie VoiceInk in Ihren sozialen Netzwerken und schalten Sie sofort 30 % Rabatt auf VoiceInk Pro frei."
+          }
+        }
+      }
+    },
+    "Share VoiceInk with friends or your audience and receive 30% on every referral that upgrades.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfehlen Sie VoiceInk Freunden oder Ihrem Publikum und erhalten Sie 30 % für jede geworbene Person, die ein Upgrade durchführt."
+          }
+        }
+      }
+    },
+    "Shift + Return (⇧⏎)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschalttaste + Eingabe (⇧⏎)"
+          }
+        }
+      }
+    },
+    "Shortcut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel"
+          }
+        }
+      }
+    },
+    "Shortcut already used by %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel wird bereits von %@ verwendet"
+          }
+        }
+      }
+    },
+    "Shortcut not allowed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel nicht erlaubt: %@"
+          }
+        }
+      }
+    },
+    "Shortcut reserved by macOS: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzel von macOS reserviert: %@"
+          }
+        }
+      }
+    },
+    "Shortcuts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturkürzel"
+          }
+        }
+      }
+    },
+    "Show Announcements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ankündigungen anzeigen"
+          }
+        }
+      }
+    },
+    "Show Dock Icon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock-Symbol anzeigen"
+          }
+        }
+      }
+    },
+    "Show in Finder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Finder zeigen"
+          }
+        }
+      }
+    },
+    "Skip": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überspringen"
+          }
+        }
+      }
+    },
+    "Skip API setup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Einrichtung überspringen"
+          }
+        }
+      }
+    },
+    "Skip API Setup": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Einrichtung überspringen"
+          }
+        }
+      }
+    },
+    "Skip API setup?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Einrichtung überspringen?"
+          }
+        }
+      }
+    },
+    "Skip onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung überspringen"
+          }
+        }
+      }
+    },
+    "Skip Onboarding": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung überspringen"
+          }
+        }
+      }
+    },
+    "Skip onboarding?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung überspringen?"
+          }
+        }
+      }
+    },
+    "Skip short transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurze Transkriptionen überspringen"
+          }
+        }
+      }
+    },
+    "Slower than Real-time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langsamer als Echtzeit"
+          }
+        }
+      }
+    },
+    "Sort alphabetically": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alphabetisch sortieren"
+          }
+        }
+      }
+    },
+    "Sort by original": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Original sortieren"
+          }
+        }
+      }
+    },
+    "Sort by replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Ersatz sortieren"
+          }
+        }
+      }
+    },
+    "Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klang"
+          }
+        }
+      }
+    },
+    "SpeechAnalyzer requires macOS 26 or later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SpeechAnalyzer erfordert macOS 26 oder neuer."
+          }
+        }
+      }
+    },
+    "Speed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschwindigkeit"
+          }
+        }
+      }
+    },
+    "Start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten"
+          }
+        }
+      }
+    },
+    "Start 7-day Trial": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7-tägige Testversion starten"
+          }
+        }
+      }
+    },
+    "Start or stop the VoiceInk recorder for voice transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme für Sprachtranskription starten oder stoppen."
+          }
+        }
+      }
+    },
+    "Start recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme starten"
+          }
+        }
+      }
+    },
+    "Start Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Startklang"
+          }
+        }
+      }
+    },
+    "Start transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription starten"
+          }
+        }
+      }
+    },
+    "Start with a template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit einer Vorlage beginnen"
+          }
+        }
+      }
+    },
+    "Start your first recording to unlock value insights.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie Ihre erste Aufnahme, um wertvolle Einblicke zu erhalten."
+          }
+        }
+      }
+    },
+    "Starting recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme wird gestartet"
+          }
+        }
+      }
+    },
+    "Stop recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme stoppen"
+          }
+        }
+      }
+    },
+    "Stop Sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stoppklang"
+          }
+        }
+      }
+    },
+    "Storage Warning": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherwarnung"
+          }
+        }
+      }
+    },
+    "Streaming connection failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Streaming-Verbindung fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Streaming server error: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Streaming-Serverfehler: %@"
+          }
+        }
+      }
+    },
+    "Streaming transcription timed out waiting for final result": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung der Streaming-Transkription beim Warten auf das Endergebnis"
+          }
+        }
+      }
+    },
+    "Suggested": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgeschlagen"
+          }
+        }
+      }
+    },
+    "Summarize": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusammenfassen"
+          }
+        }
+      }
+    },
+    "Supports any provider that uses the same API format as OpenAI chat completion.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Chat Completion verwendet."
+          }
+        }
+      }
+    },
+    "Supports any provider that uses the same API format as OpenAI transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Transcription verwendet."
+          }
+        }
+      }
+    },
+    "Supports WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP"
+          }
+        }
+      }
+    },
+    "Switch AI provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Anbieter wechseln"
+          }
+        }
+      }
+    },
+    "Switched to: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gewechselt zu: %@"
+          }
+        }
+      }
+    },
+    "System Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemstandard"
+          }
+        }
+      }
+    },
+    "System Default (%@)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemstandard (%@)"
+          }
+        }
+      }
+    },
+    "System Information": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeminformationen"
+          }
+        }
+      }
+    },
+    "System Prompt": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemprompt"
+          }
+        }
+      }
+    },
+    "System prompt is required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemprompt ist erforderlich"
+          }
+        }
+      }
+    },
+    "Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlage"
+          }
+        }
+      }
+    },
+    "Test": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testen"
+          }
+        }
+      }
+    },
+    "Test connection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung testen"
+          }
+        }
+      }
+    },
+    "Test the connection to continue.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung testen, um fortzufahren."
+          }
+        }
+      }
+    },
+    "Testing...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird getestet..."
+          }
+        }
+      }
+    },
+    "Thank you for using VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danke, dass Sie VoiceInk verwenden"
+          }
+        }
+      }
+    },
+    "The AI provider's server encountered an error. Please try again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Server des KI-Anbieters ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut."
+          }
+        }
+      }
+    },
+    "The API request failed with status code %lld: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die API-Anfrage ist mit Statuscode %lld fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "The API returned an empty or invalid response.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die API hat eine leere oder ungültige Antwort zurückgegeben."
+          }
+        }
+      }
+    },
+    "The app '%@' is already configured in the '%@' mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die App '%@' ist bereits im Modus '%@' konfiguriert."
+          }
+        }
+      }
+    },
+    "The audio file is invalid or corrupted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Audiodatei ist ungültig oder beschädigt"
+          }
+        }
+      }
+    },
+    "The audio file to transcribe could not be found.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die zu transkribierende Audiodatei konnte nicht gefunden werden."
+          }
+        }
+      }
+    },
+    "The audio format is not supported": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Audioformat wird nicht unterstützt"
+          }
+        }
+      }
+    },
+    "The core transcription engine failed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Kern-Transkriptionsengine ist fehlgeschlagen."
+          }
+        }
+      }
+    },
+    "The downloaded Core ML model archive might be corrupted. Try deleting the model and downloading it again. Check available disk space.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das heruntergeladene Core-ML-Modellarchiv ist möglicherweise beschädigt. Löschen Sie das Modell und laden Sie es erneut herunter. Prüfen Sie den verfügbaren Speicherplatz."
+          }
+        }
+      }
+    },
+    "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die importierte Einstellungsdatei (Version %@) stammt aus einer anderen Version als Ihre Anwendung (Version %@). Der Import wird fortgesetzt, mögliche Inkompatibilitäten sind jedoch zu beachten."
+          }
+        }
+      }
+    },
+    "The key worked, but VoiceInk could not save it securely.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schlüssel funktioniert, aber VoiceInk konnte ihn nicht sicher speichern."
+          }
+        }
+      }
+    },
+    "The model provider is not supported by this service.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Modellanbieter wird von diesem Dienst nicht unterstützt."
+          }
+        }
+      }
+    },
+    "The provided API key is invalid.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der angegebene API-Schlüssel ist ungültig."
+          }
+        }
+      }
+    },
+    "The selected language is not supported by SpeechAnalyzer.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die ausgewählte Sprache wird von SpeechAnalyzer nicht unterstützt."
+          }
+        }
+      }
+    },
+    "The settings export operation was canceled.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Einstellungsexport wurde abgebrochen."
+          }
+        }
+      }
+    },
+    "The settings import operation was canceled.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Einstellungsimport wurde abgebrochen."
+          }
+        }
+      }
+    },
+    "The transcription language is automatically detected by the model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Transkriptionssprache wird vom Modell automatisch erkannt."
+          }
+        }
+      }
+    },
+    "The website '%@' is already configured in the '%@' mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Website '%@' ist bereits im Modus '%@' konfiguriert."
+          }
+        }
+      }
+    },
+    "Thinking": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verarbeitet"
+          }
+        }
+      }
+    },
+    "This action cannot be undone. Are you sure you want to delete %lld items?": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Diese Aktion kann nicht rückgängig gemacht werden. Soll wirklich %lld Element gelöscht werden?"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Diese Aktion kann nicht rückgängig gemacht werden. Sollen wirklich %lld Elemente gelöscht werden?"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This action cannot be undone. Are you sure you want to delete %lld item?"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This action cannot be undone. Are you sure you want to delete %lld items?"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "This can happen due to an issue with the audio recording or insufficient system resources. Please try again, or restart the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dies kann durch ein Problem mit der Audioaufnahme oder durch unzureichende Systemressourcen auftreten. Bitte versuchen Sie es erneut oder starten Sie die App neu."
+          }
+        }
+      }
+    },
+    "This filler word already exists.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Füllwort existiert bereits."
+          }
+        }
+      }
+    },
+    "This is an English-optimized model and only supports English transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Modell ist für Englisch optimiert und unterstützt nur Transkription auf Englisch."
+          }
+        }
+      }
+    },
+    "This license has been revoked or disabled. Please contact support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Lizenz wurde widerrufen oder deaktiviert. Bitte kontaktieren Sie den Support."
+          }
+        }
+      }
+    },
+    "This license has reached its device limit. Visit the License Management Portal to deactivate other devices.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Lizenz hat ihr Gerätelimit erreicht. Besuchen Sie das Lizenzverwaltungsportal, um andere Geräte zu deaktivieren."
+          }
+        }
+      }
+    },
+    "This model supports multiple languages. Select a specific language or auto-detect(if available)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Modell unterstützt mehrere Sprachen. Wählen Sie eine bestimmte Sprache oder die automatische Erkennung (falls verfügbar)."
+          }
+        }
+      }
+    },
+    "This removes the license from this Mac. You can activate it again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dadurch wird die Lizenz von diesem Mac entfernt. Sie können sie später wieder aktivieren."
+          }
+        }
+      }
+    },
+    "This will delete %lld audio files (%@).": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodatei (%@) wird gelöscht."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Audiodateien (%@) werden gelöscht."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This will delete %lld audio file (%@)."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "This will delete %lld audio files (%@)."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "This will remove your": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dadurch wird Ihr"
+          }
+        }
+      }
+    },
+    "This will remove your %@ API key. You can add it again later.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihr %@ API-Schlüssel wird entfernt. Sie können ihn später wieder hinzufügen."
+          }
+        }
+      }
+    },
+    "This Year": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Jahr"
+          }
+        }
+      }
+    },
+    "Timeout": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout"
+          }
+        }
+      }
+    },
+    "Timeout duration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout-Dauer"
+          }
+        }
+      }
+    },
+    "Toggle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschalten"
+          }
+        }
+      }
+    },
+    "Toggle Inspector": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inspektor ein-/ausblenden"
+          }
+        }
+      }
+    },
+    "Toggle Menu Bar Only": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur-Menüleistenmodus umschalten"
+          }
+        }
+      }
+    },
+    "Toggle Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme umschalten"
+          }
+        }
+      }
+    },
+    "Toggle Sidebar": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleiste ein-/ausblenden"
+          }
+        }
+      }
+    },
+    "Toggle VoiceInk Recorder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme umschalten"
+          }
+        }
+      }
+    },
+    "Total Transcripts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen gesamt"
+          }
+        }
+      }
+    },
+    "Transcribe": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkribieren"
+          }
+        }
+      }
+    },
+    "Transcribing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird transkribiert"
+          }
+        }
+      }
+    },
+    "Transcribing recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme wird transkribiert"
+          }
+        }
+      }
+    },
+    "Transcribing...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird transkribiert..."
+          }
+        }
+      }
+    },
+    "Transcript Cleanup": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptions-Bereinigung"
+          }
+        }
+      }
+    },
+    "Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription"
+          }
+        }
+      }
+    },
+    "Transcription failed using SpeechAnalyzer.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription mit SpeechAnalyzer fehlgeschlagen."
+          }
+        }
+      }
+    },
+    "Transcription Failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen: %@"
+          }
+        }
+      }
+    },
+    "Transcription Failed: No model selected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen: Kein Modell ausgewählt"
+          }
+        }
+      }
+    },
+    "Transcription Formatting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsformatierung"
+          }
+        }
+      }
+    },
+    "Transcription Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionssprache"
+          }
+        }
+      }
+    },
+    "Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell"
+          }
+        }
+      }
+    },
+    "Transcription Models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodelle"
+          }
+        }
+      }
+    },
+    "Transcription Time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionszeit"
+          }
+        }
+      }
+    },
+    "Transcription was cancelled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription wurde abgebrochen"
+          }
+        }
+      }
+    },
+    "Translate": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersetzen"
+          }
+        }
+      }
+    },
+    "Trial Active": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testversion aktiv"
+          }
+        }
+      }
+    },
+    "Trial ended": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testphase beendet"
+          }
+        }
+      }
+    },
+    "Trial Ending Soon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testversion endet bald"
+          }
+        }
+      }
+    },
+    "Trial Expired": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testversion abgelaufen"
+          }
+        }
+      }
+    },
+    "Trigger Words": {
+      "comment": "A label displayed above the user's trigger words.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöserwörter"
+          }
+        }
+      }
+    },
+    "Triggers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auslöser"
+          }
+        }
+      }
+    },
+    "Try a different search term": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anderen Suchbegriff versuchen"
+          }
+        }
+      }
+    },
+    "Try a few short samples and see how VoiceInk works before you start.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probieren Sie ein paar kurze Beispiele aus und sehen Sie, wie VoiceInk funktioniert, bevor Sie beginnen."
+          }
+        }
+      }
+    },
+    "Try selecting a different model or redownloading the current model.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie ein anderes Modell aus oder laden Sie das aktuelle Modell erneut herunter."
+          }
+        }
+      }
+    },
+    "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie diese Option, wenn Transkriptionen mit lokalen Modellen länger als erwartet dauern. Führt beim App-Start und Aufwachen im Hintergrund stille Transkriptionen aus, um die Optimierung anzustoßen."
+          }
+        }
+      }
+    },
+    "Unavailable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verfügbar"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannt"
+          }
+        }
+      }
+    },
+    "Unlock VoiceInk Pro For Less": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk Pro günstiger freischalten"
+          }
+        }
+      }
+    },
+    "Unsupported provider": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht unterstützter Anbieter"
+          }
+        }
+      }
+    },
+    "Update the word or phrase that should be automatically replaced.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Wort oder den Ausdruck aktualisieren, der automatisch ersetzt werden soll."
+          }
+        }
+      }
+    },
+    "Use captured on-screen text as context for this mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfassten Bildschirmtext als Kontext für diesen Modus verwenden."
+          }
+        }
+      }
+    },
+    "Use clipboard text as context for this mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text aus der Zwischenablage als Kontext für diesen Modus verwenden."
+          }
+        }
+      }
+    },
+    "Use Cloud": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud verwenden"
+          }
+        }
+      }
+    },
+    "Use selected text from the active app as context for this mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählten Text der aktiven App als Kontext für diesen Modus verwenden."
+          }
+        }
+      }
+    },
+    "Use System Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemvorlage verwenden"
+          }
+        }
+      }
+    },
+    "Use VoiceInk now.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk jetzt nutzen."
+          }
+        }
+      }
+    },
+    "User Message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzernachricht"
+          }
+        }
+      }
+    },
+    "Using: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendet: %@"
+          }
+        }
+      }
+    },
+    "Variables: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT"
+          }
+        }
+      }
+    },
+    "Verification Successful": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfung erfolgreich"
+          }
+        }
+      }
+    },
+    "Verified": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifiziert"
+          }
+        }
+      }
+    },
+    "Verify": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen"
+          }
+        }
+      }
+    },
+    "Verify and Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen und speichern"
+          }
+        }
+      }
+    },
+    "Verify API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel überprüfen"
+          }
+        }
+      }
+    },
+    "Verifying": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft"
+          }
+        }
+      }
+    },
+    "Verifying...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft..."
+          }
+        }
+      }
+    },
+    "Version %@ (%@)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ (%@)"
+          }
+        }
+      }
+    },
+    "Version Mismatch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionskonflikt"
+          }
+        }
+      }
+    },
+    "View details": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details anzeigen"
+          }
+        }
+      }
+    },
+    "View transcription and enhancement model performance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptions- und Verbesserungsmodell-Leistung anzeigen"
+          }
+        }
+      }
+    },
+    "Vocabulary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vokabular"
+          }
+        }
+      }
+    },
+    "Vocabulary is used only with AI enhancement to preserve important names, technical terms, and unique spellings in the final output.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vokabular wird nur mit KI-Verbesserung verwendet, um wichtige Namen, Fachbegriffe und besondere Schreibweisen in der finalen Ausgabe beizubehalten."
+          }
+        }
+      }
+    },
+    "Vocabulary Words": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vokabular-Wörter"
+          }
+        }
+      }
+    },
+    "Vocabulary Words (%lld)": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vokabular-Wort (%lld)"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vokabular-Wörter (%lld)"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vocabulary Word (%lld)"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vocabulary Words (%lld)"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Voice Activity Detection (VAD)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachaktivitätserkennung (VAD)"
+          }
+        }
+      }
+    },
+    "VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
+        }
+      }
+    },
+    "VoiceInk app is not available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-App ist nicht verfügbar"
+          }
+        }
+      }
+    },
+    "VoiceInk automatically understands what you are working with and selects your preferred setup. You can always configure this by editing or creating new modes.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erkennt automatisch, woran Sie arbeiten, und wählt Ihre bevorzugte Konfiguration aus. Sie können dies jederzeit konfigurieren, indem Sie Modi bearbeiten oder neue Modi erstellen."
+          }
+        }
+      }
+    },
+    "VoiceInk can select the right mode from the app you are using and the rules you configure.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk kann anhand der verwendeten App und der konfigurierten Regeln den passenden Modus auswählen."
+          }
+        }
+      }
+    },
+    "VoiceInk couldn't access its storage location. Your transcriptions will not be saved between sessions.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk konnte nicht auf den Speicherort zugreifen. Ihre Transkriptionen werden nicht zwischen Sitzungen gespeichert."
+          }
+        }
+      }
+    },
+    "VoiceInk Insights": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Einblicke"
+          }
+        }
+      }
+    },
+    "VoiceInk is also open source, so you can inspect every single line of code.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist auch Open Source, sodass Sie jede Codezeile einsehen können."
+          }
+        }
+      }
+    },
+    "VoiceInk is Context-Aware": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erkennt den Kontext"
+          }
+        }
+      }
+    },
+    "VoiceInk is context-aware.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk erkennt den Kontext."
+          }
+        }
+      }
+    },
+    "VoiceInk is Open Source": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist Open Source"
+          }
+        }
+      }
+    },
+    "VoiceInk is private by default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist standardmäßig privat"
+          }
+        }
+      }
+    },
+    "VoiceInk is private by default. No data leaves your device unless you opt in.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk ist standardmäßig privat. Keine Daten verlassen Ihr Gerät, sofern Sie dem nicht zustimmen."
+          }
+        }
+      }
+    },
+    "VoiceInk Modes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Modi"
+          }
+        }
+      }
+    },
+    "VoiceInk modes include Dictation, Enhance, Email, Assistant, Rewrite, Ask, Summarize, and Translate.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Modi umfassen Diktat, Verbesserung, E-Mail, Assistent, Umschreiben, Fragen, Zusammenfassen und Übersetzen."
+          }
+        }
+      }
+    },
+    "VoiceInk Pro": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk Pro"
+          }
+        }
+      }
+    },
+    "VoiceInk reads visible screen content to improve the accuracy of transcripts.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk liest sichtbare Bildschirminhalte, um die Genauigkeit der Transkripte zu verbessern."
+          }
+        }
+      }
+    },
+    "VoiceInk recorder dismissed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme geschlossen"
+          }
+        }
+      }
+    },
+    "VoiceInk recorder toggled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahme umgeschaltet"
+          }
+        }
+      }
+    },
+    "VoiceInk recording service is not available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Aufnahmedienst ist nicht verfügbar"
+          }
+        }
+      }
+    },
+    "VoiceInk sessions completed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk-Sitzungen abgeschlossen"
+          }
+        }
+      }
+    },
+    "VoiceInk temporarily uses the clipboard to paste transcription. When enabled, it restores your previous clipboard content after the selected delay. When disabled, the pasted transcription stays on your clipboard.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk nutzt die Zwischenablage vorübergehend zum Einfügen der Transkription. Wenn aktiviert, wird der frühere Inhalt der Zwischenablage nach der gewählten Verzögerung wiederhergestellt. Wenn deaktiviert, bleibt die Transkription in der Zwischenablage."
+          }
+        }
+      }
+    },
+    "VoiceInk uses Accessibility to type transcriptions directly into any app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk verwendet Bedienungshilfen, um Transkriptionen direkt in jede App einzugeben."
+          }
+        }
+      }
+    },
+    "VoiceInk uses LLMs to enhance transcripts and perform AI actions. Set up an API key before continuing.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk verwendet LLMs, um Transkripte zu verbessern und KI-Aktionen auszuführen. Richten Sie einen API-Schlüssel ein, bevor Sie fortfahren."
+          }
+        }
+      }
+    },
+    "VoiceInk uses your microphone to capture your voice.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk verwendet Ihr Mikrofon, um Ihre Stimme aufzunehmen."
+          }
+        }
+      }
+    },
+    "VoiceInk vs. typing by hand": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk vs. Tippen von Hand"
+          }
+        }
+      }
+    },
+    "VoiceInk will download NVIDIA's Parakeet model to set up fast local transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk lädt das Parakeet-Modell von NVIDIA herunter, um schnelle lokale Transkription einzurichten."
+          }
+        }
+      }
+    },
+    "Voicing, Voice ink": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voicing, Voice ink"
+          }
+        }
+      }
+    },
+    "Voicing, Voice ink, Voiceing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voicing, Voice ink, Voiceing"
+          }
+        }
+      }
+    },
+    "Waiting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet"
+          }
+        }
+      }
+    },
+    "With": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit"
+          }
+        }
+      }
+    },
+    "word": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wort"
+          }
+        }
+      }
+    },
+    "Word Replacement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzung"
+          }
+        }
+      }
+    },
+    "Word replacement examples": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispiele für Wortersetzungen"
+          }
+        }
+      }
+    },
+    "Word Replacements": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzungen"
+          }
+        }
+      }
+    },
+    "Word Replacements run after transcription to replace misheard words, phrases, abbreviations, or boilerplate text.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzungen werden nach der Transkription ausgeführt, um falsch erkannte Wörter, Ausdrücke, Abkürzungen oder Textbausteine zu ersetzen."
+          }
+        }
+      }
+    },
+    "Word Replacements run after transcription. Vocabulary is used with AI enhancement to better understand names, technical terms, and unique spellings in your transcript.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wortersetzungen werden nach der Transkription angewendet. Das Vokabular wird mit KI-Verbesserung verwendet, um Namen, Fachbegriffe und besondere Schreibweisen in Ihrer Transkription besser zu verstehen."
+          }
+        }
+      }
+    },
+    "words": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter"
+          }
+        }
+      }
+    },
+    "Words": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter"
+          }
+        }
+      }
+    },
+    "Words Dictated": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktierte Wörter"
+          }
+        }
+      }
+    },
+    "words generated": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter generiert"
+          }
+        }
+      }
+    },
+    "Words Per Minute": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wörter pro Minute"
+          }
+        }
+      }
+    },
+    "Write prompt instructions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt-Anweisungen schreiben"
+          }
+        }
+      }
+    },
+    "You Control It": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben die Kontrolle"
+          }
+        }
+      }
+    },
+    "You have %lld days left in your trial": {
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ihre Testphase läuft noch %lld Tag"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ihre Testphase läuft noch %lld Tage"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "You have %lld day left in your trial"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "You have %lld days left in your trial"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "You have saved %@ with VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben %@ mit VoiceInk gespart"
+          }
+        }
+      }
+    },
+    "You'll see the introduction screens again the next time you launch the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim nächsten App-Start werden die Einführungsbildschirme erneut angezeigt."
+          }
+        }
+      }
+    },
+    "Your data never has to leave your device.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Daten müssen Ihr Gerät nie verlassen."
+          }
+        }
+      }
+    },
+    "Your license key is verified. VoiceInk is ready to use on this Mac.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihr Lizenzschlüssel wurde verifiziert. VoiceInk ist auf diesem Mac einsatzbereit."
+          }
+        }
+      }
+    },
+    "Your settings have been successfully exported to %@.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Einstellungen wurden erfolgreich in %@ exportiert."
+          }
+        }
+      }
+    },
+    "Your transcription history will appear here": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Transkriptionshistorie wird hier angezeigt"
+          }
+        }
+      }
+    },
+    "Your trial has ended. Upgrade to VoiceInk Pro at %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Testversion ist beendet. Upgraden Sie auf VoiceInk Pro unter %@"
+          }
+        }
+      }
+    },
+    "Your trial has expired. Upgrade to continue using VoiceInk": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Testversion ist abgelaufen. Upgraden Sie, um VoiceInk weiter zu verwenden."
+          }
+        }
+      }
+    },
+    "Your usage summary will appear here.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre Nutzungsübersicht wird hier angezeigt."
+          }
+        }
+      }
+    },
+    "Your VoiceInk journey starts with your first recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihre VoiceInk-Reise beginnt mit der ersten Aufnahme."
+          }
+        }
+      }
+    },
+    "YouTube Videos & Guides": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YouTube-Videos & Anleitungen"
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Completes German localization and removes stale strings so the German UI is fully translated and consistent. Adds missing de-DE entries and deletes obsolete keys in Localizable.xcstrings.

- **Bug Fixes**
  - Filled all missing German translations to reach 100% coverage.
  - Removed outdated/unused keys to prevent mismatches and fallback text.

<sup>Written for commit dea2f4fcf30a7003c4d7d4f4be6b2bc1d16459bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

