### PR TITLE
Add Simplified Chinese (zh-Hans) localization

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 				en,
 				Base,
 				de,
+				"zh-Hans",
 			);
 			mainGroup = E11473A72CBE0F0A00318EE4;
 			minimizedProjectReferenceProxies = 1;

--- a/VoiceInk/InfoPlist.xcstrings
+++ b/VoiceInk/InfoPlist.xcstrings
@@ -16,6 +16,12 @@
             "state" : "new",
             "value" : "VoiceInk"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
         }
       }
     },
@@ -34,6 +40,12 @@
             "state" : "new",
             "value" : "VoiceInk"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
         }
       }
     },
@@ -50,6 +62,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Audio/Video File"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频/视频文件"
           }
         }
       }
@@ -69,6 +87,12 @@
             "state" : "new",
             "value" : "VoiceInk needs to interact with your browser to detect the current website for applying website-specific configurations."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 需要与浏览器交互以检测当前网站，从而应用针对特定网站的配置。"
+          }
         }
       }
     },
@@ -86,6 +110,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : ""
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         }
       }
@@ -105,6 +135,12 @@
             "state" : "new",
             "value" : "VoiceInk needs access to your microphone to record audio for transcription."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 需要访问麦克风以录制音频用于转录。"
+          }
         }
       }
     },
@@ -121,6 +157,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "VoiceInk needs screen recording access to understand context from your screen for improved transcription accuracy."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 需要屏幕录制权限以理解屏幕上的上下文，提高转录准确性。"
           }
         }
       }

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -8,12 +8,24 @@
             "state": "translated",
             "value": ""
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
+          }
         }
       }
     },
     " ": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " "
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": " "
@@ -28,6 +40,12 @@
             "state": "translated",
             "value": " (zum Neuordnen ziehen)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（拖动以重新排序）"
+          }
         }
       }
     },
@@ -37,6 +55,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "'%@' existiert bereits in den Wortersetzungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」已存在于词语替换中"
           }
         }
       }
@@ -48,6 +72,12 @@
             "state": "translated",
             "value": "'%@' ist bereits im Vokabular enthalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」已在词汇中"
+          }
         }
       }
     },
@@ -57,6 +87,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ API-Schlüssel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API 密钥"
           }
         }
       }
@@ -68,6 +104,12 @@
             "state": "translated",
             "value": "%@-Verbindung verifiziert."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 连接已验证。"
+          }
         }
       }
     },
@@ -77,6 +119,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-Modus"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 模式"
           }
         }
       }
@@ -88,6 +136,12 @@
             "state": "translated",
             "value": "%@ erfordert macOS 26 oder neuer"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 需要 macOS 26 或更高版本"
+          }
         }
       }
     },
@@ -98,12 +152,24 @@
             "state": "translated",
             "value": "%d Sekunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 秒"
+          }
         }
       }
     },
     "%lld": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "%lld"
@@ -148,6 +214,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个应用"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -184,6 +262,18 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld Apps"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个应用"
                 }
               }
             }
@@ -228,6 +318,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "试用期剩余 %lld 天"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -264,6 +366,18 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld Enhancement models"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个润色模型"
                 }
               }
             }
@@ -308,6 +422,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个文件"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -344,6 +470,18 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld models"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个模型"
                 }
               }
             }
@@ -388,6 +526,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个可用模型"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -399,6 +549,12 @@
             "state": "translated",
             "value": "%lld Sekunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 秒"
+          }
         }
       }
     },
@@ -408,6 +564,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld ausgewählt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选择 %lld 项"
           }
         }
       }
@@ -445,6 +607,18 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld sessions"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 次会话"
                 }
               }
             }
@@ -489,6 +663,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个转录模型"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -525,6 +711,18 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld transcripts"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 条转录记录"
                 }
               }
             }
@@ -569,6 +767,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个网站"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -605,6 +815,18 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld Websites"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个网站"
                 }
               }
             }
@@ -649,6 +871,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个词"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -659,12 +893,24 @@
             "state": "translated",
             "value": "%lld %%"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
         }
       }
     },
     "••••••••": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "••••••••"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "••••••••"
@@ -679,12 +925,24 @@
             "state": "translated",
             "value": "↵"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "↵"
+          }
         }
       }
     },
     "+": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "+"
@@ -699,6 +957,12 @@
             "state": "translated",
             "value": "+%lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld"
+          }
         }
       }
     },
@@ -708,6 +972,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "0 s"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0 秒"
           }
         }
       }
@@ -719,6 +989,12 @@
             "state": "translated",
             "value": "1 Tag"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 天"
+          }
         }
       }
     },
@@ -728,6 +1004,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 Stunde"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小时"
           }
         }
       }
@@ -739,12 +1021,24 @@
             "state": "translated",
             "value": "1,5×"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1.5×"
+          }
         }
       }
     },
     "1×": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1×"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "1×"
@@ -759,12 +1053,24 @@
             "state": "translated",
             "value": "1 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 秒"
+          }
         }
       }
     },
     "2×": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2×"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "2×"
@@ -779,6 +1085,12 @@
             "state": "translated",
             "value": "2 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 秒"
+          }
         }
       }
     },
@@ -788,6 +1100,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "3 Tage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 天"
           }
         }
       }
@@ -799,6 +1117,12 @@
             "state": "translated",
             "value": "3 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 秒"
+          }
         }
       }
     },
@@ -808,6 +1132,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "4 s"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4 秒"
           }
         }
       }
@@ -819,6 +1149,12 @@
             "state": "translated",
             "value": "5 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 秒"
+          }
         }
       }
     },
@@ -828,6 +1164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "7 Tage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 天"
           }
         }
       }
@@ -839,6 +1181,12 @@
             "state": "translated",
             "value": "14 Tage"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "14 天"
+          }
         }
       }
     },
@@ -848,6 +1196,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "15 s"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 秒"
           }
         }
       }
@@ -859,6 +1213,12 @@
             "state": "translated",
             "value": "25+ Sprachen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25+ 种语言"
+          }
         }
       }
     },
@@ -868,6 +1228,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "30 Tage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 天"
           }
         }
       }
@@ -879,6 +1245,12 @@
             "state": "translated",
             "value": "30% RABATT"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "七折优惠"
+          }
         }
       }
     },
@@ -888,6 +1260,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "30 s"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 秒"
           }
         }
       }
@@ -899,6 +1277,12 @@
             "state": "translated",
             "value": "45 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "45 秒"
+          }
         }
       }
     },
@@ -908,6 +1292,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "60 s"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "60 秒"
           }
         }
       }
@@ -919,6 +1309,12 @@
             "state": "translated",
             "value": "90 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 秒"
+          }
         }
       }
     },
@@ -928,6 +1324,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "120 s"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "120 秒"
           }
         }
       }
@@ -939,6 +1341,12 @@
             "state": "translated",
             "value": "180 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "180 秒"
+          }
         }
       }
     },
@@ -948,6 +1356,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "250 ms"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "250 毫秒"
           }
         }
       }
@@ -959,6 +1373,12 @@
             "state": "translated",
             "value": "300 s"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "300 秒"
+          }
         }
       }
     },
@@ -968,6 +1388,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "500 ms"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "500 毫秒"
           }
         }
       }
@@ -979,6 +1405,12 @@
             "state": "translated",
             "value": "Ein eigenes Verbesserungsmodell mit diesem Anzeigenamen existiert bereits"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存在使用此显示名称的自定义润色模型"
+          }
         }
       }
     },
@@ -988,6 +1420,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ein eigenes Verbesserungsmodell mit diesem Modellnamen existiert bereits"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存在使用此模型名称的自定义润色模型"
           }
         }
       }
@@ -999,6 +1437,12 @@
             "state": "translated",
             "value": "Ein Modus mit dem Namen '%@' existiert bereits."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存在名为「%@」的模式。"
+          }
         }
       }
     },
@@ -1008,6 +1452,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ein Modell namens %@.bin existiert bereits"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存在名为 %@.bin 的模型"
           }
         }
       }
@@ -1019,6 +1469,12 @@
             "state": "translated",
             "value": "Ein Modell mit diesem Namen existiert bereits"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存在同名模型"
+          }
         }
       }
     },
@@ -1028,6 +1484,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ein Netzwerkfehler ist aufgetreten: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发生网络错误：%@"
           }
         }
       }
@@ -1039,6 +1501,12 @@
             "state": "translated",
             "value": "Bedienungshilfen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助功能"
+          }
         }
       }
     },
@@ -1048,6 +1516,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kein Zugriff auf Bedienungshilfen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未授予辅助功能权限"
           }
         }
       }
@@ -1059,6 +1533,12 @@
             "state": "translated",
             "value": "Genauigkeit"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "准确度"
+          }
         }
       }
     },
@@ -1068,6 +1548,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aktivieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "激活"
           }
         }
       }
@@ -1079,6 +1565,12 @@
             "state": "translated",
             "value": "Aktiviere eine Lizenz, um VoiceInk weiter zu verwenden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "激活许可证以继续使用 VoiceInk。"
+          }
         }
       }
     },
@@ -1088,6 +1580,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aktiviere einen vorhandenen Schlüssel, kaufe eine Lizenz oder starte eine 7-tägige kostenlose Testversion."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "激活现有密钥、购买许可证，或开始 7 天免费试用。"
           }
         }
       }
@@ -1099,6 +1597,12 @@
             "state": "translated",
             "value": "Lizenz aktivieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "激活许可证"
+          }
         }
       }
     },
@@ -1108,6 +1612,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird aktiviert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在激活"
           }
         }
       }
@@ -1119,6 +1629,12 @@
             "state": "translated",
             "value": "Aktivierungsverzögerung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "激活延迟"
+          }
         }
       }
     },
@@ -1128,6 +1644,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aktiv"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用中"
           }
         }
       }
@@ -1139,6 +1661,12 @@
             "state": "translated",
             "value": "Hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
         }
       }
     },
@@ -1148,6 +1676,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加 %@"
           }
         }
       }
@@ -1160,6 +1694,12 @@
             "state": "translated",
             "value": "Ein eigenes, feinjustiertes Whisper-Modell für VoiceInk hinzufügen. Wähle die heruntergeladene .bin-Datei aus."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加自定义微调的 whisper 模型以在 VoiceInk 中使用。请选择已下载的 .bin 文件。"
+          }
         }
       }
     },
@@ -1169,6 +1709,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Neuen Modus hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加新模式"
           }
         }
       }
@@ -1181,6 +1727,12 @@
             "state": "translated",
             "value": "Ein abschließendes Leerzeichen nach der eingefügten Transkription hinzufügen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在粘贴的转录输出末尾添加一个空格。"
+          }
         }
       }
     },
@@ -1190,6 +1742,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "App oder Website hinzufügen..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加应用或网站…"
           }
         }
       }
@@ -1201,6 +1759,12 @@
             "state": "translated",
             "value": "Eigenes Emoji hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加自定义表情符号"
+          }
         }
       }
     },
@@ -1210,6 +1774,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigenes Verbesserungsmodell hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加自定义润色模型"
           }
         }
       }
@@ -1222,6 +1792,12 @@
             "state": "translated",
             "value": "Eigenes Modell hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加自定义模型"
+          }
         }
       }
     },
@@ -1231,6 +1807,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigenes Transkriptionsmodell hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加自定义转录模型"
           }
         }
       }
@@ -1242,6 +1824,12 @@
             "state": "translated",
             "value": "Eigene Modi für verschiedene Kontexte hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为不同场景添加自定义模式"
+          }
         }
       }
     },
@@ -1251,6 +1839,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbesserungsmodell hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加润色模型"
           }
         }
       }
@@ -1262,6 +1856,12 @@
             "state": "translated",
             "value": "Dateien hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加文件"
+          }
         }
       }
     },
@@ -1271,6 +1871,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Füllwort hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加填充词"
           }
         }
       }
@@ -1282,6 +1888,12 @@
             "state": "translated",
             "value": "Füllwort hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加填充词"
+          }
         }
       }
     },
@@ -1291,6 +1903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mikrofone in der Reihenfolge hinzufügen, in der VoiceInk sie verwenden soll."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按 VoiceInk 应依次尝试的顺序添加麦克风。"
           }
         }
       }
@@ -1303,6 +1921,12 @@
             "state": "translated",
             "value": "Modell hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加模型"
+          }
         }
       }
     },
@@ -1312,6 +1936,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modell hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加模型"
           }
         }
       }
@@ -1323,6 +1953,12 @@
             "state": "translated",
             "value": "Neu hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增"
+          }
         }
       }
     },
@@ -1332,6 +1968,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Neuen Modus hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加新模式"
           }
         }
       }
@@ -1343,6 +1985,12 @@
             "state": "translated",
             "value": "Neuen Prompt hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加新提示词"
+          }
         }
       }
     },
@@ -1352,6 +2000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Prompt hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加提示词"
           }
         }
       }
@@ -1363,6 +2017,12 @@
             "state": "translated",
             "value": "Zweites Tastenkürzel hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加第二个快捷键"
+          }
         }
       }
     },
@@ -1372,6 +2032,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Leerzeichen nach dem Einfügen hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴后添加空格"
           }
         }
       }
@@ -1383,6 +2049,12 @@
             "state": "translated",
             "value": "Transkriptionsmodell hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加转录模型"
+          }
         }
       }
     },
@@ -1392,6 +2064,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auslöser hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加触发条件"
           }
         }
       }
@@ -1405,6 +2083,12 @@
             "state": "translated",
             "value": "Auslöserwort hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加触发词"
+          }
         }
       }
     },
@@ -1414,6 +2098,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Website hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加网站"
           }
         }
       }
@@ -1425,6 +2115,12 @@
             "state": "translated",
             "value": "Wort hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加词语"
+          }
         }
       }
     },
@@ -1434,6 +2130,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wortersetzung hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加词语替换"
           }
         }
       }
@@ -1445,6 +2147,12 @@
             "state": "translated",
             "value": "Wort zum Vokabular hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加词语到词汇"
+          }
         }
       }
     },
@@ -1455,6 +2163,12 @@
             "state": "translated",
             "value": "Weitere Tastaturkürzel"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他快捷键"
+          }
         }
       }
     },
@@ -1464,6 +2178,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erweitert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级"
           }
         }
       }
@@ -1476,6 +2196,12 @@
             "state": "translated",
             "value": "Partnerprogramm"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "联盟计划"
+          }
         }
       }
     },
@@ -1485,6 +2211,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AFFILIATE 30%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "联盟计划 30%"
           }
         }
       }
@@ -1496,6 +2228,12 @@
             "state": "translated",
             "value": "KI-Verbesserung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 润色"
+          }
         }
       }
     },
@@ -1505,6 +2243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Die KI-Verbesserung konnte den Text nicht verarbeiten."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 润色处理文本失败。"
           }
         }
       }
@@ -1516,6 +2260,12 @@
             "state": "translated",
             "value": "KI-Verbesserung ist nicht aktiviert oder konfiguriert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 润色未启用或未配置"
+          }
         }
       }
     },
@@ -1525,6 +2275,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "KI-Modell"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 模型"
           }
         }
       }
@@ -1537,6 +2293,12 @@
             "state": "translated",
             "value": "KI-Modelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 模型"
+          }
         }
       }
     },
@@ -1546,6 +2308,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "KI-Anbieter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 提供商"
           }
         }
       }
@@ -1557,6 +2325,12 @@
             "state": "translated",
             "value": "KI-Anbieter-Integration"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 提供商集成"
+          }
         }
       }
     },
@@ -1566,6 +2340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "KI-Anbieter nicht konfiguriert. Bitte überprüfe deinen API-Schlüssel."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配置 AI 提供商。请检查你的 API 密钥。"
           }
         }
       }
@@ -1577,6 +2357,12 @@
             "state": "translated",
             "value": "KI-Anfrage"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 请求"
+          }
         }
       }
     },
@@ -1586,6 +2372,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alle Einstellungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有设置"
           }
         }
       }
@@ -1598,6 +2390,12 @@
             "state": "translated",
             "value": "Gesamt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部时间"
+          }
         }
       }
     },
@@ -1607,6 +2405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erlauben"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许"
           }
         }
       }
@@ -1618,6 +2422,12 @@
             "state": "translated",
             "value": "Berechtigungen erlauben"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许权限"
+          }
         }
       }
     },
@@ -1627,6 +2437,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erlaube VoiceInk, in all deinen Apps zu funktionieren."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许 VoiceInk 在你的所有应用中工作。"
           }
         }
       }
@@ -1638,6 +2454,12 @@
             "state": "translated",
             "value": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut oder kontaktiere den Support unter %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发生意外错误。请重试，或通过 %@ 联系支持人员"
+          }
         }
       }
     },
@@ -1647,6 +2469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ein unbekannter Fehler ist aufgetreten."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发生未知错误。"
           }
         }
       }
@@ -1658,6 +2486,12 @@
             "state": "translated",
             "value": "Analysierbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可分析"
+          }
         }
       }
     },
@@ -1667,6 +2501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Analysieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析"
           }
         }
       }
@@ -1678,6 +2518,12 @@
             "state": "translated",
             "value": "Wird analysiert..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在分析…"
+          }
         }
       }
     },
@@ -1687,6 +2533,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Endpunkt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 端点"
           }
         }
       }
@@ -1698,6 +2550,12 @@
             "state": "translated",
             "value": "API-Endpunkt darf nicht leer sein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 端点不能为空"
+          }
         }
       }
     },
@@ -1707,6 +2565,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Endpunkt muss eine gültige URL sein"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 端点必须是有效的 URL"
           }
         }
       }
@@ -1719,6 +2583,12 @@
             "state": "translated",
             "value": "API-Schlüssel"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
+          }
         }
       }
     },
@@ -1728,6 +2598,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
           }
         }
       }
@@ -1739,6 +2615,12 @@
             "state": "translated",
             "value": "API-Schlüssel darf nicht leer sein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥不能为空"
+          }
         }
       }
     },
@@ -1748,6 +2630,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel-Konfiguration"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥配置"
           }
         }
       }
@@ -1759,6 +2647,12 @@
             "state": "translated",
             "value": "Der API-Schlüssel für diesen Dienst fehlt. Bitte konfiguriere ihn in den Einstellungen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少此服务的 API 密钥。请在设置中进行配置。"
+          }
         }
       }
     },
@@ -1768,6 +2662,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel für Streaming-Transkription ist nicht konfiguriert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未为流式转录配置 API 密钥"
           }
         }
       }
@@ -1779,6 +2679,12 @@
             "state": "translated",
             "value": "An Journal anhängen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加到日记"
+          }
         }
       }
     },
@@ -1788,6 +2694,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Apple Speech kann bis zu 5 Sprachen reservieren. Wähle eine zum Entfernen aus, bevor du die neue Sprache herunterlädst."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 最多可保留 5 种语言。下载所选语言前，请先选择一种移除。"
           }
         }
       }
@@ -1799,6 +2711,12 @@
             "state": "translated",
             "value": "Apple Speech kann bis zu 5 Sprachen reservieren. Verwalte reservierte Sprachen in den Moduseinstellungen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 最多可保留 5 种语言。请在「模式」设置中管理已保留的语言。"
+          }
         }
       }
     },
@@ -1808,6 +2726,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Apple Speech konnte die Sprachressourcen für %@ nicht reservieren. Verwalte reservierte Apple-Speech-Sprachen in den Einstellungen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 无法为 %@ 预留语言资源。请在设置中管理已预留的 Apple Speech 语言。"
           }
         }
       }
@@ -1819,6 +2743,12 @@
             "state": "translated",
             "value": "Apple Speech hat die Rückgabe der Transkriptionsergebnisse nicht abgeschlossen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 未能完整返回转录结果。"
+          }
         }
       }
     },
@@ -1828,6 +2758,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Apple Speech unterstützt diese Sprache nicht."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 不支持此语言。"
           }
         }
       }
@@ -1839,6 +2775,12 @@
             "state": "translated",
             "value": "Download der Apple-Speech-Sprache fehlgeschlagen: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 语言下载失败：%@"
+          }
         }
       }
     },
@@ -1848,6 +2790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Downloads für Apple-Speech-Sprachen sind auf diesem System nicht verfügbar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此系统不支持下载 Apple Speech 语言。"
           }
         }
       }
@@ -1859,12 +2807,24 @@
             "state": "translated",
             "value": "Die Apple-Speech-Sprache wurde heruntergeladen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Speech 语言已下载。"
+          }
         }
       }
     },
     "AppleScript": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppleScript"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "AppleScript"
@@ -1880,6 +2840,12 @@
             "state": "translated",
             "value": "Intelligente Textformatierung anwenden, um große Textblöcke in Absätze zu unterteilen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用智能文本排版，将大段文字拆分为段落。"
+          }
         }
       }
     },
@@ -1889,6 +2855,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Soll der Prompt „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定要删除「%@」提示词吗？此操作无法撤销。"
           }
         }
       }
@@ -1900,6 +2872,12 @@
             "state": "translated",
             "value": "Soll „%@“ wirklich gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定要删除「%@」吗？此操作无法撤销。"
+          }
         }
       }
     },
@@ -1909,6 +2887,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Möchtest du das eigene Verbesserungsmodell „%@“ wirklich löschen?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定要删除自定义润色模型「%@」吗？"
           }
         }
       }
@@ -1920,6 +2904,12 @@
             "state": "translated",
             "value": "Möchtest du das eigene Modell „%@“ wirklich löschen?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定要删除自定义模型「%@」吗？"
+          }
         }
       }
     },
@@ -1929,6 +2919,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Möchtest du das Modell „%@“ wirklich löschen?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定要删除模型「%@」吗？"
           }
         }
       }
@@ -1941,6 +2937,12 @@
             "state": "translated",
             "value": "Pfeil"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "箭头"
+          }
         }
       }
     },
@@ -1951,6 +2953,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fragen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提问"
           }
         }
       }
@@ -1963,6 +2971,12 @@
             "state": "translated",
             "value": "Assistent"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "助手"
+          }
         }
       }
     },
@@ -1972,6 +2986,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Assistentenantwort wurde nicht gespeichert: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "助手回复未保存：%@"
           }
         }
       }
@@ -1984,6 +3004,12 @@
             "state": "translated",
             "value": "Audio"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频"
+          }
         }
       }
     },
@@ -1993,6 +3019,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Audio-Bereinigung"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频清理"
           }
         }
       }
@@ -2004,6 +3036,12 @@
             "state": "translated",
             "value": "Audiogerät ist nicht mehr verfügbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频设备已不可用"
+          }
         }
       }
     },
@@ -2013,6 +3051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Die Audiodatei ist %.1f Sekunden lang. Bitte verwende für Start- und Stopptöne eine Audiodatei, die %.0f Sekunden oder kürzer ist."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频文件长度为 %.1f 秒。请为开始和停止提示音使用 %.0f 秒或更短的音频文件。"
           }
         }
       }
@@ -2024,6 +3068,12 @@
             "state": "translated",
             "value": "Audiodatei nicht gefunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到音频文件"
+          }
         }
       }
     },
@@ -2033,6 +3083,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Audioeingabe"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频输入"
           }
         }
       }
@@ -2044,6 +3100,12 @@
             "state": "translated",
             "value": "AudioUnit nicht initialisiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AudioUnit 未初始化"
+          }
         }
       }
     },
@@ -2053,6 +3115,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatisch senden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动发送"
           }
         }
       }
@@ -2064,6 +3132,12 @@
             "state": "translated",
             "value": "Updates automatisch prüfen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查更新"
+          }
         }
       }
     },
@@ -2073,6 +3147,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Audiodateien automatisch löschen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动删除音频文件"
           }
         }
       }
@@ -2084,6 +3164,12 @@
             "state": "translated",
             "value": "Transkriptionen automatisch löschen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动删除转录记录"
+          }
         }
       }
     },
@@ -2093,6 +3179,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatisch erkannt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检测"
           }
         }
       }
@@ -2104,6 +3196,12 @@
             "state": "translated",
             "value": "Audioaufnahmen automatisch löschen, während Texttranskriptionen erhalten bleiben."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动删除音频录音，同时完整保留文字转录记录。"
+          }
         }
       }
     },
@@ -2113,6 +3211,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkriptionshistorie automatisch basierend auf dem festgelegten Aufbewahrungszeitraum löschen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根据你设置的保留期限自动删除转录记录。"
           }
         }
       }
@@ -2125,6 +3229,12 @@
             "state": "translated",
             "value": "Drückt nach dem Einfügen automatisch eine Tastenkombination. Nützlich für Chat-Apps oder Formulare mit abweichenden Sendekürzeln."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴文本后自动按下组合键。适用于使用不同发送快捷键的聊天应用或表单。"
+          }
         }
       }
     },
@@ -2136,6 +3246,12 @@
             "state": "translated",
             "value": "Konfigurierte Füllwörter wie „ähm“, „äh“ oder „hmm“ automatisch aus Transkriptionen entfernen. Wenn keine Füllwörter konfiguriert sind, wird diese Bereinigung übersprungen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动从转录中移除已配置的填充词，例如「uh」「um」或「hmm」。如果未配置任何填充词，将跳过此清理。"
+          }
         }
       }
     },
@@ -2145,6 +3261,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "KI-Verbesserung automatisch überspringen, wenn die Transkription sehr wenige Wörter enthält. Kurze Phrasen wie „ja“, „danke“ oder schnelle Befehle profitieren nicht von der Verbesserung."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当转录内容字数很少时，自动跳过 AI 润色。「是的」「谢谢」之类的简短用语或快速指令并不能从润色中获益。"
           }
         }
       }
@@ -2156,6 +3278,12 @@
             "state": "translated",
             "value": "Verfügbare Verbesserungsmodelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用的润色模型"
+          }
         }
       }
     },
@@ -2165,6 +3293,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verfügbare Mikrofone"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用麦克风"
           }
         }
       }
@@ -2176,6 +3310,12 @@
             "state": "translated",
             "value": "Verfügbare Transkriptionsmodelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用的转录模型"
+          }
         }
       }
     },
@@ -2185,6 +3325,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ø Audio"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平均音频时长"
           }
         }
       }
@@ -2196,6 +3342,12 @@
             "state": "translated",
             "value": "Ø Verbesserungszeit"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平均润色用时"
+          }
         }
       }
     },
@@ -2205,6 +3357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ø Verarbeitungszeit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平均处理时间"
           }
         }
       }
@@ -2216,6 +3374,12 @@
             "state": "translated",
             "value": "Ø Verarbeitungszeit"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平均处理时间"
+          }
         }
       }
     },
@@ -2225,6 +3389,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zurück"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
           }
         }
       }
@@ -2236,6 +3406,12 @@
             "state": "translated",
             "value": "Sicherung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份"
+          }
         }
       }
     },
@@ -2245,6 +3421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Basis-URL"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base URL"
           }
         }
       }
@@ -2256,6 +3438,12 @@
             "state": "translated",
             "value": "Basis-URL darf nicht leer sein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base URL 不能为空"
+          }
         }
       }
     },
@@ -2265,6 +3453,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Basis-URL muss eine gültige URL sein"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base URL 必须是有效的 URL"
           }
         }
       }
@@ -2276,6 +3470,12 @@
             "state": "translated",
             "value": "Lizenz kaufen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "购买许可证"
+          }
         }
       }
     },
@@ -2285,6 +3485,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Lizenz kaufen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "购买 VoiceInk 许可证"
           }
         }
       }
@@ -2296,6 +3502,12 @@
             "state": "translated",
             "value": "Abbrechen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
         }
       }
     },
@@ -2305,6 +3517,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme abbrechen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消录音"
           }
         }
       }
@@ -2316,6 +3534,12 @@
             "state": "translated",
             "value": "Transkription abbrechen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消转录"
+          }
         }
       }
     },
@@ -2325,6 +3549,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wiederholung nicht möglich: Audiodatei nicht gefunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法重试：未找到音频文件"
           }
         }
       }
@@ -2336,6 +3566,12 @@
             "state": "translated",
             "value": "Modus kann nicht gespeichert werden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存模式"
+          }
         }
       }
     },
@@ -2345,6 +3581,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Änderungsprotokoll"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新日志"
           }
         }
       }
@@ -2356,6 +3598,12 @@
             "state": "translated",
             "value": "Nach Updates suchen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
         }
       }
     },
@@ -2365,6 +3613,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nach Updates suchen …"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新…"
           }
         }
       }
@@ -2376,6 +3630,12 @@
             "state": "translated",
             "value": "Überprüfe das Standardmodell und versuche es erneut. Wenn das Problem weiterhin besteht, probiere ein anderes Modell."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请检查默认模型并重试。如果问题仍然存在，请尝试其他模型。"
+          }
         }
       }
     },
@@ -2385,6 +3645,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird geprüft"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查"
           }
         }
       }
@@ -2396,6 +3662,12 @@
             "state": "translated",
             "value": "Zwischengespeicherte Modelle werden geprüft..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查缓存的模型…"
+          }
         }
       }
     },
@@ -2405,6 +3677,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Es wird geprüft, ob diese Apple-Speech-Sprache heruntergeladen ist."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查此 Apple Speech 语言是否已下载。"
           }
         }
       }
@@ -2416,6 +3694,12 @@
             "state": "translated",
             "value": "Auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
+          }
         }
       }
     },
@@ -2425,6 +3709,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-Klang auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取 %@ 提示音"
           }
         }
       }
@@ -2436,6 +3726,12 @@
             "state": "translated",
             "value": "Sprache zum Entfernen auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取要移除的语言"
+          }
         }
       }
     },
@@ -2446,6 +3742,12 @@
             "state": "translated",
             "value": "Wähle einen Speicherort für deine Einstellungen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取一个位置来保存你的设置。"
+          }
         }
       }
     },
@@ -2455,6 +3757,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wähle ein Einstellungs-Backup und dann, was importiert werden soll."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个设置备份，然后选择要导入的内容。"
           }
         }
       }
@@ -2467,6 +3775,12 @@
             "state": "translated",
             "value": "Wähle eine Tastenkombination, um loszulegen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个快捷键以开始。"
+          }
         }
       }
     },
@@ -2476,6 +3790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dateien auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取文件"
           }
         }
       }
@@ -2487,6 +3807,12 @@
             "state": "translated",
             "value": "Mikrofon auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取麦克风"
+          }
         }
       }
     },
@@ -2496,6 +3822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wähle aus, was aus diesem Backup importiert werden soll."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择要从此备份中导入的内容。"
           }
         }
       }
@@ -2507,6 +3839,12 @@
             "state": "translated",
             "value": "Claude, Codex, Skripte oder beliebige Befehle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude、Codex、脚本或任何命令"
+          }
         }
       }
     },
@@ -2516,6 +3854,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bereinigung abgeschlossen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理完成"
           }
         }
       }
@@ -2527,6 +3871,12 @@
             "state": "translated",
             "value": "Bereinigung abgeschlossen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理完成。"
+          }
         }
       }
     },
@@ -2536,6 +3886,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Leeren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
           }
         }
       }
@@ -2547,6 +3903,12 @@
             "state": "translated",
             "value": "Alle Elemente löschen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除所有项目"
+          }
         }
       }
     },
@@ -2556,6 +3918,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zwischenablage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剪贴板"
           }
         }
       }
@@ -2567,6 +3935,12 @@
             "state": "translated",
             "value": "Schließen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
         }
       }
     },
@@ -2576,6 +3950,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "云端"
           }
         }
       }
@@ -2587,6 +3967,12 @@
             "state": "translated",
             "value": "Cloud-Anbieter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "云端提供商"
+          }
         }
       }
     },
@@ -2596,6 +3982,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Befehl"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令"
           }
         }
       }
@@ -2607,6 +3999,12 @@
             "state": "translated",
             "value": "Befehlstaste + Eingabe (⌘⏎)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command + Return (⌘⏎)"
+          }
         }
       }
     },
@@ -2616,6 +4014,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ wird kompiliert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在编译 %@"
           }
         }
       }
@@ -2627,6 +4031,12 @@
             "state": "translated",
             "value": "Einführung abschließen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成新手引导"
+          }
         }
       }
     },
@@ -2636,6 +4046,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Konfigurieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置"
           }
         }
       }
@@ -2647,6 +4063,12 @@
             "state": "translated",
             "value": "API-Schlüssel konfigurieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置 API 密钥"
+          }
         }
       }
     },
@@ -2656,6 +4078,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Konfiguriert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已配置"
           }
         }
       }
@@ -2667,6 +4095,12 @@
             "state": "translated",
             "value": "Verbinden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
         }
       }
     },
@@ -2676,6 +4110,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schließe ein Mikrofon an oder erlaube den Mikrofonzugriff und aktualisiere dann."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请连接麦克风或允许麦克风访问，然后刷新。"
           }
         }
       }
@@ -2687,6 +4127,12 @@
             "state": "translated",
             "value": "Anbieter hier verbinden, dann Modelle in Modi auswählen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在此处连接提供商，然后在「模式」中选择模型。"
+          }
         }
       }
     },
@@ -2696,6 +4142,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接"
           }
         }
       }
@@ -2707,6 +4159,12 @@
             "state": "translated",
             "value": "Verbindung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
         }
       }
     },
@@ -2716,6 +4174,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbindung verifiziert."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接已验证。"
           }
         }
       }
@@ -2727,6 +4191,12 @@
             "state": "translated",
             "value": "Kontexterkennung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上下文感知"
+          }
         }
       }
     },
@@ -2737,6 +4207,12 @@
             "state": "translated",
             "value": "Weiter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
+          }
         }
       }
     },
@@ -2746,6 +4222,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Steuere, wie VoiceInk deine Transkriptionsdaten und Audioaufnahmen verwaltet."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制 VoiceInk 如何处理你的转录数据和录音。"
           }
         }
       }
@@ -2758,6 +4240,12 @@
             "state": "translated",
             "value": "Transkriptionsausgabe in Kleinbuchstaben umwandeln."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将转录输出转换为小写。"
+          }
         }
       }
     },
@@ -2767,6 +4255,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kopiert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拷贝"
           }
         }
       }
@@ -2778,6 +4272,12 @@
             "state": "translated",
             "value": "In Zwischenablage kopiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拷贝到剪贴板"
+          }
         }
       }
     },
@@ -2787,6 +4287,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kopiert!"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拷贝！"
           }
         }
       }
@@ -2798,6 +4304,12 @@
             "state": "translated",
             "value": "Letzte Transkription kopieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝上次转录"
+          }
         }
       }
     },
@@ -2807,6 +4319,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenzschlüssel kopieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝许可证密钥"
           }
         }
       }
@@ -2818,6 +4336,12 @@
             "state": "translated",
             "value": "Systeminfo kopieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝系统信息"
+          }
         }
       }
     },
@@ -2827,6 +4351,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Emoji konnte nicht hinzugefügt werden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法添加表情符号。"
           }
         }
       }
@@ -2838,6 +4368,12 @@
             "state": "translated",
             "value": "Einstellungen konnten nicht als JSON kodiert werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法将设置编码为 JSON：%@"
+          }
         }
       }
     },
@@ -2847,6 +4383,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Die Datei-URL konnte nicht aus dem Öffnen-Dialog ermittelt werden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法从打开面板获取文件 URL。"
           }
         }
       }
@@ -2858,6 +4400,12 @@
             "state": "translated",
             "value": "Der Server konnte nicht erreicht werden. Bitte überprüfe deine Internetverbindung und versuche es erneut."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接到服务器。请检查互联网连接后重试。"
+          }
         }
       }
     },
@@ -2867,6 +4415,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ konnte nicht aus den reservierten Apple-Speech-Sprachen entfernt werden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法将 %@ 从 Apple Speech 保留语言中移除。"
           }
         }
       }
@@ -2878,6 +4432,12 @@
             "state": "translated",
             "value": "Einstellungen konnten nicht in der Datei gespeichert werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法将设置保存到文件：%@"
+          }
         }
       }
     },
@@ -2887,6 +4447,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dieser API-Schlüssel konnte nicht verifiziert werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法验证此 API 密钥"
           }
         }
       }
@@ -2898,6 +4464,12 @@
             "state": "translated",
             "value": "Dieser API-Schlüssel konnte nicht verifiziert werden. Überprüfe den Schlüssel und versuche es erneut."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法验证此 API 密钥。请检查密钥后重试。"
+          }
         }
       }
     },
@@ -2908,6 +4480,12 @@
             "state": "translated",
             "value": "Erstellen & auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建并选择"
+          }
         }
       }
     },
@@ -2917,6 +4495,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erstelle deinen ersten Modus, um deinen VoiceInk-Workflow basierend auf verwendeten Apps und Websites zu automatisieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建第一个模式，根据你正在使用的应用或网站自动化你的 VoiceInk 工作流程"
           }
         }
       }
@@ -2929,6 +4513,12 @@
             "state": "translated",
             "value": "Erstellt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建时间"
+          }
         }
       }
     },
@@ -2938,6 +4528,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigene"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
           }
         }
       }
@@ -2949,6 +4545,12 @@
             "state": "translated",
             "value": "Eigener Befehl"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令"
+          }
         }
       }
     },
@@ -2958,6 +4560,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigener Befehl darf nicht leer sein."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令不能为空。"
           }
         }
       }
@@ -2969,6 +4577,12 @@
             "state": "translated",
             "value": "Eigener Befehl konnte nicht gestartet werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令无法启动：%@"
+          }
         }
       }
     },
@@ -2978,6 +4592,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigener Befehl wurde mit Status %d beendet: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令以退出状态码 %d 结束：%@"
           }
         }
       }
@@ -2989,6 +4609,12 @@
             "state": "translated",
             "value": "Eigener Befehl wurde mit Status %d beendet."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令以退出状态码 %d 结束。"
+          }
         }
       }
     },
@@ -2999,6 +4625,12 @@
             "state": "translated",
             "value": "Eigener Befehl ist leer."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令为空。"
+          }
         }
       }
     },
@@ -3008,6 +4640,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigener Befehl hat nach %.0f Sekunden das Zeitlimit überschritten."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令在 %.0f 秒后超时。"
           }
         }
       }
@@ -3020,6 +4658,12 @@
             "state": "translated",
             "value": "Eigenes Gerät"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义设备"
+          }
         }
       }
     },
@@ -3029,6 +4673,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigene Verbesserungsmodelle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义润色模型"
           }
         }
       }
@@ -3040,6 +4690,12 @@
             "state": "translated",
             "value": "Eigene Modelldefinitionen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义模型定义"
+          }
         }
       }
     },
@@ -3049,6 +4705,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigene Prompts"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义提示词"
           }
         }
       }
@@ -3060,6 +4722,12 @@
             "state": "translated",
             "value": "Eigene Transkriptionsmodelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义转录模型"
+          }
         }
       }
     },
@@ -3069,6 +4737,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigene: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义：%@"
           }
         }
       }
@@ -3081,6 +4755,12 @@
             "state": "translated",
             "value": "Dashboard"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仪表盘"
+          }
         }
       }
     },
@@ -3090,6 +4770,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Datum"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期"
           }
         }
       }
@@ -3101,6 +4787,12 @@
             "state": "translated",
             "value": "Deaktivieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用"
+          }
         }
       }
     },
@@ -3110,6 +4802,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenz deaktivieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用许可证"
           }
         }
       }
@@ -3121,6 +4819,12 @@
             "state": "translated",
             "value": "Lizenz deaktivieren?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用许可证？"
+          }
         }
       }
     },
@@ -3131,6 +4835,12 @@
             "state": "translated",
             "value": "Standard"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
         }
       }
     },
@@ -3140,6 +4850,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当没有匹配的应用或网站时，将使用默认模式"
           }
         }
       }
@@ -3152,6 +4868,12 @@
             "state": "translated",
             "value": "Der Standardmodus wird verwendet, wenn keine App oder Website übereinstimmt."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当未找到匹配的特定应用或网站时，将使用默认模式。"
+          }
         }
       }
     },
@@ -3163,6 +4885,12 @@
             "state": "translated",
             "value": "Standard verwendet simulierte Cmd+V-Tastenereignisse. AppleScript kann helfen, wenn eigene Tastaturlayouts nicht korrekt einfügen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认使用模拟的 Cmd+V 按键事件。当自定义键盘布局无法正确粘贴时，AppleScript 会有所帮助。"
+          }
         }
       }
     },
@@ -3172,6 +4900,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Löschen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
           }
         }
       }
@@ -3213,6 +4947,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "删除 %lld 个文件"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -3222,6 +4968,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Löschen nach"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除时限"
           }
         }
       }
@@ -3233,6 +4985,12 @@
             "state": "translated",
             "value": "Eigenes Verbesserungsmodell löschen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除自定义润色模型"
+          }
         }
       }
     },
@@ -3242,6 +5000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigenes Modell löschen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除自定义模型"
           }
         }
       }
@@ -3253,6 +5017,12 @@
             "state": "translated",
             "value": "Modus löschen?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要删除此模式吗？"
+          }
         }
       }
     },
@@ -3262,6 +5032,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modell löschen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除模型"
           }
         }
       }
@@ -3273,6 +5049,12 @@
             "state": "translated",
             "value": "Prompt löschen?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除提示词？"
+          }
         }
       }
     },
@@ -3282,6 +5064,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ausgewählte Elemente löschen?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除所选项目？"
           }
         }
       }
@@ -3293,6 +5081,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gelöscht"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已删除"
           }
         }
       }
@@ -3334,6 +5128,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "已删除 %lld 个音频文件。"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -3343,6 +5149,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gelöschte Dateien: %lld. Fehlgeschlagen: %lld."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已删除文件：%lld。失败：%lld。"
           }
         }
       }
@@ -3354,6 +5166,12 @@
             "state": "translated",
             "value": "Verweigert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拒绝"
+          }
         }
       }
     },
@@ -3364,6 +5182,12 @@
             "state": "translated",
             "value": "Alle abwählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消全选"
+          }
         }
       }
     },
@@ -3373,6 +5197,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Details"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "详细信息"
           }
         }
       }
@@ -3385,6 +5215,12 @@
             "state": "translated",
             "value": "Sprachsegmente erkennen und Stille herausfiltern, um die Genauigkeit lokaler Modelle zu verbessern."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测语音片段并过滤静音，以提高本地模型的准确性。"
+          }
         }
       }
     },
@@ -3395,6 +5231,12 @@
             "state": "translated",
             "value": "Gerät"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备"
+          }
         }
       }
     },
@@ -3404,6 +5246,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Diagnose"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "诊断"
           }
         }
       }
@@ -3446,6 +5294,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "已听写 %@ 个词，共 %lld 次会话。"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -3457,6 +5317,12 @@
             "state": "translated",
             "value": "Diktat"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "听写"
+          }
         }
       }
     },
@@ -3466,6 +5332,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wörterbuch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词典"
           }
         }
       }
@@ -3477,6 +5349,12 @@
             "state": "translated",
             "value": "Wörterbuch-Einstellungen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词典设置"
+          }
         }
       }
     },
@@ -3486,6 +5364,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deaktiviert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已停用"
           }
         }
       }
@@ -3497,6 +5381,12 @@
             "state": "translated",
             "value": "Getrennt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已断开连接"
+          }
         }
       }
     },
@@ -3506,6 +5396,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schließen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
           }
         }
       }
@@ -3517,6 +5413,12 @@
             "state": "translated",
             "value": "Aufnahme schließen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭录音器"
+          }
         }
       }
     },
@@ -3526,6 +5428,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tastenkürzel-Hinweis schließen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭快捷键提示"
           }
         }
       }
@@ -3537,6 +5445,12 @@
             "state": "translated",
             "value": "VoiceInk-Aufnahme schließen und aktive Aufnahme abbrechen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭 VoiceInk 录音器，并取消所有正在进行的录音。"
+          }
         }
       }
     },
@@ -3546,6 +5460,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dieses Angebot ausblenden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭此推广"
           }
         }
       }
@@ -3557,6 +5477,12 @@
             "state": "translated",
             "value": "VoiceInk-Aufnahme schließen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭 VoiceInk 录音器"
+          }
         }
       }
     },
@@ -3566,6 +5492,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Anzeigename"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示名称"
           }
         }
       }
@@ -3577,6 +5509,12 @@
             "state": "translated",
             "value": "Anzeigename darf nicht leer sein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示名称不能为空"
+          }
         }
       }
     },
@@ -3586,6 +5524,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dokumentation"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文档"
           }
         }
       }
@@ -3597,6 +5541,12 @@
             "state": "translated",
             "value": "Dokumentation"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文档"
+          }
         }
       }
     },
@@ -3606,6 +5556,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fertig"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         }
       }
@@ -3617,6 +5573,12 @@
             "state": "translated",
             "value": "Doppelklick zum Bearbeiten • Rechtsklick für weitere Optionen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "双击编辑 • 右键查看更多选项"
+          }
         }
       }
     },
@@ -3626,6 +5588,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Herunterladen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载"
           }
         }
       }
@@ -3637,6 +5605,12 @@
             "state": "translated",
             "value": "Modell herunterladen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载模型"
+          }
         }
       }
     },
@@ -3646,6 +5620,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Download für %@ erforderlich."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 需要下载。"
           }
         }
       }
@@ -3657,6 +5637,12 @@
             "state": "translated",
             "value": "Diese Apple-Speech-Sprache herunterladen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载此 Apple Speech 语言。"
+          }
         }
       }
     },
@@ -3666,6 +5652,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkriptionsmodell herunterladen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载转录模型"
           }
         }
       }
@@ -3677,6 +5669,12 @@
             "state": "translated",
             "value": "Heruntergeladen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已下载"
+          }
         }
       }
     },
@@ -3686,6 +5684,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-Modell wird heruntergeladen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载 %@ 模型"
           }
         }
       }
@@ -3697,6 +5701,12 @@
             "state": "translated",
             "value": "Ressourcen für die ausgewählte Apple-Speech-Sprache werden heruntergeladen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载所选 Apple Speech 语言的资源。"
+          }
         }
       }
     },
@@ -3706,6 +5716,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Core-ML-Modell für %@ wird heruntergeladen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在为 %@ 下载 Core ML 模型"
           }
         }
       }
@@ -3717,6 +5733,12 @@
             "state": "translated",
             "value": "Modelldateien werden heruntergeladen: %lld/%lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载模型文件：%lld/%lld"
+          }
         }
       }
     },
@@ -3726,6 +5748,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird heruntergeladen..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载…"
           }
         }
       }
@@ -3737,6 +5765,12 @@
             "state": "translated",
             "value": "Audio- oder Videodateien hier ablegen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将音频或视频文件拖放到此处"
+          }
         }
       }
     },
@@ -3746,6 +5780,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dateien irgendwo ablegen, um weitere hinzuzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将文件拖放到任意位置以添加更多"
           }
         }
       }
@@ -3757,6 +5797,12 @@
             "state": "translated",
             "value": "Ablegen zum Hinzufügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "松开以添加文件"
+          }
         }
       }
     },
@@ -3766,6 +5812,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dauer"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时长"
           }
         }
       }
@@ -3777,6 +5829,12 @@
             "state": "translated",
             "value": "Drücke während der Aufnahme Option + 1-9, um schnell den Modus zu wechseln."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音时，按 Option + 1-9 可快速切换模式。"
+          }
         }
       }
     },
@@ -3786,6 +5844,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "z. B. meine E-Mail, meine Mail"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如：my email, my mail"
           }
         }
       }
@@ -3797,6 +5861,12 @@
             "state": "translated",
             "value": "z. B. Prakash, VoiceInk"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如：Prakash, VoiceInk"
+          }
         }
       }
     },
@@ -3806,6 +5876,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "z. B. support@tryvoiceink.com"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如：support@tryvoiceink.com"
           }
         }
       }
@@ -3817,6 +5893,12 @@
             "state": "translated",
             "value": "Mit dem VoiceInk-Partnerprogramm Geld verdienen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过 VoiceInk 联盟计划赚取收益"
+          }
         }
       }
     },
@@ -3826,6 +5908,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bearbeiten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑"
           }
         }
       }
@@ -3837,6 +5925,12 @@
             "state": "translated",
             "value": "Eigenes Verbesserungsmodell bearbeiten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑自定义润色模型"
+          }
         }
       }
     },
@@ -3846,6 +5940,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigenes Transkriptionsmodell bearbeiten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑自定义转录模型"
           }
         }
       }
@@ -3857,6 +5957,12 @@
             "state": "translated",
             "value": "Modus bearbeiten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑模式"
+          }
         }
       }
     },
@@ -3866,6 +5972,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modell bearbeiten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑模型"
           }
         }
       }
@@ -3877,6 +5989,12 @@
             "state": "translated",
             "value": "Prompt bearbeiten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑提示词"
+          }
         }
       }
     },
@@ -3886,6 +6004,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ersetzung bearbeiten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑替换项"
           }
         }
       }
@@ -3897,6 +6021,12 @@
             "state": "translated",
             "value": "Apps und Websites in dieser Gruppe bearbeiten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑此分组中的应用与网站。"
+          }
         }
       }
     },
@@ -3907,6 +6037,12 @@
             "state": "translated",
             "value": "Auslösergruppe bearbeiten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑触发条件组"
+          }
         }
       }
     },
@@ -3916,6 +6052,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wortersetzung bearbeiten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑词语替换"
           }
         }
       }
@@ -3928,6 +6070,12 @@
             "state": "translated",
             "value": "E-Mail"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邮件"
+          }
         }
       }
     },
@@ -3937,6 +6085,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "E-Mail-Support"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邮件支持"
           }
         }
       }
@@ -3948,6 +6102,12 @@
             "state": "translated",
             "value": "Emoji existiert bereits."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表情符号已存在。"
+          }
         }
       }
     },
@@ -3958,6 +6118,12 @@
             "state": "translated",
             "value": "Emoji darf nicht leer sein."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表情符号不能为空。"
+          }
         }
       }
     },
@@ -3967,6 +6133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bedienungshilfen aktivieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用辅助功能访问"
           }
         }
       }
@@ -3979,6 +6151,12 @@
             "state": "translated",
             "value": "Aktiviert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用"
+          }
         }
       }
     },
@@ -3990,6 +6168,12 @@
             "state": "translated",
             "value": "Verbessern"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色"
+          }
         }
       }
     },
@@ -3999,6 +6183,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbessert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已润色"
           }
         }
       }
@@ -4011,6 +6201,12 @@
             "state": "translated",
             "value": "Verbesserung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色"
+          }
         }
       }
     },
@@ -4020,6 +6216,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbesserung fehlgeschlagen: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色失败：%@"
           }
         }
       }
@@ -4031,6 +6233,12 @@
             "state": "translated",
             "value": "Verbesserungsmodell"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色模型"
+          }
         }
       }
     },
@@ -4040,6 +6248,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbesserungsmodelle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色模型"
           }
         }
       }
@@ -4051,6 +6265,12 @@
             "state": "translated",
             "value": "Verbesserungsmodi und KI-Aktionen bleiben deaktiviert. Du kannst dies später einrichten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色模式与 AI 操作将保持关闭。之后你随时可以在应用中设置。"
+          }
         }
       }
     },
@@ -4060,6 +6280,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zeitüberschreitung bei der Verbesserungsanfrage. Überprüfe deine Verbindung oder verlängere die maximale Wartezeit."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色请求超时。请检查网络连接或延长超时时长。"
           }
         }
       }
@@ -4071,6 +6297,12 @@
             "state": "translated",
             "value": "Verbesserungseinstellungen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色设置"
+          }
         }
       }
     },
@@ -4080,6 +6312,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbesserungszeit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "润色用时"
           }
         }
       }
@@ -4091,6 +6329,12 @@
             "state": "translated",
             "value": "Wird verbessert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在润色"
+          }
         }
       }
     },
@@ -4100,6 +6344,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme wird verbessert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在润色录音"
           }
         }
       }
@@ -4112,6 +6362,12 @@
             "state": "translated",
             "value": "Wird verbessert..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在润色…"
+          }
         }
       }
     },
@@ -4121,6 +6377,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenz eingeben"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入许可证"
           }
         }
       }
@@ -4132,6 +6394,12 @@
             "state": "translated",
             "value": "Lizenzschlüssel eingeben"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入许可证密钥"
+          }
         }
       }
     },
@@ -4141,6 +6409,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wort oder Ausdruck eingeben (mehrere mit Komma trennen)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入要替换的词语或短语（多个用逗号分隔）"
           }
         }
       }
@@ -4153,6 +6427,12 @@
             "state": "translated",
             "value": "Gib deinen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入你的"
+          }
         }
       }
     },
@@ -4162,6 +6442,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ API-Schlüssel eingeben"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入你的 %@ API 密钥"
           }
         }
       }
@@ -4173,6 +6459,12 @@
             "state": "translated",
             "value": "Verfügbare Umgebungsvariablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT. VoiceInk schreibt außerdem VOICEINK_FULL_PROMPT für jeden Befehl nach stdin."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用的环境变量：VOICEINK_SYSTEM_PROMPT、VOICEINK_USER_PROMPT、VOICEINK_FULL_PROMPT。VoiceInk 还会在每次执行命令时将 VOICEINK_FULL_PROMPT 写入 stdin。"
+          }
         }
       }
     },
@@ -4182,6 +6474,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fehler"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误"
           }
         }
       }
@@ -4193,6 +6491,12 @@
             "state": "translated",
             "value": "Fehler beim Importieren der Einstellungen: %@. Die Datei könnte beschädigt oder im falschen Format sein."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入设置时出错：%@。文件可能已损坏或格式不正确。"
+          }
         }
       }
     },
@@ -4202,6 +6506,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Esc"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "esc"
           }
         }
       }
@@ -4213,6 +6523,12 @@
             "state": "translated",
             "value": "Beispiele"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "示例"
+          }
         }
       }
     },
@@ -4222,6 +6538,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk erleben"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "体验 VoiceInk"
           }
         }
       }
@@ -4235,6 +6557,12 @@
             "state": "translated",
             "value": "Experimentell"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实验性"
+          }
         }
       }
     },
@@ -4244,6 +6572,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Partnerprogramm erkunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "了解联盟计划"
           }
         }
       }
@@ -4255,6 +6589,12 @@
             "state": "translated",
             "value": "Exportieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出"
+          }
         }
       }
     },
@@ -4264,6 +6604,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alle Einstellungen exportieren oder beim Importieren bestimmte Kategorien wählen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出全部设置，或在导入备份时选择特定类别。"
           }
         }
       }
@@ -4275,6 +6621,12 @@
             "state": "translated",
             "value": "Export abgebrochen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出已取消"
+          }
         }
       }
     },
@@ -4284,6 +6636,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Exportfehler"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出错误"
           }
         }
       }
@@ -4295,6 +6653,12 @@
             "state": "translated",
             "value": "Export fehlgeschlagen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出失败"
+          }
         }
       }
     },
@@ -4304,6 +6668,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Protokolle exportieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出日志"
           }
         }
       }
@@ -4315,6 +6685,12 @@
             "state": "translated",
             "value": "Einstellungen exportieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出设置"
+          }
         }
       }
     },
@@ -4324,6 +6700,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Export erfolgreich"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出成功"
           }
         }
       }
@@ -4335,6 +6717,12 @@
             "state": "translated",
             "value": "VoiceInk-Einstellungen exportieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出 VoiceInk 设置"
+          }
         }
       }
     },
@@ -4344,6 +6732,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sofort abbrechen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即失败"
           }
         }
       }
@@ -4355,6 +6749,12 @@
             "state": "translated",
             "value": "'%@' konnte nicht hinzugefügt werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法添加「%@」：%@"
+          }
         }
       }
     },
@@ -4364,6 +6764,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ersetzung konnte nicht hinzugefügt werden: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加替换项失败：%@"
           }
         }
       }
@@ -4377,6 +6783,12 @@
             "state": "translated",
             "value": "Audio-Chunk konnte nicht für das Streaming konvertiert werden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法转换用于流式传输的音频块"
+          }
         }
       }
     },
@@ -4386,6 +6798,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Audioformat konnte nicht konvertiert werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法转换音频格式"
           }
         }
       }
@@ -4397,6 +6815,12 @@
             "state": "translated",
             "value": "Audiodatei konnte nicht kopiert werden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝音频文件失败"
+          }
         }
       }
     },
@@ -4406,6 +6830,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkription konnte nicht kopiert werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法拷贝转录内容"
           }
         }
       }
@@ -4417,6 +6847,12 @@
             "state": "translated",
             "value": "Audiodatei konnte nicht erstellt werden: %lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建音频文件失败：%lld"
+          }
         }
       }
     },
@@ -4426,6 +6862,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AudioUnit konnte nicht erstellt werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建 AudioUnit 失败：%lld"
           }
         }
       }
@@ -4437,6 +6879,12 @@
             "state": "translated",
             "value": "Ordner für eigene Töne konnte nicht erstellt werden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法创建自定义提示音目录"
+          }
         }
       }
     },
@@ -4446,6 +6894,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ausgabe konnte nicht deaktiviert werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法停用输出：%lld"
           }
         }
       }
@@ -4457,6 +6911,12 @@
             "state": "translated",
             "value": "Eingabe konnte nicht aktiviert werden: %lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用输入失败：%lld"
+          }
         }
       }
     },
@@ -4466,6 +6926,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Anfragetext konnte nicht codiert werden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法编码请求正文。"
           }
         }
       }
@@ -4477,6 +6943,12 @@
             "state": "translated",
             "value": "Lokaler CLI-Befehl konnte nicht ausgeführt werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "执行本地 CLI 命令失败：%@"
+          }
         }
       }
     },
@@ -4486,6 +6958,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verarbeitete Audiodatei konnte nicht exportiert werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法导出处理后的音频"
           }
         }
       }
@@ -4497,6 +6975,12 @@
             "state": "translated",
             "value": "Audiosamples konnten nicht extrahiert werden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提取音频样本失败"
+          }
         }
       }
     },
@@ -4506,6 +6990,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geräteformat konnte nicht gelesen werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取设备格式失败：%lld"
           }
         }
       }
@@ -4517,6 +7007,12 @@
             "state": "translated",
             "value": "Modell konnte nicht importiert werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入模型失败：%@"
+          }
         }
       }
     },
@@ -4526,6 +7022,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AudioUnit konnte nicht initialisiert werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法初始化 AudioUnit：%lld"
           }
         }
       }
@@ -4537,6 +7039,12 @@
             "state": "translated",
             "value": "Transkriptionsmodell konnte nicht geladen werden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "载入转录模型失败。"
+          }
         }
       }
     },
@@ -4546,6 +7054,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ersetzung konnte nicht entfernt werden: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法移除替换项：%@"
           }
         }
       }
@@ -4557,6 +7071,12 @@
             "state": "translated",
             "value": "Wort konnte nicht entfernt werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除词语失败：%@"
+          }
         }
       }
     },
@@ -4566,6 +7086,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel konnte nicht sicher gespeichert werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法安全地保存 API 密钥"
           }
         }
       }
@@ -4577,6 +7103,12 @@
             "state": "translated",
             "value": "Änderungen konnten nicht gespeichert werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存更改失败：%@"
+          }
         }
       }
     },
@@ -4586,6 +7118,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eigenes Verbesserungsmodell konnte nicht gespeichert werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存自定义润色模型失败"
           }
         }
       }
@@ -4597,6 +7135,12 @@
             "state": "translated",
             "value": "Importiertes %@ konnte nicht gespeichert werden: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存导入的 %@：%@"
+          }
         }
       }
     },
@@ -4606,6 +7150,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Audioformat konnte nicht gesetzt werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法设置音频格式：%lld"
           }
         }
       }
@@ -4617,6 +7167,12 @@
             "state": "translated",
             "value": "Dateiformat konnte nicht gesetzt werden: %lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置文件格式失败：%lld"
+          }
         }
       }
     },
@@ -4626,6 +7182,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eingabe-Callback konnte nicht gesetzt werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法设置输入回调：%lld"
           }
         }
       }
@@ -4637,6 +7199,12 @@
             "state": "translated",
             "value": "Eingabegerät konnte nicht gesetzt werden: %lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置输入设备失败：%lld"
+          }
         }
       }
     },
@@ -4646,6 +7214,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AudioUnit konnte nicht gestartet werden: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法启动 AudioUnit：%lld"
           }
         }
       }
@@ -4657,6 +7231,12 @@
             "state": "translated",
             "value": "Audio konnte nicht transkribiert werden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频转录失败。"
+          }
         }
       }
     },
@@ -4666,6 +7246,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Heruntergeladenes Core-ML-Modell konnte nicht entpackt werden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解压缩已下载的 Core ML 模型失败。"
           }
         }
       }
@@ -4677,6 +7263,12 @@
             "state": "translated",
             "value": "Schnelle mehrsprachige Transkription, die lokal auf dem Mac läuft."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 上本地运行的快速多语言转录。"
+          }
         }
       }
     },
@@ -4686,6 +7278,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schneller als Echtzeit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快于实时"
           }
         }
       }
@@ -4697,6 +7295,12 @@
             "state": "translated",
             "value": "Feedback oder Probleme?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有反馈或问题？"
+          }
         }
       }
     },
@@ -4706,6 +7310,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "weniger Tastenanschläge"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更少的按键次数"
           }
         }
       }
@@ -4717,6 +7327,12 @@
             "state": "translated",
             "value": "Füllwort"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "填充词"
+          }
         }
       }
     },
@@ -4726,6 +7342,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modelle werden fertiggestellt..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成模型设置…"
           }
         }
       }
@@ -4738,6 +7360,12 @@
             "state": "translated",
             "value": "Einführung abschließen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成新手引导"
+          }
         }
       }
     },
@@ -4747,6 +7375,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kostenlose Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "免费更新"
           }
         }
       }
@@ -4758,6 +7392,12 @@
             "state": "translated",
             "value": "Allgemein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
+          }
         }
       }
     },
@@ -4767,6 +7407,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Allgemeine Einstellungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用设置"
           }
         }
       }
@@ -4778,6 +7424,12 @@
             "state": "translated",
             "value": "%@-API-Schlüssel abrufen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 %@ API 密钥"
+          }
         }
       }
     },
@@ -4787,6 +7439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel abrufen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 API 密钥"
           }
         }
       }
@@ -4798,6 +7456,12 @@
             "state": "translated",
             "value": "API-Schlüssel abrufen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 API 密钥"
+          }
         }
       }
     },
@@ -4808,6 +7472,12 @@
             "state": "translated",
             "value": "Gewährt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已授权"
+          }
         }
       }
     },
@@ -4817,6 +7487,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "HAL Output AudioUnit nicht gefunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 HAL Output AudioUnit"
           }
         }
       }
@@ -4830,6 +7506,12 @@
             "state": "translated",
             "value": "Hat Auslöserwörter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含触发词"
+          }
         }
       }
     },
@@ -4839,6 +7521,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hast du einen Lizenzschlüssel?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已有许可证密钥？"
           }
         }
       }
@@ -4850,6 +7538,12 @@
             "state": "translated",
             "value": "Hast du Feedback, einen Fehlerbericht oder stimmt etwas nicht? Sende eine E-Mail mit Systeminformationen oder tritt dem Discord bei. Jeder Bericht hilft, VoiceInk zuverlässiger und einfacher nutzbar zu machen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有反馈、错误报告，或觉得哪里不对劲？可以通过电子邮件发送附带系统信息的留言，或加入 Discord 参与社区讨论。每一条报告都会让 VoiceInk 更可靠、更易用。"
+          }
         }
       }
     },
@@ -4859,6 +7553,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hilfe & Ressourcen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帮助与资源"
           }
         }
       }
@@ -4870,6 +7570,12 @@
             "state": "translated",
             "value": "Dock-Symbol ausblenden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏程序坞图标"
+          }
         }
       }
     },
@@ -4879,6 +7585,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verlauf"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录"
           }
         }
       }
@@ -4890,6 +7602,12 @@
             "state": "translated",
             "value": "Verwendung von Wortersetzungen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如何使用词语替换"
+          }
         }
       }
     },
@@ -4899,6 +7617,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hybrid"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "混合"
           }
         }
       }
@@ -4910,6 +7634,12 @@
             "state": "translated",
             "value": "Sofort"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即"
+          }
         }
       }
     },
@@ -4919,6 +7649,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Importieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入"
           }
         }
       }
@@ -4930,6 +7666,12 @@
             "state": "translated",
             "value": "Import abgebrochen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入已取消"
+          }
         }
       }
     },
@@ -4939,6 +7681,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Importfehler"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入错误"
           }
         }
       }
@@ -4950,6 +7698,12 @@
             "state": "translated",
             "value": "Lokales Modell importieren…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入本地模型…"
+          }
         }
       }
     },
@@ -4959,6 +7713,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Einstellungen importieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入设置"
           }
         }
       }
@@ -4970,6 +7730,12 @@
             "state": "translated",
             "value": "Import erfolgreich"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入成功"
+          }
         }
       }
     },
@@ -4979,6 +7745,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Einstellungen importieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入 VoiceInk 设置"
           }
         }
       }
@@ -4990,6 +7762,12 @@
             "state": "translated",
             "value": "WICHTIG: Falls du KI-Verbesserungsfunktionen verwendet hast, konfiguriere bitte deine API-Schlüssel im Bereich KI-Modelle neu."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要提示：如果你之前在使用 AI 润色功能，请务必在「AI 模型」部分重新配置你的 API 密钥。"
+          }
         }
       }
     },
@@ -4999,6 +7777,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ importiert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已导入 %@"
           }
         }
       }
@@ -5010,6 +7794,12 @@
             "state": "translated",
             "value": "Lokales Modell importiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已导入的本地模型"
+          }
         }
       }
     },
@@ -5020,6 +7810,12 @@
             "state": "translated",
             "value": "Info"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信息"
+          }
         }
       }
     },
@@ -5029,6 +7825,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Oberfläche"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "界面"
           }
         }
       }
@@ -5041,6 +7843,12 @@
             "state": "translated",
             "value": "Ungültige Audiodatei"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的音频文件"
+          }
         }
       }
     },
@@ -5050,6 +7858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ungültiges Audiodateiformat"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频文件格式无效"
           }
         }
       }
@@ -5061,6 +7875,12 @@
             "state": "translated",
             "value": "Ungültiges Emoji."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的表情符号。"
+          }
         }
       }
     },
@@ -5070,6 +7890,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ungültiger Modelltyp für native Apple-Transkription angegeben."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为 Apple 原生转录提供的模型类型无效。"
           }
         }
       }
@@ -5081,6 +7907,12 @@
             "state": "translated",
             "value": "Ungültige Ollama-Server-URL"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama 服务器 URL 无效"
+          }
         }
       }
     },
@@ -5090,6 +7922,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ungültige Antwort vom KI-Anbieter."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 提供商返回的响应无效。"
           }
         }
       }
@@ -5101,6 +7939,12 @@
             "state": "translated",
             "value": "Ungültige Antwort vom Ollama-Server"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama 服务器响应无效"
+          }
         }
       }
     },
@@ -5110,6 +7954,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Es wird empfohlen, die Einführung abzuschließen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建议你完成新手引导。"
           }
         }
       }
@@ -5121,6 +7971,12 @@
             "state": "translated",
             "value": "Es wird empfohlen, VoiceInk neu zu starten, damit alle Änderungen vollständig wirksam werden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建议重新启动 VoiceInk，以使所有更改完全生效。"
+          }
         }
       }
     },
@@ -5130,6 +7986,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Discord beitreten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入 Discord"
           }
         }
       }
@@ -5141,6 +8003,12 @@
             "state": "translated",
             "value": "Beibehalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留"
+          }
         }
       }
     },
@@ -5151,6 +8019,12 @@
             "state": "translated",
             "value": "Audio aufbewahren für"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频保留时长"
+          }
         }
       }
     },
@@ -5160,6 +8034,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zwischenablage-Inhalt beibehalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留剪贴板内容"
           }
         }
       }
@@ -5172,6 +8052,12 @@
             "state": "translated",
             "value": "„Behalten“ bewahrt die Zeichensetzung wie transkribiert. „Alle entfernen“ entfernt alle Satzzeichen. „Nur abschließenden Punkt“ entfernt nur den letzten Punkt des Textes."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「保留」会按转录原样保留标点。「全部移除」会移除转录文本中的所有标点符号。「移除句尾句号」仅会移除转录文本末尾的句号。"
+          }
         }
       }
     },
@@ -5181,6 +8067,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schlüssel verifiziert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密钥已验证"
           }
         }
       }
@@ -5192,6 +8084,12 @@
             "state": "translated",
             "value": "Tastaturkürzel"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键盘快捷键"
+          }
         }
       }
     },
@@ -5201,6 +8099,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tastenanschläge gespart"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "节省的按键次数"
           }
         }
       }
@@ -5212,6 +8116,12 @@
             "state": "translated",
             "value": "Sprache"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
         }
       }
     },
@@ -5221,6 +8131,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sprache: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言：%@"
           }
         }
       }
@@ -5232,6 +8148,12 @@
             "state": "translated",
             "value": "Sprache: Automatisch erkannt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言：自动检测"
+          }
         }
       }
     },
@@ -5242,6 +8164,12 @@
             "state": "translated",
             "value": "Sprache: Englisch"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言：英语"
+          }
         }
       }
     },
@@ -5251,6 +8179,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sprache: Nur Englisch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言：仅英语"
           }
         }
       }
@@ -5263,6 +8197,12 @@
             "state": "translated",
             "value": "Letzte 7 Tage"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近 7 天"
+          }
         }
       }
     },
@@ -5274,6 +8214,12 @@
             "state": "translated",
             "value": "Letzte 30 Tage"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近 30 天"
+          }
         }
       }
     },
@@ -5283,6 +8229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Letzte Transkription kopiert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拷贝上次转录"
           }
         }
       }
@@ -5294,6 +8246,12 @@
             "state": "translated",
             "value": "Bei Anmeldung starten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动"
+          }
         }
       }
     },
@@ -5303,6 +8261,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mehr erfahren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "了解更多"
           }
         }
       }
@@ -5314,6 +8278,12 @@
             "state": "translated",
             "value": "Lizenz erfolgreich aktiviert!"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证激活成功！"
+          }
         }
       }
     },
@@ -5323,6 +8293,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenz auf diesem Mac aktiv."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证已在这台 Mac 上激活。"
           }
         }
       }
@@ -5334,6 +8310,12 @@
             "state": "translated",
             "value": "Lizenzschlüssel"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证密钥"
+          }
         }
       }
     },
@@ -5343,6 +8325,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenzschlüssel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证密钥"
           }
         }
       }
@@ -5354,6 +8342,12 @@
             "state": "translated",
             "value": "Lizenzschlüssel nicht gefunden. Bitte überprüfe deinen Schlüssel und versuche es erneut."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到许可证密钥。请仔细核对你的密钥后重试。"
+          }
         }
       }
     },
@@ -5363,6 +8357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenzverwaltung"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证管理"
           }
         }
       }
@@ -5374,6 +8374,12 @@
             "state": "translated",
             "value": "Lizenz erforderlich"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要许可证"
+          }
         }
       }
     },
@@ -5383,6 +8389,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenz erforderlich"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要许可证"
           }
         }
       }
@@ -5394,6 +8406,12 @@
             "state": "translated",
             "value": "Lizenz erfolgreich validiert!"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证验证成功！"
+          }
         }
       }
     },
@@ -5403,6 +8421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenziert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已激活"
           }
         }
       }
@@ -5415,6 +8439,12 @@
             "state": "translated",
             "value": "Lizenziert (Pro)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已激活（Pro）"
+          }
         }
       }
     },
@@ -5424,6 +8454,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lebenslanger Zugang"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终身使用权"
           }
         }
       }
@@ -5436,6 +8472,12 @@
             "state": "translated",
             "value": "Lebenslanger Zugang."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终身使用权。"
+          }
         }
       }
     },
@@ -5445,6 +8487,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dateien aus dem Repository werden aufgelistet..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在列出仓库中的文件…"
           }
         }
       }
@@ -5456,6 +8504,12 @@
             "state": "translated",
             "value": "Lade eine Vorlage oder gib einen Befehl ein, um die lokale CLI-Verbesserung zu aktivieren."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "载入模板或输入命令，以启用本地 CLI 润色。"
+          }
         }
       }
     },
@@ -5465,6 +8519,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mehr laden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "载入更多"
           }
         }
       }
@@ -5476,6 +8536,12 @@
             "state": "translated",
             "value": "Vorlage laden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "载入模板"
+          }
         }
       }
     },
@@ -5486,6 +8552,12 @@
             "state": "translated",
             "value": "Wird geladen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在载入"
+          }
         }
       }
     },
@@ -5495,6 +8567,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Apps werden geladen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在载入应用"
           }
         }
       }
@@ -5507,6 +8585,12 @@
             "state": "translated",
             "value": "Modell wird geladen..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在载入模型…"
+          }
         }
       }
     },
@@ -5516,6 +8600,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird geladen …"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在载入…"
           }
         }
       }
@@ -5527,6 +8617,12 @@
             "state": "translated",
             "value": "Lokal"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地"
+          }
         }
       }
     },
@@ -5536,6 +8632,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lokale & CLI-Anbieter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地与 CLI 提供商"
           }
         }
       }
@@ -5547,6 +8649,12 @@
             "state": "translated",
             "value": "Lokale CLI"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地 CLI"
+          }
         }
       }
     },
@@ -5556,6 +8664,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地 CLI 命令执行失败，退出码 %lld：%@"
           }
         }
       }
@@ -5567,6 +8681,12 @@
             "state": "translated",
             "value": "Lokaler CLI-Befehl ist mit Exit-Code %lld fehlgeschlagen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地 CLI 命令失败，退出代码为 %lld。"
+          }
         }
       }
     },
@@ -5576,6 +8696,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lokaler CLI-Befehl ist nicht konfiguriert. Lade eine Vorlage oder gib zuerst einen Befehl ein."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地 CLI 命令尚未配置。请先载入模板或输入命令。"
           }
         }
       }
@@ -5587,6 +8713,12 @@
             "state": "translated",
             "value": "Lokaler CLI-Befehl hat eine leere Ausgabe zurückgegeben."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地 CLI 命令返回了空输出。"
+          }
         }
       }
     },
@@ -5596,6 +8728,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zeitüberschreitung des lokalen CLI-Befehls nach %lld Sekunden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地 CLI 命令在 %lld 秒后超时。"
           }
         }
       }
@@ -5607,6 +8745,12 @@
             "state": "translated",
             "value": "Lokaler CLI-Befehl wurde nicht gefunden. Verwende einen absoluten Pfad oder korrigiere deinen Shell-PATH. Details: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到本地 CLI 命令。请使用绝对路径，或修复 shell 的 PATH。详细信息：%@"
+          }
         }
       }
     },
@@ -5617,6 +8761,12 @@
             "state": "translated",
             "value": "Lokale Modelle funktionieren auf Intel-Macs nicht zuverlässig"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地模型在 Intel Mac 上无法可靠运行"
+          }
         }
       }
     },
@@ -5626,6 +8776,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lokaler Server"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地服务器"
           }
         }
       }
@@ -5638,6 +8794,12 @@
             "state": "translated",
             "value": "Lokaler Speicher"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地存储"
+          }
         }
       }
     },
@@ -5647,6 +8809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gesperrt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已锁定"
           }
         }
       }
@@ -5658,6 +8826,12 @@
             "state": "translated",
             "value": "Schlüssel verloren?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "丢失密钥？"
+          }
         }
       }
     },
@@ -5668,12 +8842,24 @@
             "state": "translated",
             "value": "Ausgabe in Kleinbuchstaben"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小写输出"
+          }
         }
       }
     },
     "macOS 26+": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 26+"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "macOS 26+"
@@ -5688,6 +8874,12 @@
             "state": "translated",
             "value": "Eigene Verbesserungsmodelle im Tab „Eigene“ verwalten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在「自定义」标签页中管理自定义润色模型。"
+          }
         }
       }
     },
@@ -5697,6 +8889,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lizenz verwalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理许可证"
           }
         }
       }
@@ -5708,6 +8906,12 @@
             "state": "translated",
             "value": "Modelle verwalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理模型"
+          }
         }
       }
     },
@@ -5717,6 +8921,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modi verwalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理模式"
           }
         }
       }
@@ -5728,6 +8938,12 @@
             "state": "translated",
             "value": "Arbeitsspeicher"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内存"
+          }
         }
       }
     },
@@ -5737,6 +8953,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mikrofon"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麦克风"
           }
         }
       }
@@ -5748,6 +8970,12 @@
             "state": "translated",
             "value": "Mikrofon-Modus"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麦克风模式"
+          }
         }
       }
     },
@@ -5757,6 +8985,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mittelklick-Aufnahme"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中键点按录音"
           }
         }
       }
@@ -5768,6 +9002,12 @@
             "state": "translated",
             "value": "Mini"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "迷你"
+          }
         }
       }
     },
@@ -5777,6 +9017,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mindestwörter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最少词数"
           }
         }
       }
@@ -5788,6 +9034,12 @@
             "state": "translated",
             "value": "Modus"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式"
+          }
         }
       }
     },
@@ -5797,6 +9049,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modusname"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式名称"
           }
         }
       }
@@ -5808,6 +9066,12 @@
             "state": "translated",
             "value": "Modusname darf nicht leer sein."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式名称不能为空。"
+          }
         }
       }
     },
@@ -5817,6 +9081,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modus-Tastenkürzel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式快捷键"
           }
         }
       }
@@ -5829,6 +9099,12 @@
             "state": "translated",
             "value": "Modus:"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式："
+          }
         }
       }
     },
@@ -5838,6 +9114,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modus: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式：%@"
           }
         }
       }
@@ -5850,6 +9132,12 @@
             "state": "translated",
             "value": "Modell"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
+          }
         }
       }
     },
@@ -5859,6 +9147,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modell"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
           }
         }
       }
@@ -5870,6 +9164,12 @@
             "state": "translated",
             "value": "Modellkatalog"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型目录"
+          }
         }
       }
     },
@@ -5879,6 +9179,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modellname"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型名称"
           }
         }
       }
@@ -5890,6 +9196,12 @@
             "state": "translated",
             "value": "Modellname darf nicht leer sein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型名称不能为空"
+          }
         }
       }
     },
@@ -5900,6 +9212,12 @@
             "state": "translated",
             "value": "Modell-Leistung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型性能"
+          }
         }
       }
     },
@@ -5909,6 +9227,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modelleinstellungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型设置"
           }
         }
       }
@@ -5921,6 +9245,12 @@
             "state": "translated",
             "value": "Modelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
+          }
         }
       }
     },
@@ -5932,6 +9262,12 @@
             "state": "translated",
             "value": "Modelle verfügbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "个可用模型"
+          }
         }
       }
     },
@@ -5941,6 +9277,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式"
           }
         }
       }
@@ -5952,6 +9294,12 @@
             "state": "translated",
             "value": "Modi helfen Ihnen, VoiceInk für verschiedene Schreibaufgaben, Arbeitsabläufe und Szenarien einzurichten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式可帮助你针对不同的写作任务、工作流程和使用场景来设置 VoiceInk。"
+          }
         }
       }
     },
@@ -5961,6 +9309,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modi-Einstellungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模式设置"
           }
         }
       }
@@ -5972,6 +9326,12 @@
             "state": "translated",
             "value": "Weitere Verbesserungsmodelle verfügbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还有更多润色模型可用"
+          }
         }
       }
     },
@@ -5981,6 +9341,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weitere Transkriptionsmodelle verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还有更多转录模型可用"
           }
         }
       }
@@ -5992,6 +9358,12 @@
             "state": "translated",
             "value": "Nach unten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下移"
+          }
         }
       }
     },
@@ -6001,6 +9373,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nach oben"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上移"
           }
         }
       }
@@ -6012,6 +9390,12 @@
             "state": "translated",
             "value": "ms"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "毫秒"
+          }
         }
       }
     },
@@ -6021,6 +9405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mehrsprachiges Modell"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多语言模型"
           }
         }
       }
@@ -6032,6 +9422,12 @@
             "state": "translated",
             "value": "Audio während Aufnahme stummschalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音时将音频静音"
+          }
         }
       }
     },
@@ -6041,6 +9437,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mein eigenes Modell"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我的自定义模型"
           }
         }
       }
@@ -6052,6 +9454,12 @@
             "state": "translated",
             "value": "Mein Verbesserungsmodell"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我的润色模型"
+          }
         }
       }
     },
@@ -6061,6 +9469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "mein Website-Link"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我的网站链接"
           }
         }
       }
@@ -6072,6 +9486,12 @@
             "state": "translated",
             "value": "Name darf nicht leer sein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称不能为空"
+          }
         }
       }
     },
@@ -6081,6 +9501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Natives Apple"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 原生"
           }
         }
       }
@@ -6092,6 +9518,12 @@
             "state": "translated",
             "value": "Zugriff erforderlich"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要访问权限"
+          }
         }
       }
     },
@@ -6101,6 +9533,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Netzwerkverbindung fehlgeschlagen. Überprüfe deine Internetverbindung."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络连接失败。请检查你的网络。"
           }
         }
       }
@@ -6112,6 +9550,12 @@
             "state": "translated",
             "value": "Kein KI-Modell ausgewählt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择 AI 模型"
+          }
         }
       }
     },
@@ -6122,6 +9566,12 @@
             "state": "translated",
             "value": "Keine Apps"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无 App"
+          }
         }
       }
     },
@@ -6131,6 +9581,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Apps gefunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到应用"
           }
         }
       }
@@ -6172,6 +9628,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "未找到超过 %lld 天的音频文件。"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -6181,6 +9649,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine automatischen Auslöser"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无自动触发条件"
           }
         }
       }
@@ -6192,6 +9666,12 @@
             "state": "translated",
             "value": "Keine eigenen Verbesserungsmodelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无自定义润色模型"
+          }
         }
       }
     },
@@ -6201,6 +9681,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine eigenen Transkriptionsmodelle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无自定义转录模型"
           }
         }
       }
@@ -6212,6 +9698,12 @@
             "state": "translated",
             "value": "Keine Daten für diesen Zeitraum"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此时间段内无数据"
+          }
         }
       }
     },
@@ -6221,6 +9713,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Geräte verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无可用设备"
           }
         }
       }
@@ -6232,6 +9730,12 @@
             "state": "translated",
             "value": "Keine passenden Apps"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的应用"
+          }
         }
       }
     },
@@ -6241,6 +9745,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Metadaten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无元数据"
           }
         }
       }
@@ -6252,6 +9762,12 @@
             "state": "translated",
             "value": "Keine Mikrofone gefunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到麦克风"
+          }
         }
       }
     },
@@ -6261,6 +9777,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kein Modus ausgewählt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择模式"
           }
         }
       }
@@ -6272,6 +9794,12 @@
             "state": "translated",
             "value": "Kein Modell konfiguriert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配置模型"
+          }
         }
       }
     },
@@ -6281,6 +9809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kein Modell ausgewählt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择模型"
           }
         }
       }
@@ -6292,6 +9826,12 @@
             "state": "translated",
             "value": "Keine Modelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无模型"
+          }
         }
       }
     },
@@ -6301,6 +9841,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Modelle verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无可用模型"
           }
         }
       }
@@ -6312,6 +9858,12 @@
             "state": "translated",
             "value": "Keine Modelle aufgelistet."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未列出任何模型。"
+          }
         }
       }
     },
@@ -6321,6 +9873,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Modelle geladen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未载入任何模型"
           }
         }
       }
@@ -6332,6 +9890,12 @@
             "state": "translated",
             "value": "Keine Modelle geladen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未载入任何模型。"
+          }
         }
       }
     },
@@ -6341,6 +9905,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Modi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无模式"
           }
         }
       }
@@ -6352,6 +9922,12 @@
             "state": "translated",
             "value": "Keine Modi verfügbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的模式"
+          }
         }
       }
     },
@@ -6361,6 +9937,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Modi verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无可用模式"
           }
         }
       }
@@ -6372,6 +9954,12 @@
             "state": "translated",
             "value": "Noch keine Modi"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无模式"
+          }
         }
       }
     },
@@ -6381,6 +9969,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Prompts verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的提示词"
           }
         }
       }
@@ -6392,6 +9986,12 @@
             "state": "translated",
             "value": "Keine Prompts verfügbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的提示词"
+          }
         }
       }
     },
@@ -6401,6 +10001,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Anbieter verbunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未连接任何提供商"
           }
         }
       }
@@ -6412,6 +10018,12 @@
             "state": "translated",
             "value": "Noch keine Aufnahmesitzungen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无录音器会话"
+          }
         }
       }
     },
@@ -6421,6 +10033,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine entfernbaren Sprachreservierungen gefunden."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到可移除的语言预留。"
           }
         }
       }
@@ -6432,6 +10050,12 @@
             "state": "translated",
             "value": "Keine Ergebnisse gefunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到结果"
+          }
         }
       }
     },
@@ -6441,6 +10065,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Auswahl"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择"
           }
         }
       }
@@ -6452,6 +10082,12 @@
             "state": "translated",
             "value": "Es wurden keine Einstellungen importiert."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未导入任何设置。"
+          }
         }
       }
     },
@@ -6461,6 +10097,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Transkription verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的转录内容"
           }
         }
       }
@@ -6472,6 +10114,12 @@
             "state": "translated",
             "value": "Kein Transkriptionsmodell ausgewählt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择转录模型"
+          }
         }
       }
     },
@@ -6481,6 +10129,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Transkriptionsmodelle verfügbar. Verbinde dich mit einem Cloud-Dienst oder lade im Tab „KI-Modelle“ ein lokales Modell herunter."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的转录模型。请在「AI 模型」标签页中连接云服务或下载本地模型。"
           }
         }
       }
@@ -6492,6 +10146,12 @@
             "state": "translated",
             "value": "Für den eigenen Befehl war kein Transkriptionstext verfügbar."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可供自定义命令使用的转录文本。"
+          }
         }
       }
     },
@@ -6501,6 +10161,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Transkriptionen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无转录记录"
           }
         }
       }
@@ -6512,6 +10178,12 @@
             "state": "translated",
             "value": "Noch keine Transkriptionen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无转录记录"
+          }
         }
       }
     },
@@ -6521,6 +10193,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keine Auslöser"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无触发条件"
           }
         }
       }
@@ -6532,6 +10210,12 @@
             "state": "translated",
             "value": "Keine Auslöser in dieser Gruppe"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此分组中没有触发条件"
+          }
         }
       }
     },
@@ -6542,6 +10226,12 @@
             "state": "translated",
             "value": "Keine Websites"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无网站"
+          }
         }
       }
     },
@@ -6551,6 +10241,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kein"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
           }
         }
       }
@@ -6563,6 +10259,12 @@
             "state": "translated",
             "value": "Nichts erkannt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未检测到"
+          }
         }
       }
     },
@@ -6574,6 +10276,12 @@
             "state": "translated",
             "value": "Nichts ausgewählt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择"
+          }
         }
       }
     },
@@ -6583,6 +10291,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nicht konfiguriert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配置"
           }
         }
       }
@@ -6594,6 +10308,12 @@
             "state": "translated",
             "value": "Nicht verbunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未连接"
+          }
         }
       }
     },
@@ -6603,6 +10323,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nicht mit dem Streaming-Transkriptionsdienst verbunden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未连接到流式转录服务"
           }
         }
       }
@@ -6615,6 +10341,12 @@
             "state": "translated",
             "value": "Nicht festgelegt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未确定"
+          }
         }
       }
     },
@@ -6625,6 +10357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nicht gewährt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未授予"
           }
         }
       }
@@ -6637,6 +10375,12 @@
             "state": "translated",
             "value": "Nicht lizenziert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未激活"
+          }
         }
       }
     },
@@ -6646,6 +10390,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Notch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刘海"
           }
         }
       }
@@ -6657,6 +10407,12 @@
             "state": "translated",
             "value": "Hinweis: Drücke Option 1-9 während der Aufnahme, um manuell den Modus zu wechseln."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注意：录音时按 Option 1-9 可手动切换模式。"
+          }
         }
       }
     },
@@ -6666,6 +10422,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Notizen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备忘录"
           }
         }
       }
@@ -6677,6 +10439,12 @@
             "state": "translated",
             "value": "OK"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
         }
       }
     },
@@ -6686,6 +10454,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zeitüberschreitung bei der Ollama-Anfrage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama 请求超时"
           }
         }
       }
@@ -6697,6 +10471,12 @@
             "state": "translated",
             "value": "Ollama-Serverfehler"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama 服务器错误"
+          }
         }
       }
     },
@@ -6706,6 +10486,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ollama-Dienst ist nicht verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama 服务不可用"
           }
         }
       }
@@ -6717,6 +10503,12 @@
             "state": "translated",
             "value": "Bei Timeout"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超时时"
+          }
         }
       }
     },
@@ -6726,6 +10518,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auf dem Gerät"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备端"
           }
         }
       }
@@ -6737,6 +10535,12 @@
             "state": "translated",
             "value": "%@ API-Schlüssel-Seite öffnen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 %@ API 密钥页面"
+          }
         }
       }
     },
@@ -6746,6 +10550,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Einstellungen für Bedienungshilfen öffnen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开辅助功能设置"
           }
         }
       }
@@ -6757,6 +10567,12 @@
             "state": "translated",
             "value": "Verlauf von überall mit einem globalen Tastenkürzel öffnen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用全局快捷键随时随地打开历史记录"
+          }
         }
       }
     },
@@ -6767,6 +10583,12 @@
             "state": "translated",
             "value": "Verlaufsfenster öffnen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开历史记录窗口"
+          }
         }
       }
     },
@@ -6776,6 +10598,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Einstellungen öffnen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
           }
         }
       }
@@ -6788,6 +10616,12 @@
             "state": "translated",
             "value": "Open Source"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开源"
+          }
         }
       }
     },
@@ -6797,6 +10631,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "OpenAI-kompatibel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI 兼容"
           }
         }
       }
@@ -6808,6 +10648,12 @@
             "state": "translated",
             "value": "Modell wird für Ihr Gerät optimiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在为你的设备优化模型"
+          }
         }
       }
     },
@@ -6817,6 +10663,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "oder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "或"
           }
         }
       }
@@ -6828,6 +10680,12 @@
             "state": "translated",
             "value": "Original"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原文"
+          }
         }
       }
     },
@@ -6837,6 +10695,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Originaltext"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原文"
           }
         }
       }
@@ -6848,6 +10712,12 @@
             "state": "translated",
             "value": "Originaltext (mehrere mit Komma trennen)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原始文本（多个请用逗号分隔）"
+          }
         }
       }
     },
@@ -6857,6 +10727,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Original:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原文："
           }
         }
       }
@@ -6868,6 +10744,12 @@
             "state": "translated",
             "value": "Ausgabe"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输出"
+          }
         }
       }
     },
@@ -6877,6 +10759,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Absatzumbrüche"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "段落分隔"
           }
         }
       }
@@ -6888,6 +10776,12 @@
             "state": "translated",
             "value": "Einfügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴"
+          }
         }
       }
     },
@@ -6897,6 +10791,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-API-Schlüssel einfügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴 %@ API 密钥"
           }
         }
       }
@@ -6908,6 +10808,12 @@
             "state": "translated",
             "value": "Einfügen und Tab drücken"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴并按下 Tab 键"
+          }
         }
       }
     },
@@ -6917,6 +10823,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel einfügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴 API 密钥"
           }
         }
       }
@@ -6928,6 +10840,12 @@
             "state": "translated",
             "value": "Letzte verbesserte Transkription einfügen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴上次转录（已润色）"
+          }
         }
       }
     },
@@ -6937,6 +10855,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Letzte Transkription einfügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴上次转录"
           }
         }
       }
@@ -6948,6 +10872,12 @@
             "state": "translated",
             "value": "Letzte Transkription einfügen (Verbessert)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴上次转录（已润色）"
+          }
         }
       }
     },
@@ -6957,6 +10887,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Letzte Transkription einfügen (Original)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴上次转录（原始）"
           }
         }
       }
@@ -6968,6 +10904,12 @@
             "state": "translated",
             "value": "Einfügemethode"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴方式"
+          }
         }
       }
     },
@@ -6977,6 +10919,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Einfügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在粘贴"
           }
         }
       }
@@ -6988,6 +10936,12 @@
             "state": "translated",
             "value": "Medien während Aufnahme pausieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音时暂停媒体播放"
+          }
         }
       }
     },
@@ -6997,6 +10951,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Leistungsanalyse"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "性能分析"
           }
         }
       }
@@ -7008,6 +10968,12 @@
             "state": "translated",
             "value": "Wähle das Mikrofon aus, das VoiceInk für Aufnahmen verwenden soll."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取 VoiceInk 录音时应使用的麦克风。"
+          }
         }
       }
     },
@@ -7017,6 +10983,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wiedergabegeschwindigkeit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放速度"
           }
         }
       }
@@ -7028,6 +11000,12 @@
             "state": "translated",
             "value": "Bitte gib einen Lizenzschlüssel ein"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入许可证密钥"
+          }
         }
       }
     },
@@ -7037,6 +11015,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bitte behebe die Validierungsfehler vor dem Speichern."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请先修正验证错误，然后再保存。"
           }
         }
       }
@@ -7048,6 +11032,12 @@
             "state": "translated",
             "value": "Bitte starte die Anwendung neu. Wenn das Problem weiterhin besteht, kontaktiere den Support."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请重新启动应用程序。如果问题仍然存在，请联系支持人员。"
+          }
         }
       }
     },
@@ -7057,6 +11047,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Premium-Funktionen aktiviert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级功能已激活"
           }
         }
       }
@@ -7068,6 +11064,12 @@
             "state": "translated",
             "value": "Esc erneut drücken, um abzubrechen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再按一次 Esc 取消"
+          }
         }
       }
     },
@@ -7077,6 +11079,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tastenkürzel drücken"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按下快捷键"
           }
         }
       }
@@ -7089,6 +11097,12 @@
             "state": "translated",
             "value": "Drücke dein Tastenkürzel, stelle die Frage und drücke dann erneut."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按下快捷键，提出问题，然后再次按下。"
+          }
         }
       }
     },
@@ -7100,6 +11114,12 @@
             "state": "translated",
             "value": "Drücke dein Tastenkürzel, lies den Beispieltext vor und drücke dann erneut."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按下快捷键，朗读示例文本，然后再次按下。"
+          }
         }
       }
     },
@@ -7110,6 +11130,12 @@
             "state": "translated",
             "value": "Modell vorwärmen (Experimentell)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预热模型（实验性）"
+          }
         }
       }
     },
@@ -7119,6 +11145,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Primäres Tastenkürzel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主快捷键"
           }
         }
       }
@@ -7131,6 +11163,12 @@
             "state": "translated",
             "value": "Priorisiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "优先"
+          }
         }
       }
     },
@@ -7140,6 +11178,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Prioritätsreihenfolge"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "优先级顺序"
           }
         }
       }
@@ -7151,6 +11195,12 @@
             "state": "translated",
             "value": "Bevorzugter Support"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "优先支持"
+          }
         }
       }
     },
@@ -7160,6 +11210,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Datenschutz"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私"
           }
         }
       }
@@ -7172,12 +11228,24 @@
             "state": "translated",
             "value": "Datenschutz beginnt hier"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私从这里开始"
+          }
         }
       }
     },
     "PRO": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRO"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "PRO"
@@ -7193,6 +11261,12 @@
             "state": "translated",
             "value": "Audio wird verarbeitet..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在处理音频…"
+          }
         }
       }
     },
@@ -7202,6 +11276,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Prozessor"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "处理器"
           }
         }
       }
@@ -7213,6 +11293,12 @@
             "state": "translated",
             "value": "Prompt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示词"
+          }
         }
       }
     },
@@ -7222,6 +11308,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Prompt-Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示词名称"
           }
         }
       }
@@ -7233,6 +11325,12 @@
             "state": "translated",
             "value": "Anbieter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供商"
+          }
         }
       }
     },
@@ -7243,6 +11341,12 @@
             "state": "translated",
             "value": "Anbieter wird nicht unterstützt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不支持该提供商"
+          }
         }
       }
     },
@@ -7252,6 +11356,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zeichensetzung"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标点符号"
           }
         }
       }
@@ -7264,6 +11374,12 @@
             "state": "translated",
             "value": "Lizenz kaufen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "购买许可证"
+          }
         }
       }
     },
@@ -7273,6 +11389,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Push-to-Talk"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按住说话"
           }
         }
       }
@@ -7284,6 +11406,12 @@
             "state": "translated",
             "value": "Schnellzugriff"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速访问"
+          }
         }
       }
     },
@@ -7293,6 +11421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schnell zum Wörterbuch hinzufügen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速添加到词典"
           }
         }
       }
@@ -7304,6 +11438,12 @@
             "state": "translated",
             "value": "Beenden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
+          }
         }
       }
     },
@@ -7313,6 +11453,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk beenden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 VoiceInk"
           }
         }
       }
@@ -7324,6 +11470,12 @@
             "state": "translated",
             "value": "Ratenlimit überschritten. Bitte versuche es später erneut."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已超出速率限制。请稍后重试。"
+          }
         }
       }
     },
@@ -7333,6 +11485,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mit ausgewähltem Prompt neu verbessern"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用所选提示词重新润色"
           }
         }
       }
@@ -7344,6 +11502,12 @@
             "state": "translated",
             "value": "Erneute Verbesserung fehlgeschlagen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新润色失败"
+          }
         }
       }
     },
@@ -7353,6 +11517,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erneute Verbesserung erfolgreich"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新润色成功"
           }
         }
       }
@@ -7364,6 +11534,12 @@
             "state": "translated",
             "value": "KONTAKT"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "联系我们"
+          }
         }
       }
     },
@@ -7374,6 +11550,12 @@
             "state": "translated",
             "value": "Mehr über eigene lokale Modelle erfahren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "进一步了解自定义本地模型"
+          }
         }
       }
     },
@@ -7383,6 +11565,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Echtzeit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时"
           }
         }
       }
@@ -7395,6 +11583,12 @@
             "state": "translated",
             "value": "Erneut prüfen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新检查"
+          }
         }
       }
     },
@@ -7404,6 +11598,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Empfohlen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推荐"
           }
         }
       }
@@ -7415,6 +11615,12 @@
             "state": "translated",
             "value": "Empfohlene Modelle"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推荐模型"
+          }
         }
       }
     },
@@ -7424,6 +11630,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnehmen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制"
           }
         }
       }
@@ -7435,6 +11647,12 @@
             "state": "translated",
             "value": "Tastenkürzel aufnehmen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制快捷键"
+          }
         }
       }
     },
@@ -7444,6 +11662,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme abbrechen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消录音"
           }
         }
       }
@@ -7455,6 +11679,12 @@
             "state": "translated",
             "value": "Recorder-Stil"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音器样式"
+          }
         }
       }
     },
@@ -7464,6 +11694,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme nicht verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音器不可用"
           }
         }
       }
@@ -7475,6 +11711,12 @@
             "state": "translated",
             "value": "Aufnahmeverhalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音行为"
+          }
         }
       }
     },
@@ -7484,6 +11726,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme konnte nicht gestartet werden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音启动失败"
           }
         }
       }
@@ -7495,6 +11743,12 @@
             "state": "translated",
             "value": "Aufnahme fehlgeschlagen: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音失败：%@"
+          }
         }
       }
     },
@@ -7504,6 +11758,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahmesounds"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音提示音"
           }
         }
       }
@@ -7515,6 +11775,12 @@
             "state": "translated",
             "value": "Aktualisieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
         }
       }
     },
@@ -7524,6 +11790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mikrofone aktualisieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新麦克风"
           }
         }
       }
@@ -7535,6 +11807,12 @@
             "state": "translated",
             "value": "Modelle aktualisieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新模型"
+          }
         }
       }
     },
@@ -7544,6 +11822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modelle aktualisieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新模型"
           }
         }
       }
@@ -7555,6 +11839,12 @@
             "state": "translated",
             "value": "Wird aktualisiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在刷新"
+          }
         }
       }
     },
@@ -7564,6 +11854,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Entfernen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
           }
         }
       }
@@ -7575,6 +11871,12 @@
             "state": "translated",
             "value": "%@ aus reservierten Apple-Speech-Sprachen entfernen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 %@ 从 Apple Speech 保留语言中移除。"
+          }
         }
       }
     },
@@ -7584,6 +11886,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alle entfernen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部移除"
           }
         }
       }
@@ -7595,6 +11903,12 @@
             "state": "translated",
             "value": "API-Schlüssel entfernen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 API 密钥"
+          }
         }
       }
     },
@@ -7604,6 +11918,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Schlüssel entfernen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 API 密钥"
           }
         }
       }
@@ -7615,6 +11935,12 @@
             "state": "translated",
             "value": "API-Schlüssel entfernen?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 API 密钥？"
+          }
         }
       }
     },
@@ -7624,6 +11950,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Füllwörter entfernen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除填充词"
           }
         }
       }
@@ -7635,6 +11967,12 @@
             "state": "translated",
             "value": "Lizenz entfernen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除许可证"
+          }
         }
       }
     },
@@ -7644,6 +11982,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eine reservierte Sprache entfernen, um %@ herunterzuladen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除一个已保留的语言以下载 %@。"
           }
         }
       }
@@ -7655,6 +11999,12 @@
             "state": "translated",
             "value": "Ersetzung entfernen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除替换项"
+          }
         }
       }
     },
@@ -7665,6 +12015,12 @@
             "state": "translated",
             "value": "Schlusspunkt entfernen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除末尾句号"
+          }
         }
       }
     },
@@ -7674,6 +12030,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auslöser entfernen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除触发条件"
           }
         }
       }
@@ -7687,6 +12049,12 @@
             "state": "translated",
             "value": "Auslöserwort entfernen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除触发词"
+          }
         }
       }
     },
@@ -7696,6 +12064,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Website entfernen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除网站"
           }
         }
       }
@@ -7707,6 +12081,12 @@
             "state": "translated",
             "value": "Wort entfernen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除词语"
+          }
         }
       }
     },
@@ -7716,6 +12096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modi neu anordnen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新排序模式"
           }
         }
       }
@@ -7727,6 +12113,12 @@
             "state": "translated",
             "value": "Ersetzen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换"
+          }
         }
       }
     },
@@ -7736,6 +12128,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ersetzung"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换为"
           }
         }
       }
@@ -7747,6 +12145,12 @@
             "state": "translated",
             "value": "Ersatztext"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换文本"
+          }
         }
       }
     },
@@ -7756,6 +12160,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ersatztext"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换文本"
           }
         }
       }
@@ -7767,6 +12177,12 @@
             "state": "translated",
             "value": "Ersetzung:"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换为："
+          }
         }
       }
     },
@@ -7776,6 +12192,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bericht oder Feedback"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告或反馈"
           }
         }
       }
@@ -7787,6 +12209,12 @@
             "state": "translated",
             "value": "Anfrage-Timeout"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请求超时"
+          }
         }
       }
     },
@@ -7796,6 +12224,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erforderlich"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必需"
           }
         }
       }
@@ -7807,6 +12241,12 @@
             "state": "translated",
             "value": "Erforderlich für VoiceInk-Tastaturkürzel und app-weite Steuerung."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 的快捷键和全局控制需要此权限才能正常工作。"
+          }
         }
       }
     },
@@ -7816,6 +12256,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zurücksetzen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
           }
         }
       }
@@ -7827,6 +12273,12 @@
             "state": "translated",
             "value": "Einführung zurücksetzen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置新手引导"
+          }
         }
       }
     },
@@ -7836,6 +12288,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auf Standard zurücksetzen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还原为默认"
           }
         }
       }
@@ -7847,6 +12305,12 @@
             "state": "translated",
             "value": "Antworten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回复"
+          }
         }
       }
     },
@@ -7856,6 +12320,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk nach dem Aktivieren der Bildschirmaufnahme neu starten."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用屏幕录制后，请重新启动 VoiceInk。"
           }
         }
       }
@@ -7867,6 +12337,12 @@
             "state": "translated",
             "value": "Wiederherstellungsverzögerung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复延迟"
+          }
         }
       }
     },
@@ -7876,6 +12352,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eingeschränkt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受限"
           }
         }
       }
@@ -7887,6 +12369,12 @@
             "state": "translated",
             "value": "Wiederaufnahmeverzögerung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复播放延迟"
+          }
         }
       }
     },
@@ -7896,6 +12384,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Download fortsetzen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续下载"
           }
         }
       }
@@ -7907,6 +12401,12 @@
             "state": "translated",
             "value": "Dieses Audio neu transkribieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新转录此音频"
+          }
         }
       }
     },
@@ -7916,6 +12416,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erneute Transkription fehlgeschlagen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新转录失败"
           }
         }
       }
@@ -7927,6 +12433,12 @@
             "state": "translated",
             "value": "Erneute Transkription erfolgreich"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新转录成功"
+          }
         }
       }
     },
@@ -7936,6 +12448,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wiederholen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
           }
         }
       }
@@ -7947,6 +12465,12 @@
             "state": "translated",
             "value": "Wiederholung fehlgeschlagen: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试失败：%@"
+          }
         }
       }
     },
@@ -7957,6 +12481,12 @@
             "state": "translated",
             "value": "Letzte Transkription wiederholen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试上次转录"
+          }
         }
       }
     },
@@ -7966,6 +12496,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eingabe (⏎)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return (⏎)"
           }
         }
       }
@@ -7978,6 +12514,12 @@
             "state": "translated",
             "value": "Überprüfe, wie VoiceInk deine Daten handhabt, bevor du eine Lizenz auswählst."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择许可证前，请先查看 VoiceInk 如何处理你的数据。"
+          }
         }
       }
     },
@@ -7989,6 +12531,12 @@
             "state": "translated",
             "value": "Umschreiben"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "改写"
+          }
         }
       }
     },
@@ -7998,6 +12546,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bereinigung jetzt ausführen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即运行清理"
           }
         }
       }
@@ -8009,6 +12563,12 @@
             "state": "translated",
             "value": "Verbesserung mit Ollama auf diesem Mac ausführen oder an einen CLI-Befehl senden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在这台 Mac 上使用 Ollama 运行润色，或将其发送给任意 CLI 命令。"
+          }
         }
       }
     },
@@ -8018,6 +12578,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird lokal mit deinen Benutzerberechtigungen ausgeführt. Das finale Transkript wird über stdin gesendet und als VOICEINK_TRANSCRIPT bereitgestellt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以你的用户权限在本地运行。最终转录文本通过 stdin 传入，并以 VOICEINK_TRANSCRIPT 形式提供。"
           }
         }
       }
@@ -8029,6 +12595,12 @@
             "state": "translated",
             "value": "Speichern"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
         }
       }
     },
@@ -8038,6 +12610,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Speichern & auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存并选择"
           }
         }
       }
@@ -8049,6 +12627,12 @@
             "state": "translated",
             "value": "Als MD speichern"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存为 MD"
+          }
         }
       }
     },
@@ -8058,6 +12642,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Als TXT speichern"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存为 TXT"
           }
         }
       }
@@ -8069,6 +12659,12 @@
             "state": "translated",
             "value": "Änderungen speichern"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存更改"
+          }
         }
       }
     },
@@ -8078,6 +12674,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Diesen Prompt speichern und auswählen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存并选择此提示词。"
           }
         }
       }
@@ -8089,6 +12691,12 @@
             "state": "translated",
             "value": "In Datei speichern"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存到文件"
+          }
         }
       }
     },
@@ -8098,6 +12706,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkription speichern"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存转录内容"
           }
         }
       }
@@ -8109,6 +12723,12 @@
             "state": "translated",
             "value": "Wird gespeichert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在保存"
+          }
         }
       }
     },
@@ -8118,6 +12738,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bildschirm"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏幕"
           }
         }
       }
@@ -8129,6 +12755,12 @@
             "state": "translated",
             "value": "Bildschirmaufnahme"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏幕录制"
+          }
         }
       }
     },
@@ -8138,6 +12770,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Apps suchen oder Website eingeben..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索应用或输入网址…"
           }
         }
       }
@@ -8149,6 +12787,12 @@
             "state": "translated",
             "value": "Transkriptionen suchen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索转录记录"
+          }
         }
       }
     },
@@ -8158,6 +12802,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkriptionen suchen..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索转录记录…"
           }
         }
       }
@@ -8169,6 +12819,12 @@
             "state": "translated",
             "value": "Web durchsuchen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索网页"
+          }
         }
       }
     },
@@ -8178,6 +12834,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sekundäres Tastenkürzel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助快捷键"
           }
         }
       }
@@ -8190,6 +12852,12 @@
             "state": "translated",
             "value": "Sekunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "秒"
+          }
         }
       }
     },
@@ -8199,6 +12867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkription auswählen, um Details anzuzeigen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一条转录记录以查看详情"
           }
         }
       }
@@ -8210,6 +12884,12 @@
             "state": "translated",
             "value": "Whisper-ggml-.bin-Modell auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Whisper ggml .bin 模型"
+          }
         }
       }
     },
@@ -8219,6 +12899,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alle auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全选"
           }
         }
       }
@@ -8231,6 +12917,12 @@
             "state": "translated",
             "value": "Gesamten Text auswählen, Tastenkürzel drücken, Beispieltext laut vorlesen, dann erneut drücken."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选中所有文本，按下快捷键，朗读示例文本，然后再次按下。"
+          }
         }
       }
     },
@@ -8240,6 +12932,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Audiodatei auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择音频文件"
           }
         }
       }
@@ -8251,6 +12949,12 @@
             "state": "translated",
             "value": "Aktivierten Modus zum Starten auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个已启用的模式以开始"
+          }
         }
       }
     },
@@ -8260,6 +12964,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wähle mindestens eine Kategorie zum Importieren aus."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请至少选择一个要导入的类别。"
           }
         }
       }
@@ -8271,6 +12981,12 @@
             "state": "translated",
             "value": "Sprache auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择语言"
+          }
         }
       }
     },
@@ -8280,6 +12996,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modus auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择模式"
           }
         }
       }
@@ -8291,6 +13013,12 @@
             "state": "translated",
             "value": "Modus auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择模式"
+          }
         }
       }
     },
@@ -8300,6 +13028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modus %@ auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择模式 %@"
           }
         }
       }
@@ -8311,6 +13045,12 @@
             "state": "translated",
             "value": "Prompt auswählen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择提示词"
+          }
         }
       }
     },
@@ -8320,6 +13060,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klang auswählen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择提示音"
           }
         }
       }
@@ -8332,6 +13078,12 @@
             "state": "translated",
             "value": "ausgewählt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选中"
+          }
         }
       }
     },
@@ -8341,6 +13093,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ausgewähltes Mikrofon"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选麦克风"
           }
         }
       }
@@ -8352,6 +13110,12 @@
             "state": "translated",
             "value": "Ausgewähltes Modell nicht gefunden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到所选模型"
+          }
         }
       }
     },
@@ -8361,6 +13125,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ausgewählter Text"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选中的文本"
           }
         }
       }
@@ -8372,6 +13142,12 @@
             "state": "translated",
             "value": "Folgenachricht senden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送后续消息"
+          }
         }
       }
     },
@@ -8381,6 +13157,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mehrere Originale mit Komma trennen:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多个原文请用逗号分隔："
           }
         }
       }
@@ -8392,6 +13174,12 @@
             "state": "translated",
             "value": "Server"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器"
+          }
         }
       }
     },
@@ -8401,6 +13189,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Serverfehler (%d). Bitte versuche es später erneut oder kontaktiere den Support."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器错误（%d）。请稍后重试或联系支持人员。"
           }
         }
       }
@@ -8413,6 +13207,12 @@
             "state": "translated",
             "value": "Server:"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器："
+          }
         }
       }
     },
@@ -8422,6 +13222,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Server: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器：%@"
           }
         }
       }
@@ -8433,6 +13239,12 @@
             "state": "translated",
             "value": "Aufgenommene Sitzungen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制会话数"
+          }
         }
       }
     },
@@ -8442,6 +13254,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Als Standard festlegen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设为默认"
           }
         }
       }
@@ -8454,6 +13272,12 @@
             "state": "translated",
             "value": "Lege fest, wie lange auf eine Antwort des KI-Anbieters gewartet werden soll. Wenn innerhalb dieser Dauer keine Antwort eingeht, kannst du entweder sofort abbrechen und die ursprüngliche Transkription einfügen oder die Anfrage bis zu 3-mal wiederholen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置等待 AI 提供商响应的时长。如果在该时长内未收到响应，你可以选择立即失败并粘贴原始转录内容，或重试请求（最多 3 次）。"
+          }
         }
       }
     },
@@ -8463,6 +13287,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Einstellungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
           }
         }
       }
@@ -8474,6 +13304,12 @@
             "state": "translated",
             "value": "Einstellungen erfolgreich aus %@ importiert.\n\nImportiert: %@."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已成功从 %@ 导入设置。\n\n已导入：%@。"
+          }
         }
       }
     },
@@ -8483,6 +13319,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Teilen & freischalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享并解锁"
           }
         }
       }
@@ -8494,6 +13336,12 @@
             "state": "translated",
             "value": "Teile VoiceInk in deinen sozialen Netzwerken und schalte sofort 30 % Rabatt auf VoiceInk Pro frei."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在社交媒体上分享 VoiceInk，立即解锁 VoiceInk Pro 七折优惠。"
+          }
         }
       }
     },
@@ -8503,6 +13351,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Empfiehl VoiceInk Freunden oder deinem Publikum und erhalte 30 % für jede geworbene Person, die ein Upgrade durchführt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 VoiceInk 分享给朋友或你的受众，每有一位经你推荐并升级的用户，你都将获得 30% 的分成。"
           }
         }
       }
@@ -8514,6 +13368,12 @@
             "state": "translated",
             "value": "Umschalttaste + Eingabe (⇧⏎)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shift + Return (⇧⏎)"
+          }
         }
       }
     },
@@ -8523,6 +13383,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tastenkürzel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
           }
         }
       }
@@ -8534,6 +13400,12 @@
             "state": "translated",
             "value": "Tastenkürzel wird bereits von %@ verwendet"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键已被 %@ 使用"
+          }
         }
       }
     },
@@ -8543,6 +13415,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tastenkürzel nicht erlaubt: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不允许的快捷键：%@"
           }
         }
       }
@@ -8554,6 +13432,12 @@
             "state": "translated",
             "value": "Tastenkürzel von macOS reserviert: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键已被 macOS 保留：%@"
+          }
         }
       }
     },
@@ -8563,6 +13447,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tastaturkürzel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
           }
         }
       }
@@ -8574,6 +13464,12 @@
             "state": "translated",
             "value": "Ankündigungen anzeigen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示公告"
+          }
         }
       }
     },
@@ -8583,6 +13479,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dock-Symbol anzeigen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示程序坞图标"
           }
         }
       }
@@ -8594,6 +13496,12 @@
             "state": "translated",
             "value": "Im Finder zeigen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中显示"
+          }
         }
       }
     },
@@ -8604,6 +13512,12 @@
             "state": "translated",
             "value": "Überspringen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过"
+          }
         }
       }
     },
@@ -8613,6 +13527,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Einrichtung überspringen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过 API 设置"
           }
         }
       }
@@ -8625,6 +13545,12 @@
             "state": "translated",
             "value": "API-Einrichtung überspringen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过 API 设置"
+          }
         }
       }
     },
@@ -8634,6 +13560,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-Einrichtung überspringen?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过 API 设置？"
           }
         }
       }
@@ -8645,6 +13577,12 @@
             "state": "translated",
             "value": "Einführung überspringen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过新手引导"
+          }
         }
       }
     },
@@ -8654,6 +13592,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Einführung überspringen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过新手引导"
           }
         }
       }
@@ -8665,6 +13609,12 @@
             "state": "translated",
             "value": "Einführung überspringen?"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过新手引导？"
+          }
         }
       }
     },
@@ -8674,6 +13624,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kurze Transkriptionen überspringen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过简短转录"
           }
         }
       }
@@ -8685,6 +13641,12 @@
             "state": "translated",
             "value": "Langsamer als Echtzeit"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "慢于实时"
+          }
         }
       }
     },
@@ -8694,6 +13656,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alphabetisch sortieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按字母顺序排序"
           }
         }
       }
@@ -8705,6 +13673,12 @@
             "state": "translated",
             "value": "Nach Original sortieren"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按原文排序"
+          }
         }
       }
     },
@@ -8714,6 +13688,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nach Ersatz sortieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按替换内容排序"
           }
         }
       }
@@ -8725,6 +13705,12 @@
             "state": "translated",
             "value": "Klang"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "声音"
+          }
         }
       }
     },
@@ -8734,6 +13720,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "SpeechAnalyzer erfordert macOS 26 oder neuer."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SpeechAnalyzer 需要 macOS 26 或更高版本。"
           }
         }
       }
@@ -8745,6 +13737,12 @@
             "state": "translated",
             "value": "Geschwindigkeit"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度"
+          }
         }
       }
     },
@@ -8754,6 +13752,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Starten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始"
           }
         }
       }
@@ -8766,6 +13770,12 @@
             "state": "translated",
             "value": "7-tägige Testversion starten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始 7 天试用"
+          }
         }
       }
     },
@@ -8775,6 +13785,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Aufnahme für Sprachtranskription starten oder stoppen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动或停止 VoiceInk 录音器，以进行语音转录。"
           }
         }
       }
@@ -8786,6 +13802,12 @@
             "state": "translated",
             "value": "Aufnahme starten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始录音"
+          }
         }
       }
     },
@@ -8795,6 +13817,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Startklang"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始提示音"
           }
         }
       }
@@ -8806,6 +13834,12 @@
             "state": "translated",
             "value": "Transkription starten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始转录"
+          }
         }
       }
     },
@@ -8815,6 +13849,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mit einer Vorlage beginnen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从模板开始"
           }
         }
       }
@@ -8826,6 +13866,12 @@
             "state": "translated",
             "value": "Starte deine erste Aufnahme, um wertvolle Einblicke zu erhalten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始你的第一次录音，解锁价值洞察。"
+          }
         }
       }
     },
@@ -8835,6 +13881,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme wird gestartet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在开始录音"
           }
         }
       }
@@ -8846,6 +13898,12 @@
             "state": "translated",
             "value": "Aufnahme stoppen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止录音"
+          }
         }
       }
     },
@@ -8855,6 +13913,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stoppklang"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止提示音"
           }
         }
       }
@@ -8866,6 +13930,12 @@
             "state": "translated",
             "value": "Speicherwarnung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储警告"
+          }
         }
       }
     },
@@ -8875,6 +13945,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Streaming-Verbindung fehlgeschlagen: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流式连接失败：%@"
           }
         }
       }
@@ -8886,6 +13962,12 @@
             "state": "translated",
             "value": "Streaming-Serverfehler: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流式服务器错误：%@"
+          }
         }
       }
     },
@@ -8896,6 +13978,12 @@
             "state": "translated",
             "value": "Zeitüberschreitung der Streaming-Transkription beim Warten auf das Endergebnis"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流式转录在等待最终结果时超时"
+          }
         }
       }
     },
@@ -8905,6 +13993,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vorgeschlagen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建议"
           }
         }
       }
@@ -8917,6 +14011,12 @@
             "state": "translated",
             "value": "Zusammenfassen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "总结"
+          }
         }
       }
     },
@@ -8926,6 +14026,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Chat Completion verwendet."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持任何使用与 OpenAI 聊天补全相同 API 格式的提供商。"
           }
         }
       }
@@ -8937,6 +14043,12 @@
             "state": "translated",
             "value": "Unterstützt jeden Anbieter, der das gleiche API-Format wie OpenAI Transcription verwendet."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持任何使用与 OpenAI 转录相同 API 格式的提供商。"
+          }
         }
       }
     },
@@ -8946,6 +14058,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Unterstützt WAV, MP3, M4A, AIFF, MP4, MOV, AAC, FLAC, CAF, AMR, OGG, OPUS, 3GP"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 WAV、MP3、M4A、AIFF、MP4、MOV、AAC、FLAC、CAF、AMR、OGG、OPUS、3GP"
           }
         }
       }
@@ -8957,6 +14075,12 @@
             "state": "translated",
             "value": "KI-Anbieter wechseln"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换 AI 提供商"
+          }
         }
       }
     },
@@ -8966,6 +14090,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gewechselt zu: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已切换到：%@"
           }
         }
       }
@@ -8977,6 +14107,12 @@
             "state": "translated",
             "value": "Systemstandard"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统默认"
+          }
         }
       }
     },
@@ -8986,6 +14122,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Systemstandard (%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统默认（%@）"
           }
         }
       }
@@ -8997,6 +14139,12 @@
             "state": "translated",
             "value": "Systeminformationen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统信息"
+          }
         }
       }
     },
@@ -9006,6 +14154,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Systemprompt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统提示词"
           }
         }
       }
@@ -9017,6 +14171,12 @@
             "state": "translated",
             "value": "Systemprompt ist erforderlich"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统提示词不能为空"
+          }
         }
       }
     },
@@ -9026,6 +14186,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vorlage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模板"
           }
         }
       }
@@ -9037,6 +14203,12 @@
             "state": "translated",
             "value": "Testen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试"
+          }
         }
       }
     },
@@ -9046,6 +14218,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbindung testen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试连接"
           }
         }
       }
@@ -9057,6 +14235,12 @@
             "state": "translated",
             "value": "Verbindung testen, um fortzufahren."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请测试连接以继续。"
+          }
         }
       }
     },
@@ -9066,6 +14250,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird getestet..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在测试…"
           }
         }
       }
@@ -9077,6 +14267,12 @@
             "state": "translated",
             "value": "Danke, dass du VoiceInk verwendest"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "感谢你使用 VoiceInk"
+          }
         }
       }
     },
@@ -9086,6 +14282,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Beim Server des KI-Anbieters ist ein Fehler aufgetreten. Bitte versuche es später erneut."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 提供商的服务器发生错误。请稍后重试。"
           }
         }
       }
@@ -9097,6 +14299,12 @@
             "state": "translated",
             "value": "Die API-Anfrage ist mit Statuscode %lld fehlgeschlagen: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 请求失败，状态码 %lld：%@"
+          }
         }
       }
     },
@@ -9106,6 +14314,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Die API hat eine leere oder ungültige Antwort zurückgegeben."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 返回了空响应或无效响应。"
           }
         }
       }
@@ -9117,6 +14331,12 @@
             "state": "translated",
             "value": "Die App '%@' ist bereits im Modus '%@' konfiguriert."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用「%@」已在「%@」模式中配置。"
+          }
         }
       }
     },
@@ -9126,6 +14346,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Die Audiodatei ist ungültig oder beschädigt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频文件无效或已损坏"
           }
         }
       }
@@ -9137,6 +14363,12 @@
             "state": "translated",
             "value": "Die zu transkribierende Audiodatei konnte nicht gefunden werden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到要转录的音频文件。"
+          }
         }
       }
     },
@@ -9146,6 +14378,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Das Audioformat wird nicht unterstützt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不支持该音频格式"
           }
         }
       }
@@ -9157,6 +14395,12 @@
             "state": "translated",
             "value": "Die Kern-Transkriptionsengine ist fehlgeschlagen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "核心转录引擎运行失败。"
+          }
         }
       }
     },
@@ -9166,6 +14410,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Das heruntergeladene Core-ML-Modellarchiv ist möglicherweise beschädigt. Lösche das Modell und lade es erneut herunter. Prüfe den verfügbaren Speicherplatz."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载的 Core ML 模型压缩包可能已损坏。请尝试删除该模型后重新下载。请检查可用磁盘空间。"
           }
         }
       }
@@ -9177,6 +14427,12 @@
             "state": "translated",
             "value": "Die importierte Einstellungsdatei (Version %@) stammt aus einer anderen Version als deine Anwendung (Version %@). Der Import wird fortgesetzt, mögliche Inkompatibilitäten sind jedoch zu beachten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入的设置文件（版本 %@）与你的应用程序（版本 %@）版本不同。将继续导入，但请注意可能存在的不兼容问题。"
+          }
         }
       }
     },
@@ -9186,6 +14442,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Der Schlüssel funktioniert, aber VoiceInk konnte ihn nicht sicher speichern."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密钥有效，但 VoiceInk 无法安全地保存它。"
           }
         }
       }
@@ -9197,6 +14459,12 @@
             "state": "translated",
             "value": "Der Modellanbieter wird von diesem Dienst nicht unterstützt."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此服务不支持该模型提供商。"
+          }
         }
       }
     },
@@ -9206,6 +14474,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Der angegebene API-Schlüssel ist ungültig."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供的 API 密钥无效。"
           }
         }
       }
@@ -9217,6 +14491,12 @@
             "state": "translated",
             "value": "Die ausgewählte Sprache wird von SpeechAnalyzer nicht unterstützt."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SpeechAnalyzer 不支持所选语言。"
+          }
         }
       }
     },
@@ -9226,6 +14506,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Der Einstellungsexport wurde abgebrochen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置导出操作已取消。"
           }
         }
       }
@@ -9237,6 +14523,12 @@
             "state": "translated",
             "value": "Der Einstellungsimport wurde abgebrochen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置导入操作已取消。"
+          }
         }
       }
     },
@@ -9246,6 +14538,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Die Transkriptionssprache wird vom Modell automatisch erkannt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录语言由模型自动检测。"
           }
         }
       }
@@ -9257,6 +14555,12 @@
             "state": "translated",
             "value": "Die Website '%@' ist bereits im Modus '%@' konfiguriert."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网站「%@」已在「%@」模式中配置。"
+          }
         }
       }
     },
@@ -9266,6 +14570,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird verarbeitet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在思考"
           }
         }
       }
@@ -9307,6 +14617,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "此操作无法撤销。确定要删除 %lld 个项目吗？"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -9316,6 +14638,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dies kann durch ein Problem mit der Audioaufnahme oder durch unzureichende Systemressourcen auftreten. Bitte versuche es erneut oder starte die App neu."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这可能是由录音问题或系统资源不足导致的。请重试，或重新启动应用。"
           }
         }
       }
@@ -9328,6 +14656,12 @@
             "state": "translated",
             "value": "Dieses Füllwort existiert bereits."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此填充词已存在。"
+          }
         }
       }
     },
@@ -9337,6 +14671,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dieses Modell ist für Englisch optimiert und unterstützt nur Transkription auf Englisch."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这是针对英语优化的模型，仅支持英语转录。"
           }
         }
       }
@@ -9348,6 +14688,12 @@
             "state": "translated",
             "value": "Diese Lizenz wurde widerrufen oder deaktiviert. Bitte kontaktiere den Support."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此许可证已被吊销或停用。请联系支持人员。"
+          }
         }
       }
     },
@@ -9357,6 +14703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Diese Lizenz hat ihr Gerätelimit erreicht. Besuche das Lizenzverwaltungsportal, um andere Geräte zu deaktivieren."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此许可证已达到设备数量上限。请前往许可证管理门户取消其他设备的激活。"
           }
         }
       }
@@ -9368,6 +14720,12 @@
             "state": "translated",
             "value": "Dieses Modell unterstützt mehrere Sprachen. Wähle eine bestimmte Sprache oder die automatische Erkennung (falls verfügbar)."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此模型支持多种语言。请选择特定语言或自动检测（如可用）"
+          }
         }
       }
     },
@@ -9377,6 +14735,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dadurch wird die Lizenz von diesem Mac entfernt. Du kannst sie später wieder aktivieren."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这将从这台 Mac 上移除许可证。你可以稍后重新激活。"
           }
         }
       }
@@ -9418,6 +14782,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "将删除 %lld 个音频文件（%@）。"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -9429,6 +14805,12 @@
             "state": "translated",
             "value": "Dadurch wird Ihr"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这将移除你的"
+          }
         }
       }
     },
@@ -9438,6 +14820,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dein %@-API-Schlüssel wird entfernt. Du kannst ihn später wieder hinzufügen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这将移除你的 %@ API 密钥。你可以稍后再次添加。"
           }
         }
       }
@@ -9450,6 +14838,12 @@
             "state": "translated",
             "value": "Dieses Jahr"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今年"
+          }
         }
       }
     },
@@ -9459,6 +14853,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Timeout"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超时"
           }
         }
       }
@@ -9470,6 +14870,12 @@
             "state": "translated",
             "value": "Timeout-Dauer"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超时时长"
+          }
         }
       }
     },
@@ -9480,6 +14886,12 @@
             "state": "translated",
             "value": "Umschalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换"
+          }
         }
       }
     },
@@ -9489,6 +14901,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Inspektor ein-/ausblenden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换检查器"
           }
         }
       }
@@ -9501,6 +14919,12 @@
             "state": "translated",
             "value": "Nur-Menüleistenmodus umschalten"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换仅菜单栏模式"
+          }
         }
       }
     },
@@ -9510,6 +14934,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme umschalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换录音器"
           }
         }
       }
@@ -9521,6 +14951,12 @@
             "state": "translated",
             "value": "Seitenleiste ein-/ausblenden"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换边栏"
+          }
         }
       }
     },
@@ -9530,6 +14966,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Aufnahme umschalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换 VoiceInk 录音器"
           }
         }
       }
@@ -9541,6 +14983,12 @@
             "state": "translated",
             "value": "Transkriptionen gesamt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录记录总数"
+          }
         }
       }
     },
@@ -9550,6 +14998,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkribieren"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录"
           }
         }
       }
@@ -9561,6 +15015,12 @@
             "state": "translated",
             "value": "Wird transkribiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在转录"
+          }
         }
       }
     },
@@ -9570,6 +15030,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aufnahme wird transkribiert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在转录录音"
           }
         }
       }
@@ -9582,6 +15048,12 @@
             "state": "translated",
             "value": "Wird transkribiert..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在转录…"
+          }
         }
       }
     },
@@ -9591,6 +15063,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkriptions-Bereinigung"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录记录清理"
           }
         }
       }
@@ -9602,6 +15080,12 @@
             "state": "translated",
             "value": "Transkription"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录"
+          }
         }
       }
     },
@@ -9611,6 +15095,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkription mit SpeechAnalyzer fehlgeschlagen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 SpeechAnalyzer 转录失败。"
           }
         }
       }
@@ -9622,6 +15112,12 @@
             "state": "translated",
             "value": "Transkription fehlgeschlagen: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录失败：%@"
+          }
         }
       }
     },
@@ -9631,6 +15127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkription fehlgeschlagen: Kein Modell ausgewählt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录失败：未选择模型"
           }
         }
       }
@@ -9642,6 +15144,12 @@
             "state": "translated",
             "value": "Transkriptionsformatierung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录格式"
+          }
         }
       }
     },
@@ -9651,6 +15159,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkriptionssprache"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录语言"
           }
         }
       }
@@ -9662,6 +15176,12 @@
             "state": "translated",
             "value": "Transkriptionsmodell"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录模型"
+          }
         }
       }
     },
@@ -9671,6 +15191,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkriptionsmodelle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录模型"
           }
         }
       }
@@ -9682,6 +15208,12 @@
             "state": "translated",
             "value": "Transkriptionszeit"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录用时"
+          }
         }
       }
     },
@@ -9691,6 +15223,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transkription wurde abgebrochen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录已取消"
           }
         }
       }
@@ -9703,6 +15241,12 @@
             "state": "translated",
             "value": "Übersetzen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "翻译"
+          }
         }
       }
     },
@@ -9712,6 +15256,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Testversion aktiv"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "试用中"
           }
         }
       }
@@ -9723,6 +15273,12 @@
             "state": "translated",
             "value": "Testphase beendet"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "试用已结束"
+          }
         }
       }
     },
@@ -9733,6 +15289,12 @@
             "state": "translated",
             "value": "Testversion endet bald"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "试用即将到期"
+          }
         }
       }
     },
@@ -9742,6 +15304,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Testversion abgelaufen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "试用已结束"
           }
         }
       }
@@ -9755,6 +15323,12 @@
             "state": "translated",
             "value": "Auslöserwörter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触发词"
+          }
         }
       }
     },
@@ -9764,6 +15338,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auslöser"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触发条件"
           }
         }
       }
@@ -9775,6 +15355,12 @@
             "state": "translated",
             "value": "Anderen Suchbegriff versuchen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请尝试其他搜索词"
+          }
         }
       }
     },
@@ -9785,6 +15371,12 @@
             "state": "translated",
             "value": "Probiere ein paar kurze Beispiele aus und sieh dir an, wie VoiceInk funktioniert."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始之前，先试几个简短的示例，看看 VoiceInk 是如何工作的。"
+          }
         }
       }
     },
@@ -9794,6 +15386,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wähle ein anderes Modell aus oder lade das aktuelle Modell erneut herunter."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请尝试选择其他模型，或重新下载当前模型。"
           }
         }
       }
@@ -9806,6 +15404,12 @@
             "state": "translated",
             "value": "Aktiviere diese Option, wenn Transkriptionen mit lokalen Modellen länger als erwartet dauern. Führt beim App-Start und Aufwachen im Hintergrund stille Transkriptionen aus, um die Optimierung anzustoßen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果本地模型转录耗时超出预期，请开启此选项。应用在启动和唤醒时会静默运行后台转录，以触发优化。"
+          }
         }
       }
     },
@@ -9815,6 +15419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nicht verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不可用"
           }
         }
       }
@@ -9826,6 +15436,12 @@
             "state": "translated",
             "value": "Unbekannt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
         }
       }
     },
@@ -9835,6 +15451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk Pro günstiger freischalten"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以更优惠的价格解锁 VoiceInk Pro"
           }
         }
       }
@@ -9846,6 +15468,12 @@
             "state": "translated",
             "value": "Nicht unterstützter Anbieter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不支持的提供商"
+          }
         }
       }
     },
@@ -9855,6 +15483,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Das Wort oder den Ausdruck aktualisieren, der automatisch ersetzt werden soll."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新需要被自动替换的词语或短语。"
           }
         }
       }
@@ -9867,6 +15501,12 @@
             "state": "translated",
             "value": "Erfassten Bildschirmtext als Kontext für diesen Modus verwenden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将捕获的屏幕文本用作此模式的上下文。"
+          }
         }
       }
     },
@@ -9878,6 +15518,12 @@
             "state": "translated",
             "value": "Text aus der Zwischenablage als Kontext für diesen Modus verwenden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将剪贴板文本用作此模式的上下文。"
+          }
         }
       }
     },
@@ -9887,6 +15533,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cloud verwenden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用云端"
           }
         }
       }
@@ -9899,6 +15551,12 @@
             "state": "translated",
             "value": "Ausgewählten Text der aktiven App als Kontext für diesen Modus verwenden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将当前应用中选中的文本用作此模式的上下文。"
+          }
         }
       }
     },
@@ -9908,6 +15566,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Systemvorlage verwenden"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用系统模板"
           }
         }
       }
@@ -9920,6 +15584,12 @@
             "state": "translated",
             "value": "VoiceInk jetzt nutzen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即使用 VoiceInk。"
+          }
         }
       }
     },
@@ -9929,6 +15599,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Benutzernachricht"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户消息"
           }
         }
       }
@@ -9940,6 +15616,12 @@
             "state": "translated",
             "value": "Verwendet: %@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在使用：%@"
+          }
         }
       }
     },
@@ -9949,6 +15631,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Variablen: VOICEINK_SYSTEM_PROMPT, VOICEINK_USER_PROMPT, VOICEINK_FULL_PROMPT"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "变量：VOICEINK_SYSTEM_PROMPT、VOICEINK_USER_PROMPT、VOICEINK_FULL_PROMPT"
           }
         }
       }
@@ -9961,6 +15649,12 @@
             "state": "translated",
             "value": "Überprüfung erfolgreich"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证成功"
+          }
         }
       }
     },
@@ -9970,6 +15664,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verifiziert"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已验证"
           }
         }
       }
@@ -9981,6 +15681,12 @@
             "state": "translated",
             "value": "Überprüfen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证"
+          }
         }
       }
     },
@@ -9990,6 +15696,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Überprüfen und speichern"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证并保存"
           }
         }
       }
@@ -10001,6 +15713,12 @@
             "state": "translated",
             "value": "API-Schlüssel überprüfen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证 API 密钥"
+          }
         }
       }
     },
@@ -10010,6 +15728,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wird überprüft"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在验证"
           }
         }
       }
@@ -10021,6 +15745,12 @@
             "state": "translated",
             "value": "Wird überprüft..."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在验证…"
+          }
         }
       }
     },
@@ -10030,6 +15760,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Version %@ (%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@（%@）"
           }
         }
       }
@@ -10041,6 +15777,12 @@
             "state": "translated",
             "value": "Versionskonflikt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本不匹配"
+          }
         }
       }
     },
@@ -10050,6 +15792,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Details anzeigen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看详情"
           }
         }
       }
@@ -10061,6 +15809,12 @@
             "state": "translated",
             "value": "Transkriptions- und Verbesserungsmodell-Leistung anzeigen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看转录与润色模型的性能"
+          }
         }
       }
     },
@@ -10070,6 +15824,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vokabular"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词汇"
           }
         }
       }
@@ -10081,6 +15841,12 @@
             "state": "translated",
             "value": "Vokabular wird nur mit KI-Verbesserung verwendet, um wichtige Namen, Fachbegriffe und besondere Schreibweisen in der finalen Ausgabe beizubehalten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词汇仅在 AI 润色时使用，用于在最终输出中保留重要的名称、专业术语和独特的拼写。"
+          }
         }
       }
     },
@@ -10091,6 +15857,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vokabular-Wörter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词汇"
           }
         }
       }
@@ -10132,6 +15904,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "词汇（%lld）"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -10142,12 +15926,24 @@
             "state": "translated",
             "value": "Sprachaktivitätserkennung (VAD)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音活动检测（VAD）"
+          }
         }
       }
     },
     "VoiceInk": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk"
@@ -10162,6 +15958,12 @@
             "state": "translated",
             "value": "VoiceInk-App ist nicht verfügbar"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk App 不可用"
+          }
         }
       }
     },
@@ -10171,6 +15973,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk erkennt automatisch, woran du arbeitest, und wählt deine bevorzugte Konfiguration aus. Du kannst dies jederzeit anpassen, indem du Modi bearbeitest oder neue erstellst."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 会自动识别你正在处理的内容，并选用你偏好的设置。你随时可以通过编辑或创建新模式来进行配置。"
           }
         }
       }
@@ -10182,6 +15990,12 @@
             "state": "translated",
             "value": "VoiceInk kann anhand der verwendeten App und der konfigurierten Regeln den passenden Modus auswählen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 可以根据你正在使用的应用和你配置的规则选择合适的模式。"
+          }
         }
       }
     },
@@ -10191,6 +16005,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk konnte nicht auf den Speicherort zugreifen. Deine Transkriptionen werden nicht zwischen Sitzungen gespeichert."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 无法访问其存储位置。你的转录记录将无法在会话之间保存。"
           }
         }
       }
@@ -10202,6 +16022,12 @@
             "state": "translated",
             "value": "VoiceInk-Einblicke"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 洞察"
+          }
         }
       }
     },
@@ -10211,6 +16037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk ist auch Open Source, sodass du jede Codezeile einsehen kannst."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 还是开源软件，你可以查看每一行代码。"
           }
         }
       }
@@ -10222,6 +16054,12 @@
             "state": "translated",
             "value": "VoiceInk erkennt den Kontext"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 支持上下文感知"
+          }
         }
       }
     },
@@ -10231,6 +16069,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk erkennt den Kontext."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 支持上下文感知。"
           }
         }
       }
@@ -10242,6 +16086,12 @@
             "state": "translated",
             "value": "VoiceInk ist Open Source"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 是开源软件"
+          }
         }
       }
     },
@@ -10251,6 +16101,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk ist standardmäßig privat"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 默认保护隐私"
           }
         }
       }
@@ -10262,6 +16118,12 @@
             "state": "translated",
             "value": "VoiceInk ist standardmäßig privat. Keine Daten verlassen dein Gerät, sofern du dem nicht zustimmst."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 默认保护隐私。除非你主动选择，否则任何数据都不会离开你的设备。"
+          }
         }
       }
     },
@@ -10271,6 +16133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Modi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 模式"
           }
         }
       }
@@ -10282,12 +16150,24 @@
             "state": "translated",
             "value": "VoiceInk-Modi umfassen Diktat, Verbesserung, E-Mail, Assistent, Umschreiben, Fragen, Zusammenfassen und Übersetzen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 的模式包括听写、润色、邮件、助手、改写、提问、总结和翻译。"
+          }
         }
       }
     },
     "VoiceInk Pro": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk Pro"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk Pro"
@@ -10302,6 +16182,12 @@
             "state": "translated",
             "value": "VoiceInk liest sichtbare Bildschirminhalte, um die Genauigkeit der Transkripte zu verbessern."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 会读取屏幕上的可见内容，以提高转录的准确性。"
+          }
         }
       }
     },
@@ -10311,6 +16197,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Aufnahme geschlossen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 录音器已关闭"
           }
         }
       }
@@ -10322,6 +16214,12 @@
             "state": "translated",
             "value": "VoiceInk-Aufnahme umgeschaltet"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已切换 VoiceInk 录音器"
+          }
         }
       }
     },
@@ -10331,6 +16229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk-Aufnahmedienst ist nicht verfügbar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 录音服务不可用"
           }
         }
       }
@@ -10342,6 +16246,12 @@
             "state": "translated",
             "value": "VoiceInk-Sitzungen abgeschlossen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已完成的 VoiceInk 会话"
+          }
         }
       }
     },
@@ -10351,6 +16261,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk nutzt die Zwischenablage vorübergehend zum Einfügen der Transkription. Wenn aktiviert, wird der frühere Inhalt der Zwischenablage nach der gewählten Verzögerung wiederhergestellt. Wenn deaktiviert, bleibt die Transkription in der Zwischenablage."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 会临时使用剪贴板来粘贴转录内容。启用后，它会在所选延迟后恢复你之前的剪贴板内容。停用后，粘贴的转录内容会保留在剪贴板中。"
           }
         }
       }
@@ -10362,6 +16278,12 @@
             "state": "translated",
             "value": "VoiceInk verwendet Bedienungshilfen, um Transkriptionen direkt in jede App einzugeben."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 使用辅助功能将转录内容直接输入到任何应用中。"
+          }
         }
       }
     },
@@ -10371,6 +16293,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk verwendet LLMs, um Transkripte zu verbessern und KI-Aktionen auszuführen. Richte einen API-Schlüssel ein, bevor du fortfährst."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 使用大语言模型润色转录记录并执行 AI 操作。请先设置 API 密钥再继续。"
           }
         }
       }
@@ -10382,6 +16310,12 @@
             "state": "translated",
             "value": "VoiceInk verwendet dein Mikrofon, um deine Stimme aufzunehmen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 使用你的麦克风来采集语音。"
+          }
         }
       }
     },
@@ -10391,6 +16325,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "VoiceInk vs. Tippen von Hand"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 与手动打字对比"
           }
         }
       }
@@ -10402,12 +16342,24 @@
             "state": "translated",
             "value": "VoiceInk lädt das Parakeet-Modell von NVIDIA herunter, um schnelle lokale Transkription einzurichten."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VoiceInk 将下载 NVIDIA 的 Parakeet 模型，以设置快速的本地转录。"
+          }
         }
       }
     },
     "Voicing, Voice ink": {
       "localizations": {
         "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voicing, Voice ink"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "Voicing, Voice ink"
@@ -10422,6 +16374,12 @@
             "state": "translated",
             "value": "Voicing, Voice ink, Voiceing"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voicing, Voice ink, Voiceing"
+          }
         }
       }
     },
@@ -10432,6 +16390,12 @@
             "state": "translated",
             "value": "Wartet"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待中"
+          }
         }
       }
     },
@@ -10441,6 +16405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换为"
           }
         }
       }
@@ -10453,6 +16423,12 @@
             "state": "translated",
             "value": "Wort"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词"
+          }
         }
       }
     },
@@ -10463,6 +16439,12 @@
             "state": "translated",
             "value": "Wortersetzung"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词语替换"
+          }
         }
       }
     },
@@ -10472,6 +16454,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Beispiele für Wortersetzungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词语替换示例"
           }
         }
       }
@@ -10484,6 +16472,12 @@
             "state": "translated",
             "value": "Wortersetzungen"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词语替换"
+          }
         }
       }
     },
@@ -10494,6 +16488,12 @@
             "state": "translated",
             "value": "Wortersetzungen werden nach der Transkription ausgeführt, um falsch erkannte Wörter, Ausdrücke, Abkürzungen oder Textbausteine zu ersetzen."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词语替换会在转录之后运行，用于替换听错的词语、短语、缩写或模板文本。"
+          }
         }
       }
     },
@@ -10503,6 +16503,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wortersetzungen werden nach der Transkription angewendet. Das Vokabular wird mit KI-Verbesserung verwendet, um Namen, Fachbegriffe und besondere Schreibweisen in deiner Transkription besser zu verstehen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词语替换会在转录完成后运行。词汇则与 AI 润色配合使用，以便更好地理解转录记录中的人名、技术术语和特殊拼写。"
           }
         }
       }
@@ -10515,6 +16521,12 @@
             "state": "translated",
             "value": "Wörter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词"
+          }
         }
       }
     },
@@ -10526,6 +16538,12 @@
             "state": "translated",
             "value": "Wörter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字词"
+          }
         }
       }
     },
@@ -10535,6 +16553,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Diktierte Wörter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "听写字数"
           }
         }
       }
@@ -10546,6 +16570,12 @@
             "state": "translated",
             "value": "Wörter generiert"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已生成的字词"
+          }
         }
       }
     },
@@ -10555,6 +16585,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wörter pro Minute"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每分钟字数"
           }
         }
       }
@@ -10566,6 +16602,12 @@
             "state": "translated",
             "value": "Prompt-Anweisungen schreiben"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编写提示词指令"
+          }
         }
       }
     },
@@ -10576,6 +16618,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Du hast die Kontrolle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由你掌控"
           }
         }
       }
@@ -10617,6 +16665,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "你的试用期还剩 %lld 天"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -10626,6 +16686,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Du hast %@ mit VoiceInk gespart"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已使用 VoiceInk 节省了 %@"
           }
         }
       }
@@ -10637,6 +16703,12 @@
             "state": "translated",
             "value": "Beim nächsten App-Start werden die Einführungsbildschirme erneut angezeigt."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下次启动应用时，你会再次看到介绍页面。"
+          }
         }
       }
     },
@@ -10646,6 +16718,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deine Daten müssen dein Gerät nie verlassen."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的数据永远无需离开设备。"
           }
         }
       }
@@ -10658,6 +16736,12 @@
             "state": "translated",
             "value": "Ihr Lizenzschlüssel wurde verifiziert. VoiceInk ist auf diesem Mac einsatzbereit."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的许可证密钥已通过验证。VoiceInk 已可在这台 Mac 上使用。"
+          }
         }
       }
     },
@@ -10667,6 +16751,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deine Einstellungen wurden erfolgreich in %@ exportiert."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的设置已成功导出到 %@。"
           }
         }
       }
@@ -10678,6 +16768,12 @@
             "state": "translated",
             "value": "Deine Transkriptionshistorie wird hier angezeigt"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的转录记录将显示在这里"
+          }
         }
       }
     },
@@ -10687,6 +16783,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deine Testversion ist beendet. Upgrade auf VoiceInk Pro unter %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的试用已结束。请前往 %@ 升级到 VoiceInk Pro"
           }
         }
       }
@@ -10698,6 +16800,12 @@
             "state": "translated",
             "value": "Deine Testversion ist abgelaufen. Upgrade, um VoiceInk weiter zu verwenden."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的试用已结束。请升级以继续使用 VoiceInk"
+          }
         }
       }
     },
@@ -10707,6 +16815,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deine Nutzungsübersicht wird hier angezeigt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的使用摘要将显示在这里。"
           }
         }
       }
@@ -10718,6 +16832,12 @@
             "state": "translated",
             "value": "Deine VoiceInk-Reise beginnt mit der ersten Aufnahme."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的 VoiceInk 之旅从第一次录音开始。"
+          }
         }
       }
     },
@@ -10727,6 +16847,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "YouTube-Videos & Anleitungen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YouTube 视频与指南"
           }
         }
       }

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -1409,7 +1409,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已存在使用此显示名称的自定义润色模型"
+            "value": "已存在使用此显示名称的自定润色模型"
           }
         }
       }
@@ -1425,7 +1425,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已存在使用此模型名称的自定义润色模型"
+            "value": "已存在使用此模型名称的自定润色模型"
           }
         }
       }
@@ -1698,7 +1698,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加自定义微调的 whisper 模型以在 VoiceInk 中使用。请选择已下载的 .bin 文件。"
+            "value": "添加自定微调的 whisper 模型以在 VoiceInk 中使用。请选择已下载的 .bin 文件。"
           }
         }
       }
@@ -1747,7 +1747,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加应用或网站…"
+            "value": "添加 App 或网站…"
           }
         }
       }
@@ -1763,7 +1763,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加自定义表情符号"
+            "value": "添加自定表情符号"
           }
         }
       }
@@ -1779,7 +1779,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加自定义润色模型"
+            "value": "添加自定润色模型"
           }
         }
       }
@@ -1796,7 +1796,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加自定义模型"
+            "value": "添加自定模型"
           }
         }
       }
@@ -1812,7 +1812,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加自定义转录模型"
+            "value": "添加自定转录模型"
           }
         }
       }
@@ -1828,7 +1828,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "为不同场景添加自定义模式"
+            "value": "为不同场景添加自定模式"
           }
         }
       }
@@ -1957,7 +1957,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增"
+            "value": "新建"
           }
         }
       }
@@ -2248,7 +2248,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "AI 润色处理文本失败。"
+            "value": "AI 润色无法处理该文本。"
           }
         }
       }
@@ -2264,7 +2264,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "AI 润色未启用或未配置"
+            "value": "AI 润色未开启或未配置"
           }
         }
       }
@@ -2442,7 +2442,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "允许 VoiceInk 在你的所有应用中工作。"
+            "value": "允许 VoiceInk 在你的所有 App 中工作。"
           }
         }
       }
@@ -2699,7 +2699,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apple Speech 最多可保留 5 种语言。下载所选语言前，请先选择一种移除。"
+            "value": "Apple Speech 最多可保留 5 种语言。下载所选语言前，请先选取一种移除。"
           }
         }
       }
@@ -2860,7 +2860,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "确定要删除「%@」提示词吗？此操作无法撤销。"
+            "value": "确定要删除提示词「%@」吗？此操作无法撤销。"
           }
         }
       }
@@ -2892,7 +2892,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "确定要删除自定义润色模型「%@」吗？"
+            "value": "确定要删除自定润色模型「%@」吗？"
           }
         }
       }
@@ -2908,7 +2908,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "确定要删除自定义模型「%@」吗？"
+            "value": "确定要删除自定模型「%@」吗？"
           }
         }
       }
@@ -2991,7 +2991,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "助手回复未保存：%@"
+            "value": "助手回复未存储：%@"
           }
         }
       }
@@ -3233,7 +3233,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "粘贴文本后自动按下组合键。适用于使用不同发送快捷键的聊天应用或表单。"
+            "value": "粘贴文本后自动按下组合键。适用于使用不同发送快捷键的聊天 App 或表单。"
           }
         }
       }
@@ -3570,7 +3570,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法保存模式"
+            "value": "无法存储模式"
           }
         }
       }
@@ -3698,7 +3698,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择"
+            "value": "选取"
           }
         }
       }
@@ -3746,7 +3746,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选取一个位置来保存你的设置。"
+            "value": "选取一个位置来存储你的设置。"
           }
         }
       }
@@ -3762,7 +3762,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择一个设置备份，然后选择要导入的内容。"
+            "value": "选取一个设置备份，然后选择要导入的内容。"
           }
         }
       }
@@ -3779,7 +3779,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择一个快捷键以开始。"
+            "value": "选取一个快捷键以开始。"
           }
         }
       }
@@ -3827,7 +3827,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择要从此备份中导入的内容。"
+            "value": "选取要从此备份中导入的内容。"
           }
         }
       }
@@ -4436,7 +4436,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法将设置保存到文件：%@"
+            "value": "无法将设置存储到文件：%@"
           }
         }
       }
@@ -4500,7 +4500,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "创建第一个模式，根据你正在使用的应用或网站自动化你的 VoiceInk 工作流程"
+            "value": "创建第一个模式，根据你正在使用的 App 或网站自动化你的 VoiceInk 工作流程"
           }
         }
       }
@@ -4533,7 +4533,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义"
+            "value": "自定"
           }
         }
       }
@@ -4549,7 +4549,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义命令"
+            "value": "自定命令"
           }
         }
       }
@@ -4565,7 +4565,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义命令不能为空。"
+            "value": "自定命令不能为空。"
           }
         }
       }
@@ -4581,7 +4581,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义命令无法启动：%@"
+            "value": "自定命令无法启动：%@"
           }
         }
       }
@@ -4597,7 +4597,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义命令以退出状态码 %d 结束：%@"
+            "value": "自定命令以状态码 %d 退出：%@"
           }
         }
       }
@@ -4613,7 +4613,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义命令以退出状态码 %d 结束。"
+            "value": "自定命令以状态码 %d 退出。"
           }
         }
       }
@@ -4629,7 +4629,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义命令为空。"
+            "value": "自定命令为空。"
           }
         }
       }
@@ -4662,7 +4662,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义设备"
+            "value": "自定设备"
           }
         }
       }
@@ -4678,7 +4678,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义润色模型"
+            "value": "自定润色模型"
           }
         }
       }
@@ -4694,7 +4694,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义模型定义"
+            "value": "自定模型定义"
           }
         }
       }
@@ -4710,7 +4710,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义提示词"
+            "value": "自定提示词"
           }
         }
       }
@@ -4726,7 +4726,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义转录模型"
+            "value": "自定转录模型"
           }
         }
       }
@@ -4742,7 +4742,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自定义：%@"
+            "value": "自定：%@"
           }
         }
       }
@@ -4759,7 +4759,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仪表盘"
+            "value": "概览"
           }
         }
       }
@@ -4823,7 +4823,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "停用许可证？"
+            "value": "要停用许可证吗？"
           }
         }
       }
@@ -4855,7 +4855,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "当没有匹配的应用或网站时，将使用默认模式"
+            "value": "当没有匹配的 App 或网站时，将使用默认模式"
           }
         }
       }
@@ -4872,7 +4872,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "当未找到匹配的特定应用或网站时，将使用默认模式。"
+            "value": "当未找到匹配的特定 App 或网站时，将使用默认模式。"
           }
         }
       }
@@ -4889,7 +4889,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "默认使用模拟的 Cmd+V 按键事件。当自定义键盘布局无法正确粘贴时，AppleScript 会有所帮助。"
+            "value": "默认使用模拟的 Cmd+V 按键事件。当自定键盘布局无法正确粘贴时，AppleScript 会有所帮助。"
           }
         }
       }
@@ -4989,7 +4989,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除自定义润色模型"
+            "value": "删除自定润色模型"
           }
         }
       }
@@ -5005,7 +5005,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除自定义模型"
+            "value": "删除自定模型"
           }
         }
       }
@@ -5053,7 +5053,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除提示词？"
+            "value": "要删除此提示词吗？"
           }
         }
       }
@@ -5069,7 +5069,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除所选项目？"
+            "value": "要删除所选项目吗？"
           }
         }
       }
@@ -5577,7 +5577,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "双击编辑 • 右键查看更多选项"
+            "value": "连按两下以编辑 • 右键点按查看更多选项"
           }
         }
       }
@@ -5625,7 +5625,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 需要下载。"
+            "value": "需要先下载 %@。"
           }
         }
       }
@@ -5929,7 +5929,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "编辑自定义润色模型"
+            "value": "编辑自定润色模型"
           }
         }
       }
@@ -5945,7 +5945,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "编辑自定义转录模型"
+            "value": "编辑自定转录模型"
           }
         }
       }
@@ -6025,7 +6025,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "编辑此分组中的应用与网站。"
+            "value": "编辑此分组中的 App 与网站。"
           }
         }
       }
@@ -6269,7 +6269,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "润色模式与 AI 操作将保持关闭。之后你随时可以在应用中设置。"
+            "value": "润色模式与 AI 操作将保持关闭。之后你随时可以在 App 中设置。"
           }
         }
       }
@@ -6769,7 +6769,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加替换项失败：%@"
+            "value": "无法添加替换项：%@"
           }
         }
       }
@@ -6819,7 +6819,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "拷贝音频文件失败"
+            "value": "无法拷贝音频文件"
           }
         }
       }
@@ -6851,7 +6851,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "创建音频文件失败：%lld"
+            "value": "无法创建音频文件：%lld"
           }
         }
       }
@@ -6867,7 +6867,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "创建 AudioUnit 失败：%lld"
+            "value": "无法创建 AudioUnit：%lld"
           }
         }
       }
@@ -6883,7 +6883,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法创建自定义提示音目录"
+            "value": "无法创建自定提示音目录"
           }
         }
       }
@@ -6915,7 +6915,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启用输入失败：%lld"
+            "value": "无法启用输入：%lld"
           }
         }
       }
@@ -6947,7 +6947,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "执行本地 CLI 命令失败：%@"
+            "value": "无法执行本地 CLI 命令：%@"
           }
         }
       }
@@ -6979,7 +6979,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "提取音频样本失败"
+            "value": "无法提取音频样本"
           }
         }
       }
@@ -6995,7 +6995,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "获取设备格式失败：%lld"
+            "value": "无法获取设备格式：%lld"
           }
         }
       }
@@ -7011,7 +7011,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "导入模型失败：%@"
+            "value": "无法导入模型：%@"
           }
         }
       }
@@ -7043,7 +7043,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "载入转录模型失败。"
+            "value": "无法载入转录模型。"
           }
         }
       }
@@ -7075,7 +7075,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "移除词语失败：%@"
+            "value": "无法移除词语：%@"
           }
         }
       }
@@ -7091,7 +7091,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法安全地保存 API 密钥"
+            "value": "无法安全地存储 API 密钥"
           }
         }
       }
@@ -7107,7 +7107,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存更改失败：%@"
+            "value": "无法存储更改：%@"
           }
         }
       }
@@ -7123,7 +7123,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存自定义润色模型失败"
+            "value": "无法存储自定润色模型"
           }
         }
       }
@@ -7139,7 +7139,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法保存导入的 %@：%@"
+            "value": "无法存储导入的 %@：%@"
           }
         }
       }
@@ -7171,7 +7171,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "设置文件格式失败：%lld"
+            "value": "无法设置文件格式：%lld"
           }
         }
       }
@@ -7203,7 +7203,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "设置输入设备失败：%lld"
+            "value": "无法设置输入设备：%lld"
           }
         }
       }
@@ -7235,7 +7235,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "音频转录失败。"
+            "value": "无法转录该音频。"
           }
         }
       }
@@ -7251,7 +7251,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "解压缩已下载的 Core ML 模型失败。"
+            "value": "无法解压缩已下载的 Core ML 模型。"
           }
         }
       }
@@ -8266,7 +8266,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "了解更多"
+            "value": "进一步了解"
           }
         }
       }
@@ -8572,7 +8572,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在载入应用"
+            "value": "正在载入 App"
           }
         }
       }
@@ -8669,7 +8669,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "本地 CLI 命令执行失败，退出码 %lld：%@"
+            "value": "本地 CLI 命令执行失败，退出代码 %lld：%@"
           }
         }
       }
@@ -8685,7 +8685,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "本地 CLI 命令失败，退出代码为 %lld。"
+            "value": "本地 CLI 命令执行失败，退出代码 %lld。"
           }
         }
       }
@@ -8830,7 +8830,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "丢失密钥？"
+            "value": "找不到密钥？"
           }
         }
       }
@@ -8878,7 +8878,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在「自定义」标签页中管理自定义润色模型。"
+            "value": "在「自定」标签页中管理自定润色模型。"
           }
         }
       }
@@ -9442,7 +9442,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "我的自定义模型"
+            "value": "我的自定模型"
           }
         }
       }
@@ -9586,7 +9586,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "未找到应用"
+            "value": "未找到 App"
           }
         }
       }
@@ -9670,7 +9670,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "暂无自定义润色模型"
+            "value": "暂无自定润色模型"
           }
         }
       }
@@ -9686,7 +9686,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无自定义转录模型"
+            "value": "无自定转录模型"
           }
         }
       }
@@ -9734,7 +9734,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有匹配的应用"
+            "value": "没有匹配的 App"
           }
         }
       }
@@ -9926,7 +9926,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可用的模式"
+            "value": "无可用模式"
           }
         }
       }
@@ -9974,7 +9974,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可用的提示词"
+            "value": "无可用提示词"
           }
         }
       }
@@ -9990,7 +9990,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可用的提示词"
+            "value": "无可用提示词"
           }
         }
       }
@@ -10102,7 +10102,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可用的转录内容"
+            "value": "无可用转录内容"
           }
         }
       }
@@ -10150,7 +10150,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可供自定义命令使用的转录文本。"
+            "value": "没有可供自定命令使用的转录文本。"
           }
         }
       }
@@ -10507,7 +10507,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "超时时"
+            "value": "超时后"
           }
         }
       }
@@ -10716,7 +10716,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "原始文本（多个请用逗号分隔）"
+            "value": "原文（多个用逗号分隔）"
           }
         }
       }
@@ -11020,7 +11020,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请先修正验证错误，然后再保存。"
+            "value": "请先修正验证错误，然后再存储。"
           }
         }
       }
@@ -11036,7 +11036,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请重新启动应用程序。如果问题仍然存在，请联系支持人员。"
+            "value": "请重新启动 App。如果问题仍然存在，请联系支持人员。"
           }
         }
       }
@@ -11554,7 +11554,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "进一步了解自定义本地模型"
+            "value": "进一步了解自定本地模型"
           }
         }
       }
@@ -11731,7 +11731,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音启动失败"
+            "value": "无法开始录音"
           }
         }
       }
@@ -11939,7 +11939,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "移除 API 密钥？"
+            "value": "要移除 API 密钥吗？"
           }
         }
       }
@@ -12599,7 +12599,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存"
+            "value": "存储"
           }
         }
       }
@@ -12615,7 +12615,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存并选择"
+            "value": "存储并选择"
           }
         }
       }
@@ -12631,7 +12631,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存为 MD"
+            "value": "存储为 MD"
           }
         }
       }
@@ -12647,7 +12647,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存为 TXT"
+            "value": "存储为 TXT"
           }
         }
       }
@@ -12663,7 +12663,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存更改"
+            "value": "存储更改"
           }
         }
       }
@@ -12679,7 +12679,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存并选择此提示词。"
+            "value": "存储并选择此提示词。"
           }
         }
       }
@@ -12695,7 +12695,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存到文件"
+            "value": "存储到文件"
           }
         }
       }
@@ -12711,7 +12711,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存转录内容"
+            "value": "存储转录内容"
           }
         }
       }
@@ -12727,7 +12727,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在保存"
+            "value": "正在存储"
           }
         }
       }
@@ -12775,7 +12775,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "搜索应用或输入网址…"
+            "value": "搜索 App 或输入网址…"
           }
         }
       }
@@ -13565,7 +13565,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "跳过 API 设置？"
+            "value": "要跳过 API 设置吗？"
           }
         }
       }
@@ -13613,7 +13613,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "跳过新手引导？"
+            "value": "要跳过新手引导吗？"
           }
         }
       }
@@ -13870,7 +13870,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "开始你的第一次录音，解锁价值洞察。"
+            "value": "开始第一次录音，看看 VoiceInk 为你节省了多少。"
           }
         }
       }
@@ -14335,7 +14335,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "应用「%@」已在「%@」模式中配置。"
+            "value": "App「%@」已在「%@」模式中配置。"
           }
         }
       }
@@ -14431,7 +14431,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "导入的设置文件（版本 %@）与你的应用程序（版本 %@）版本不同。将继续导入，但请注意可能存在的不兼容问题。"
+            "value": "导入的设置文件（版本 %@）与你的 App（版本 %@）版本不同。将继续导入，但请注意可能存在的不兼容问题。"
           }
         }
       }
@@ -14447,7 +14447,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "密钥有效，但 VoiceInk 无法安全地保存它。"
+            "value": "密钥有效，但 VoiceInk 无法安全地存储它。"
           }
         }
       }
@@ -14643,7 +14643,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这可能是由录音问题或系统资源不足导致的。请重试，或重新启动应用。"
+            "value": "这可能是由录音问题或系统资源不足导致的。请重试，或重新启动 App。"
           }
         }
       }
@@ -15408,7 +15408,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "如果本地模型转录耗时超出预期，请开启此选项。应用在启动和唤醒时会静默运行后台转录，以触发优化。"
+            "value": "如果本地模型转录耗时超出预期，请开启此选项。App 在启动和唤醒时会静默运行后台转录，以触发优化。"
           }
         }
       }
@@ -15555,7 +15555,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将当前应用中选中的文本用作此模式的上下文。"
+            "value": "将当前 App 中选中的文本用作此模式的上下文。"
           }
         }
       }
@@ -15701,7 +15701,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "验证并保存"
+            "value": "验证并存储"
           }
         }
       }
@@ -15994,7 +15994,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "VoiceInk 可以根据你正在使用的应用和你配置的规则选择合适的模式。"
+            "value": "VoiceInk 可以根据你正在使用的 App 和你配置的规则选择合适的模式。"
           }
         }
       }
@@ -16010,7 +16010,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "VoiceInk 无法访问其存储位置。你的转录记录将无法在会话之间保存。"
+            "value": "VoiceInk 无法访问其存储位置。你的转录记录将无法跨会话存储。"
           }
         }
       }
@@ -16026,7 +16026,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "VoiceInk 洞察"
+            "value": "VoiceInk 使用分析"
           }
         }
       }
@@ -16266,7 +16266,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "VoiceInk 会临时使用剪贴板来粘贴转录内容。启用后，它会在所选延迟后恢复你之前的剪贴板内容。停用后，粘贴的转录内容会保留在剪贴板中。"
+            "value": "VoiceInk 会临时使用剪贴板来粘贴转录内容。打开后，它会在所选延迟后恢复你之前的剪贴板内容。关闭后，粘贴的转录内容会保留在剪贴板中。"
           }
         }
       }
@@ -16282,7 +16282,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "VoiceInk 使用辅助功能将转录内容直接输入到任何应用中。"
+            "value": "VoiceInk 使用辅助功能将转录内容直接输入到任何 App 中。"
           }
         }
       }
@@ -16542,7 +16542,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "字词"
+            "value": "词数"
           }
         }
       }
@@ -16558,7 +16558,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "听写字数"
+            "value": "听写词数"
           }
         }
       }
@@ -16574,7 +16574,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已生成的字词"
+            "value": "已生成词数"
           }
         }
       }
@@ -16590,7 +16590,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "每分钟字数"
+            "value": "每分钟词数"
           }
         }
       }
@@ -16707,7 +16707,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "下次启动应用时，你会再次看到介绍页面。"
+            "value": "下次启动 App 时，你会再次看到介绍页面。"
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds full **Simplified Chinese (zh-Hans)** localization for VoiceInk, following the existing German (`de`) localization structure.

- `VoiceInk/Localizable.xcstrings` — all 1000 string keys now have a `zh-Hans` translation
- `VoiceInk/InfoPlist.xcstrings` — all 7 keys (permission usage descriptions, file type names) translated
- `VoiceInk.xcodeproj/project.pbxproj` — registers `zh-Hans` in `knownRegions`

This branch is rebased on the latest `main`, so it cleanly includes the recently merged strings for **Custom Command** and **Trigger Words**, plus the German review changes.

## Translation style

Translations follow Apple Human Interface Guidelines Simplified Chinese conventions for terminology and tone, and are internally consistent across the file:

- Apple system register: **存储** (Save), **自定** (Custom), **连按两下** (double-click), **App** (not 应用), **选取** (Choose)
- Full-width punctuation throughout (，。：；？！「」（）)
- Consistent domain terms: 转录 (transcription), 快捷键 (shortcut), 润色 (enhancement), 触发词 (trigger words)

## Verification

A structural (per-key) diff against `main` confirms that **no English or German string was modified** — every key only gains a `zh-Hans` entry. All 1000 + 7 keys are covered with zero gaps.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full Simplified Chinese (`zh-Hans`) localization across the app and registers the locale in the project. Covers all UI strings and InfoPlist entries.

- New Features
  - Added `zh-Hans` translations for all `Localizable.xcstrings` keys and 7 `InfoPlist.xcstrings` entries.
  - Registered `zh-Hans` in Xcode `knownRegions`.
  - Applied Apple HIG zh-Hans terminology and full‑width punctuation; consistent domain terms.
  - Used CLDR plural category `other` for Chinese.
  - Verified no changes to existing English or German strings; only added `zh-Hans` entries.

<sup>Written for commit eb6a67d8d45243e059b1cb8935deb937eeb95db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

