### PR TITLE
Make transcription delivery robust against mid-flight cancellation + slow custom endpoints

### DIFF
--- a/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 class OpenAICompatibleTranscriptionService {
+    // Dedicated URLSession with EXTENDED timeouts instead of URLSession.shared.
+    //
+    // URLSession.shared uses the default 60s request timeout. Custom OpenAI-compatible
+    // endpoints (self-hosted Whisper, proxies that do their own upstream retries, etc.)
+    // can legitimately hold a multipart audio upload open for well over 60s on longer
+    // recordings — and tripping the 60s wall mid-request surfaces to the user as a flat
+    // "Request timed out" failure even though the server was still working. Giving slow
+    // endpoints a 180s per-request inactivity window plus a 300s total resource cap lets
+    // them finish without changing any success-path behaviour. Built once and reused so we
+    // don't allocate a session per transcription.
+    private let urlSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 180   // per-request inactivity window (was the default 60s)
+        configuration.timeoutIntervalForResource = 300  // total wall-clock cap for the whole upload + response
+        return URLSession(configuration: configuration)
+    }()
+
     func transcribe(audioURL: URL, model: CustomCloudModel, context: TranscriptionRequestContext) async throws -> String {
         guard let url = URL(string: model.apiEndpoint) else {
             throw NSError(domain: "CustomWhisperTranscriptionService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid API endpoint URL"])
@@ -13,7 +30,7 @@ class OpenAICompatibleTranscriptionService {
         request.setValue("Bearer \(model.apiKey)", forHTTPHeaderField: "Authorization")
 
         let body = try buildRequestBody(audioURL: audioURL, modelName: model.modelName, boundary: boundary, context: context)
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -166,8 +166,30 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
             switch engine.recordingState {
             case .recording:
                 await engine.toggleRecord(modeId: modeId)
-            case .starting, .transcribing, .enhancing:
+            case .starting:
+                // Pre-recording: nothing has been captured yet, so a re-press here genuinely
+                // means "abandon this not-yet-started session" — cancelling is correct.
                 await cancelRecording()
+            case .transcribing, .enhancing:
+                // Do NOT cancel an in-flight transcription/enhancement on a plain toggle press.
+                //
+                // Stopping a recording hands off to the async pipeline (transcribe → enhance →
+                // paste) while the recorder panel is still visible. Any extra record-hotkey
+                // event that arrives during that window — key-repeat, a quick re-press to begin
+                // the *next* dictation, or a modifier-combo interruption — used to re-enter here
+                // and fall straight into cancelRecording(). That tears down the active pipeline:
+                // the already-returned transcription is discarded and the panel hides with
+                // nothing pasted, and the in-flight upload Task is cancelled mid-flight. From the
+                // user's side it looks like "recorded fine, briefly said 'Transcribing', then the
+                // bar vanished and nothing appeared" — and rapid toggling could corrupt the
+                // recording state entirely.
+                //
+                // Once transcription has begun the work is already committed, so a toggle press
+                // should be a no-op — let it finish and paste. Explicit cancellation is still
+                // available via Esc / the close button (handleDismissRecorderPanelNotification
+                // and the panel's onCloseTapped both route to cancelRecording()), which remain
+                // the intended ways to abort an in-flight transcription.
+                return
             case .idle:
                 if engine.assistantSession.canSendFollowUp {
                     SoundManager.shared.playStartSound()

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -114,7 +114,18 @@ class TranscriptionPipeline {
             text = TranscriptionOutputFilter.filter(text)
             let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
-            if shouldCancel() { await finishCanceledTranscription(); return }
+            // A cancellation can race in AFTER the transcription network round-trip has
+            // already returned real text (e.g. a stray hotkey press, or a quick re-press to
+            // start the next dictation, lands while we were awaiting the result). Treating
+            // *any* late cancel as "discard" here silently throws away a perfectly good,
+            // already-completed transcription — the user spoke, the model returned text,
+            // and then nothing gets pasted. Only honour the cancel when there is genuinely
+            // nothing to deliver (empty text). If we have real text, the work is already
+            // done, so deliver it rather than discarding the user's words. The pre-transcribe
+            // gate above still short-circuits *before* any network cost when cancelled early.
+            if shouldCancel(), text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                await finishCanceledTranscription(); return
+            }
 
             text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -252,7 +263,14 @@ class TranscriptionPipeline {
             }
         }
 
-        if shouldCancel() {
+        // Final pre-delivery cancel gate. Same reasoning as the post-transcribe gate above:
+        // by this point the whole pipeline (transcribe → filter → enhance) has finished and
+        // `finalText` holds the result we're about to paste. A cancel that races in here used
+        // to discard that finished result, which is exactly the "transcribed fine but nothing
+        // got pasted" symptom. Only abandon delivery when there is no usable text; if we have
+        // real text, deliver it even if a late cancel arrived — the user's words are ready.
+        let hasDeliverableText = !(finalText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        if shouldCancel(), !hasDeliverableText {
             await finishCanceledTranscription()
             return
         }


### PR DESCRIPTION
## Summary

Three small, related fixes so a recording that **transcribed successfully always reaches the user**, and slow custom transcription endpoints don't false-timeout. One coherent theme: make transcription delivery robust against mid-flight cancellation and slow custom endpoints.

These came out of debugging an intermittent "recorded fine, briefly showed *Transcribing*, then the bar vanished and nothing got pasted" symptom. Each fix stands on its own and helps any VoiceInk user.

## The fixes

### 1. Don't cancel an in-flight transcription on a re-entrant record-hotkey toggle
**`RecorderUIManager.swift`**

When you stop a recording, the panel stays visible while the async pipeline (transcribe → enhance → paste) runs. Previously, `toggleRecorderPanel` treated `.starting`, `.transcribing`, and `.enhancing` identically — any of them fell into `cancelRecording()`.

The problem is that once transcription has begun, **any extra record-hotkey event that lands during that window** — key-repeat, a quick re-press to start the *next* dictation, or a modifier-combo interruption — re-enters `toggleRecorderPanel` while the state is `.transcribing` and used to cancel the active pipeline. That discards the (often already-returned) transcription, hides the bar with nothing pasted, and tears down the in-flight upload task.

The fix splits the cases:
- `.starting` still cancels (nothing has been captured yet, so abandoning is correct).
- `.transcribing` / `.enhancing` now **no-op** on a plain toggle press — the work is already committed, so let it finish and paste.

Explicit cancellation is unchanged: Esc and the close button both route through `handleDismissRecorderPanelNotification` / `onCloseTapped` → `cancelRecording()`, which remain the intended ways to abort an in-flight transcription.

### 2. Deliver already-transcribed text even if a cancel races in late
**`TranscriptionPipeline.swift`**

There are two `shouldCancel()` gates that fire *after* the transcription network round-trip has already returned real text (one right after transcription, one right before delivery). Previously **any** late cancel at those points discarded the result — the user spoke, the model returned text, and then nothing got pasted.

Both gates now only honour the cancel when there is genuinely **nothing to deliver** (empty/whitespace text). If real text is present, the work is already done, so it's delivered. The *pre*-transcribe gate is untouched, so an early cancel still short-circuits before any network cost.

This is a useful defence in its own right, independent of fix #1: it guarantees a completed 200 is never silently dropped on a late cancel.

### 3. Extended timeouts for slow custom OpenAI-compatible endpoints
**`OpenAICompatibleTranscriptionService.swift`**

This service used `URLSession.shared`, whose default request timeout is 60s. Custom OpenAI-compatible endpoints (self-hosted Whisper, proxies that do their own upstream retries) can legitimately hold a multipart audio upload open for well over 60s on longer recordings — and tripping the 60s wall surfaces to the user as a flat "Request timed out" even though the server was still working.

The fix uses a dedicated `URLSession` with a **180s per-request** inactivity window and a **300s per-resource** wall-clock cap. No success-path behaviour changes; slow endpoints just get room to finish.

## Related issues

- **Addresses #392** (*State Corruption — recording state machine allows invalid transitions*; labelled bug / critical / data-loss). That issue describes "lost recordings when user triggers hotkey during transcription" and "starting a new recording while transcription is still in progress" — exactly what fixes #1 and #2 prevent.
- **Related to #111** (*Allow starting the next recording while post-processing is in progress*) — a quick re-press to start the next dictation is one of the triggers for the lost-transcription bug fix #1 guards against.
- **Addresses #437** (*Request timed out when transcribing a file*) — fix #3 raises the timeout ceiling so longer uploads against slow endpoints don't false-timeout.

## Notes for review

- The diff is intentionally minimal (3 files, ~60 lines, mostly explanatory comments) and contains no behavioural change on the happy path.
- I haven't been able to run a local build in this environment, but the changes are re-implemented from a known-compiling build and use only existing types/APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes transcription delivery robust against mid-flight cancellation and slow custom endpoints so successful transcriptions always paste. Addresses #392 and #437.

- **Bug Fixes**
  - A record-hotkey re-press no longer cancels an active `.transcribing`/`.enhancing` pipeline; only `.starting` cancels. Esc/close still cancel.
  - If a cancel arrives after transcription returns non-empty text (or right before delivery), we deliver the text instead of discarding it.
  - `OpenAICompatibleTranscriptionService` now uses a dedicated `URLSession` with 180s request and 300s resource timeouts to prevent false “Request timed out” on slow custom endpoints.

<sup>Written for commit 671bc397fa8b4404fa36e376ca36ecddc2a8290d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

