### PR TITLE
Refine menu bar window activation handling

### DIFF
--- a/VoiceInk/MenuBarManager.swift
+++ b/VoiceInk/MenuBarManager.swift
@@ -1,10 +1,8 @@
 import SwiftUI
 import SwiftData
 import AppKit
-import OSLog
 
 class MenuBarManager: ObservableObject {
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarManager")
     @Published var isMenuBarOnly: Bool {
         didSet {
             UserDefaults.standard.set(isMenuBarOnly, forKey: "IsMenuBarOnly")
@@ -34,12 +32,11 @@ class MenuBarManager: ObservableObject {
     @objc private func windowDidClose(_ notification: Notification) {
         guard isMenuBarOnly else { return }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let hasVisibleWindows = NSApplication.shared.windows.contains {
                 $0.isVisible && $0.level == .normal && !$0.styleMask.contains(.nonactivatingPanel)
             }
             if !hasVisibleWindows && NSApplication.shared.activationPolicy() != .accessory {
-                self?.logger.notice("windowDidClose: no visible windows, switching to .accessory policy")
                 NSApplication.shared.setActivationPolicy(.accessory)
             }
         }
@@ -60,10 +57,7 @@ class MenuBarManager: ObservableObject {
     
     func focusMainWindow() {
         NSApplication.shared.setActivationPolicy(.regular)
-        logger.notice("focusMainWindow: activation policy set to .regular")
-        if WindowManager.shared.showMainWindow() == nil {
-            logger.error("focusMainWindow: showMainWindow returned nil")
-        }
+        WindowManager.shared.showMainWindow()
     }
     
     private func updateAppActivationPolicy() {
@@ -71,11 +65,9 @@ class MenuBarManager: ObservableObject {
             guard let self else { return }
             let application = NSApplication.shared
             if self.isMenuBarOnly {
-                self.logger.notice("updateAppActivationPolicy: switching to .accessory (dock icon hidden)")
                 application.setActivationPolicy(.accessory)
                 WindowManager.shared.hideMainWindow()
             } else {
-                self.logger.notice("updateAppActivationPolicy: switching to .regular (dock icon visible)")
                 application.setActivationPolicy(.regular)
                 WindowManager.shared.showMainWindow()
             }
@@ -89,38 +81,28 @@ class MenuBarManager: ObservableObject {
     }
     
     func openMainWindowAndNavigate(to destination: String) {
-        logger.notice("openMainWindowAndNavigate: requested destination=\(destination, privacy: .public), isMenuBarOnly=\(self.isMenuBarOnly, privacy: .public)")
-
         NSApplication.shared.setActivationPolicy(.regular)
-        logger.notice("openMainWindowAndNavigate: activation policy set to .regular")
 
         guard WindowManager.shared.showMainWindow() != nil else {
-            logger.error("openMainWindowAndNavigate: showMainWindow returned nil — cannot navigate to \(destination, privacy: .public)")
             return
         }
 
-        logger.notice("openMainWindowAndNavigate: window shown, posting navigation notification for \(destination, privacy: .public)")
-
         // Post a notification to navigate to the desired destination
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             NotificationCenter.default.post(
                 name: .navigateToDestination,
                 object: nil,
                 userInfo: ["destination": destination]
             )
-            self?.logger.notice("openMainWindowAndNavigate: navigation notification posted for \(destination, privacy: .public)")
         }
     }
 
     func openHistoryWindow() {
         guard let modelContainer = modelContainer,
               let engine = engine else {
-            logger.error("openHistoryWindow: dependencies not configured (modelContainer=\(self.modelContainer != nil, privacy: .public), engine=\(self.engine != nil, privacy: .public))")
             return
         }
-        logger.notice("openHistoryWindow: opening history window")
         NSApplication.shared.setActivationPolicy(.regular)
-        logger.notice("openHistoryWindow: activation policy set to .regular")
         HistoryWindowController.shared.showHistoryWindow(
             modelContainer: modelContainer,
             engine: engine

--- a/VoiceInk/WindowManager.swift
+++ b/VoiceInk/WindowManager.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import AppKit
-import OSLog
 
 class WindowManager: NSObject {
     static let shared = WindowManager()
@@ -8,8 +7,7 @@ class WindowManager: NSObject {
     private static let mainWindowIdentifier = NSUserInterfaceItemIdentifier("com.prakashjoshipax.voiceink.mainWindow")
     private static let mainWindowAutosaveName = NSWindow.FrameAutosaveName("VoiceInkMainWindowFrame")
 
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "WindowManager")
-    private weak var mainWindow: NSWindow?
+    private var mainWindow: NSWindow?
     private var didApplyInitialPlacement = false
 
     private override init() {
@@ -18,12 +16,10 @@ class WindowManager: NSObject {
     
     func configureWindow(_ window: NSWindow) {
         if let existingWindow = NSApplication.shared.windows.first(where: { $0.identifier == Self.mainWindowIdentifier && $0 != window }) {
-            logger.notice("configureWindow: duplicate detected, reusing existing window")
             window.close()
             existingWindow.makeKeyAndOrderFront(nil)
             return
         }
-        logger.notice("configureWindow: registering main window")
         
         let requiredStyleMask: NSWindow.StyleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
         window.styleMask.formUnion(requiredStyleMask)
@@ -53,7 +49,11 @@ class WindowManager: NSObject {
         guard let window = resolveMainWindow() else {
             return nil
         }
-        
+
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+
         window.makeKeyAndOrderFront(nil)
         NSApplication.shared.activate(ignoringOtherApps: true)
         return window
@@ -63,6 +63,7 @@ class WindowManager: NSObject {
         guard let window = resolveMainWindow() else {
             return
         }
+
         window.orderOut(nil)
     }
     
@@ -91,27 +92,44 @@ class WindowManager: NSObject {
             return window
         }
 
-        logger.notice("resolveMainWindow: weak ref is nil, searching \(NSApplication.shared.windows.count, privacy: .public) windows by identifier")
-
         if let window = NSApplication.shared.windows.first(where: { $0.identifier == Self.mainWindowIdentifier }) {
-            logger.notice("resolveMainWindow: recovered window via identifier fallback")
             mainWindow = window
             window.delegate = self
             return window
         }
 
-        let windowIDs = NSApplication.shared.windows.map { $0.identifier?.rawValue ?? "nil" }.joined(separator: ", ")
-        logger.error("resolveMainWindow: FAILED — no window found with main identifier. Total windows: \(NSApplication.shared.windows.count, privacy: .public), identifiers: \(windowIDs, privacy: .public)")
         return nil
+    }
+
+    private func restoreAccessoryPolicyIfNeededAfterWindowHide() {
+        guard UserDefaults.standard.bool(forKey: "IsMenuBarOnly") else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            let hasVisibleWindows = NSApplication.shared.windows.contains {
+                $0.isVisible && $0.level == .normal && !$0.styleMask.contains(.nonactivatingPanel)
+            }
+
+            if !hasVisibleWindows && NSApplication.shared.activationPolicy() != .accessory {
+                NSApplication.shared.setActivationPolicy(.accessory)
+            }
+        }
     }
 }
 
 extension WindowManager: NSWindowDelegate {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard sender.identifier == Self.mainWindowIdentifier else {
+            return true
+        }
+
+        sender.orderOut(nil)
+        restoreAccessoryPolicyIfNeededAfterWindowHide()
+        return false
+    }
+
     func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
         if window.identifier == Self.mainWindowIdentifier {
-            logger.notice("windowWillClose: main window closing, clearing weak reference")
-            window.orderOut(nil)
             mainWindow = nil
             didApplyInitialPlacement = false
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves menu bar mode window handling: the main window now hides instead of closing, the app returns to accessory mode when no windows are visible, and showing the window restores it from the Dock if minimized. Also removes internal logging noise.

- **Bug Fixes**
  - Intercept main window close to order it out and restore accessory policy in menu-bar-only mode when no windows remain.
  - Deminiaturize the main window on show and activate the app to reliably bring it to front.
  - Keep a strong reference to the main window and recover it by identifier to prevent losing the window across lifecycle events.

<sup>Written for commit 8f7d750dad517d1e65f31111777bf2600069ebb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

