### PR TITLE
Record while previous recording is still transcribing (multi-session stack)

### DIFF
--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -95,9 +95,24 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
                             await self?.dismissRecorderPanel()
                         }
                     },
+                    // Cancel ("X") button → discard the active recording/transcription
+                    // with NO paste, then resume any paused media. cancelRecording()
+                    // is the existing clean teardown path (engine.cancelRecording →
+                    // recorder.stopRecording → resumeMedia) followed by dismiss.
+                    onCancelTapped: { [weak self] in
+                        Task { @MainActor in
+                            await self?.cancelRecording()
+                        }
+                    },
                     onAssistantFollowUp: { [weak engine] text in
                         Task { @MainActor in
                             await engine?.sendAssistantFollowUp(text)
+                        }
+                    },
+                    // Per-card cancel for a specific background transcribing session.
+                    onCancelSession: { [weak engine] id in
+                        Task { @MainActor in
+                            await engine?.cancelSession(id: id)
                         }
                     }
                 )
@@ -119,9 +134,23 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
                             await self?.dismissRecorderPanel()
                         }
                     },
+                    // Cancel ("X") button → discard the active recording/transcription
+                    // with NO paste, then resume any paused media. Same clean teardown
+                    // path as the notch panel above.
+                    onCancelTapped: { [weak self] in
+                        Task { @MainActor in
+                            await self?.cancelRecording()
+                        }
+                    },
                     onAssistantFollowUp: { [weak engine] text in
                         Task { @MainActor in
                             await engine?.sendAssistantFollowUp(text)
+                        }
+                    },
+                    // Per-card cancel for a specific background transcribing session.
+                    onCancelSession: { [weak engine] id in
+                        Task { @MainActor in
+                            await engine?.cancelSession(id: id)
                         }
                     }
                 )
@@ -166,15 +195,59 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
             switch engine.recordingState {
             case .recording:
                 await engine.toggleRecord(modeId: modeId)
-            case .starting, .transcribing, .enhancing:
+            case .starting:
+                // Pre-recording: a re-press here genuinely cancels a not-yet-started
+                // session, so cancelling is correct.
                 await cancelRecording()
+            case .transcribing, .enhancing:
+                // ═══════════════════════════════════════════════════════════════
+                // MULTI-SESSION TRANSITION (record-while-transcribing).
+                //
+                // OLD BEHAVIOUR: a toggle press while state == .transcribing/.enhancing
+                //   was IGNORED, because the stop AWAITED the whole pipeline INLINE on the
+                //   MainActor; a stray re-entrant toggle during that await would fall into
+                //   cancelRecording(), poison the active pipeline id, and discard an
+                //   already-returned result. So re-entrant toggles were ignored to protect
+                //   the in-flight pipeline.
+                //
+                // WHY THE GUARD IS NOW OBSOLETE:
+                //   Transcription no longer runs inline-awaited on the MainActor. STOP now
+                //   ENQUEUES the pipeline on the engine's SERIAL transcription queue (a
+                //   detached Task chain) and returns immediately. The MainActor is NOT held
+                //   during transcription, so the re-entrancy hazard that motivated the guard
+                //   is gone — a toggle press during a background transcription is safe.
+                //
+                // NEW BEHAVIOUR:
+                //   This branch is only reached if engine.recordingState is
+                //   .transcribing/.enhancing — and the DERIVED recordingState reflects the
+                //   ACTIVE recording session only, falling back to .idle when nothing is
+                //   recording. So once a session stops and goes to the background,
+                //   recordingState reads .idle and a toggle takes the .idle branch below to
+                //   START A NEW SESSION (the point of the feature). This branch therefore
+                //   only fires in the narrow window where a session's own live state is
+                //   transcribing AND it is still the active recording session
+                //   (effectively never, post-stop); we START A NEW SESSION rather than
+                //   ignoring — record-while-transcribing is desired and now race-free.
+                // ═══════════════════════════════════════════════════════════════
+                SoundManager.shared.playStartSound()
+                await engine.toggleRecord(modeId: modeId)
             case .idle:
+                // .idle now also covers "a previous session is transcribing in the
+                // background but none is actively recording" (derived state falls back to
+                // .idle so the record shortcut stays usable). If there are in-flight
+                // sessions OR the user is starting fresh, a toggle here STARTS a new
+                // recording — UNLESS the assistant is awaiting a follow-up, which takes
+                // precedence as before.
                 if engine.assistantSession.canSendFollowUp {
                     SoundManager.shared.playStartSound()
                     await engine.toggleRecord(
                         modeId: modeId,
                         isAssistantFollowUp: true
                     )
+                } else if !engine.sessions.isEmpty {
+                    // Background transcription(s) in flight → start ANOTHER recording.
+                    SoundManager.shared.playStartSound()
+                    await engine.toggleRecord(modeId: modeId)
                 } else {
                     await dismissRecorderPanel()
                 }
@@ -191,6 +264,29 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
     func dismissRecorderPanel() async {
         guard let engine = engine else { return }
 
+        // ── MULTI-SESSION VISIBILITY GUARD ──
+        // The pipeline + delivery paths call dismiss when an individual job finishes. In the
+        // multi-session world the panel must STAY VISIBLE while ANY session is still in flight
+        // (recording or transcribing) OR the assistant is showing a response — otherwise a
+        // finishing background job would yank the bar out from under a still-active recording.
+        // We only actually hide when there's genuinely nothing left to show.
+        let hasSessions = !engine.sessions.isEmpty
+        let assistantVisible = engine.assistantSession.isVisible
+        if hasSessions || assistantVisible {
+            logger.info("dismissRecorderPanel: suppressed — sessions=\(engine.sessions.count, privacy: .public) assistantVisible=\(assistantVisible, privacy: .public) (keep bar visible)")
+            return
+        }
+
+        hideRecorderPanel()
+        isRecorderPanelVisible = false
+        engine.assistantSession.reset()
+    }
+
+    // Force-hide the panel regardless of in-flight sessions. Used by the explicit
+    // cancel/reset paths which have already torn the sessions down (or want to).
+    private func forceDismissRecorderPanel() async {
+        guard let engine = engine else { return }
+        logger.info("forceDismissRecorderPanel: hide bar unconditionally (state=\(String(describing: engine.recordingState), privacy: .public))")
         hideRecorderPanel()
         isRecorderPanelVisible = false
         engine.assistantSession.reset()
@@ -200,9 +296,9 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
         guard let engine = engine else { return }
         logger.notice("Resetting recording state on launch")
         await engine.resetRecordingSession()
-        hideRecorderPanel()
-        isRecorderPanelVisible = false
-        engine.assistantSession.reset()
+        // resetRecordingSession() empties `sessions`, so the guarded dismiss would hide
+        // anyway, but force-hide to be unambiguous on launch.
+        await forceDismissRecorderPanel()
     }
 
     func cancelRecording() async {

--- a/VoiceInk/Transcription/Engine/RecordingSession.swift
+++ b/VoiceInk/Transcription/Engine/RecordingSession.swift
@@ -1,0 +1,174 @@
+import Foundation
+import SwiftUI
+import os
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RecordingSession — one in-flight "voice capture → transcription → paste" job.
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// VoiceInkEngine used to be SINGLE-FLIGHT — exactly one recording lifecycle existed
+// at a time, and the STOP press AWAITED the whole transcription pipeline INLINE on
+// the MainActor before the mic could be used again. That inline await is what blocked
+// the user from starting a new dictation while the previous one was still uploading /
+// transcribing.
+//
+// We now model each capture as an independent RecordingSession object. The engine owns
+// a COLLECTION of these (`@Published var sessions`). The mic (the single shared
+// `Recorder`) is only ever owned by the ONE session that is currently `.recording`;
+// every other session in the collection has already stopped capturing and is somewhere
+// in the transcription pipeline. So the user can stop session A (mic frees instantly),
+// start session B, and A keeps transcribing in the background on a serial queue.
+//
+// ── SESSION STATE MACHINE ──────────────────────────────────────────────────────
+//
+//        ┌───────────┐  stop press / key-up   ┌──────────────┐
+//        │ .recording│ ─────────────────────► │ .transcribing│
+//        └───────────┘  (mic released here)   └──────────────┘
+//              ▲                                      │
+//   start press│                                      │ transcription returns text,
+//   (new sess) │                                      │ enhancement runs (if enabled)
+//              │                                      ▼
+//        (engine creates                       ┌──────────────┐
+//         a fresh session)                     │  .delivering │  paste / respond / cmd
+//                                              └──────────────┘
+//                                                     │ delivery finished
+//                                                     ▼
+//                                              ┌──────────────┐
+//                                              │    .done     │  → removed from `sessions`
+//                                              └──────────────┘     (UI animates it out)
+//
+//   • .recording    — actively capturing audio. THE mic owner. At most ONE session is
+//                     ever in this phase (the one-active-recording invariant below).
+//   • .transcribing — audio captured, pipeline running (network upload / whisper /
+//                     fluidaudio transcription). Mic already released.
+//   • .delivering   — transcription (and optional AI enhancement) done; the result is
+//                     being pasted / responded / sent to a custom command. The pipeline
+//                     drives the recorder UI state through .enhancing then delivery.
+//   • .done         — terminal. The engine removes the session from `sessions`; SwiftUI
+//                     animates the card out and the stack collapses.
+//
+// NOTE: the pipeline internally also surfaces the legacy RecordingState (.transcribing
+// / .enhancing) for the per-session status display; Phase here is the coarse lifecycle
+// the engine + stack UI key off. We keep both: Phase for collection/stack management,
+// the per-session liveRecordingState for the card's spinner/waveform rendering.
+//
+// ── ONE-ACTIVE-RECORDING INVARIANT (HARD RULE) ─────────────────────────────────
+// At most ONE session in `sessions` may have phase == .recording at any time. This is
+// enforced at the only two mutation sites:
+//   1. VoiceInkEngine.toggleRecord START branch refuses to create a new .recording
+//      session if `activeRecordingSession != nil` (defensive assert; the toggle path
+//      already guarantees it because a press while one is recording STOPS it instead).
+//   2. The STOP branch transitions the active session OUT of .recording (→.transcribing)
+//      BEFORE any new session can be created.
+// Why it matters: the shared `Recorder` is a single mic owner. Two `.recording` sessions
+// would both think they own the mic and fight over start/stop + media pause/resume.
+//
+// ── ObservableObject ───────────────────────────────────────────────────────────
+// Each card in the stacked recorder UI observes ITS OWN session, so phase /
+// liveRecordingState / partialTranscript changes redraw only that card. The engine's
+// `sessions` array is @Published for add/remove (stack grows/shrinks); the per-session
+// @Published members drive each individual card's content.
+@MainActor
+final class RecordingSession: ObservableObject, Identifiable, RecorderStateProvider {
+    enum Phase: Equatable {
+        case recording
+        case transcribing
+        case delivering
+        case done
+    }
+
+    // Stable identity for SwiftUI ForEach + per-card cancel routing (engine.cancelSession(id:)).
+    let id = UUID()
+
+    // Coarse lifecycle phase (drives stack membership / which card is the base). @Published
+    // so the owning engine's array observers and this session's card both react.
+    @Published var phase: Phase
+
+    // Fine-grained recorder UI state for THIS card (idle/recording/transcribing/enhancing).
+    // The pipeline pushes .enhancing here via onStateChange; the card's RecorderStatusDisplay
+    // reads it to show the right spinner/waveform. Conforms to RecorderStateProvider so the
+    // existing MiniRecorderView / NotchRecorderView can render a single session unchanged.
+    @Published var liveRecordingState: RecordingState
+
+    // Live streaming partial (only meaningful while .recording — only the recording session
+    // streams partial transcripts from its realtime session).
+    @Published var partialTranscript: String = ""
+
+    // The recorded audio file for this session. Set at record-start, consumed by the pipeline.
+    var audioURL: URL?
+
+    // Final transcript text once the pipeline completes (kept for potential future use /
+    // debugging; delivery already pastes it).
+    var transcript: String?
+
+    // ── Per-session bits migrated OFF the old engine singletons ──
+    // Previously these were single-flight members on VoiceInkEngine; now each session
+    // carries its own so two sessions (one recording, one transcribing) never share state.
+
+    // Streaming/file transcription session prepared at record-start, used by the pipeline.
+    var transcriptionSession: TranscriptionSession?
+    // Mode-resolved transcription engine settings captured at record-start (so the pipeline
+    // uses the config that was active WHEN this recording started, not whatever is active now).
+    var transcriptionConfiguration: TranscriptionRuntimeConfiguration?
+    // App/window context snapshot store for AI enhancement context.
+    var contextStore: RecordingContextSnapshotStore?
+    // Background tasks capturing the above context; cancelled when the session ends.
+    var contextTasks: [Task<Void, Never>] = []
+
+    // Whether this capture is a brand-new dictation or an assistant follow-up turn. Mirrors
+    // the engine's old RecordingUseCase; kept per-session because two sessions could in
+    // principle have different use cases.
+    enum UseCase: Equatable {
+        case newSession
+        case assistantFollowUp
+
+        var isAssistantFollowUp: Bool { self == .assistantFollowUp }
+    }
+    var useCase: UseCase
+
+    // The Transcription model id this session's pipeline runs against. Used as the cancel
+    // "poison" key (canceledPipelineTranscriptionIDs) so cancelling THIS session can't
+    // discard another session's finished 200.
+    var pipelineTranscriptionID: UUID?
+
+    // Identity token for the record-start handshake (the async start path checks this is
+    // still the live start before transitioning to .recording — guards against a re-press
+    // cancelling a not-yet-started session). Replaces the old engine activeRecordingStartID.
+    var startID: UUID
+
+    // Per-session cancel flag. Replaces the old GLOBAL engine `shouldCancelRecording`. The
+    // pipeline's shouldCancel() gate reads this for ITS session only, so cancelling session
+    // A never poisons session B.
+    var shouldCancel: Bool = false
+
+    // Stable creation timestamp for deterministic stack ordering (oldest at the bottom/base
+    // in mini; newest nearest the pill in notch). The `sessions` array is also kept in
+    // creation order, but createdAt makes the intent explicit + survives any reordering.
+    let createdAt: Date
+
+    init(
+        phase: Phase = .recording,
+        useCase: UseCase = .newSession,
+        startID: UUID = UUID()
+    ) {
+        self.phase = phase
+        // A session is born recording, so its live UI state starts at .recording too.
+        self.liveRecordingState = (phase == .recording) ? .recording : .idle
+        self.useCase = useCase
+        self.startID = startID
+        self.createdAt = Date()
+    }
+
+    // RecorderStateProvider conformance: the card reads `recordingState` for its spinner/
+    // waveform. We expose the fine-grained liveRecordingState under that protocol name.
+    var recordingState: RecordingState {
+        liveRecordingState
+    }
+
+    // Cancel + tear down this session's background context capture. Safe to call multiple times.
+    func clearContext() {
+        contextTasks.forEach { $0.cancel() }
+        contextTasks.removeAll()
+        contextStore = nil
+    }
+}

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -81,32 +81,93 @@ private final class RealtimeAudioChunkGate: @unchecked Sendable {
     }
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// VoiceInkEngine — MULTI-SESSION refactor (record-while-transcribing)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// WHAT CHANGED vs the old single-flight engine:
+//   OLD: one `currentSession`/`recordedFile`/`shouldCancelRecording`/`partialTranscript`
+//        set, and STOP awaited `runPipeline` INLINE before the mic could be reused.
+//   NEW: a COLLECTION of RecordingSession objects (`sessions`). At most one is
+//        `.recording` (owns the mic); the rest are transcribing/delivering in the
+//        background. STOP no longer awaits the pipeline — it ENQUEUES the pipeline on
+//        a SERIAL FIFO queue and returns immediately, freeing the mic for a new record.
+//
+// See RecordingSession.swift for the per-session state machine + the one-active invariant.
+//
+// ── CONCURRENCY: SERIAL FIFO transcription queue (NOT concurrent) ──────────────
+// Transcription jobs run one-at-a-time on a chained-Task serial queue. This is a
+// DELIBERATE correctness decision, not a perf compromise:
+//   • WhisperTranscriptionService reuses a single mutable `whisperContext`, and
+//     `whisperModelManager.whisperContext` is a SHARED singleton actor. setLanguage /
+//     setPrompt then fullTranscribe are sequential stateful mutations on ONE shared
+//     context — running two whisper jobs concurrently would interleave language/prompt
+//     state and corrupt output.
+//   • `whisperModelManager.cleanupResources()` / `serviceRegistry.cleanup()` release the
+//     SHARED model — concurrent jobs would tear each other's model down mid-transcribe.
+//   • FluidAudio also loads a single shared model.
+//   • The cloud/Deepgram path COULD be concurrency-safe, but the provider is chosen
+//     per-job and we can't assume it, so a single serial queue is the only universally
+//     safe choice.
+//   • The UX goal is STILL met: the new RECORDING starts immediately (mic frees the
+//     instant the prior session stops); only the transcription WORK queues behind
+//     earlier jobs. Serial = simplest race-free correctness.
+//
+// ── DELIVERY ORDERING: FIFO for free ───────────────────────────────────────────
+// We deliver/paste results in RECORDING (FIFO) order so pasted text stays in the order
+// the user spoke. Because transcription itself is serial FIFO, completion order already
+// EQUALS recording order — so the serial transcription queue gives FIFO delivery for
+// free with NO separate delivery reorder buffer required.
+// NOTE: RecorderStateProvider conformance is declared in VoiceInkEngine+Protocols.swift
+// (extension VoiceInkEngine: RecorderStateProvider {}). We intentionally do NOT repeat it
+// here — the engine already exposes `recordingState` + `partialTranscript` (the protocol
+// requirements) as @Published members below, so the extension's conformance is satisfied.
 @MainActor
 class VoiceInkEngine: NSObject, ObservableObject {
-    private enum RecordingUseCase {
-        case newSession
-        case assistantFollowUp
 
-        var isAssistantFollowUp: Bool {
-            self == .assistantFollowUp
-        }
-    }
+    // ── Session collection (drives the UI stack) ──
+    // Ordered oldest→newest (creation order). The base/active recording card renders from
+    // the .recording session; transcribing cards stack above it. @Published so the stack
+    // container redraws on add/remove.
+    @Published var sessions: [RecordingSession] = []
 
+    // ── DERIVED compat state ──
+    // Existing single-card UI (the active MiniRecorderView/NotchRecorderView via the
+    // window managers) + RecorderUIManager + the shortcut gate all read `recordingState`
+    // and `partialTranscript` off the engine. We KEEP those as DERIVED values so nothing
+    // downstream has to change to keep compiling.
+    //
+    // IMPORTANT DESIGN CHOICE (shortcut-gate safety): `recordingState` reflects ONLY the
+    // ACTIVE recording session's state, else `.idle` — it does NOT report `.transcribing`
+    // when there is no active recording. Rationale: RecordingShortcutManager.canHandleShort
+    // cutAction() BLOCKS a record toggle whenever recordingState is .transcribing/.enhancing/
+    // .busy. If the derived state reported `.transcribing` while a background job ran, the
+    // user could NOT start a new recording — which would defeat this entire feature. The
+    // stacked-card UI shows the "transcribing…" cards directly off each session.phase, so
+    // the derived engine state never needs to surface .transcribing for the stack to render.
+    // (Per-card status spinners read the session's own liveRecordingState, not this.)
     @Published var recordingState: RecordingState = .idle
-    @Published var shouldCancelRecording = false
+
+    // Live partial of the ACTIVE recording session (only the recording session streams partials).
     @Published var partialTranscript: String = ""
-    var currentSession: TranscriptionSession?
-    private var currentSessionTranscriptionConfiguration: TranscriptionRuntimeConfiguration?
-    private var activeRecordingStartID: UUID?
-    private var activePipelineTranscriptionID: UUID?
+
+    // ── Pipeline cancel-poisoning ──
+    // Set of Transcription ids whose pipeline result must be DISCARDED (per-session cancel).
+    // Keyed by RecordingSession.pipelineTranscriptionID so cancelling one session can never
+    // discard another's finished 200. (The old global shouldCancelRecording flag is gone;
+    // cancel is now per-session via RecordingSession.shouldCancel + this set.)
     private var canceledPipelineTranscriptionIDs = Set<UUID>()
-    private var activeRecordingUseCase: RecordingUseCase = .newSession
-    private var activePipelineUseCase: RecordingUseCase = .newSession
-    private var activeRecordingContextStore: RecordingContextSnapshotStore?
-    private var activeRecordingContextTasks: [Task<Void, Never>] = []
+
+    // ── Serial transcription queue (chained Task on the MainActor) ──
+    // Each enqueue appends to a Task chain: the new tail awaits the previous tail's value
+    // before running its pipeline. This guarantees:
+    //   (a) FIFO order — jobs run in the order they were enqueued (= recording order), and
+    //   (b) full serialization — each pipeline fully finishes (transcribe→enhance→deliver)
+    //       before the next begins, so they never share the whisper/fluidaudio model.
+    // `prev?.value` never throws (Task<Void, Never>); we simply await it to chain.
+    private var transcriptionQueueTail: Task<Void, Never>?
 
     let recorder = Recorder()
-    var recordedFile: URL? = nil
     let recordingsDirectory: URL
 
     // Injected managers
@@ -175,26 +236,91 @@ class VoiceInkEngine: NSObject, ObservableObject {
         return enhancementService
     }
 
+    // MARK: - Session Accessors
+
+    /// The one session currently capturing audio (mic owner), if any. By the one-active
+    /// invariant there is at most one. nil ⇒ no recording in progress (idle OR only
+    /// background transcriptions running).
+    var activeRecordingSession: RecordingSession? {
+        sessions.first { $0.phase == .recording }
+    }
+
+    /// The most-recent in-flight transcribing/delivering session (the "top card"). Used as
+    /// the cancel target when no session is actively recording.
+    private var topInFlightSession: RecordingSession? {
+        sessions.last { $0.phase == .transcribing || $0.phase == .delivering }
+    }
+
+    /// Recompute the DERIVED compat `recordingState` + `partialTranscript` from the active
+    /// recording session. See the big comment on `recordingState` for why we deliberately
+    /// fall back to `.idle` (NOT a transcribing session's state) when nothing is recording.
+    private func recomputeDerivedState() {
+        if let active = activeRecordingSession {
+            recordingState = active.liveRecordingState
+            partialTranscript = active.partialTranscript
+        } else {
+            // No active recording. Background jobs may still be transcribing, but we report
+            // .idle so the record shortcut stays usable (can start a new dictation).
+            recordingState = .idle
+            partialTranscript = ""
+        }
+    }
+
+    /// Remove a finished/aborted session from the collection + recompute derived state.
+    /// SwiftUI animates the card out (transition on the `sessions` array).
+    private func removeSession(_ session: RecordingSession) {
+        session.phase = .done
+        session.clearContext()
+        sessions.removeAll { $0.id == session.id }
+        recomputeDerivedState()
+    }
+
     // MARK: - Toggle Record
 
+    // The single entry point for the record shortcut / record button. Behaviour:
+    //   • A session is actively RECORDING → STOP it (move to .transcribing + enqueue its
+    //     pipeline on the serial queue, NON-blocking). Mic frees immediately.
+    //   • The active session is mid-START handshake (.starting) → cancel that not-yet-
+    //     started session (re-press during the brief start window).
+    //   • Otherwise (idle OR only background transcriptions running) → START a fresh
+    //     active session.
     func toggleRecord(modeId: UUID? = nil, isAssistantFollowUp: Bool = false) async {
-        if recordingState == .starting {
-            await cancelRecording()
+        // Mid-start re-press: the active session is still starting → cancel it.
+        if let active = activeRecordingSession, active.liveRecordingState == .starting {
+            await cancelSession(active)
             return
         }
 
-        if recordingState == .recording {
-            activePipelineUseCase = activeRecordingUseCase
-            activeRecordingUseCase = .newSession
-            activeRecordingStartID = nil
-            partialTranscript = ""
-            recordingState = .transcribing
-            await recorder.stopRecording()
+        if let active = activeRecordingSession {
+            // ── STOP branch ──────────────────────────────────────────────────────────
+            // The mic owner stops. We flip its phase .recording→.transcribing, release the
+            // mic (recorder.stopRecording), build its Transcription record, and ENQUEUE the
+            // pipeline on the serial queue. CRITICAL: we do NOT await the pipeline here —
+            // that inline await is exactly what blocked the next start in the old engine.
+            // The function returns as soon as the mic is free, so a record press right after
+            // can immediately START a new session.
+            logger.info("toggleRecord: STOP session \(active.id.uuidString, privacy: .public) → .transcribing (shouldCancel=\(active.shouldCancel, privacy: .public))")
 
-            if let recordedFile {
-                if !shouldCancelRecording {
+            active.phase = .transcribing
+            active.liveRecordingState = .transcribing
+            active.partialTranscript = ""
+            active.startID = UUID() // invalidate the start handshake token (it has fully started)
+            recomputeDerivedState()
+
+            await recorder.stopRecording()
+            // ── MEDIA RESUME-BETWEEN-SESSIONS NUANCE ──
+            // recorder.stopRecording() schedules resumeMedia()/unmuteSystemAudio(). If the
+            // user immediately starts session B, recorder.startRecording() will pauseMedia()/
+            // muteSystemAudio() again. So media may briefly resume in the gap between stop and
+            // the next start — that's acceptable and self-consistent: the single Recorder is
+            // only ever owned by the single active recording session, so its pause/resume
+            // bracketing always pairs with exactly one recording at a time.
+
+            if let audioURL = active.audioURL {
+                if !active.shouldCancel {
+                    // Build the pending Transcription record and enqueue the pipeline.
                     let transcription = makeRecordingTranscription(
-                        for: recordedFile,
+                        for: audioURL,
                         text: "",
                         duration: 0,
                         transcriptionStatus: .pending
@@ -203,181 +329,207 @@ class VoiceInkEngine: NSObject, ObservableObject {
                     try? modelContext.save()
                     NotificationCenter.default.post(name: .transcriptionCreated, object: transcription)
 
-                    await runPipeline(
-                        on: transcription,
-                        audioURL: recordedFile,
-                        contextStore: activeRecordingContextStore
-                    )
+                    active.pipelineTranscriptionID = transcription.id
+                    enqueueTranscription(for: active, transcription: transcription)
                 } else {
-                    await finishActiveRecorderCancellation()
+                    // Cancelled while recording → save a canceled record, no pipeline.
+                    await finishCanceledRecording(active)
+                    removeSession(active)
                 }
             } else {
-                cancelCurrentSession()
-                if !shouldCancelRecording {
+                // No file captured (e.g. start failed). Just tear the session down.
+                if !active.shouldCancel {
                     logger.error("❌ No recorded file found after stopping recording")
                 }
-                recordingState = .idle
+                active.transcriptionSession?.cancel()
+                removeSession(active)
                 await cleanupResources()
             }
         } else {
+            // ── START branch ─────────────────────────────────────────────────────────
+            // Defensive invariant assert: never create a second .recording session. The
+            // toggle path guarantees this (a press while recording hits the STOP branch),
+            // but assert it anyway.
+            assert(activeRecordingSession == nil, "one-active-recording invariant violated")
+
             let canContinueAssistantSession = isAssistantFollowUp && assistantSession.canSendFollowUp
-            let recordingUseCase: RecordingUseCase = canContinueAssistantSession ? .assistantFollowUp : .newSession
+            let useCase: RecordingSession.UseCase = canContinueAssistantSession ? .assistantFollowUp : .newSession
 
-            activePipelineTranscriptionID = nil
-            shouldCancelRecording = false
-            partialTranscript = ""
-            activeRecordingUseCase = recordingUseCase
-            clearActiveRecordingContext()
-
-            if !recordingUseCase.isAssistantFollowUp {
+            if !useCase.isAssistantFollowUp {
                 assistantSession.reset()
             }
 
             requestRecordPermission { [self] granted in
                 if granted {
                     Task { @MainActor [self] in
-                        let startID = UUID()
-                        self.activeRecordingStartID = startID
-                        let activeModeTask = ActiveWindowService.shared.beginApplyingConfiguration(modeId: modeId) { [weak self] in
-                            guard let self else { return false }
-                            return self.activeRecordingStartID == startID && !self.shouldCancelRecording
-                        }
-
-                        do {
-                            let fileName = "\(UUID().uuidString).wav"
-                            let permanentURL = self.recordingsDirectory.appendingPathComponent(fileName)
-                            self.recordedFile = permanentURL
-
-                            let realtimeAudioGate = RealtimeAudioChunkGate()
-                            self.recorder.onAudioChunk = realtimeAudioGate.receive
-
-                            self.recordingState = .starting
-
-                            try await self.recorder.startRecording(toOutputFile: permanentURL)
-
-                            guard self.activeRecordingStartID == startID,
-                                  self.recorderUIManager?.isRecorderPanelVisible ?? false,
-                                  !self.shouldCancelRecording else {
-                                activeModeTask.cancel()
-                                let shouldKeepRecordingFile = self.shouldCancelRecording
-                                if self.activeRecordingStartID == startID {
-                                    await self.recorder.stopRecording()
-                                    if !shouldKeepRecordingFile {
-                                        self.recordedFile = nil
-                                    }
-                                    self.recordingState = .idle
-                                    self.activeRecordingStartID = nil
-                                }
-                                return
-                            }
-
-                            self.recordingState = .recording
-
-                            await activeModeTask.value
-
-                            guard self.recordingState == .recording,
-                                  self.activeRecordingStartID == startID,
-                                  !self.shouldCancelRecording else {
-                                return
-                            }
-
-                            self.startRecordingContextCapture()
-
-                            guard let transcriptionConfiguration = ModeRuntimeResolver.transcriptionConfiguration(
-                                transcriptionModelManager: self.transcriptionModelManager
-                            ) else {
-                                NotificationManager.shared.showNotification(title: String(localized: "No AI Model Selected"), type: .error)
-                                await self.recorder.stopRecording()
-                                try? FileManager.default.removeItem(at: permanentURL)
-                                self.recordedFile = nil
-                                self.recordingState = .idle
-                                self.activeRecordingStartID = nil
-                                self.clearActiveRecordingContext()
-                                await self.cleanupResources()
-                                await self.recorderUIManager?.dismissRecorderPanel()
-                                return
-                            }
-
-                            if self.serviceRegistry.shouldUseRealtimeTranscription(for: transcriptionConfiguration) {
-                                let session = self.serviceRegistry.createSession(
-                                    for: transcriptionConfiguration,
-                                    onPartialTranscript: { [weak self] partial in
-                                        Task { @MainActor in
-                                            guard let self,
-                                                  self.activeRecordingStartID == startID,
-                                                  self.recordingState == .recording else {
-                                                return
-                                            }
-                                            self.partialTranscript = partial
-                                        }
-                                    }
-                                )
-                                self.currentSession = session
-                                self.currentSessionTranscriptionConfiguration = transcriptionConfiguration
-                                let realCallback = try await session.prepare(
-                                    configuration: transcriptionConfiguration
-                                )
-
-                                if let realCallback {
-                                    let droppedStartupChunks = realtimeAudioGate.activate(realCallback)
-                                    if droppedStartupChunks > 0 {
-                                        self.logger.warning("Realtime startup audio gate dropped \(droppedStartupChunks, privacy: .public) chunks before streaming became active")
-                                    }
-                                } else {
-                                    _ = realtimeAudioGate.reset()
-                                    self.recorder.onAudioChunk = nil
-                                }
-                            } else {
-                                self.currentSession = nil
-                                self.currentSessionTranscriptionConfiguration = nil
-                                self.recorder.onAudioChunk = nil
-                                _ = realtimeAudioGate.reset()
-                            }
-
-                            Task { @MainActor [weak self] in
-                                guard let self else { return }
-
-                                let currentModel = ModeRuntimeResolver.transcriptionConfiguration(
-                                    transcriptionModelManager: self.transcriptionModelManager
-                                )?.model
-
-                                if let model = currentModel,
-                                   model.provider == .whisper {
-                                    if let localWhisperModel = self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
-                                       self.whisperModelManager.whisperContext == nil {
-                                        do {
-                                            try await self.whisperModelManager.loadModel(localWhisperModel)
-                                        } catch {
-                                            self.logger.error("❌ Model loading failed: \(error, privacy: .public)")
-                                        }
-                                    }
-                                } else if let fluidAudioModel = currentModel as? FluidAudioModel {
-                                    try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
-                                }
-
-                            }
-
-                        } catch {
-                            activeModeTask.cancel()
-                            self.logger.error("Recording failed to start: \(error, privacy: .public)")
-                            await self.recorder.stopRecording()
-                            self.cancelCurrentSession()
-                            if let recordedFile = self.recordedFile {
-                                try? FileManager.default.removeItem(at: recordedFile)
-                            }
-                            self.recordingState = .idle
-                            self.recordedFile = nil
-                            self.activeRecordingStartID = nil
-                            self.clearActiveRecordingContext()
-                            await self.cleanupResources()
-                            NotificationManager.shared.showNotification(title: String(localized: "Recording failed to start"), type: .error)
-                            await self.recorderUIManager?.dismissRecorderPanel()
-                        }
+                        await self.startNewSession(modeId: modeId, useCase: useCase)
                     }
                 } else {
                     logger.error("Recording permission denied")
                 }
             }
+        }
+    }
+
+    // MARK: - Start a fresh session
+
+    // Creates a brand-new RecordingSession, drives the same start handshake the old engine
+    // used (permission already granted, recorder.startRecording, mode config apply, streaming
+    // session prepare, model preload), and appends it to `sessions` with phase .recording.
+    private func startNewSession(modeId: UUID?, useCase: RecordingSession.UseCase) async {
+        let startID = UUID()
+        let session = RecordingSession(phase: .recording, useCase: useCase, startID: startID)
+        // Born .recording but we drive it through .starting → .recording during the handshake.
+        session.liveRecordingState = .starting
+
+        // Append to the collection so the card appears immediately (shows the .starting state).
+        sessions.append(session)
+        recomputeDerivedState()
+
+        let activeModeTask = ActiveWindowService.shared.beginApplyingConfiguration(modeId: modeId) { [weak self, weak session] in
+            guard let self, let session else { return false }
+            // Only keep applying config while THIS session is still the live start.
+            return session.startID == startID && !session.shouldCancel && self.sessions.contains(where: { $0.id == session.id })
+        }
+
+        do {
+            let fileName = "\(UUID().uuidString).wav"
+            let permanentURL = self.recordingsDirectory.appendingPathComponent(fileName)
+            session.audioURL = permanentURL
+
+            // Buffer audio chunks until the streaming session (if any) is ready to receive them.
+            let pendingChunks = OSAllocatedUnfairLock(initialState: [Data]())
+            self.recorder.onAudioChunk = { data in
+                pendingChunks.withLock { $0.append(data) }
+            }
+
+            session.liveRecordingState = .starting
+            recomputeDerivedState()
+
+            try await self.recorder.startRecording(toOutputFile: permanentURL)
+
+            // Re-press / cancel / panel-gone guard: if this is no longer the live start, abort.
+            guard session.startID == startID,
+                  self.sessions.contains(where: { $0.id == session.id }),
+                  self.recorderUIManager?.isRecorderPanelVisible ?? false,
+                  !session.shouldCancel else {
+                activeModeTask.cancel()
+                let shouldKeepRecordingFile = session.shouldCancel
+                if session.startID == startID {
+                    await self.recorder.stopRecording()
+                    if !shouldKeepRecordingFile {
+                        session.audioURL = nil
+                    }
+                    self.removeSession(session)
+                }
+                return
+            }
+
+            session.liveRecordingState = .recording
+            session.phase = .recording
+            recomputeDerivedState()
+
+            await activeModeTask.value
+
+            guard session.liveRecordingState == .recording,
+                  session.startID == startID,
+                  !session.shouldCancel else {
+                return
+            }
+
+            // Begin app/window context capture for AI enhancement.
+            self.startRecordingContextCapture(for: session)
+
+            guard let transcriptionConfiguration = ModeRuntimeResolver.transcriptionConfiguration(
+                transcriptionModelManager: self.transcriptionModelManager
+            ) else {
+                NotificationManager.shared.showNotification(title: String(localized: "No AI Model Selected"), type: .error)
+                await self.recorder.stopRecording()
+                try? FileManager.default.removeItem(at: permanentURL)
+                session.audioURL = nil
+                self.removeSession(session)
+                await self.cleanupResources()
+                await self.recorderUIManager?.dismissRecorderPanel()
+                return
+            }
+
+            session.transcriptionConfiguration = transcriptionConfiguration
+
+            if self.serviceRegistry.shouldUseRealtimeTranscription(for: transcriptionConfiguration) {
+                let streamingSession = self.serviceRegistry.createSession(
+                    for: transcriptionConfiguration,
+                    onPartialTranscript: { [weak self, weak session] partial in
+                        Task { @MainActor in
+                            guard let self, let session,
+                                  session.startID == startID,
+                                  session.liveRecordingState == .recording else {
+                                return
+                            }
+                            session.partialTranscript = partial
+                            // Mirror to the engine's derived partial only while this is the
+                            // active recording session (it always is here, but be explicit).
+                            if self.activeRecordingSession?.id == session.id {
+                                self.partialTranscript = partial
+                            }
+                        }
+                    }
+                )
+                session.transcriptionSession = streamingSession
+                let realCallback = try await streamingSession.prepare(
+                    configuration: transcriptionConfiguration
+                )
+
+                if let realCallback {
+                    self.recorder.onAudioChunk = realCallback
+                    let buffered = pendingChunks.withLock { chunks -> [Data] in
+                        let result = chunks
+                        chunks.removeAll()
+                        return result
+                    }
+                    for chunk in buffered { realCallback(chunk) }
+                }
+            } else {
+                session.transcriptionSession = nil
+                self.recorder.onAudioChunk = nil
+                pendingChunks.withLock { $0.removeAll() }
+            }
+
+            // Best-effort model preload so the eventual transcribe is fast.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+
+                let currentModel = ModeRuntimeResolver.transcriptionConfiguration(
+                    transcriptionModelManager: self.transcriptionModelManager
+                )?.model
+
+                if let model = currentModel,
+                   model.provider == .whisper {
+                    if let localWhisperModel = self.whisperModelManager.availableModels.first(where: { $0.name == model.name }),
+                       self.whisperModelManager.whisperContext == nil {
+                        do {
+                            try await self.whisperModelManager.loadModel(localWhisperModel)
+                        } catch {
+                            self.logger.error("❌ Model loading failed: \(error, privacy: .public)")
+                        }
+                    }
+                } else if let fluidAudioModel = currentModel as? FluidAudioModel {
+                    try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(for: fluidAudioModel)
+                }
+            }
+
+        } catch {
+            activeModeTask.cancel()
+            self.logger.error("Recording failed to start: \(error, privacy: .public)")
+            await self.recorder.stopRecording()
+            session.transcriptionSession?.cancel()
+            if let recordedFile = session.audioURL {
+                try? FileManager.default.removeItem(at: recordedFile)
+            }
+            session.audioURL = nil
+            self.removeSession(session)
+            await self.cleanupResources()
+            NotificationManager.shared.showNotification(title: String(localized: "Recording failed to start"), type: .error)
+            await self.recorderUIManager?.dismissRecorderPanel()
         }
     }
 
@@ -387,40 +539,56 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
     // MARK: - Recording Context
 
-    private func startRecordingContextCapture() {
-        clearActiveRecordingContext()
+    private func startRecordingContextCapture(for session: RecordingSession) {
+        session.clearContext()
 
         let store = RecordingContextSnapshotStore()
-        activeRecordingContextStore = store
-        activeRecordingContextTasks = RecordingContextCaptureService.startCapture(into: store)
+        session.contextStore = store
+        session.contextTasks = RecordingContextCaptureService.startCapture(into: store)
     }
 
-    private func clearActiveRecordingContext() {
-        activeRecordingContextTasks.forEach { $0.cancel() }
-        activeRecordingContextTasks.removeAll()
-        activeRecordingContextStore = nil
+    // MARK: - Serial Transcription Queue
+
+    // Enqueue this session's pipeline onto the serial FIFO chain. See the
+    // `transcriptionQueueTail` declaration for the full serialization rationale. We capture
+    // the previous tail, then replace it with a new Task that first awaits the previous
+    // tail's completion, then runs THIS session's pipeline to completion. Result: pipelines
+    // run strictly one-after-another in enqueue (= recording) order ⇒ FIFO delivery for free.
+    private func enqueueTranscription(for session: RecordingSession, transcription: Transcription) {
+        let previousTail = transcriptionQueueTail
+        transcriptionQueueTail = Task { @MainActor [weak self] in
+            // Wait for all earlier-enqueued pipelines to finish first (serial chain).
+            await previousTail?.value
+            guard let self else { return }
+            await self.runPipeline(for: session, transcription: transcription)
+        }
     }
 
     // MARK: - Pipeline Dispatch
 
-    private func runPipeline(
-        on transcription: Transcription,
-        audioURL: URL,
-        contextStore: RecordingContextSnapshotStore?
-    ) async {
-        guard let transcriptionConfiguration = currentSessionTranscriptionConfiguration ??
+    // Run the full transcribe→enhance→deliver pipeline for ONE session, using that session's
+    // stored config / transcription session / context store / pipeline id (NOT engine
+    // singletons). On completion the session is removed from the collection.
+    private func runPipeline(for session: RecordingSession, transcription: Transcription) async {
+        guard let transcriptionConfiguration = session.transcriptionConfiguration ??
             ModeRuntimeResolver.transcriptionConfiguration(transcriptionModelManager: transcriptionModelManager) else {
             transcription.text = String(localized: "Transcription Failed: No model selected")
             transcription.transcriptionStatus = TranscriptionStatus.failed.rawValue
             try? modelContext.save()
-            recordingState = .idle
-            activePipelineUseCase = .newSession
+            removeSession(session)
             return
         }
 
-        let session = currentSession
+        guard let audioURL = session.audioURL else {
+            removeSession(session)
+            return
+        }
+
+        let streamingSession = session.transcriptionSession
         let transcriptionID = transcription.id
-        activePipelineTranscriptionID = transcriptionID
+        session.pipelineTranscriptionID = transcriptionID
+        session.phase = .delivering // pipeline is running; mark past pure-transcribing
+        session.liveRecordingState = .transcribing
 
         await pipeline.run(
             transcription: transcription,
@@ -429,7 +597,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
             formattingConfiguration: {
                 ModeRuntimeResolver.transcriptionFormattingConfiguration()
             },
-            session: session,
+            session: streamingSession,
             triggerWordModeSelection: { [weak self] text in
                 self?.selectTriggerWordModeIfNeeded(for: text)
             },
@@ -444,39 +612,50 @@ class VoiceInkEngine: NSObject, ObservableObject {
                     aiService: aiService
                 )
             },
-            recordingContextSnapshot: {
+            recordingContextSnapshot: { [weak session] in
                 await MainActor.run {
-                    contextStore?.snapshot
+                    session?.contextStore?.snapshot
                 }
             },
             outputConfiguration: {
                 ModeRuntimeResolver.outputConfiguration()
             },
-            onStateChange: { [weak self] state in
-                guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
-                self.recordingState = state
+            // Per-session UI state: drive this session's card spinner (.enhancing etc.).
+            onStateChange: { [weak self, weak session] state in
+                guard let session else { return }
+                session.liveRecordingState = state
+                // Keep the engine's derived state fresh ONLY if this session is the active
+                // recording one (it never is during the pipeline, but be defensive).
+                self?.recomputeDerivedState()
             },
-            shouldCancel: { [weak self] in
+            shouldCancel: { [weak self, weak session] in
                 guard let self else { return false }
+                // Per-session cancel: poisoned id OR this session's own cancel flag.
                 return self.canceledPipelineTranscriptionIDs.contains(transcriptionID)
-                    || (self.activePipelineTranscriptionID == transcriptionID && self.shouldCancelRecording)
+                    || (session?.shouldCancel ?? false)
             },
-            onCancel: { [weak self, session] in
+            onCancel: { [weak self, streamingSession] in
                 guard let self else { return }
-                self.cancelPipelineSession(transcriptionID: transcriptionID, session: session)
+                self.cancelPipelineSession(transcriptionID: transcriptionID, session: streamingSession)
             },
-            onDismiss: { [weak self] in
-                guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
-                await self.recorderUIManager?.dismissRecorderPanel()
+            onDismiss: { [weak self, weak session] in
+                guard let self, let session else { return }
+                // Only the pipeline owning the TOP/most-recent card should be allowed to
+                // dismiss the whole panel; but in practice each pipeline's onDismiss fires
+                // at its own completion. We dismiss the panel only when removing the LAST
+                // session leaves the collection empty (handled in removeSession + the
+                // RecorderUIManager visibility logic). Here we just no-op the per-pipeline
+                // dismiss; final hide is decided after removal below.
+                _ = session
             },
             assistant: TranscriptionPipeline.AssistantHooks(
-                isFollowUp: activePipelineUseCase.isAssistantFollowUp,
+                isFollowUp: session.useCase.isAssistantFollowUp,
                 sendFollowUp: { [weak self] text, transcription in
-                    guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
+                    guard let self else { return }
                     await self.sendAssistantFollowUp(text, transcription: transcription)
                 },
                 startResponse: { [weak self] transcript, configuration in
-                    guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
+                    guard let self else { return }
                     self.assistantSession.beginInitialResponse(
                         transcript: transcript,
                         provider: configuration.provider,
@@ -487,33 +666,39 @@ class VoiceInkEngine: NSObject, ObservableObject {
                     )
                 },
                 showResponse: { [weak self] response, systemPrompt in
-                    guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
+                    guard let self else { return }
                     await self.completeAssistantResponse(response, systemPrompt: systemPrompt)
                 },
                 failResponse: { [weak self] message in
-                    guard let self, self.activePipelineTranscriptionID == transcriptionID else { return }
+                    guard let self else { return }
                     self.assistantSession.fail(message)
                 }
             )
         )
 
-        let didFinishActivePipeline = activePipelineTranscriptionID == transcriptionID
-        if didFinishActivePipeline {
-            await finishRecorderSession()
-            await cleanupResources()
-            activePipelineTranscriptionID = nil
-            currentSession = nil
-            currentSessionTranscriptionConfiguration = nil
-            recordedFile = nil
-            shouldCancelRecording = false
-            activePipelineUseCase = .newSession
-            clearActiveRecordingContext()
-        }
+        // Pipeline finished (delivered, failed, or canceled). Capture the result, release
+        // shared model resources, drop the poison key, and remove the session from the stack.
+        session.transcript = transcription.text
         canceledPipelineTranscriptionIDs.remove(transcriptionID)
+        session.transcriptionSession = nil
 
-        if didFinishActivePipeline &&
-            (recordingState == .transcribing || recordingState == .enhancing || recordingState == .busy) {
-            recordingState = .idle
+        await finishRecorderSession()
+        // Release shared model resources only when NO other session still needs them, i.e.
+        // when this was the last in-flight job. cleanupResources() tears down the SHARED
+        // whisper/fluidaudio model; doing it while another queued job is about to run would
+        // force a reload, but the serial queue means the NEXT job hasn't started yet, so a
+        // cleanup here is safe (the next job reloads on demand). We still guard on "no other
+        // transcribing/delivering session" to avoid needless reload churn.
+        removeSession(session)
+        if !sessions.contains(where: { $0.phase == .transcribing || $0.phase == .delivering }) {
+            await cleanupResources()
+        }
+
+        // If the panel is now empty (no sessions + no assistant response), let the UI manager
+        // hide it. We trigger a generic dismiss; RecorderUIManager only actually hides when
+        // there is nothing left to show.
+        if sessions.isEmpty {
+            await recorderUIManager?.dismissRecorderPanel()
         }
     }
 
@@ -528,78 +713,103 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
     // MARK: - Cancellation
 
+    // Public cancel from the RecorderUIManager / shortcuts. Targets:
+    //   • the ACTIVE recording session if one is recording, else
+    //   • the most-recent in-flight transcribing/delivering session (top card).
+    // This preserves the old "cancel button aborts what's live" UX in the multi-session world.
     func cancelRecording() async {
-        let shouldFinishSessionImmediately: Bool
-        switch recordingState {
-        case .starting, .recording:
-            requestRecordingCancellation()
-            await finishActiveRecorderCancellation()
-            shouldFinishSessionImmediately = true
-        case .transcribing, .enhancing:
-            requestRecordingCancellation()
-            partialTranscript = ""
-            recordingState = .idle
-            shouldFinishSessionImmediately = false
-        case .idle, .busy:
-            partialTranscript = ""
-            shouldCancelRecording = false
-            recordingState = .idle
-            shouldFinishSessionImmediately = true
-        }
-
-        if shouldFinishSessionImmediately {
-            await finishRecorderSession()
+        if let active = activeRecordingSession {
+            await cancelSession(active)
+        } else if let top = topInFlightSession {
+            await cancelSession(top)
+        } else {
+            // Nothing to cancel — just recompute derived state.
+            recomputeDerivedState()
         }
     }
 
+    // Per-card cancel entry point wired to the per-session "X" (engine.cancelSession(id:)).
+    func cancelSession(id: UUID) async {
+        guard let session = sessions.first(where: { $0.id == id }) else { return }
+        await cancelSession(session)
+    }
+
+    // Cancel a SPECIFIC session. Behaviour depends on its phase:
+    //   • .recording / .starting → stop the mic, save a "canceled" record, remove the card.
+    //   • .transcribing / .delivering → poison its pipeline id so its result is DISCARDED
+    //     (not pasted). The pipeline's defensive gates still deliver a finished 200 if text
+    //     is already in hand (see TranscriptionPipeline) — that's intentional: we never throw
+    //     away words the user already got transcribed. The card is removed when the pipeline
+    //     unwinds; here we just flag + mark it cancelling.
+    func cancelSession(_ session: RecordingSession) async {
+        // Poison point. For a recording session this is a clean discard; for an in-flight one
+        // it inserts into canceledPipelineTranscriptionIDs which the pipeline's shouldCancel()
+        // gate reads to discard the result (subject to the "don't discard a finished result"
+        // defensive gates).
+        logger.info("cancelSession: \(session.id.uuidString, privacy: .public) phase=\(String(describing: session.phase), privacy: .public) liveState=\(String(describing: session.liveRecordingState), privacy: .public)")
+
+        session.shouldCancel = true
+        session.transcriptionSession?.cancel()
+
+        switch session.phase {
+        case .recording:
+            // Mic owner. Stop capture, persist a canceled record, drop the card.
+            session.startID = UUID() // invalidate start handshake
+            session.clearContext()
+            await recorder.stopRecording()
+            await finishCanceledRecording(session)
+            removeSession(session)
+            await cleanupResources()
+
+        case .transcribing, .delivering:
+            // In-flight job. Poison its pipeline id; the running pipeline will pick this up
+            // at its next shouldCancel() gate. The card stays until the pipeline unwinds and
+            // removeSession() fires in runPipeline's tail (or here if there's no live pipeline).
+            if let pipelineID = session.pipelineTranscriptionID {
+                logger.info("cancelSession: poisoning pipeline id \(pipelineID.uuidString, privacy: .public)")
+                canceledPipelineTranscriptionIDs.insert(pipelineID)
+            } else {
+                // No pipeline started yet (queued but not running) → just drop the card.
+                removeSession(session)
+            }
+            session.liveRecordingState = .idle
+            recomputeDerivedState()
+
+        case .done:
+            removeSession(session)
+        }
+    }
+
+    // Full reset (launch / hard reset): cancel everything, clear the queue, drop all sessions.
     func resetRecordingSession() async {
-        cancelCurrentSession()
-        activeRecordingStartID = nil
-        activePipelineTranscriptionID = nil
+        // Cancel the serial queue chain so no queued pipeline starts after reset.
+        transcriptionQueueTail?.cancel()
+        transcriptionQueueTail = nil
+
+        for session in sessions {
+            session.shouldCancel = true
+            session.transcriptionSession?.cancel()
+            session.clearContext()
+        }
+        sessions.removeAll()
         canceledPipelineTranscriptionIDs.removeAll()
-        shouldCancelRecording = false
         partialTranscript = ""
         assistantSession.reset()
-        activeRecordingUseCase = .newSession
-        activePipelineUseCase = .newSession
-        clearActiveRecordingContext()
-        await recorder.stopRecording()
-        recordedFile = nil
         recordingState = .idle
+        await recorder.stopRecording()
         await cleanupResources()
         await finishRecorderSession()
     }
 
-    private func requestRecordingCancellation() {
-        shouldCancelRecording = true
-
-        if (recordingState == .transcribing || recordingState == .enhancing),
-           let activePipelineTranscriptionID {
-            canceledPipelineTranscriptionIDs.insert(activePipelineTranscriptionID)
-        }
-
-        cancelCurrentSession()
-    }
-
-    private func finishActiveRecorderCancellation() async {
-        activeRecordingStartID = nil
-        clearActiveRecordingContext()
-        await recorder.stopRecording()
-        await saveCanceledRecording()
-        recordedFile = nil
-        partialTranscript = ""
-        recordingState = .idle
-        await cleanupResources()
-    }
-
-    private func saveCanceledRecording() async {
-        guard let recordedFile,
-              FileManager.default.fileExists(atPath: recordedFile.path)
+    // Persist a "canceled" Transcription record for a session whose recording was aborted.
+    private func finishCanceledRecording(_ session: RecordingSession) async {
+        guard let audioURL = session.audioURL,
+              FileManager.default.fileExists(atPath: audioURL.path)
         else { return }
 
-        let duration = await AudioFileMetadata.duration(for: recordedFile)
+        let duration = await AudioFileMetadata.duration(for: audioURL)
         let transcription = makeRecordingTranscription(
-            for: recordedFile,
+            for: audioURL,
             text: Transcription.canceledTranscriptionText,
             duration: duration,
             transcriptionStatus: .canceled
@@ -649,20 +859,6 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
     private func cancelPipelineSession(transcriptionID: UUID, session: TranscriptionSession?) {
         session?.cancel()
-
-        guard activePipelineTranscriptionID == transcriptionID else {
-            logger.notice("Skipping stale pipeline cleanup")
-            return
-        }
-
-        currentSession = nil
-        currentSessionTranscriptionConfiguration = nil
-    }
-
-    private func cancelCurrentSession() {
-        currentSession?.cancel()
-        currentSession = nil
-        currentSessionTranscriptionConfiguration = nil
     }
 
     private func finishRecorderSession() async {
@@ -671,8 +867,6 @@ class VoiceInkEngine: NSObject, ObservableObject {
 
     func cleanupResources() async {
         logger.notice("cleanupResources: releasing model resources")
-        activeRecordingStartID = nil
-        activeRecordingUseCase = .newSession
         await whisperModelManager.cleanupResources()
         await serviceRegistry.cleanup()
         logger.notice("cleanupResources: completed")

--- a/VoiceInk/Views/Recorder/MiniRecorderView.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderView.swift
@@ -6,6 +6,9 @@ struct MiniRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     @ObservedObject var assistantSession: AssistantSession
     let onRecordButtonTapped: () -> Void
     let onCloseTapped: () -> Void
+    // Cancel ("X"): discard the active recording/transcription with NO paste + resume
+    // paused media. Routed up to RecorderUIManager.cancelRecording().
+    let onCancelTapped: () -> Void
     let onAssistantFollowUp: (String) -> Void
 
     // MARK: - Layout Constants
@@ -33,6 +36,20 @@ struct MiniRecorderView<S: RecorderStateProvider & ObservableObject>: View {
             !assistantSession.isBusy
     }
 
+    // The cancel ("X") button is reachable whenever there is something to abort:
+    // while RECORDING (discard the audio) AND while a transcription is IN-FLIGHT
+    // (.transcribing/.enhancing — abort delivery before it pastes) and during the
+    // brief .starting handshake. Hidden at .idle/.busy where there's nothing to
+    // cancel (the assistant close-button affordance covers idle dismissal instead).
+    private var shouldShowCancelButton: Bool {
+        switch stateProvider.recordingState {
+        case .starting, .recording, .transcribing, .enhancing:
+            return true
+        case .idle, .busy:
+            return false
+        }
+    }
+
     private var liveAssistantFollowUpText: String {
         guard stateProvider.recordingState == .recording else { return "" }
         return stateProvider.partialTranscript
@@ -40,17 +57,29 @@ struct MiniRecorderView<S: RecorderStateProvider & ObservableObject>: View {
 
     private var controlBar: some View {
         HStack(spacing: 0) {
-            Group {
-                if shouldShowCloseButton {
-                    RecorderCloseButton(action: onCloseTapped)
-                } else {
-                    RecorderRecordButton(
-                        recordingState: stateProvider.recordingState,
-                        action: onRecordButtonTapped
-                    )
+            HStack(spacing: 6) {
+                Group {
+                    if shouldShowCloseButton {
+                        RecorderCloseButton(action: onCloseTapped)
+                    } else {
+                        RecorderRecordButton(
+                            recordingState: stateProvider.recordingState,
+                            action: onRecordButtonTapped
+                        )
+                    }
+                }
+
+                // Cancel ("X") sits immediately to the RIGHT of the Stop/record control
+                // so an abort is one glance + one tap away from Stop. Only shown while a
+                // recording or in-flight transcription is cancellable (see
+                // shouldShowCancelButton); collapses out otherwise so idle bars are unchanged.
+                if shouldShowCancelButton {
+                    RecorderCancelButton(action: onCancelTapped)
+                        .transition(.opacity)
                 }
             }
             .padding(.leading, 10)
+            .animation(.easeInOut(duration: 0.2), value: shouldShowCancelButton)
 
             Spacer(minLength: 0)
 

--- a/VoiceInk/Views/Recorder/MiniWindowManager.swift
+++ b/VoiceInk/Views/Recorder/MiniWindowManager.swift
@@ -14,17 +14,28 @@ class MiniWindowManager {
         assistantSession: AssistantSession,
         onRecordButtonTapped: @escaping () -> Void,
         onCloseTapped: @escaping () -> Void,
-        onAssistantFollowUp: @escaping (String) -> Void
+        // onCancelTapped: fired by the red "X" → discard the recording/transcription
+        // (no paste) and resume paused media. Routed to RecorderUIManager.cancelRecording().
+        onCancelTapped: @escaping () -> Void,
+        onAssistantFollowUp: @escaping (String) -> Void,
+        // onCancelSession: per-card cancel for a SPECIFIC background transcribing session
+        // (record-while-transcribing stack). Routed to engine.cancelSession(id:).
+        onCancelSession: @escaping (UUID) -> Void
     ) {
         self.makeView = {
             AnyView(
-                MiniRecorderView(
-                    stateProvider: engine,
+                // Host the STACK container (one card per engine.sessions entry) rather than
+                // a single MiniRecorderView. The stack renders the active/base card with full
+                // controls and older transcribing cards piled upward.
+                MiniRecorderStackView(
+                    engine: engine,
                     recorder: recorder,
                     assistantSession: assistantSession,
                     onRecordButtonTapped: onRecordButtonTapped,
                     onCloseTapped: onCloseTapped,
-                    onAssistantFollowUp: onAssistantFollowUp
+                    onCancelTapped: onCancelTapped,
+                    onAssistantFollowUp: onAssistantFollowUp,
+                    onCancelSession: onCancelSession
                 )
             )
         }

--- a/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
@@ -64,6 +64,11 @@ class NotchRecorderPanel: KeyablePanel {
         let sideMargin: CGFloat = 10
         let totalWidth = notchWidth + (maxSideExpansion + sideMargin) * 2
 
+        // 430 already accommodates the assistant panel (320). It also comfortably fits the
+        // record-while-transcribing stack: the notch pill (~43) plus several "transcribing…"
+        // chips (~38 each incl. spacing) beneath it stay well under 430, so no enlargement is
+        // needed for the stacked-chip UI. (If the chip count ever grows past ~8 this would
+        // need bumping.)
         let maxContentHeight: CGFloat = 430
         let xPosition = screen.frame.midX - (totalWidth / 2)
         let yPosition = screen.frame.maxY - maxContentHeight

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -6,6 +6,9 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     @ObservedObject var assistantSession: AssistantSession
     let onRecordButtonTapped: () -> Void
     let onCloseTapped: () -> Void
+    // Cancel ("X"): discard the active recording/transcription with NO paste + resume
+    // paused media. Routed up to RecorderUIManager.cancelRecording().
+    let onCancelTapped: () -> Void
     let onAssistantFollowUp: (String) -> Void
 
     // MARK: - Display State
@@ -102,6 +105,18 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
             !assistantSession.isBusy
     }
 
+    // Cancel ("X") visibility — mirrors the mini panel: reachable while RECORDING
+    // (discard audio) and while a transcription is IN-FLIGHT (.transcribing/.enhancing,
+    // abort before paste) plus the brief .starting handshake. Hidden at .idle/.busy.
+    private var shouldShowCancelButton: Bool {
+        switch stateProvider.recordingState {
+        case .starting, .recording, .transcribing, .enhancing:
+            return true
+        case .idle, .busy:
+            return false
+        }
+    }
+
     private var liveAssistantFollowUpText: String {
         guard stateProvider.recordingState == .recording else { return "" }
         return stateProvider.partialTranscript
@@ -158,9 +173,20 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
                         action: onRecordButtonTapped
                     )
                 }
+
+                // Cancel ("X") immediately to the right of the Stop/record control so an
+                // abort is one tap from Stop. Only while a recording/transcription is
+                // cancellable (see shouldShowCancelButton); collapses out at idle/busy so
+                // the notch pill's normal layout is unchanged.
+                if shouldShowCancelButton {
+                    RecorderCancelButton(action: onCancelTapped)
+                        .transition(.opacity)
+                }
+
                 RecorderModeButton(buttonSize: 20, padding: EdgeInsets())
                 Spacer(minLength: 0)
             }
+            .animation(.easeInOut(duration: 0.2), value: shouldShowCancelButton)
             .padding(.leading, sideEdgePadding)
             .frame(width: sideExpansion)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/VoiceInk/Views/Recorder/NotchWindowManager.swift
+++ b/VoiceInk/Views/Recorder/NotchWindowManager.swift
@@ -14,17 +14,27 @@ class NotchWindowManager {
         assistantSession: AssistantSession,
         onRecordButtonTapped: @escaping () -> Void,
         onCloseTapped: @escaping () -> Void,
-        onAssistantFollowUp: @escaping (String) -> Void
+        // onCancelTapped: fired by the red "X" → discard the recording/transcription
+        // (no paste) and resume paused media. Routed to RecorderUIManager.cancelRecording().
+        onCancelTapped: @escaping () -> Void,
+        onAssistantFollowUp: @escaping (String) -> Void,
+        // onCancelSession: per-card cancel for a SPECIFIC background transcribing session
+        // (record-while-transcribing stack). Routed to engine.cancelSession(id:).
+        onCancelSession: @escaping (UUID) -> Void
     ) {
         self.makeView = {
             AnyView(
-                NotchRecorderView(
-                    stateProvider: engine,
+                // Host the STACK container: the active session is the notch pill, background
+                // transcribing sessions render as chips stacked beneath it.
+                NotchRecorderStackView(
+                    engine: engine,
                     recorder: recorder,
                     assistantSession: assistantSession,
                     onRecordButtonTapped: onRecordButtonTapped,
                     onCloseTapped: onCloseTapped,
-                    onAssistantFollowUp: onAssistantFollowUp
+                    onCancelTapped: onCancelTapped,
+                    onAssistantFollowUp: onAssistantFollowUp,
+                    onCancelSession: onCancelSession
                 )
             )
         }

--- a/VoiceInk/Views/Recorder/RecorderComponents.swift
+++ b/VoiceInk/Views/Recorder/RecorderComponents.swift
@@ -180,6 +180,60 @@ struct RecorderCloseButton: View {
     }
 }
 
+// MARK: - Cancel (Discard) Button
+//
+// A dedicated red "X" button that lives RIGHT NEXT TO the record/stop control in every
+// recorder panel — a one-tap way to ABORT a recording (or an in-flight transcription)
+// WITHOUT delivering/pasting any text. Distinct from the normal Stop control, which
+// finishes + transcribes + pastes.
+//
+// WHY a separate component (not the grey RecorderCloseButton):
+//   - RecorderCloseButton is grey + only shown for the assistant-idle "close" affordance.
+//     Reusing it would visually conflate "discard this recording" with "dismiss the
+//     assistant panel". This button is RED so it reads unambiguously as a destructive
+//     abort, and it's always adjacent to Stop while a recording/transcription is live.
+//
+// WIRING: the tap calls the `action` closure, which the panels route to
+// RecorderUIManager.cancelRecording() → VoiceInkEngine.cancelRecording(). That path:
+//   • aborts/poisons any in-flight transcription pipeline so its result is DISCARDED,
+//     never pasted (see requestRecordingCancellation / canceledPipelineTranscriptionIDs),
+//   • stops audio capture via recorder.stopRecording(), which is the SAME stop path
+//     normal Stop uses and therefore resumes paused Spotify/Music (playbackController
+//     .resumeMedia()) + unmutes system audio,
+//   • clears the partial transcript + recorded file, returns state to .idle,
+//   • then dismisses the recorder panel.
+// It is idempotent/safe if pressed when nothing is active (the engine's .idle/.busy
+// branch just resets state).
+struct RecorderCancelButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    // Subtle red-tinted fill so the control is clearly an abort, but
+                    // not as loud as the solid-red recording indicator on the Stop button.
+                    .fill(AppTheme.Status.error.opacity(0.20))
+                    .overlay(
+                        Circle()
+                            .strokeBorder(AppTheme.Status.error.opacity(0.55), lineWidth: 0.6)
+                    )
+
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(AppTheme.Status.error)
+            }
+            // Match the 21pt hit-target sizing of the record/close buttons so it lines
+            // up cleanly beside Stop in both the mini bar and the notch pill.
+            .frame(width: 21, height: 21)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .help("Cancel recording (discard, no paste)")
+        .accessibilityLabel(Text("Cancel recording"))
+    }
+}
+
 // MARK: - Processing Indicator
 
 struct ProcessingIndicator: View {

--- a/VoiceInk/Views/Recorder/RecorderStackView.swift
+++ b/VoiceInk/Views/Recorder/RecorderStackView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RecorderStackView(s) — stacked recorder cards for record-while-transcribing.
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The engine now holds a COLLECTION of RecordingSession objects (`engine.sessions`), at
+// most one of which is actively .recording (the mic owner). The recorder window used to
+// host ONE card bound to the engine; it now hosts a STACK container that renders ONE card
+// per session.
+//
+// LAYOUT MODEL (Mini):
+//   • The ACTIVE recording session (or, if none is recording, the newest session) sits at
+//     the BASE (bottom) — that's the "live" card with full record/stop/cancel/mode controls.
+//   • Older in-flight transcribing sessions stack UPWARD above it: each is offset by
+//     -cardHeight * indexFromBottom so they appear as a vertical pile growing up off-screen-
+//     wards (the panel is bottom-anchored). Each upward card shows just a compact
+//     "transcribing…" status + a per-card cancel "X".
+//   • As each transcription completes its card animates out (opacity + move) and the stack
+//     collapses — driven by SwiftUI's implicit animation on the `sessions` array plus the
+//     per-index `.offset(y:)`.
+//
+// STACK OFFSET MATH (Mini):
+//   sessions are ordered oldest→newest. We render so the BASE card is the active/newest one.
+//   For a card at array index i (0 = oldest), let N = sessions.count. We want the
+//   active/newest card (highest createdAt) at offset 0 and older ones stacked upward.
+//   We compute `indexFromBottom` = (N-1 - i) when the newest is the base. Each card is
+//   shifted up by `cardSpacing * indexFromBottom`. cardSpacing ≈ control-bar height + gap.
+//
+// The active/base card uses the FULL MiniRecorderView (with live waveform, controls,
+// assistant panel). Background transcribing cards use a slim TranscribingChip to keep
+// the pile compact.
+//
+// NOTE on which card is "base": the spec says the active .recording card is the base and
+// transcribing cards stack upward. When NOTHING is recording (all sessions transcribing)
+// we keep the NEWEST as the visual base for a stable anchor; controls on it are inert
+// (it's not recording) but its TranscribingChip still shows + can be cancelled.
+
+// MARK: - Mini Stack
+
+struct MiniRecorderStackView: View {
+    @ObservedObject var engine: VoiceInkEngine
+    @ObservedObject var recorder: Recorder
+    @ObservedObject var assistantSession: AssistantSession
+    let onRecordButtonTapped: () -> Void
+    let onCloseTapped: () -> Void
+    let onCancelTapped: () -> Void
+    let onAssistantFollowUp: (String) -> Void
+    // Per-card cancel: cancels THAT specific session (engine.cancelSession(id:)).
+    let onCancelSession: (UUID) -> Void
+
+    // Approx vertical advance per stacked card. Matches the mini control-bar height (40)
+    // plus a small gap so stacked chips read as a discrete pile, not overlapping.
+    private let cardSpacing: CGFloat = 46
+
+    // Sessions oldest→newest as stored by the engine.
+    private var ordered: [RecordingSession] { engine.sessions }
+
+    // The base (live) session: the active recording one if present, else the newest.
+    private var baseSession: RecordingSession? {
+        engine.activeRecordingSession ?? ordered.last
+    }
+
+    // Show an assistant-only base card when there are NO sessions left but the assistant is
+    // still presenting a response/follow-up. The session that produced the response has
+    // already been removed from `sessions` (its pipeline finished), but the AssistantPanelView
+    // lives INSIDE MiniRecorderView and must keep rendering. We bind that card to the engine
+    // (RecorderStateProvider → reports .idle) which is exactly the old single-card behaviour.
+    private var showAssistantOnlyCard: Bool {
+        ordered.isEmpty && assistantSession.isVisible
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            if showAssistantOnlyCard {
+                MiniRecorderView(
+                    stateProvider: engine,
+                    recorder: recorder,
+                    assistantSession: assistantSession,
+                    onRecordButtonTapped: onRecordButtonTapped,
+                    onCloseTapped: onCloseTapped,
+                    onCancelTapped: onCancelTapped,
+                    onAssistantFollowUp: onAssistantFollowUp
+                )
+            }
+
+            ForEach(ordered) { session in
+                cardView(for: session)
+                    // Each card is shifted UP by its distance from the base. The base card
+                    // (indexFromBottom == 0) stays at offset 0; older transcribing cards
+                    // climb upward in the bottom-anchored panel.
+                    .offset(y: -cardSpacing * CGFloat(indexFromBottom(of: session)))
+                    .zIndex(zIndex(for: session))
+                    .transition(
+                        .move(edge: .bottom).combined(with: .opacity)
+                    )
+            }
+        }
+        // Implicit animation keyed on the session id list so add/remove (and the resulting
+        // offset shuffles) animate the pile growing/collapsing.
+        .animation(.spring(response: 0.38, dampingFraction: 0.85), value: engine.sessions.map(\.id))
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+    }
+
+    // Distance of a session from the base, in card units. Base = 0, next-older = 1, etc.
+    // We pile by reverse-chronological position relative to the base. Sessions newer than
+    // the base (shouldn't normally exist, but be safe) also pile upward.
+    private func indexFromBottom(of session: RecordingSession) -> Int {
+        guard let baseSession,
+              let baseIdx = ordered.firstIndex(where: { $0.id == baseSession.id }),
+              let myIdx = ordered.firstIndex(where: { $0.id == session.id }) else {
+            return 0
+        }
+        // Older sessions have a SMALLER array index (oldest first). The base is usually the
+        // newest (largest index). Distance upward = baseIdx - myIdx for older cards.
+        return max(0, baseIdx - myIdx)
+    }
+
+    // Base card on top of the z-order so its controls are tappable; older cards behind.
+    private func zIndex(for session: RecordingSession) -> Double {
+        Double(ordered.count - indexFromBottom(of: session))
+    }
+
+    @ViewBuilder
+    private func cardView(for session: RecordingSession) -> some View {
+        if session.id == baseSession?.id {
+            // BASE/live card — full mini recorder with controls. Bound to the session as
+            // its state provider so it shows that session's live state (recording waveform,
+            // partial transcript, etc.). Controls route to the engine-level closures.
+            MiniRecorderView(
+                stateProvider: session,
+                recorder: recorder,
+                assistantSession: assistantSession,
+                onRecordButtonTapped: onRecordButtonTapped,
+                onCloseTapped: onCloseTapped,
+                onCancelTapped: onCancelTapped,
+                onAssistantFollowUp: onAssistantFollowUp
+            )
+        } else {
+            // Background transcribing card — slim chip with per-card cancel.
+            TranscribingChip(
+                session: session,
+                style: .mini,
+                onCancel: { onCancelSession(session.id) }
+            )
+        }
+    }
+}
+
+// MARK: - Notch Stack
+
+// LAYOUT MODEL (Notch):
+//   The notch pill is anchored at the TOP center of the screen. "Upward" stacking makes no
+//   sense there, so for the notch the ACTIVE session is the notch pill (full NotchRecorderView)
+//   and in-flight transcribing sessions render as small "transcribing…" chips stacked BELOW
+//   the pill (newest nearest the pill), animating in/out as they complete. The NotchRecorderPanel
+//   window height was extended to fit up to a few stacked chips beneath the pill.
+struct NotchRecorderStackView: View {
+    @ObservedObject var engine: VoiceInkEngine
+    @ObservedObject var recorder: Recorder
+    @ObservedObject var assistantSession: AssistantSession
+    let onRecordButtonTapped: () -> Void
+    let onCloseTapped: () -> Void
+    let onCancelTapped: () -> Void
+    let onAssistantFollowUp: (String) -> Void
+    let onCancelSession: (UUID) -> Void
+
+    private var ordered: [RecordingSession] { engine.sessions }
+
+    // The pill session: active recording one if present, else newest.
+    private var pillSession: RecordingSession? {
+        engine.activeRecordingSession ?? ordered.last
+    }
+
+    // Background (non-pill) in-flight sessions, newest first so the newest chip sits nearest
+    // the pill directly beneath it.
+    private var backgroundSessions: [RecordingSession] {
+        ordered
+            .filter { $0.id != pillSession?.id && ($0.phase == .transcribing || $0.phase == .delivering) }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    // Assistant-only fallback (see the mini stack's equivalent): when the producing session
+    // is gone but the assistant is still visible, render the pill bound to the engine so the
+    // AssistantPanelView inside NotchRecorderView keeps showing.
+    private var showAssistantOnlyPill: Bool {
+        pillSession == nil && assistantSession.isVisible
+    }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            // The pill at the top (the notch itself).
+            if let pillSession {
+                NotchRecorderView(
+                    stateProvider: pillSession,
+                    recorder: recorder,
+                    assistantSession: assistantSession,
+                    onRecordButtonTapped: onRecordButtonTapped,
+                    onCloseTapped: onCloseTapped,
+                    onCancelTapped: onCancelTapped,
+                    onAssistantFollowUp: onAssistantFollowUp
+                )
+            } else if showAssistantOnlyPill {
+                NotchRecorderView(
+                    stateProvider: engine,
+                    recorder: recorder,
+                    assistantSession: assistantSession,
+                    onRecordButtonTapped: onRecordButtonTapped,
+                    onCloseTapped: onCloseTapped,
+                    onCancelTapped: onCancelTapped,
+                    onAssistantFollowUp: onAssistantFollowUp
+                )
+            }
+
+            // Stacked transcribing chips beneath the pill, newest nearest the pill.
+            ForEach(backgroundSessions) { session in
+                TranscribingChip(
+                    session: session,
+                    style: .notch,
+                    onCancel: { onCancelSession(session.id) }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.spring(response: 0.38, dampingFraction: 0.85), value: engine.sessions.map(\.id))
+        .frame(maxWidth: .infinity, alignment: .top)
+    }
+}
+
+// MARK: - Transcribing Chip
+
+// Compact card for a background (non-base/non-pill) session that is transcribing. Shows a
+// spinner + label + a per-card cancel "X" that discards THAT session's result. Observes the
+// session so its label/spinner reflect its live state (transcribing → enhancing).
+struct TranscribingChip: View {
+    enum Style { case mini, notch }
+
+    @ObservedObject var session: RecordingSession
+    let style: Style
+    let onCancel: () -> Void
+
+    private var label: String {
+        switch session.liveRecordingState {
+        case .enhancing: return String(localized: "Enhancing…")
+        default:         return String(localized: "Transcribing…")
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // Reuse the existing spinning processing indicator for visual consistency.
+            ProcessingIndicator(color: .white.opacity(0.86))
+                .frame(width: 14, height: 14)
+
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.white.opacity(0.82))
+                .lineLimit(1)
+
+            // Per-card cancel — discards THIS session only.
+            RecorderCancelButton(action: onCancel)
+                .scaleEffect(0.82)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .frame(width: style == .mini ? 184 : 200)
+        .background(Color.black.opacity(style == .mini ? 1.0 : 0.92))
+        .clipShape(RoundedRectangle(cornerRadius: style == .mini ? 16 : 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: style == .mini ? 16 : 12, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.6)
+        )
+    }
+}


### PR DESCRIPTION
## What this does

Lets you start a **new dictation while the previous one is still transcribing**, instead of having to wait for transcription to finish before the mic frees up.

- The **active recorder** sits at the base of the panel. When you stop it, its card flips to a "transcribing…" state and **stacks** above it (mini bar) / below it (notch pill), and the mic frees **immediately** so you can start the next dictation right away.
- Finished sessions animate out and the stack collapses.
- Only **one mic at a time** (one active recording session); everything else is transcribing in the background.
- Delivery is **FIFO** — pasted text stays in the order you spoke.
- Each in-flight session has its own cancel ("X") to discard just that result.

## Why it's useful

The single most common friction with fast back-to-back dictation is the dead time between pressing stop and being allowed to record again while the previous clip uploads/transcribes (especially with cloud models or large local models). This removes that wait entirely — capture is decoupled from transcription.

## How it's implemented

- **`RecordingSession`** state machine (`recording → transcribing → delivering → done`). The engine now owns a *collection* of sessions rather than a single in-flight lifecycle, with a one-active-recording invariant (at most one session owns the shared `Recorder`). `RecordingSession` conforms to the existing `RecorderStateProvider`, so each card binds to its own session's live state.
- **Non-blocking stop:** STOP flips the active session to `.transcribing`, releases the mic, and **enqueues** its pipeline on a serial transcription queue instead of awaiting it inline. That inline await was what previously blocked the next recording.
- **Serial FIFO transcription queue** (`transcriptionQueueTail`): jobs run one-at-a-time. This is deliberate — the whisper context / shared model is a single mutable singleton (`setLanguage`/`setPrompt`/`fullTranscribe` are sequential stateful mutations, and `cleanupResources` tears the shared model down), so concurrent transcriptions would corrupt each other. Serial ⇒ completion order == recording order ⇒ FIFO delivery for free.
- **Derived `recordingState`** reflects only the *active* recording session, falling back to `.idle` when none is recording — this keeps the record shortcut usable mid-transcription (a press while earlier sessions transcribe just starts a new one).
- **Stacked UI:** `MiniRecorderStackView` / `NotchRecorderStackView` render one card per session over the existing recorder views; background sessions show a slim `TranscribingChip` with a per-card cancel.
- Also includes a per-panel **Cancel ("X") button** that the stacked cards reuse for per-session discard (abort + discard, no paste — distinct from Stop).

Built against the existing `TranscriptionPipeline.run()` API — no pipeline changes were required. This has been running in production in a fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start a new recording while the previous one is still transcribing. Adds a stacked recorder UI with per-session cancel so you can dictate back-to-back without waiting.

- New Features
  - Stop frees the mic immediately; the prior session transcribes in the background.
  - Stacked cards in mini/notch: active recorder at the base/pill; background “Transcribing…” chips; finished sessions animate out.
  - FIFO delivery preserved so pasted text stays in the order you spoke.
  - Red “Cancel” (X) to discard the active or a specific in-flight session without pasting.

- Refactors
  - Introduced `RecordingSession` state machine; engine manages multiple sessions with one mic owner.
  - Non-blocking stop; transcription runs on a serial FIFO queue to protect shared models.
  - Derived `recordingState` reflects only the active recording so the record shortcut remains usable mid-transcription.
  - Recorder windows now host `MiniRecorderStackView` / `NotchRecorderStackView` with `TranscribingChip` and `RecorderCancelButton`; panel stays visible while any session or the assistant is active. Built on existing `TranscriptionPipeline.run()` (no API changes).

<sup>Written for commit 24e8ef08d0ed49d167cbb12c86bf0362178b5978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

