### PR TITLE
Improve Simplified Chinese (zh-Hans) localization

### DIFF
--- a/VoiceInk/CustomSoundManager.swift
+++ b/VoiceInk/CustomSoundManager.swift
@@ -17,7 +17,7 @@ class CustomSoundManager: ObservableObject {
         var id: String { rawValue }
 
         var displayName: String {
-            "Sound \(number)"
+            String(localized: "Sound \(number)")
         }
 
         var fileExtension: String {

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -768,7 +768,7 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%lld 个转录模型"
+                  "value" : "%lld 个转写模型"
                 }
               }
             }
@@ -820,7 +820,7 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%lld 条转录记录"
+                  "value" : "%lld 条转写记录"
                 }
               }
             }
@@ -1887,7 +1887,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在粘贴的转录输出末尾添加一个空格。"
+            "value" : "在粘贴的转写输出末尾添加一个空格。"
           }
         }
       }
@@ -1968,7 +1968,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加自定转录模型"
+            "value" : "添加自定转写模型"
           }
         }
       }
@@ -2209,7 +2209,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加转录模型"
+            "value" : "添加转写模型"
           }
         }
       }
@@ -2914,7 +2914,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未为流式转录配置 API 密钥"
+            "value" : "未为流式转写配置 API 密钥"
           }
         }
       }
@@ -3010,7 +3010,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Speech 未能完整返回转录结果。"
+            "value" : "Apple Speech 未能完整返回转写结果。"
           }
         }
       }
@@ -3451,7 +3451,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动删除转录历史记录"
+            "value" : "自动删除转写历史记录"
           }
         }
       }
@@ -3468,7 +3468,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动删除转录记录"
+            "value" : "自动删除转写记录"
           }
         }
       }
@@ -3501,7 +3501,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动删除音频录音，同时完整保留文字转录记录。"
+            "value" : "自动删除音频录音，同时完整保留文字转写记录。"
           }
         }
       }
@@ -3518,7 +3518,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "根据你设置的保留期限自动删除转录记录。"
+            "value" : "根据你设置的保留期限自动删除转写记录。"
           }
         }
       }
@@ -3552,7 +3552,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动从转录中移除已配置的填充词，例如「uh」「um」或「hmm」。如果未配置任何填充词，将跳过此清理。"
+            "value" : "自动从转写中移除已配置的填充词，例如「uh」「um」或「hmm」。如果未配置任何填充词，将跳过此清理。"
           }
         }
       }
@@ -3568,7 +3568,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当转录内容字数很少时，自动跳过 AI 润色。「是的」「谢谢」之类的简短用语或快速指令并不能从润色中获益。"
+            "value" : "当转写内容字数很少时，自动跳过 AI 润色。「是的」「谢谢」之类的简短用语或快速指令并不能从润色中获益。"
           }
         }
       }
@@ -3616,7 +3616,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "可用的转录模型"
+            "value" : "可用的转写模型"
           }
         }
       }
@@ -3876,7 +3876,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "取消转录"
+            "value" : "取消转写"
           }
         }
       }
@@ -4343,7 +4343,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将转录与 LLM 结合，生成润色后的版本。"
+            "value" : "将转写与 LLM 结合，生成润色后的版本。"
           }
         }
       }
@@ -4457,7 +4457,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "配置转录模型"
+            "value" : "配置转写模型"
           }
         }
       }
@@ -4672,7 +4672,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "控制 VoiceInk 如何处理你的转录数据和录音。"
+            "value" : "控制 VoiceInk 如何处理你的转写数据和录音。"
           }
         }
       }
@@ -4689,7 +4689,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将转录输出转换为小写。"
+            "value" : "将转写输出转换为小写。"
           }
         }
       }
@@ -4771,7 +4771,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "拷贝上次转录"
+            "value" : "拷贝上次转写"
           }
         }
       }
@@ -4821,7 +4821,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制转录文本"
+            "value" : "复制转写文本"
           }
         }
       }
@@ -5207,7 +5207,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定转录模型"
+            "value" : "自定转写模型"
           }
         }
       }
@@ -5554,7 +5554,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除旧录音，同时保留转录历史记录。"
+            "value" : "删除旧录音，同时保留转写历史记录。"
           }
         }
       }
@@ -5604,7 +5604,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在保留期后删除转录历史记录和相关音频文件。"
+            "value" : "在保留期后删除转写历史记录和相关音频文件。"
           }
         }
       }
@@ -6304,7 +6304,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下载转录模型"
+            "value" : "下载转写模型"
           }
         }
       }
@@ -6611,7 +6611,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑自定转录模型"
+            "value" : "编辑自定转写模型"
           }
         }
       }
@@ -7520,7 +7520,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法拷贝转录内容"
+            "value" : "无法拷贝转写内容"
           }
         }
       }
@@ -7728,7 +7728,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法载入转录模型。"
+            "value" : "无法载入转写模型。"
           }
         }
       }
@@ -7920,7 +7920,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法转录该音频。"
+            "value" : "无法转写该音频。"
           }
         }
       }
@@ -7952,7 +7952,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Mac 上本地运行的快速多语言转录。"
+            "value" : "在 Mac 上本地运行的快速多语言转写。"
           }
         }
       }
@@ -7968,7 +7968,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "快速转录，不使用 AI 增强。"
+            "value" : "快速转写，不使用 AI 增强。"
           }
         }
       }
@@ -8068,7 +8068,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查找最佳转录设置"
+            "value" : "查找最佳转写设置"
           }
         }
       }
@@ -8815,7 +8815,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "为 Apple 原生转录提供的模型类型无效。"
+            "value" : "为 Apple 原生转写提供的模型类型无效。"
           }
         }
       }
@@ -9122,7 +9122,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已拷贝上次转录"
+            "value" : "已拷贝上次转写"
           }
         }
       }
@@ -9834,7 +9834,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "管理模型"
+            "value" : "模型目录"
           }
         }
       }
@@ -9850,7 +9850,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "管理模式"
+            "value" : "转写模式"
           }
         }
       }
@@ -10306,7 +10306,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "还有更多转录模型可用"
+            "value" : "还有更多转写模型可用"
           }
         }
       }
@@ -10646,7 +10646,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无自定转录模型"
+            "value" : "无自定转写模型"
           }
         }
       }
@@ -11081,7 +11081,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无可用转录内容"
+            "value" : "无可用转写内容"
           }
         }
       }
@@ -11097,7 +11097,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未选择转录模型"
+            "value" : "未选择转写模型"
           }
         }
       }
@@ -11113,7 +11113,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有可用的转录模型。请在「AI 模型」标签页中连接云服务或下载本地模型。"
+            "value" : "没有可用的转写模型。请在「AI 模型」标签页中连接云服务或下载本地模型。"
           }
         }
       }
@@ -11129,7 +11129,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有可供自定命令使用的转录文本。"
+            "value" : "没有可供自定命令使用的转写文本。"
           }
         }
       }
@@ -11145,7 +11145,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无转录记录"
+            "value" : "无转写记录"
           }
         }
       }
@@ -11161,7 +11161,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "暂无转录记录"
+            "value" : "暂无转写记录"
           }
         }
       }
@@ -11307,7 +11307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未连接到流式转录服务"
+            "value" : "未连接到流式转写服务"
           }
         }
       }
@@ -11877,7 +11877,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴上次转录（已润色）"
+            "value" : "粘贴上次转写（已润色）"
           }
         }
       }
@@ -11893,7 +11893,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴上次转录"
+            "value" : "粘贴上次转写"
           }
         }
       }
@@ -11909,7 +11909,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴上次转录（已润色）"
+            "value" : "粘贴上次转写（已润色）"
           }
         }
       }
@@ -11925,7 +11925,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴上次转录（原始）"
+            "value" : "粘贴上次转写（原始）"
           }
         }
       }
@@ -12660,7 +12660,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近转录"
+            "value" : "最近转写"
           }
         }
       }
@@ -13567,7 +13567,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新转录此音频"
+            "value" : "重新转写此音频"
           }
         }
       }
@@ -13583,7 +13583,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新转录失败"
+            "value" : "重新转写失败"
           }
         }
       }
@@ -13599,7 +13599,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新转录成功"
+            "value" : "重新转写成功"
           }
         }
       }
@@ -13647,7 +13647,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重试上次转录"
+            "value" : "重试上次转写"
           }
         }
       }
@@ -13745,7 +13745,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以你的用户权限在本地运行。最终转录文本通过 stdin 传入，并以 VOICEINK_TRANSCRIPT 形式提供。"
+            "value" : "以你的用户权限在本地运行。最终转写文本通过 stdin 传入，并以 VOICEINK_TRANSCRIPT 形式提供。"
           }
         }
       }
@@ -13873,7 +13873,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "存储转录内容"
+            "value" : "存储转写内容"
           }
         }
       }
@@ -13955,7 +13955,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "搜索转录记录"
+            "value" : "搜索转写记录"
           }
         }
       }
@@ -13971,7 +13971,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "搜索转录记录…"
+            "value" : "搜索转写记录…"
           }
         }
       }
@@ -14036,7 +14036,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择一条转录记录以查看详情"
+            "value" : "选择一条转写记录以查看详情"
           }
         }
       }
@@ -14477,7 +14477,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设置等待 AI 提供商响应的时长。如果在该时长内未收到响应，你可以选择立即失败并粘贴原始转录内容，或重试请求（最多 3 次）。"
+            "value" : "设置等待 AI 提供商响应的时长。如果在该时长内未收到响应，你可以选择立即失败并粘贴原始转写内容，或重试请求（最多 3 次）。"
           }
         }
       }
@@ -14817,7 +14817,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "跳过简短转录"
+            "value" : "跳过简短转写"
           }
         }
       }
@@ -14978,7 +14978,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "启动或停止 VoiceInk 录音器，以进行语音转录。"
+            "value" : "启动或停止 VoiceInk 录音器，以进行语音转写。"
           }
         }
       }
@@ -15044,7 +15044,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开始转录"
+            "value" : "开始转写"
           }
         }
       }
@@ -15189,7 +15189,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "流式转录在等待最终结果时超时"
+            "value" : "流式转写在等待最终结果时超时"
           }
         }
       }
@@ -15254,7 +15254,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "支持任何使用与 OpenAI 转录相同 API 格式的提供商。"
+            "value" : "支持任何使用与 OpenAI 转写相同 API 格式的提供商。"
           }
         }
       }
@@ -15610,7 +15610,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "找不到要转录的音频文件。"
+            "value" : "找不到要转写的音频文件。"
           }
         }
       }
@@ -15642,7 +15642,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "核心转录引擎运行失败。"
+            "value" : "核心转写引擎运行失败。"
           }
         }
       }
@@ -15822,7 +15822,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录语言由模型自动检测。"
+            "value" : "转写语言由模型自动检测。"
           }
         }
       }
@@ -15973,7 +15973,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这是针对英语优化的模型，仅支持英语转录。"
+            "value" : "这是针对英语优化的模型，仅支持英语转写。"
           }
         }
       }
@@ -16320,7 +16320,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录记录总数"
+            "value" : "转写记录总数"
           }
         }
       }
@@ -16336,7 +16336,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录"
+            "value" : "转写"
           }
         }
       }
@@ -16352,7 +16352,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在转录"
+            "value" : "正在转写"
           }
         }
       }
@@ -16368,7 +16368,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在转录录音"
+            "value" : "正在转写录音"
           }
         }
       }
@@ -16385,7 +16385,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在转录…"
+            "value" : "正在转写…"
           }
         }
       }
@@ -16401,7 +16401,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录记录清理"
+            "value" : "转写记录清理"
           }
         }
       }
@@ -16419,7 +16419,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "来自 %@ 的转录"
+            "value" : "来自 %@ 的转写"
           }
         }
       }
@@ -16437,7 +16437,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录历史记录"
+            "value" : "转写历史记录"
           }
         }
       }
@@ -16453,7 +16453,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录"
+            "value" : "转写"
           }
         }
       }
@@ -16469,7 +16469,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用 SpeechAnalyzer 转录失败。"
+            "value" : "使用 SpeechAnalyzer 转写失败。"
           }
         }
       }
@@ -16485,7 +16485,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录失败：%@"
+            "value" : "转写失败：%@"
           }
         }
       }
@@ -16501,7 +16501,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录失败：未选择模型"
+            "value" : "转写失败：未选择模型"
           }
         }
       }
@@ -16517,7 +16517,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录格式"
+            "value" : "转写格式"
           }
         }
       }
@@ -16533,7 +16533,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录语言"
+            "value" : "转写语言"
           }
         }
       }
@@ -16551,7 +16551,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录模型"
+            "value" : "转写模型"
           }
         }
       }
@@ -16567,7 +16567,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录模型"
+            "value" : "转写模型"
           }
         }
       }
@@ -16583,7 +16583,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录模型"
+            "value" : "转写模型"
           }
         }
       }
@@ -16599,7 +16599,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录用时"
+            "value" : "转写用时"
           }
         }
       }
@@ -16615,7 +16615,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录已取消"
+            "value" : "转写已取消"
           }
         }
       }
@@ -16777,7 +16777,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "如果本地模型转录耗时超出预期，请开启此选项。App 在启动和唤醒时会静默运行后台转录，以触发优化。"
+            "value" : "如果本地模型转写耗时超出预期，请开启此选项。App 在启动和唤醒时会静默运行后台转写，以触发优化。"
           }
         }
       }
@@ -16927,7 +16927,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在本地使用 NVIDIA 的 Parakeet 模型，或连接云端转录提供商。"
+            "value" : "在本地使用 NVIDIA 的 Parakeet 模型，或连接云端转写提供商。"
           }
         }
       }
@@ -16976,7 +16976,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当你想尽快将语音转换为文本时使用此模式。它会使用你配置的转录模型录音，并按原样粘贴转录内容。"
+            "value" : "当你想尽快将语音转换为文本时使用此模式。它会使用你配置的转写模型录音，并按原样粘贴转写内容。"
           }
         }
       }
@@ -17043,7 +17043,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用你配置的转录模型进行快速听写。"
+            "value" : "使用你配置的转写模型进行快速听写。"
           }
         }
       }
@@ -17325,7 +17325,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查看转录与润色模型的性能"
+            "value" : "查看转写与润色模型的性能"
           }
         }
       }
@@ -17522,7 +17522,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VoiceInk 无法访问其存储位置。你的转录记录将无法跨会话存储。"
+            "value" : "VoiceInk 无法访问其存储位置。你的转写记录将无法跨会话存储。"
           }
         }
       }
@@ -17716,7 +17716,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VoiceInk 会读取屏幕上的可见内容，以提高转录的准确性。"
+            "value" : "VoiceInk 会读取屏幕上的可见内容，以提高转写的准确性。"
           }
         }
       }
@@ -17797,7 +17797,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VoiceInk 会临时使用剪贴板来粘贴转录内容。打开后，它会在所选延迟后恢复你之前的剪贴板内容。关闭后，粘贴的转录内容会保留在剪贴板中。"
+            "value" : "VoiceInk 会临时使用剪贴板来粘贴转写内容。打开后，它会在所选延迟后恢复你之前的剪贴板内容。关闭后，粘贴的转写内容会保留在剪贴板中。"
           }
         }
       }
@@ -17813,7 +17813,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VoiceInk 使用辅助功能将转录内容直接输入到任何 App 中。"
+            "value" : "VoiceInk 使用辅助功能将转写内容直接输入到任何 App 中。"
           }
         }
       }
@@ -17829,7 +17829,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VoiceInk 使用大语言模型润色转录记录并执行 AI 操作。请先设置 API 密钥再继续。"
+            "value" : "VoiceInk 使用大语言模型润色转写记录并执行 AI 操作。请先设置 API 密钥再继续。"
           }
         }
       }
@@ -17879,7 +17879,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VoiceInk 将下载 NVIDIA 的 Parakeet 模型，以设置快速的本地转录。"
+            "value" : "VoiceInk 将下载 NVIDIA 的 Parakeet 模型，以设置快速的本地转写。"
           }
         }
       }
@@ -18079,7 +18079,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "词语替换会在转录之后运行，用于替换听错的词语、短语、缩写或模板文本。"
+            "value" : "词语替换会在转写之后运行，用于替换听错的词语、短语、缩写或模板文本。"
           }
         }
       }
@@ -18095,7 +18095,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "词语替换会在转录完成后运行。词汇则与 AI 润色配合使用，以便更好地理解转录记录中的人名、技术术语和特殊拼写。"
+            "value" : "词语替换会在转写完成后运行。词汇则与 AI 润色配合使用，以便更好地理解转写记录中的人名、技术术语和特殊拼写。"
           }
         }
       }
@@ -18523,7 +18523,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "你的转录记录将显示在这里"
+            "value" : "你的转写记录将显示在这里"
           }
         }
       }
@@ -18626,6 +18626,316 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "YouTube 视频与指南"
+          }
+        }
+      }
+    },
+    "Imported" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已导入"
+          }
+        }
+      }
+    },
+    "Built in" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内置"
+          }
+        }
+      }
+    },
+    "Multilingual" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多语言"
+          }
+        }
+      }
+    },
+    "English" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英语"
+          }
+        }
+      }
+    },
+    "Auto" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动"
+          }
+        }
+      }
+    },
+    "Not Set" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未设置"
+          }
+        }
+      }
+    },
+    "All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部"
+          }
+        }
+      }
+    },
+    "Individual categories" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单独类别"
+          }
+        }
+      }
+    },
+    "Custom Models" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义模型"
+          }
+        }
+      }
+    },
+    "Sound %lld" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "声音 %lld"
+          }
+        }
+      }
+    },
+    "Each website can only belong to one mode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个网站只能属于一个模式"
+          }
+        }
+      }
+    },
+    "Each trigger word can only belong to one mode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个触发词只能属于一个模式"
+          }
+        }
+      }
+    },
+    "Remove %@ triggers" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除 %@ 触发词"
+          }
+        }
+      }
+    },
+    "Try a Simple Dictation" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "试试简单听写"
+          }
+        }
+      }
+    },
+    "Try Enhancement" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "试试润色"
+          }
+        }
+      }
+    },
+    "Write an Email" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写一封邮件"
+          }
+        }
+      }
+    },
+    "Try Rewrite" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "试试改写"
+          }
+        }
+      }
+    },
+    "Ask a Quick Question" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "问个小问题"
+          }
+        }
+      }
+    },
+    "Turn your spoken note into a clean email draft with VoiceInk." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用 VoiceInk 把你的口述整理成整洁的邮件草稿。"
+          }
+        }
+      }
+    },
+    "Select the text on the screen, tell VoiceInk the changes you want, and VoiceInk will rewrite the text for you." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选中屏幕上的文字，告诉 VoiceInk 你想怎么改，它就会替你改写。"
+          }
+        }
+      }
+    },
+    "Ask quick questions and VoiceInk will serve you the answers." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "问一些简单的问题，VoiceInk 会为你解答。"
+          }
+        }
+      }
+    },
+    "Sample text" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "示例文本"
+          }
+        }
+      }
+    },
+    "Sample question" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "示例问题"
+          }
+        }
+      }
+    },
+    "Read this" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读这段"
+          }
+        }
+      }
+    },
+    "Your dictated text will appear here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你听写的文字会显示在这里。"
+          }
+        }
+      }
+    },
+    "Your enhanced message will appear here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "润色后的内容会显示在这里。"
+          }
+        }
+      }
+    },
+    "Your formatted email will appear here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整理好的邮件会显示在这里。"
+          }
+        }
+      }
+    },
+    "Text to rewrite will appear here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待改写的文字会显示在这里。"
+          }
+        }
+      }
+    },
+    "Let's try it once again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我们再试一次。"
+          }
+        }
+      }
+    },
+    "Next" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一步"
+          }
+        }
+      }
+    },
+    "Keyboard shortcut:" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "键盘快捷键："
           }
         }
       }

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -53,7 +53,7 @@ extension TranscriptionModel {
     }
 
     var language: String {
-        isMultilingualModel ? "Multilingual" : "English"
+        isMultilingualModel ? String(localized: "Multilingual") : String(localized: "English")
     }
 
     var supportsStreaming: Bool { false }

--- a/VoiceInk/Modes/ModeViewComponents.swift
+++ b/VoiceInk/Modes/ModeViewComponents.swift
@@ -124,8 +124,8 @@ struct ConfigurationRow: View {
     
     private var selectedLanguage: String? {
         if let langCode = config.selectedLanguage {
-            if langCode == "auto" { return "Auto" }
-            if langCode == "en" { return "English" }
+            if langCode == "auto" { return String(localized: "Auto") }
+            if langCode == "en" { return String(localized: "English") }
             
             if let modelName = config.selectedTranscriptionModelName,
                let model = transcriptionModelManager.allAvailableModels.first(where: { $0.name == modelName }),

--- a/VoiceInk/Modes/TriggerPickerPopover.swift
+++ b/VoiceInk/Modes/TriggerPickerPopover.swift
@@ -233,7 +233,7 @@ struct TriggerPickerPopover: View {
         systemName: String,
         isSelected: Bool,
         claimedBy: ModeConfig?,
-        unavailableMessage: String,
+        unavailableMessage: LocalizedStringKey,
         addTitle: LocalizedStringKey,
         removeTitle: LocalizedStringKey,
         detail: String,

--- a/VoiceInk/Modes/TriggerSelectionItems.swift
+++ b/VoiceInk/Modes/TriggerSelectionItems.swift
@@ -122,7 +122,7 @@ private struct TriggerTextChip: View {
     let systemName: String
     let title: String
     let truncationMode: Text.TruncationMode
-    let removeHelp: String
+    let removeHelp: LocalizedStringKey
     let onRemove: () -> Void
 
     var body: some View {

--- a/VoiceInk/Modes/TriggerTemplateRow.swift
+++ b/VoiceInk/Modes/TriggerTemplateRow.swift
@@ -65,7 +65,7 @@ struct TriggerTemplateRow: View {
             }
         }
         .buttonStyle(.plain)
-        .help(isAdded ? "Remove \(template.name) triggers" : group.summaryText)
+        .help(isAdded ? String(localized: "Remove \(template.name) triggers") : group.summaryText)
     }
 }
 

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -222,7 +222,7 @@ class AudioTranscriptionManager: ObservableObject {
                     transcription = Transcription(
                         text: cleanedText,
                         duration: duration,
-                        enhancedText: "Enhancement failed: \(error.localizedDescription)",
+                        enhancedText: String(localized: "Enhancement failed: \(error.localizedDescription)"),
                         audioFileURL: permanentURL.absoluteString,
                         transcriptionModelName: currentModel.displayName,
                         promptName: nil,

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -13,8 +13,8 @@ private final class BackupOptions: NSObject {
 
     override init() {
         self.view = NSView(frame: NSRect(x: 0, y: 0, width: 360, height: 188))
-        self.allButton = NSButton(radioButtonWithTitle: "All", target: nil, action: nil)
-        self.individualButton = NSButton(radioButtonWithTitle: "Individual categories", target: nil, action: nil)
+        self.allButton = NSButton(radioButtonWithTitle: String(localized: "All"), target: nil, action: nil)
+        self.individualButton = NSButton(radioButtonWithTitle: String(localized: "Individual categories"), target: nil, action: nil)
 
         var buttons: [BackupCategory: NSButton] = [:]
         for category in BackupCategory.allCases {
@@ -289,7 +289,7 @@ class ImportExportService {
         alert.alertStyle = .informational
         alert.accessoryView = accessory.view
         alert.addButton(withTitle: String(localized: "Import"))
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: String(localized: "Cancel"))
 
         let response = alert.runModal()
         guard response == .alertFirstButtonReturn else {

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -317,7 +317,7 @@ struct APIKeyManagementView: View {
     }
 
     private func providerTitle(_ provider: AIProvider) -> String {
-        provider == .custom ? "Custom Models" : provider.rawValue
+        provider == .custom ? String(localized: "Custom Models") : provider.rawValue
     }
 
     private func syncSelectedProviderAvailability() {

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardView.swift
@@ -130,7 +130,7 @@ struct FluidAudioModelCardView: View {
                     }
                 }) {
                     HStack(spacing: 4) {
-                        Text(isDownloading ? "Downloading..." : "Download")
+                        Text(LocalizedStringKey(isDownloading ? "Downloading..." : "Download"))
                         Image(systemName: "arrow.down.circle")
                     }
                     .font(.system(size: 12, weight: .medium))

--- a/VoiceInk/Views/AI Models/WhisperModelCardView.swift
+++ b/VoiceInk/Views/AI Models/WhisperModelCardView.swift
@@ -111,7 +111,7 @@ struct WhisperModelCardView: View {
             } else {
                 Button(action: downloadAction) {
                     HStack(spacing: 4) {
-                        Text(isDownloading ? "Downloading..." : "Download")
+                        Text(LocalizedStringKey(isDownloading ? "Downloading..." : "Download"))
                             .font(.system(size: 12, weight: .medium))
                         Image(systemName: "arrow.down.circle")
                             .font(.system(size: 12, weight: .medium))
@@ -244,7 +244,7 @@ func performanceColor(value: Double) -> Color {
     }
 }
 
-func modelStatusPill(_ text: String, systemImage: String) -> some View {
+func modelStatusPill(_ text: LocalizedStringKey, systemImage: String) -> some View {
     Label(text, systemImage: systemImage)
         .font(.system(size: 11, weight: .medium))
         .foregroundColor(Color(.secondaryLabelColor))

--- a/VoiceInk/Views/Components/FillerWordsSettingsView.swift
+++ b/VoiceInk/Views/Components/FillerWordsSettingsView.swift
@@ -125,7 +125,7 @@ struct FillerWordsSettingsSection: View {
         }
 
         guard fillerWordManager.addWord(trimmed) else {
-            errorMessage = "This filler word already exists."
+            errorMessage = String(localized: "This filler word already exists.")
             return
         }
 

--- a/VoiceInk/Views/Onboarding/OnboardingExperienceIntroCard.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingExperienceIntroCard.swift
@@ -11,7 +11,7 @@ struct OnboardingExperienceIntroCard: View {
     var body: some View {
         HStack(alignment: .center, spacing: 14) {
             VStack(alignment: .leading, spacing: 4) {
-                Text(introText)
+                Text(LocalizedStringKey(introText))
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(AppTheme.Text.primary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -221,7 +221,7 @@ struct SettingsView: View {
             Section("General") {
                 Toggle("Hide Dock Icon", isOn: $menuBarManager.isMenuBarOnly)
 
-                LaunchAtLogin.Toggle("Launch at Login")
+                LaunchAtLogin.Toggle(String(localized: "Launch at Login"))
 
                 Toggle("Auto-check Updates", isOn: Binding(
                     get: { updaterViewModel.automaticallyChecksForUpdates },

--- a/VoiceInk/Views/ShortcutPreviewView.swift
+++ b/VoiceInk/Views/ShortcutPreviewView.swift
@@ -16,7 +16,7 @@ struct ShortcutPreviewView: View {
                 }
             }
         } else {
-            KeyCapView(text: "Not Set")
+            KeyCapView(text: String(localized: "Not Set"))
                 .foregroundColor(.secondary)
         }
     }


### PR DESCRIPTION
## Summary

Improvements to the Simplified Chinese (zh-Hans) localization, on top of #782.

- **Terminology** — standardize transcription to **转写** across all 104 occurrences. 转写 is the term used by mainstream Chinese ASR products (iFlytek 讯飞, Alibaba Cloud), whereas the previous 转录 carries "record/dub" and biology-transcription connotations. Menu-bar entries are clarified to **转写模式 / 模型目录** to remove the near-identical 管理模式 / 管理模型 pair (one character apart).

- **"Launch at Login" untranslated in Settings** — `LaunchAtLogin.Toggle(_:)` takes a plain `String` and bypasses SwiftUI localization, so it rendered in English while the surrounding toggles were localized. Fixed with `String(localized:)`; the key was already translated for the menu-bar toggle.

- **Untranslated UI strings** — several user-facing strings reached the UI as plain `String` (so the string catalog was never consulted): model-card status pills / download buttons via the shared `modelStatusPill(_:)` helper, language labels (`Multilingual` / `English` / `Auto`), trigger help text, the backup import dialog, filler-word validation, `Not Set`, and built-in sound names. These now use `LocalizedStringKey` / `String(localized:)`, with matching zh-Hans keys added.

- **Onboarding** — localized the experience-step chrome (titles, subtitles, sample labels, field placeholders, instructions) and fixed the intro card rendering a plain `String`. The sample read-aloud text is intentionally kept in English so the practice demo works regardless of the configured transcription model.

## Notes

- Only zh-Hans values and render paths are touched; English/German strings are unchanged.
- Builds cleanly (`xcodebuild` local Debug configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes Simplified Chinese to use “转写” and clarifies menu titles to “转写模式 / 模型目录”. Also localizes previously untranslated UI strings to improve the zh‑Hans experience.

- Bug Fixes
  - Fixed “Launch at Login” showing in English by using `String(localized:)`.
  - Localized UI strings that were passed as plain `String`: model-card status pills and download buttons, language labels (“Multilingual”/“English”/“Auto”), trigger help text, backup import dialog options (“All”/“Individual categories”), filler-word validation, “Not Set”, built‑in sound names, onboarding titles/subtitles/placeholders, and enhancement failure text.

- Refactors
  - Switched UI paths to `LocalizedStringKey`/`String(localized:)` (e.g., `modelStatusPill`, trigger chips/popovers, download button labels, provider title for “Custom Models”, settings/shortcuts).
  - Made minor API tweaks to accept `LocalizedStringKey` where needed (e.g., trigger help/unavailable messages).
  - Localized transcription model language labels via `TranscriptionModel.language`.

<sup>Written for commit 5807a5dd4c4ed0d3ab835b30db921d6b862f1d64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

