### PR TITLE
Fix 60s transcription timeouts behind VPNs by keeping custom cloud model uploads on TCP

### DIFF
--- a/Scripts/quic-vpn-repro.swift
+++ b/Scripts/quic-vpn-repro.swift
@@ -1,0 +1,96 @@
+// Diagnostic reproducer for cloud-transcription timeouts behind VPNs that
+// blackhole bulk HTTP/3 (QUIC) traffic — e.g. Palo Alto GlobalProtect.
+//
+// Symptom in VoiceInk: the first transcription of a longer dictation hangs and
+// fails after ~60s with "The request timed out" (NSURLError -1001), while an
+// immediate retry succeeds in 1-2s.
+//
+// Mechanism: a persistent URLSessionConfiguration caches the server's
+// `Alt-Svc: h3` advertisement (in ~/Library/HTTPStorages/<bundle-id>/), so new
+// connections upgrade to HTTP/3 over UDP 443. Some VPN tunnels pass small QUIC
+// packets (handshake, small requests) but silently drop full-size datagrams,
+// so multi-megabyte audio uploads stall until the request timeout. After the
+// failure URLSession falls back to TCP, which is why the retry is instant.
+//
+// Build:  swiftc -parse-as-library -O quic-vpn-repro.swift -o quic-vpn-repro
+// Usage:  quic-vpn-repro <idleSeconds> <shared|fresh> [bulkBytes]
+//   shared = one default-config session, mirrors URLSession.shared behavior
+//   fresh  = new ephemeral session per request (the fix: no cached Alt-Svc,
+//            connections stay on TCP)
+//
+// On an affected network, after the host has been visited once with a
+// persistent config (so Alt-Svc h3 is cached for the process):
+//   quic-vpn-repro 1 shared 1500000   -> h3, times out (-1001) on the upload
+//   quic-vpn-repro 1 shared 10000     -> h3, succeeds (small payload passes)
+//   quic-vpn-repro 1 fresh  1500000   -> h2, succeeds
+// The per-transaction metrics line prints the negotiated protocol and whether
+// the connection was reused, which is the evidence that matters.
+
+import Foundation
+
+let idle = UInt32(CommandLine.arguments.count > 1 ? Int(CommandLine.arguments[1]) ?? 1 : 1)
+let mode = CommandLine.arguments.count > 2 ? CommandLine.arguments[2] : "shared"
+let bulk = CommandLine.arguments.count > 3 ? Int(CommandLine.arguments[3]) ?? 1_500_000 : 1_500_000
+let url = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
+
+final class MetricsDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        for t in metrics.transactionMetrics {
+            let proto = t.networkProtocolName ?? "?"
+            print("    metrics: proto=\(proto) reused=\(t.isReusedConnection) " +
+                  "fetchStart->responseEnd=\(fmt(t.fetchStartDate, t.responseEndDate))")
+        }
+    }
+    private func fmt(_ a: Date?, _ b: Date?) -> String {
+        guard let a, let b else { return "n/a" }
+        return String(format: "%.2fs", b.timeIntervalSince(a))
+    }
+}
+
+let delegate = MetricsDelegate()
+let sharedSession = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+
+func session() -> URLSession {
+    if mode == "fresh" {
+        return URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+    }
+    return sharedSession
+}
+
+func doUpload(_ label: String) async {
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    // Invalid key on purpose: the server drains the multipart body and answers
+    // 401, which exercises the full upload path without transcribing anything.
+    request.setValue("Bearer sk-invalid-probe", forHTTPHeaderField: "Authorization")
+
+    var body = Data()
+    body.append("--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"probe.wav\"\r\nContent-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+    body.append(Data(count: bulk))
+    body.append("\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\ngpt-4o-transcribe\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+
+    let s = session()
+    let t0 = Date()
+    do {
+        let (data, response) = try await s.upload(for: request, from: body)
+        let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+        print("  \(label): HTTP \(code) in \(String(format: "%.2f", Date().timeIntervalSince(t0)))s bodyBytes=\(data.count)")
+    } catch {
+        let ns = error as NSError
+        print("  \(label): ERROR domain=\(ns.domain) code=\(ns.code) \(ns.localizedDescription) after \(String(format: "%.1f", Date().timeIntervalSince(t0)))s")
+    }
+    if mode == "fresh" { s.finishTasksAndInvalidate() }
+}
+
+@main
+struct Repro {
+    static func main() async {
+        print("[repro mode=\(mode) idle=\(idle)s bulk=\(bulk)]")
+        await doUpload("req1")
+        print("  idling \(idle)s...")
+        sleep(idle)
+        await doUpload("req2")
+    }
+}

--- a/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
@@ -13,7 +13,12 @@ class OpenAICompatibleTranscriptionService {
         request.setValue("Bearer \(model.apiKey)", forHTTPHeaderField: "Authorization")
 
         let body = try buildRequestBody(audioURL: audioURL, modelName: model.modelName, boundary: boundary, context: context)
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        // Ephemeral session per request: the shared session persists Alt-Svc and upgrades
+        // new connections to HTTP/3, but QUIC bulk uploads blackhole behind VPNs that drop
+        // full-size UDP datagrams (e.g. GlobalProtect), timing out large audio uploads.
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.finishTasksAndInvalidate() }
+        let (data, response) = try await session.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))


### PR DESCRIPTION
## Symptom

On networks behind certain VPNs (reproduced with Palo Alto GlobalProtect), transcriptions with custom cloud models intermittently hang and fail after ~60s with:

> Transcription Failed: A network error occurred: The request timed out.

An immediate retry always succeeds in 1–2 seconds. Failure probability grows with recording length — long dictations fail near-always, but small uploads are affected too (observed failures on 163 KB WAVs). Failures come in waves separated by successes, because after each timeout the OS temporarily falls back to TCP for the host. Only custom cloud models are affected — built-in providers go through LLMkit, which is already immune (see below).

## Root cause

`OpenAICompatibleTranscriptionService` uploads via `URLSession.shared`. The shared session's persistent configuration caches the server's `Alt-Svc: h3` advertisement (in `~/Library/HTTPStorages/<bundle-id>/`), so subsequent new connections upgrade to HTTP/3 (QUIC, UDP 443).

Some VPN tunnels pass small QUIC packets (the padded ≤1200-byte handshake and early flights) but silently drop full-size datagrams — and QUIC cannot fall back to IP fragmentation, so once the connection raises its datagram size above the tunnel MTU (DPLPMTUD), the upload stalls until `timeoutIntervalForRequest` (60s) and fails with `NSURLError -1001`. Short transfers can complete before that happens, which makes mid-size uploads a coin flip. After the failure URLSession falls back to TCP for the host — exactly why the retry is instant and why this bug always looks like "first attempt broken, retry fine".

Measured on an affected network (macOS URLSession task metrics):

| protocol | payload | result |
|---|---|---|
| h3 | 10 KB | OK, 0.4s |
| h3 | 1.5 MB | **timeout after 60s (-1001)**, reproducible |
| h2 | 1.5 MB | OK, 0.5s |
| ephemeral session, 1.5 MB | h2, OK, 0.5–2s (4/4 runs) |

Real-world app failures recorded on the same network include 163 KB and 288 KB uploads (each followed by an instant successful retry).

## Fix

Create an ephemeral `URLSession` per upload request. Ephemeral configurations don't read the persisted Alt-Svc cache, so connections stay on TCP (h2). This mirrors what LLMkit's HTTP client already does (`makeEphemeralURLSession` per request) — which is why built-in providers never showed this bug. Cost is one extra TLS handshake per transcription (~0.1s).

## Reproducer

`Scripts/quic-vpn-repro.swift` — standalone diagnostic that prints the negotiated protocol and connection reuse per request:

```
swiftc -parse-as-library -O Scripts/quic-vpn-repro.swift -o quic-vpn-repro
./quic-vpn-repro 1 shared 1500000   # h3 on affected setups -> -1001 timeout
./quic-vpn-repro 1 shared 10000     # h3, small payload passes
./quic-vpn-repro 1 fresh  1500000   # ephemeral -> h2 -> OK (the fix)
```

Useful for triaging future "transcription times out on VPN / corporate network" reports.