### PR TITLE
Custom model editors: editable API key with visibility toggle, copy, and Test Connection

### DIFF
--- a/VoiceInk/Services/AIEnhancement/CustomAIProviderManager.swift
+++ b/VoiceInk/Services/AIEnhancement/CustomAIProviderManager.swift
@@ -97,10 +97,18 @@ final class CustomAIProviderManager: ObservableObject {
         return true
     }
 
-    func updateProvider(_ provider: CustomAIProviderConfig) -> Bool {
+    func updateProvider(_ provider: CustomAIProviderConfig, apiKey: String? = nil) -> Bool {
         let normalizedProvider = provider.normalizedForStorage
         guard let index = providers.firstIndex(where: { $0.id == normalizedProvider.id }) else {
             return false
+        }
+
+        if let apiKey {
+            let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedKey.isEmpty,
+                  APIKeyManager.shared.saveCustomAIProviderAPIKey(trimmedKey, forProviderId: normalizedProvider.id) else {
+                return false
+            }
         }
 
         let previousModelName = providers[index].modelName

--- a/VoiceInk/Transcription/Cloud/CustomCloudModelManager.swift
+++ b/VoiceInk/Transcription/Cloud/CustomCloudModelManager.swift
@@ -39,11 +39,21 @@ class CustomCloudModelManager: ObservableObject {
         APIKeyManager.shared.deleteCustomModelAPIKey(forModelId: id)
     }
 
-    func updateCustomModel(_ updatedModel: CustomCloudModel) {
+    @discardableResult
+    func updateCustomModel(_ updatedModel: CustomCloudModel, apiKey: String? = nil) -> Bool {
+        if let apiKey {
+            let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedKey.isEmpty,
+                  APIKeyManager.shared.saveCustomModelAPIKey(trimmedKey, forModelId: updatedModel.id) else {
+                return false
+            }
+        }
+
         if let index = customModels.firstIndex(where: { $0.id == updatedModel.id }) {
             customModels[index] = updatedModel
             saveCustomModels()
         }
+        return true
     }
     
     // MARK: - Persistence

--- a/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
+++ b/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
@@ -1,0 +1,83 @@
+import Foundation
+import LLMkit
+
+enum ConnectionTestResult {
+    case success(latencyMs: Int)
+    case failure(message: String)
+}
+
+/// Lightweight connectivity checks for the custom model editors.
+struct CustomModelConnectionTester {
+    /// Probes an OpenAI-compatible transcription endpoint with a tiny junk
+    /// upload. The server authenticates before validating the audio, so a
+    /// 4xx "bad audio" answer still proves the endpoint and key are good.
+    static func testTranscriptionEndpoint(endpoint: String, apiKey: String, modelName: String) async -> ConnectionTestResult {
+        guard let url = URL(string: endpoint), url.scheme?.hasPrefix("http") == true else {
+            return .failure(String(localized: "API endpoint must be a valid URL"))
+        }
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 15
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        var body = Data()
+        body.append("--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"probe.wav\"\r\nContent-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(Data(count: 1024))
+        body.append("\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n\(modelName)\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.finishTasksAndInvalidate() }
+
+        let start = Date()
+        do {
+            let (data, response) = try await session.upload(for: request, from: body)
+            let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .failure(String(localized: "Unexpected response from the server"))
+            }
+
+            switch httpResponse.statusCode {
+            case 200, 400, 415, 422:
+                // Authenticated and routed; the junk audio being rejected is expected.
+                return .success(latencyMs: latencyMs)
+            case 401, 403:
+                return .failure(String(localized: "Invalid API key"))
+            case 404:
+                return .failure(String(localized: "Endpoint not found (HTTP 404) — check the API endpoint URL"))
+            default:
+                let message = Self.serverMessage(from: data)
+                return .failure(String(format: String(localized: "HTTP %lld: %@"), Int64(httpResponse.statusCode), message))
+            }
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+
+    /// Verifies an OpenAI-compatible chat endpoint using the same request
+    /// LLMkit performs when a custom enhancement model is added.
+    static func testEnhancementEndpoint(baseURL: String, apiKey: String, modelName: String) async -> ConnectionTestResult {
+        guard let url = URL(string: baseURL), url.scheme?.hasPrefix("http") == true else {
+            return .failure(String(localized: "Base URL must be a valid URL"))
+        }
+
+        let start = Date()
+        let result = await OpenAILLMClient.verifyAPIKey(baseURL: url, apiKey: apiKey, model: modelName)
+        let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
+
+        if result.isValid {
+            return .success(latencyMs: latencyMs)
+        }
+        return .failure(result.errorMessage ?? String(localized: "Could not verify this API key"))
+    }
+
+    private static func serverMessage(from data: Data) -> String {
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else {
+            return String(localized: "No error message")
+        }
+        return String(text.prefix(120))
+    }
+}

--- a/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
+++ b/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
@@ -12,8 +12,8 @@ struct CustomModelConnectionTester {
     /// upload. The server authenticates before validating the audio, so a
     /// 4xx "bad audio" answer still proves the endpoint and key are good.
     static func testTranscriptionEndpoint(endpoint: String, apiKey: String, modelName: String) async -> ConnectionTestResult {
-        guard let url = URL(string: endpoint), url.scheme?.hasPrefix("http") == true else {
-            return .failure(message: String(localized: "API endpoint must be a valid URL"))
+        guard let url = URL(string: endpoint), isAllowedScheme(url) else {
+            return .failure(message: String(localized: "Endpoint must use HTTPS (plain HTTP is allowed only for localhost)"))
         }
 
         let boundary = "Boundary-\(UUID().uuidString)"
@@ -60,8 +60,8 @@ struct CustomModelConnectionTester {
     /// Verifies an OpenAI-compatible chat endpoint using the same request
     /// LLMkit performs when a custom enhancement model is added.
     static func testEnhancementEndpoint(baseURL: String, apiKey: String, modelName: String) async -> ConnectionTestResult {
-        guard let url = URL(string: baseURL), url.scheme?.hasPrefix("http") == true else {
-            return .failure(message: String(localized: "Base URL must be a valid URL"))
+        guard let url = URL(string: baseURL), isAllowedScheme(url) else {
+            return .failure(message: String(localized: "Base URL must use HTTPS (plain HTTP is allowed only for localhost)"))
         }
 
         let start = Date()
@@ -72,6 +72,20 @@ struct CustomModelConnectionTester {
             return .success(latencyMs: latencyMs)
         }
         return .failure(message: result.errorMessage ?? String(localized: "Could not verify this API key"))
+    }
+
+    /// HTTPS everywhere; plain HTTP only toward loopback, matching the app's
+    /// existing local-server use cases (e.g. Ollama at http://localhost:11434).
+    private static func isAllowedScheme(_ url: URL) -> Bool {
+        switch url.scheme?.lowercased() {
+        case "https":
+            return true
+        case "http":
+            let host = url.host?.lowercased() ?? ""
+            return host == "localhost" || host == "127.0.0.1" || host == "::1"
+        default:
+            return false
+        }
     }
 
     private static func serverMessage(from data: Data) -> String {

--- a/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
+++ b/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
@@ -13,7 +13,7 @@ struct CustomModelConnectionTester {
     /// 4xx "bad audio" answer still proves the endpoint and key are good.
     static func testTranscriptionEndpoint(endpoint: String, apiKey: String, modelName: String) async -> ConnectionTestResult {
         guard let url = URL(string: endpoint), url.scheme?.hasPrefix("http") == true else {
-            return .failure(String(localized: "API endpoint must be a valid URL"))
+            return .failure(message: String(localized: "API endpoint must be a valid URL"))
         }
 
         let boundary = "Boundary-\(UUID().uuidString)"
@@ -37,7 +37,7 @@ struct CustomModelConnectionTester {
             let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                return .failure(String(localized: "Unexpected response from the server"))
+                return .failure(message: String(localized: "Unexpected response from the server"))
             }
 
             switch httpResponse.statusCode {
@@ -45,15 +45,15 @@ struct CustomModelConnectionTester {
                 // Authenticated and routed; the junk audio being rejected is expected.
                 return .success(latencyMs: latencyMs)
             case 401, 403:
-                return .failure(String(localized: "Invalid API key"))
+                return .failure(message: String(localized: "Invalid API key"))
             case 404:
-                return .failure(String(localized: "Endpoint not found (HTTP 404) — check the API endpoint URL"))
+                return .failure(message: String(localized: "Endpoint not found (HTTP 404) — check the API endpoint URL"))
             default:
                 let message = Self.serverMessage(from: data)
-                return .failure(String(format: String(localized: "HTTP %lld: %@"), Int64(httpResponse.statusCode), message))
+                return .failure(message: String(format: String(localized: "HTTP %lld: %@"), Int64(httpResponse.statusCode), message))
             }
         } catch {
-            return .failure(error.localizedDescription)
+            return .failure(message: error.localizedDescription)
         }
     }
 
@@ -61,7 +61,7 @@ struct CustomModelConnectionTester {
     /// LLMkit performs when a custom enhancement model is added.
     static func testEnhancementEndpoint(baseURL: String, apiKey: String, modelName: String) async -> ConnectionTestResult {
         guard let url = URL(string: baseURL), url.scheme?.hasPrefix("http") == true else {
-            return .failure(String(localized: "Base URL must be a valid URL"))
+            return .failure(message: String(localized: "Base URL must be a valid URL"))
         }
 
         let start = Date()
@@ -71,7 +71,7 @@ struct CustomModelConnectionTester {
         if result.isValid {
             return .success(latencyMs: latencyMs)
         }
-        return .failure(result.errorMessage ?? String(localized: "Could not verify this API key"))
+        return .failure(message: result.errorMessage ?? String(localized: "Could not verify this API key"))
     }
 
     private static func serverMessage(from data: Data) -> String {

--- a/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
+++ b/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
@@ -200,9 +200,12 @@ struct CustomTranscriptionModelEditorPanel: View {
                         VStack(spacing: 10) {
                             CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Custom Model"), text: $displayName)
                             CustomModelTextField(label: "API Endpoint", placeholder: "https://api.openai.com/v1/audio/transcriptions", text: $apiEndpoint)
-                            if !isEditing {
-                                CustomModelTextField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey, isSecure: true)
-                            }
+                            CustomModelTextField(
+                                label: "API Key",
+                                placeholder: isEditing ? String(localized: "Leave blank to keep current key") : String(localized: "Paste API key"),
+                                text: $apiKey,
+                                isSecure: true
+                            )
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-4o-mini-transcribe", text: $modelName)
                             CustomModelToggleRow(title: "Multilingual Model", isOn: $isMultilingual)
                         }
@@ -286,7 +289,11 @@ struct CustomTranscriptionModelEditorPanel: View {
                 isMultilingual: isMultilingual
             )
 
-            customModelManager.updateCustomModel(updatedModel)
+            guard customModelManager.updateCustomModel(updatedModel, apiKey: trimmedKey.isEmpty ? nil : trimmedKey) else {
+                validationErrors = [String(localized: "Failed to save API key securely")]
+                isSaving = false
+                return
+            }
         } else {
             let customModel = CustomCloudModel(
                 name: generatedName,
@@ -353,9 +360,12 @@ struct CustomEnhancementModelEditorPanel: View {
                         VStack(spacing: 10) {
                             CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Enhancement Model"), text: $displayName)
                             CustomModelTextField(label: "Base URL", placeholder: "https://api.openai.com/v1/chat/completions", text: $baseURL)
-                            if !isEditing {
-                                CustomModelTextField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey, isSecure: true)
-                            }
+                            CustomModelTextField(
+                                label: "API Key",
+                                placeholder: isEditing ? String(localized: "Leave blank to keep current key") : String(localized: "Paste API key"),
+                                text: $apiKey,
+                                isSecure: true
+                            )
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-5.5", text: $modelName)
                         }
                     }
@@ -451,7 +461,7 @@ struct CustomEnhancementModelEditorPanel: View {
 
         if isEditing {
             isSaving = true
-            let didSave = manager.updateProvider(provider)
+            let didSave = manager.updateProvider(provider, apiKey: trimmedKey.isEmpty ? nil : trimmedKey)
             isSaving = false
 
             if didSave {

--- a/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
+++ b/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
@@ -186,6 +186,7 @@ struct CustomTranscriptionModelEditorPanel: View {
     @State private var validationErrors: [String] = []
     @State private var isSaving = false
     @State private var connectionTest: ConnectionTestState = .idle
+    @State private var connectionTestTask: Task<Void, Never>?
 
     private var isEditing: Bool {
         editingModel != nil
@@ -197,18 +198,26 @@ struct CustomTranscriptionModelEditorPanel: View {
         !modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    private func resetConnectionTest() {
+        connectionTestTask?.cancel()
+        connectionTestTask = nil
+        connectionTest = .idle
+    }
+
     private func runConnectionTest() {
+        connectionTestTask?.cancel()
         connectionTest = .testing
         let endpoint = apiEndpoint.trimmingCharacters(in: .whitespacesAndNewlines)
         let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let model = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        Task {
+        connectionTestTask = Task {
             let result = await CustomModelConnectionTester.testTranscriptionEndpoint(
                 endpoint: endpoint,
                 apiKey: key,
                 modelName: model
             )
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 connectionTest = ConnectionTestState(result: result)
             }
@@ -249,9 +258,9 @@ struct CustomTranscriptionModelEditorPanel: View {
         .onChange(of: editingModel?.id) { _, _ in
             loadModel()
         }
-        .onChange(of: apiEndpoint) { _, _ in connectionTest = .idle }
-        .onChange(of: apiKey) { _, _ in connectionTest = .idle }
-        .onChange(of: modelName) { _, _ in connectionTest = .idle }
+        .onChange(of: apiEndpoint) { _, _ in resetConnectionTest() }
+        .onChange(of: apiKey) { _, _ in resetConnectionTest() }
+        .onChange(of: modelName) { _, _ in resetConnectionTest() }
     }
 
     private var canSave: Bool {
@@ -278,7 +287,7 @@ struct CustomTranscriptionModelEditorPanel: View {
 
         validationErrors = []
         isSaving = false
-        connectionTest = .idle
+        resetConnectionTest()
     }
 
     private func saveModel() {
@@ -368,6 +377,7 @@ struct CustomEnhancementModelEditorPanel: View {
     @State private var isSaving = false
     @State private var isVerifying = false
     @State private var connectionTest: ConnectionTestState = .idle
+    @State private var connectionTestTask: Task<Void, Never>?
 
     private var isEditing: Bool {
         editingProvider != nil
@@ -379,18 +389,26 @@ struct CustomEnhancementModelEditorPanel: View {
         !modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    private func resetConnectionTest() {
+        connectionTestTask?.cancel()
+        connectionTestTask = nil
+        connectionTest = .idle
+    }
+
     private func runConnectionTest() {
+        connectionTestTask?.cancel()
         connectionTest = .testing
         let url = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let model = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        Task {
+        connectionTestTask = Task {
             let result = await CustomModelConnectionTester.testEnhancementEndpoint(
                 baseURL: url,
                 apiKey: key,
                 modelName: model
             )
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 connectionTest = ConnectionTestState(result: result)
             }
@@ -434,9 +452,9 @@ struct CustomEnhancementModelEditorPanel: View {
         .onChange(of: editingProvider?.id) { _, _ in
             loadProvider()
         }
-        .onChange(of: baseURL) { _, _ in connectionTest = .idle }
-        .onChange(of: apiKey) { _, _ in connectionTest = .idle }
-        .onChange(of: modelName) { _, _ in connectionTest = .idle }
+        .onChange(of: baseURL) { _, _ in resetConnectionTest() }
+        .onChange(of: apiKey) { _, _ in resetConnectionTest() }
+        .onChange(of: modelName) { _, _ in resetConnectionTest() }
     }
 
     private var canSave: Bool {
@@ -462,7 +480,7 @@ struct CustomEnhancementModelEditorPanel: View {
         errorMessage = nil
         isSaving = false
         isVerifying = false
-        connectionTest = .idle
+        resetConnectionTest()
     }
 
     private var primaryButtonTitle: LocalizedStringKey {

--- a/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
+++ b/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
@@ -185,9 +185,34 @@ struct CustomTranscriptionModelEditorPanel: View {
     @State private var isMultilingual = true
     @State private var validationErrors: [String] = []
     @State private var isSaving = false
+    @State private var connectionTest: ConnectionTestState = .idle
 
     private var isEditing: Bool {
         editingModel != nil
+    }
+
+    private var canTestConnection: Bool {
+        !apiEndpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func runConnectionTest() {
+        connectionTest = .testing
+        let endpoint = apiEndpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            let result = await CustomModelConnectionTester.testTranscriptionEndpoint(
+                endpoint: endpoint,
+                apiKey: key,
+                modelName: model
+            )
+            await MainActor.run {
+                connectionTest = ConnectionTestState(result: result)
+            }
+        }
     }
 
     var body: some View {
@@ -200,14 +225,10 @@ struct CustomTranscriptionModelEditorPanel: View {
                         VStack(spacing: 10) {
                             CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Custom Model"), text: $displayName)
                             CustomModelTextField(label: "API Endpoint", placeholder: "https://api.openai.com/v1/audio/transcriptions", text: $apiEndpoint)
-                            CustomModelTextField(
-                                label: "API Key",
-                                placeholder: isEditing ? String(localized: "Leave blank to keep current key") : String(localized: "Paste API key"),
-                                text: $apiKey,
-                                isSecure: true
-                            )
+                            CustomModelSecretField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey)
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-4o-mini-transcribe", text: $modelName)
                             CustomModelToggleRow(title: "Multilingual Model", isOn: $isMultilingual)
+                            ConnectionTestRow(state: connectionTest, isDisabled: !canTestConnection, action: runConnectionTest)
                         }
                     }
 
@@ -228,20 +249,23 @@ struct CustomTranscriptionModelEditorPanel: View {
         .onChange(of: editingModel?.id) { _, _ in
             loadModel()
         }
+        .onChange(of: apiEndpoint) { _, _ in connectionTest = .idle }
+        .onChange(of: apiKey) { _, _ in connectionTest = .idle }
+        .onChange(of: modelName) { _, _ in connectionTest = .idle }
     }
 
     private var canSave: Bool {
         !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !apiEndpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        (isEditing || !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func loadModel() {
         if let editingModel {
             displayName = editingModel.displayName
             apiEndpoint = editingModel.apiEndpoint
-            apiKey = ""
+            apiKey = APIKeyManager.shared.getCustomModelAPIKey(forModelId: editingModel.id) ?? ""
             modelName = editingModel.modelName
             isMultilingual = editingModel.isMultilingualModel
         } else {
@@ -254,6 +278,7 @@ struct CustomTranscriptionModelEditorPanel: View {
 
         validationErrors = []
         isSaving = false
+        connectionTest = .idle
     }
 
     private func saveModel() {
@@ -271,7 +296,7 @@ struct CustomTranscriptionModelEditorPanel: View {
             excludingId: editingModel?.id
         )
 
-        if !isEditing && trimmedKey.isEmpty {
+        if trimmedKey.isEmpty {
             validationErrors.append(String(localized: "API key cannot be empty"))
         }
 
@@ -289,7 +314,7 @@ struct CustomTranscriptionModelEditorPanel: View {
                 isMultilingual: isMultilingual
             )
 
-            guard customModelManager.updateCustomModel(updatedModel, apiKey: trimmedKey.isEmpty ? nil : trimmedKey) else {
+            guard customModelManager.updateCustomModel(updatedModel, apiKey: trimmedKey) else {
                 validationErrors = [String(localized: "Failed to save API key securely")]
                 isSaving = false
                 return
@@ -342,9 +367,34 @@ struct CustomEnhancementModelEditorPanel: View {
     @State private var errorMessage: String?
     @State private var isSaving = false
     @State private var isVerifying = false
+    @State private var connectionTest: ConnectionTestState = .idle
 
     private var isEditing: Bool {
         editingProvider != nil
+    }
+
+    private var canTestConnection: Bool {
+        !baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func runConnectionTest() {
+        connectionTest = .testing
+        let url = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            let result = await CustomModelConnectionTester.testEnhancementEndpoint(
+                baseURL: url,
+                apiKey: key,
+                modelName: model
+            )
+            await MainActor.run {
+                connectionTest = ConnectionTestState(result: result)
+            }
+        }
     }
 
     var body: some View {
@@ -360,13 +410,9 @@ struct CustomEnhancementModelEditorPanel: View {
                         VStack(spacing: 10) {
                             CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Enhancement Model"), text: $displayName)
                             CustomModelTextField(label: "Base URL", placeholder: "https://api.openai.com/v1/chat/completions", text: $baseURL)
-                            CustomModelTextField(
-                                label: "API Key",
-                                placeholder: isEditing ? String(localized: "Leave blank to keep current key") : String(localized: "Paste API key"),
-                                text: $apiKey,
-                                isSecure: true
-                            )
+                            CustomModelSecretField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey)
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-5.5", text: $modelName)
+                            ConnectionTestRow(state: connectionTest, isDisabled: !canTestConnection, action: runConnectionTest)
                         }
                     }
 
@@ -388,20 +434,23 @@ struct CustomEnhancementModelEditorPanel: View {
         .onChange(of: editingProvider?.id) { _, _ in
             loadProvider()
         }
+        .onChange(of: baseURL) { _, _ in connectionTest = .idle }
+        .onChange(of: apiKey) { _, _ in connectionTest = .idle }
+        .onChange(of: modelName) { _, _ in connectionTest = .idle }
     }
 
     private var canSave: Bool {
         !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        (isEditing || !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func loadProvider() {
         if let editingProvider {
             displayName = editingProvider.name
             baseURL = editingProvider.baseURL
-            apiKey = ""
+            apiKey = APIKeyManager.shared.getCustomAIProviderAPIKey(forProviderId: editingProvider.id) ?? ""
             modelName = editingProvider.modelName
         } else {
             displayName = ""
@@ -413,6 +462,7 @@ struct CustomEnhancementModelEditorPanel: View {
         errorMessage = nil
         isSaving = false
         isVerifying = false
+        connectionTest = .idle
     }
 
     private var primaryButtonTitle: LocalizedStringKey {
@@ -440,7 +490,7 @@ struct CustomEnhancementModelEditorPanel: View {
             excluding: editingProvider?.id
         )
 
-        if !isEditing && trimmedKey.isEmpty {
+        if trimmedKey.isEmpty {
             validationErrors.append(String(localized: "API key cannot be empty"))
         }
 
@@ -461,7 +511,7 @@ struct CustomEnhancementModelEditorPanel: View {
 
         if isEditing {
             isSaving = true
-            let didSave = manager.updateProvider(provider, apiKey: trimmedKey.isEmpty ? nil : trimmedKey)
+            let didSave = manager.updateProvider(provider, apiKey: trimmedKey)
             isSaving = false
 
             if didSave {
@@ -561,6 +611,120 @@ private struct CustomModelTextField: View {
             .textFieldStyle(.roundedBorder)
             .font(.system(size: 12))
             .frame(maxWidth: CustomModelEditorMetrics.fieldMaxWidth, alignment: .trailing)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private enum ConnectionTestState: Equatable {
+    case idle
+    case testing
+    case success(latencyMs: Int)
+    case failure(message: String)
+
+    init(result: ConnectionTestResult) {
+        switch result {
+        case .success(let latencyMs):
+            self = .success(latencyMs: latencyMs)
+        case .failure(let message):
+            self = .failure(message: message)
+        }
+    }
+
+    var isTesting: Bool {
+        self == .testing
+    }
+}
+
+private struct CustomModelSecretField: View {
+    let label: LocalizedStringKey
+    let placeholder: String
+    @Binding var text: String
+    @State private var isRevealed = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(label)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .frame(width: CustomModelEditorMetrics.labelWidth, alignment: .leading)
+
+            HStack(spacing: 6) {
+                Group {
+                    if isRevealed {
+                        TextField("", text: $text, prompt: Text(verbatim: placeholder))
+                    } else {
+                        SecureField(placeholder, text: $text)
+                    }
+                }
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 12))
+
+                Button {
+                    isRevealed.toggle()
+                } label: {
+                    Image(systemName: isRevealed ? "eye.slash" : "eye")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.borderless)
+                .help(isRevealed ? String(localized: "Hide API key") : String(localized: "Show API key"))
+
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.borderless)
+                .disabled(text.isEmpty)
+                .help(String(localized: "Copy API key"))
+            }
+            .frame(maxWidth: CustomModelEditorMetrics.fieldMaxWidth, alignment: .trailing)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ConnectionTestRow: View {
+    let state: ConnectionTestState
+    let isDisabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(action: action) {
+                HStack(spacing: 5) {
+                    Image(systemName: "wifi")
+                        .font(.system(size: 11))
+                    Text("Test Connection")
+                        .font(.system(size: 12))
+                }
+            }
+            .disabled(isDisabled || state.isTesting)
+
+            switch state {
+            case .idle:
+                EmptyView()
+            case .testing:
+                ProgressView()
+                    .controlSize(.small)
+                Text("Testing…")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            case .success(let latencyMs):
+                Label(String(format: String(localized: "Connected (%lldms)"), Int64(latencyMs)), systemImage: "checkmark.circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.green)
+            case .failure(let message):
+                Label(message, systemImage: "exclamationmark.circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }


### PR DESCRIPTION
## Problem

The edit sheets for **custom transcription models** and **custom enhancement models** treated the API key as write-once:

- The key field was only shown when creating a model. If a key got rotated or revoked, the only way to replace it was to delete and re-create the model.
- Nothing indicated whether a key was stored at all — reopening the editor always showed nothing, indistinguishable from a missing key.
- There was no way to check that the endpoint + key combination actually works without running a real dictation and waiting for it to fail.

## Changes

**Editable, visible key**
- The API Key field is now always present in both editor panels and loads the stored key from the Keychain (masked in a `SecureField`), so it's immediately clear a key exists.
- Eye button toggles visibility, copy button puts the key on the pasteboard.
- Saving writes the key through the existing `APIKeyManager` paths; a Keychain write failure surfaces the same "Failed to save API key securely" error the add flow uses. `CustomCloudModelManager.updateCustomModel` and `CustomAIProviderManager.updateProvider` gained an optional `apiKey` parameter (default `nil`), so other callers are unaffected.

**Test Connection**
- New button in both editors reports latency on success ("Connected (312ms)") or the failure reason ("Invalid API key", HTTP status, network error), resetting whenever a relevant field changes.
- Transcription models: probes the configured endpoint with a tiny (1 KB) multipart upload over an ephemeral session — OpenAI-compatible servers authenticate before validating audio, so a 4xx "bad audio" answer still proves auth and routing without transcribing anything.
- Enhancement models: reuses `OpenAILLMClient.verifyAPIKey`, the same call the add flow already performs.

## Screenshots-in-words

`API Key  ••••••••••••••  [eye] [copy]`
`[Test Connection]  ✓ Connected (312ms)`

Tested on macOS against `api.openai.com` (gpt-4o-transcribe / chat completions): stored key loads masked, reveal/copy work, wrong key → "Invalid API key", good key → green latency badge, saved key survives editor reopen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make API keys editable in custom model editors and add one-click Test Connection, so users can rotate keys and verify endpoints without recreating models. Tests now require HTTPS (HTTP allowed only for localhost) and cancel in‑flight checks to avoid stale results.

- New Features
  - API Key is always shown for custom transcription and enhancement models; loads the stored key masked from Keychain with show/hide and copy.
  - Test Connection shows “Connected (Xms)” or a clear error; resets on field changes and cancels running tests when inputs change or a new test starts.
  - Transcription test sends a tiny multipart upload (4xx on junk audio still counts as authenticated); enhancement test uses the existing verification call.
  - Connection tests enforce HTTPS; plain HTTP is allowed only for loopback hosts (e.g. http://localhost).

- Refactors
  - `CustomCloudModelManager.updateCustomModel(_:, apiKey:)` now accepts an optional `apiKey` and returns `Bool`.
  - `CustomAIProviderManager.updateProvider(_:, apiKey:)` now accepts an optional `apiKey`.
  - Saving persists keys via Keychain and surfaces the standard “Failed to save API key securely” error on failure.

<sup>Written for commit 21e9322fb3a65b494abd836c5cc9217672fb922a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

