### PR TITLE
Simplify custom model connection handling and secure API key entry

### DIFF
--- a/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
+++ b/VoiceInk/Transcription/Cloud/CustomModelConnectionTester.swift
@@ -2,7 +2,7 @@ import Foundation
 import LLMkit
 
 enum ConnectionTestResult {
-    case success(latencyMs: Int)
+    case success
     case failure(message: String)
 }
 
@@ -31,10 +31,8 @@ struct CustomModelConnectionTester {
         let session = URLSession(configuration: .ephemeral)
         defer { session.finishTasksAndInvalidate() }
 
-        let start = Date()
         do {
             let (data, response) = try await session.upload(for: request, from: body)
-            let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return .failure(message: String(localized: "Unexpected response from the server"))
@@ -43,7 +41,7 @@ struct CustomModelConnectionTester {
             switch httpResponse.statusCode {
             case 200, 400, 415, 422:
                 // Authenticated and routed; the junk audio being rejected is expected.
-                return .success(latencyMs: latencyMs)
+                return .success
             case 401, 403:
                 return .failure(message: String(localized: "Invalid API key"))
             case 404:
@@ -64,12 +62,10 @@ struct CustomModelConnectionTester {
             return .failure(message: String(localized: "Base URL must use HTTPS (plain HTTP is allowed only for localhost)"))
         }
 
-        let start = Date()
         let result = await OpenAILLMClient.verifyAPIKey(baseURL: url, apiKey: apiKey, model: modelName)
-        let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
 
         if result.isValid {
-            return .success(latencyMs: latencyMs)
+            return .success
         }
         return .failure(message: result.errorMessage ?? String(localized: "Could not verify this API key"))
     }

--- a/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
@@ -13,7 +13,12 @@ class OpenAICompatibleTranscriptionService {
         request.setValue("Bearer \(model.apiKey)", forHTTPHeaderField: "Authorization")
 
         let body = try buildRequestBody(audioURL: audioURL, modelName: model.modelName, boundary: boundary, context: context)
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        // Ephemeral session per request: the shared session persists Alt-Svc and upgrades
+        // new connections to HTTP/3, but QUIC bulk uploads blackhole behind VPNs that drop
+        // full-size UDP datagrams (e.g. GlobalProtect), timing out large audio uploads.
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.finishTasksAndInvalidate() }
+        let (data, response) = try await session.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
+++ b/VoiceInk/Views/AI Models/CustomProviderManagementView.swift
@@ -1,6 +1,4 @@
 import SwiftUI
-import AppKit
-import LLMkit
 
 struct CustomProviderManagementView: View {
     @ObservedObject var customModelManager: CustomCloudModelManager
@@ -234,12 +232,14 @@ struct CustomTranscriptionModelEditorPanel: View {
                         VStack(spacing: 10) {
                             CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Custom Model"), text: $displayName)
                             CustomModelTextField(label: "API Endpoint", placeholder: "https://api.openai.com/v1/audio/transcriptions", text: $apiEndpoint)
-                            CustomModelSecretField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey)
+                            CustomModelTextField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey, isSecure: true)
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-4o-mini-transcribe", text: $modelName)
                             CustomModelToggleRow(title: "Multilingual Model", isOn: $isMultilingual)
                             ConnectionTestRow(state: connectionTest, isDisabled: !canTestConnection, action: runConnectionTest)
                         }
                     }
+
+                    ConnectionTestResultBox(state: connectionTest)
 
                     if !validationErrors.isEmpty {
                         CustomModelErrorBox(messages: validationErrors)
@@ -375,7 +375,6 @@ struct CustomEnhancementModelEditorPanel: View {
     @State private var modelName = ""
     @State private var errorMessage: String?
     @State private var isSaving = false
-    @State private var isVerifying = false
     @State private var connectionTest: ConnectionTestState = .idle
     @State private var connectionTestTask: Task<Void, Never>?
 
@@ -428,11 +427,13 @@ struct CustomEnhancementModelEditorPanel: View {
                         VStack(spacing: 10) {
                             CustomModelTextField(label: "Display Name", placeholder: String(localized: "My Enhancement Model"), text: $displayName)
                             CustomModelTextField(label: "Base URL", placeholder: "https://api.openai.com/v1/chat/completions", text: $baseURL)
-                            CustomModelSecretField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey)
+                            CustomModelTextField(label: "API Key", placeholder: String(localized: "Paste API key"), text: $apiKey, isSecure: true)
                             CustomModelTextField(label: "Model Name", placeholder: "gpt-5.5", text: $modelName)
                             ConnectionTestRow(state: connectionTest, isDisabled: !canTestConnection, action: runConnectionTest)
                         }
                     }
+
+                    ConnectionTestResultBox(state: connectionTest)
 
                     if let errorMessage {
                         CustomModelErrorBox(messages: [errorMessage])
@@ -443,7 +444,7 @@ struct CustomEnhancementModelEditorPanel: View {
 
             CustomModelEditorFooter(
                 primaryTitle: primaryButtonTitle,
-                isPrimaryDisabled: !canSave || isSaving || isVerifying,
+                isPrimaryDisabled: !canSave || isSaving,
                 onCancel: onClose,
                 onPrimary: saveProvider
             )
@@ -479,15 +480,10 @@ struct CustomEnhancementModelEditorPanel: View {
 
         errorMessage = nil
         isSaving = false
-        isVerifying = false
         resetConnectionTest()
     }
 
     private var primaryButtonTitle: LocalizedStringKey {
-        if isVerifying {
-            return "Verifying"
-        }
-
         if isSaving {
             return "Saving"
         }
@@ -540,38 +536,14 @@ struct CustomEnhancementModelEditorPanel: View {
             return
         }
 
-        guard let verificationURL = URL(string: trimmedURL) else {
-            errorMessage = String(localized: "Base URL must be a valid URL")
-            return
-        }
+        isSaving = true
+        let didSave = manager.addProvider(provider, apiKey: trimmedKey)
+        isSaving = false
 
-        isVerifying = true
-
-        Task {
-            let result = await OpenAILLMClient.verifyAPIKey(
-                baseURL: verificationURL,
-                apiKey: trimmedKey,
-                model: trimmedModelName
-            )
-
-            await MainActor.run {
-                isVerifying = false
-
-                guard result.isValid else {
-                    errorMessage = result.errorMessage ?? String(localized: "Could not verify this API key")
-                    return
-                }
-
-                isSaving = true
-                let didSave = manager.addProvider(provider, apiKey: trimmedKey)
-                isSaving = false
-
-                if didSave {
-                    onSave()
-                } else {
-                    errorMessage = String(localized: "Failed to save API key securely")
-                }
-            }
+        if didSave {
+            onSave()
+        } else {
+            errorMessage = String(localized: "Failed to save API key securely")
         }
     }
 }
@@ -637,13 +609,13 @@ private struct CustomModelTextField: View {
 private enum ConnectionTestState: Equatable {
     case idle
     case testing
-    case success(latencyMs: Int)
+    case success
     case failure(message: String)
 
     init(result: ConnectionTestResult) {
         switch result {
-        case .success(let latencyMs):
-            self = .success(latencyMs: latencyMs)
+        case .success:
+            self = .success
         case .failure(let message):
             self = .failure(message: message)
         }
@@ -654,97 +626,69 @@ private enum ConnectionTestState: Equatable {
     }
 }
 
-private struct CustomModelSecretField: View {
-    let label: LocalizedStringKey
-    let placeholder: String
-    @Binding var text: String
-    @State private var isRevealed = false
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Text(label)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-                .frame(width: CustomModelEditorMetrics.labelWidth, alignment: .leading)
-
-            HStack(spacing: 6) {
-                Group {
-                    if isRevealed {
-                        TextField("", text: $text, prompt: Text(verbatim: placeholder))
-                    } else {
-                        SecureField(placeholder, text: $text)
-                    }
-                }
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12))
-
-                Button {
-                    isRevealed.toggle()
-                } label: {
-                    Image(systemName: isRevealed ? "eye.slash" : "eye")
-                        .font(.system(size: 11))
-                }
-                .buttonStyle(.borderless)
-                .help(isRevealed ? String(localized: "Hide API key") : String(localized: "Show API key"))
-
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(text, forType: .string)
-                } label: {
-                    Image(systemName: "doc.on.doc")
-                        .font(.system(size: 11))
-                }
-                .buttonStyle(.borderless)
-                .disabled(text.isEmpty)
-                .help(String(localized: "Copy API key"))
-            }
-            .frame(maxWidth: CustomModelEditorMetrics.fieldMaxWidth, alignment: .trailing)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
 private struct ConnectionTestRow: View {
     let state: ConnectionTestState
     let isDisabled: Bool
     let action: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 12) {
+            Text("Connection")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .frame(width: CustomModelEditorMetrics.labelWidth, alignment: .leading)
+
             Button(action: action) {
                 HStack(spacing: 5) {
                     Image(systemName: "wifi")
                         .font(.system(size: 11))
-                    Text("Test Connection")
+                    Text("Test")
                         .font(.system(size: 12))
                 }
             }
             .disabled(isDisabled || state.isTesting)
 
-            switch state {
-            case .idle:
-                EmptyView()
-            case .testing:
-                ProgressView()
-                    .controlSize(.small)
-                Text("Testing…")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-            case .success(let latencyMs):
-                Label(String(format: String(localized: "Connected (%lldms)"), Int64(latencyMs)), systemImage: "checkmark.circle")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.green)
-            case .failure(let message):
-                Label(message, systemImage: "exclamationmark.circle")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.red)
-                    .lineLimit(2)
-            }
+            inlineStatus
 
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var inlineStatus: some View {
+        switch state {
+        case .idle, .failure:
+            EmptyView()
+        case .testing:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Testing…")
+            }
+            .font(.system(size: 12))
+            .foregroundStyle(AppTheme.Text.secondary)
+        case .success:
+            Label("Test successful", systemImage: "checkmark.circle")
+                .font(.system(size: 12))
+                .foregroundStyle(AppTheme.Status.positive)
+                .lineLimit(1)
+        }
+    }
+}
+
+private struct ConnectionTestResultBox: View {
+    let state: ConnectionTestState
+
+    @ViewBuilder
+    var body: some View {
+        switch state {
+        case .idle, .testing, .success:
+            EmptyView()
+        case .failure(let message):
+            CustomModelErrorBox(messages: [message])
+        }
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplifies custom model setup: connection tests now return a simple pass/fail and API keys are entered in secure fields. Also fixes large upload timeouts by using an ephemeral `URLSession`.

- **Bug Fixes**
  - Use an ephemeral `URLSession` for transcription uploads to avoid HTTP/3/QUIC issues behind some VPNs (e.g., GlobalProtect) that caused large uploads to hang.

- **Refactors**
  - Connection testing: removed latency reporting and now returns `.success` or `.failure(message)`. UI shows a compact “Test” button with inline status and an error box only on failure.
  - API key entry: replaced custom reveal/copy field with a secure text field (`isSecure: true`) for both transcription and enhancement models.
  - Save flow: removed pre-save API key verification for enhancement models; keys save directly, and users can verify via the Test action. Primary button state simplified accordingly.

<sup>Written for commit 23d7abc4d63d23ee45301ec891792c9f5c552e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

