### PR TITLE
Fall back to AVAssetReader when AVAudioFile fails to decode imported files

### DIFF
--- a/VoiceInk/Transcription/Engine/AudioFileProcessor.swift
+++ b/VoiceInk/Transcription/Engine/AudioFileProcessor.swift
@@ -220,12 +220,14 @@ class AudioProcessor {
 
         guard
             format.mFormatID == kAudioFormatLinearPCM,
-            format.mSampleRate == AudioFormat.targetSampleRate,
+            abs(format.mSampleRate - AudioFormat.targetSampleRate) < 1.0,
             format.mChannelsPerFrame == AudioFormat.targetChannels,
             format.mBitsPerChannel == 32,
             isFloat,
             !isBigEndian,
-            !isNonInterleaved
+            // Interleaving only changes the byte layout for multi-channel
+            // audio; mono is identical either way, so don't reject it.
+            format.mChannelsPerFrame == 1 || !isNonInterleaved
         else {
             throw AudioProcessingError.conversionFailed
         }

--- a/VoiceInk/Transcription/Engine/AudioFileProcessor.swift
+++ b/VoiceInk/Transcription/Engine/AudioFileProcessor.swift
@@ -35,10 +35,24 @@ class AudioProcessor {
     }
     
     func processAudioToSamples(_ url: URL) async throws -> [Float] {
+        do {
+            return try readUsingAudioFile(url)
+        } catch {
+            // AVAudioFile can choke on some container/codec combinations that
+            // the media stack can otherwise play (e.g. avfaudio error -50 on
+            // certain mp4/m4a meeting recordings, issue #799). AVAssetReader
+            // is a more resilient fallback for media containers and delivers
+            // target LPCM directly, avoiding manual seeking and conversion.
+            logger.warning("AVAudioFile pipeline failed for \(url.lastPathComponent, privacy: .public): \(error, privacy: .public). Falling back to AVAssetReader.")
+            return try await readUsingAssetReader(url)
+        }
+    }
+
+    private func readUsingAudioFile(_ url: URL) throws -> [Float] {
         guard let audioFile = try? AVAudioFile(forReading: url) else {
             throw AudioProcessingError.invalidAudioFile
         }
-        
+
         let format = audioFile.processingFormat
         let sampleRate = format.sampleRate
         let channels = format.channelCount
@@ -112,7 +126,111 @@ class AudioProcessor {
         
         return allSamples
     }
-    
+
+    private func readUsingAssetReader(_ url: URL) async throws -> [Float] {
+        let asset = AVURLAsset(url: url)
+        // Match the legacy behavior of processing one stream by using the
+        // primary audio track rather than attempting to mix multiple tracks.
+        guard let track = try await asset.loadTracks(withMediaType: .audio).first else {
+            throw AudioProcessingError.invalidAudioFile
+        }
+
+        let reader = try AVAssetReader(asset: asset)
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: AudioFormat.targetSampleRate,
+            AVNumberOfChannelsKey: AudioFormat.targetChannels,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false
+        ]
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: outputSettings)
+        output.alwaysCopiesSampleData = false
+
+        guard reader.canAdd(output) else {
+            throw AudioProcessingError.conversionFailed
+        }
+        reader.add(output)
+
+        guard reader.startReading() else {
+            throw reader.error ?? AudioProcessingError.sampleExtractionFailed
+        }
+
+        var samples: [Float] = []
+        do {
+            while let sampleBuffer = output.copyNextSampleBuffer() {
+                try Task.checkCancellation()
+                try validateAssetReaderOutputFormat(sampleBuffer)
+
+                guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { continue }
+                let byteCount = CMBlockBufferGetDataLength(blockBuffer)
+                guard byteCount >= MemoryLayout<Float>.size else { continue }
+
+                var chunk = [Float](repeating: 0, count: byteCount / MemoryLayout<Float>.size)
+                let status = chunk.withUnsafeMutableBytes { destination in
+                    CMBlockBufferCopyDataBytes(
+                        blockBuffer,
+                        atOffset: 0,
+                        dataLength: destination.count,
+                        destination: destination.baseAddress!
+                    )
+                }
+                guard status == kCMBlockBufferNoErr else {
+                    throw AudioProcessingError.sampleExtractionFailed
+                }
+                samples.append(contentsOf: chunk)
+            }
+        } catch {
+            reader.cancelReading()
+            throw error
+        }
+
+        if reader.status == .failed {
+            throw reader.error ?? AudioProcessingError.sampleExtractionFailed
+        }
+        if reader.status == .cancelled {
+            throw CancellationError()
+        }
+        guard !samples.isEmpty else {
+            throw AudioProcessingError.sampleExtractionFailed
+        }
+
+        // Keep the fallback output in the same normalized Float range expected
+        // by the WAV export path.
+        let maxSample = samples.map(abs).max() ?? 1
+        if maxSample > 0 {
+            samples = samples.map { $0 / maxSample }
+        }
+        return samples
+    }
+
+    private func validateAssetReaderOutputFormat(_ sampleBuffer: CMSampleBuffer) throws {
+        guard
+            let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
+            let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription)
+        else {
+            throw AudioProcessingError.sampleExtractionFailed
+        }
+
+        let format = streamDescription.pointee
+        let isFloat = (format.mFormatFlags & kAudioFormatFlagIsFloat) != 0
+        let isBigEndian = (format.mFormatFlags & kAudioFormatFlagIsBigEndian) != 0
+        let isNonInterleaved = (format.mFormatFlags & kAudioFormatFlagIsNonInterleaved) != 0
+
+        guard
+            format.mFormatID == kAudioFormatLinearPCM,
+            format.mSampleRate == AudioFormat.targetSampleRate,
+            format.mChannelsPerFrame == AudioFormat.targetChannels,
+            format.mBitsPerChannel == 32,
+            isFloat,
+            !isBigEndian,
+            !isNonInterleaved
+        else {
+            throw AudioProcessingError.conversionFailed
+        }
+    }
+
     private func convertToWhisperFormat(_ buffer: AVAudioPCMBuffer) -> [Float] {
         guard let channelData = buffer.floatChannelData else {
             return []


### PR DESCRIPTION
Addresses #799.

## Symptom

Importing certain `.mp4`/`.m4a` files (reporter's case: Teams meeting recordings, macOS 26.5.1) into Transcribe Audio fails instantly with the raw error:

> The operation couldn't be completed. (com.apple.coreaudio.avfaudio error -50.)

## Investigation

The import pipeline (`AudioProcessor.processAudioToSamples`) decodes with `AVAudioFile` + manual 50M-frame chunking + `framePosition` seeking + manual `AVAudioConverter` — three classic sources of avfaudio `-50` on compressed containers.

I could **not** reproduce locally on macOS 26.2 despite trying: 16k/32k/44.1k/48k, mono/stereo, AAC-LC and HE-AAC, plain m4a, mp4 with a video track, fragmented mp4 (SharePoint-style), multi-audio-track mp4, mismatched extensions, and a 21-minute file that forces a second chunk with a mid-AAC seek — every variant passes. The trigger appears specific to the reporter's environment (likely an AVAudioFile regression in macOS 26.5.x against the real Teams encoder output).

## Fix

Instead of chasing the exact trigger, handle the failure class: keep the existing `AVAudioFile` fast path untouched, and on **any** failure fall back to an `AVAssetReader`-based decoder. `AVAssetReader` delivers the target LPCM (16 kHz mono Float32) directly from the media stack — no manual chunk seeking, no manual converter — so it sidesteps every known `-50` source. The reporter's files play fine in QuickTime, so the fallback should decode them regardless of what breaks `AVAudioFile`.

Details:
- Decoded stream format is validated per sample buffer (LPCM Float32 16k mono little-endian interleaved) instead of blindly reinterpreting bytes.
- The read loop honors task cancellation (`Task.checkCancellation` + `reader.cancelReading()`) — file imports are cancellable from the UI.
- Output is peak-normalized like the primary path, then flows into the same WAV-export step.
- Reads the primary audio track (parity with `AVAudioFile`, which also decodes only the default track).
- The AVAudioFile failure is logged with the reason before falling back, so future reports name the underlying error instead of a bare -50.

## Verification

Harness comparing both decode paths on 8 synthetic files (mono/stereo, all sample rates above, video mp4, HE-AAC, fragmented, multi-track, 21-min long): sample-count drift 0–282 samples (<20 ms, resampler edge behavior), signal equivalent. Project builds.

Since the trigger is environment-specific, it would be great if the reporter (@sotakal) could verify against a build of this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a resilient audio import path by falling back to AVAssetReader when AVAudioFile fails, fixing instant import errors (avfaudio -50) on some .mp4/.m4a files like Teams recordings. Keeps the existing fast path; fallback decodes to 16 kHz mono Float32, preserves normalization, and relaxes format checks for mono.

- **Bug Fixes**
  - On any AVAudioFile error, fall back to AVAssetReader outputting 16 kHz mono Float32 LPCM; log the failure.
  - Validate each buffer with sample-rate tolerance; accept mono whether interleaved or non-interleaved.
  - Honor cancellation; read only the primary track; apply peak normalization.

<sup>Written for commit a1f0dc6fcd6f2fdb7a81a07a7dfc1d499f024952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

