### PR TITLE
Fix main window presentation flow

### DIFF
--- a/VoiceInk/AppDelegate.swift
+++ b/VoiceInk/AppDelegate.swift
@@ -1,20 +1,35 @@
 import Cocoa
 import SwiftUI
 import UniformTypeIdentifiers
+import OSLog
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+
     weak var menuBarManager: MenuBarManager?
     
     func applicationDidFinishLaunching(_ notification: Notification) {
+        logger.notice("🧭 Application finished launching. hasMenuBarManager=\((self.menuBarManager != nil), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
         menuBarManager?.applyActivationPolicy()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag, let menuBarManager = menuBarManager, !menuBarManager.isMenuBarOnly {
-            if WindowManager.shared.showMainWindow() != nil {
+        logger.notice("🧭 Dock/app reopen requested. hasVisibleWindowsFlag=\(flag, privacy: .public); isMenuBarOnly=\(self.menuBarManager?.isMenuBarOnly ?? UserDefaults.standard.bool(forKey: "IsMenuBarOnly"), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(sender.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+
+        if let menuBarManager, !menuBarManager.isMenuBarOnly {
+            if WindowManager.shared.currentMainWindow() != nil {
+                WindowManager.shared.showMainWindow()
+                logger.notice("🧭 Dock/app reopen presented the existing main window.")
                 return false
             }
+
+            WindowManager.shared.prepareForUserRequestedMainWindow()
+            NotificationCenter.default.post(name: .showMainWindowRequested, object: nil)
+            logger.notice("🧭 Dock/app reopen requested main window creation through SwiftUI.")
+            return false
         }
+
+        logger.notice("🧭 Dock/app reopen left to default handling.")
         return true
     }
 
@@ -26,19 +41,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var pendingOpenFileURL: URL?
     
     func application(_ application: NSApplication, open urls: [URL]) {
+        logger.notice("🧭 Application received open-URLs request. urlCount=\(urls.count, privacy: .public); hasCurrentMainWindow=\((WindowManager.shared.currentMainWindow() != nil), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(application.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+
         guard let url = urls.first(where: { SupportedMedia.isSupported(url: $0) }) else {
+            logger.notice("🧭 Open-URLs request ignored because no supported media URL was found.")
             return
         }
         
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        if let menuBarManager {
+            menuBarManager.activateForPresentedWindow(reason: "OpenMediaFile")
+        } else {
+            AppPresentationPolicy.activateForUserFacingWindow(reason: "OpenMediaFileWithoutMenuBarManager")
+        }
         
         if WindowManager.shared.currentMainWindow() == nil {
             // Cold start: do NOT create a window here to avoid extra window/tab.
-            // Defer to SwiftUI’s WindowGroup-created ContentView and let it process this later.
+            // Defer to SwiftUI's main window scene and let ContentView process this later.
             pendingOpenFileURL = url
+            WindowManager.shared.prepareForUserRequestedMainWindow()
+            logger.notice("🧭 Stored pending media URL and requested SwiftUI main window. urlLastPath=\(url.lastPathComponent, privacy: .private(mask: .hash))")
+            NotificationCenter.default.post(name: .showMainWindowRequested, object: nil)
         } else {
             // Running: focus current window and route in-place to Transcribe Audio
-            menuBarManager?.focusMainWindow()
+            logger.notice("🧭 Routing media URL to existing main window. urlLastPath=\(url.lastPathComponent, privacy: .private(mask: .hash))")
+            WindowManager.shared.showMainWindow()
             NotificationCenter.default.post(name: .navigateToDestination, object: nil, userInfo: ["destination": "Transcribe Audio"])
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: .openFileForTranscription, object: nil, userInfo: ["url": url])

--- a/VoiceInk/HistoryWindowController.swift
+++ b/VoiceInk/HistoryWindowController.swift
@@ -14,6 +14,8 @@ class HistoryWindowController: NSObject, NSWindowDelegate {
     }
 
     func showHistoryWindow(modelContainer: ModelContainer, engine: VoiceInkEngine) {
+        AppPresentationPolicy.activateForUserFacingWindow(reason: "HistoryWindow")
+
         if let existingWindow = historyWindow {
             if existingWindow.isMiniaturized {
                 existingWindow.deminiaturize(nil)
@@ -77,6 +79,6 @@ class HistoryWindowController: NSObject, NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
         guard let window = notification.object as? NSWindow,
               window.identifier == windowIdentifier else { return }
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        AppPresentationPolicy.activateForUserFacingWindow(reason: "HistoryWindowDidBecomeKey")
     }
 }

--- a/VoiceInk/MenuBarManager.swift
+++ b/VoiceInk/MenuBarManager.swift
@@ -1,25 +1,33 @@
 import SwiftUI
 import SwiftData
 import AppKit
+import OSLog
 
 class MenuBarManager: ObservableObject {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+
     @Published var isMenuBarOnly: Bool {
         didSet {
             UserDefaults.standard.set(isMenuBarOnly, forKey: "IsMenuBarOnly")
-            updateAppActivationPolicy()
+            logger.notice("🧭 Menu-bar-only preference changed. newValue=\(self.isMenuBarOnly, privacy: .public); activationPolicyBefore=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+            applyActivationPolicy()
         }
     }
 
     private var modelContainer: ModelContainer?
     private var engine: VoiceInkEngine?
+    private var configuredActivationPolicy: NSApplication.ActivationPolicy {
+        isMenuBarOnly ? .accessory : .regular
+    }
 
     init() {
         self.isMenuBarOnly = UserDefaults.standard.bool(forKey: "IsMenuBarOnly")
-        updateAppActivationPolicy()
+        logger.notice("🧭 MenuBarManager initialized. isMenuBarOnly=\(self.isMenuBarOnly, privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public)")
+        applyActivationPolicy()
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(windowDidClose),
+            selector: #selector(userFacingWindowWillClose),
             name: NSWindow.willCloseNotification,
             object: nil
         )
@@ -29,22 +37,23 @@ class MenuBarManager: ObservableObject {
         NotificationCenter.default.removeObserver(self)
     }
 
-    @objc private func windowDidClose(_ notification: Notification) {
-        guard isMenuBarOnly else { return }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            let hasVisibleWindows = NSApplication.shared.windows.contains {
-                $0.isVisible && $0.level == .normal && !$0.styleMask.contains(.nonactivatingPanel)
-            }
-            if !hasVisibleWindows && NSApplication.shared.activationPolicy() != .accessory {
-                NSApplication.shared.setActivationPolicy(.accessory)
-            }
+    @objc private func userFacingWindowWillClose(_ notification: Notification) {
+        guard isMenuBarOnly,
+              let window = notification.object as? NSWindow,
+              window.level == .normal,
+              window.styleMask.contains(.titled) else {
+            return
         }
+
+        AppPresentationPolicy.restoreAccessoryIfNeededAfterUserFacingWindowClosed(
+            reason: "userFacingWindowWillClose"
+        )
     }
 
     func configure(modelContainer: ModelContainer, engine: VoiceInkEngine) {
         self.modelContainer = modelContainer
         self.engine = engine
+        logger.notice("🧭 MenuBarManager configured. hasModelContainer=\((self.modelContainer != nil), privacy: .public); hasEngine=\((self.engine != nil), privacy: .public)")
     }
     
     func toggleMenuBarOnly() {
@@ -52,24 +61,13 @@ class MenuBarManager: ObservableObject {
     }
     
     func applyActivationPolicy() {
-        updateAppActivationPolicy()
-    }
-    
-    func focusMainWindow() {
-        NSApplication.shared.setActivationPolicy(.regular)
-        WindowManager.shared.showMainWindow()
-    }
-    
-    private func updateAppActivationPolicy() {
         let applyPolicy = { [weak self] in
             guard let self else { return }
-            let application = NSApplication.shared
+            let didSet = NSApplication.shared.setActivationPolicy(self.configuredActivationPolicy)
+            self.logger.notice("🧭 Applied menu-bar activation policy. isMenuBarOnly=\(self.isMenuBarOnly, privacy: .public); desiredPolicy=\(WindowDiagnostics.activationPolicyDescription(self.configuredActivationPolicy), privacy: .public); success=\(didSet, privacy: .public); activationPolicyAfter=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public)")
+
             if self.isMenuBarOnly {
-                application.setActivationPolicy(.accessory)
                 WindowManager.shared.hideMainWindow()
-            } else {
-                application.setActivationPolicy(.regular)
-                WindowManager.shared.showMainWindow()
             }
         }
 
@@ -79,33 +77,46 @@ class MenuBarManager: ObservableObject {
             DispatchQueue.main.async(execute: applyPolicy)
         }
     }
-    
-    func openMainWindowAndNavigate(to destination: String) {
-        NSApplication.shared.setActivationPolicy(.regular)
 
-        guard WindowManager.shared.showMainWindow() != nil else {
-            return
+    func activateForPresentedWindow() {
+        activateForPresentedWindow(reason: "Presented Window")
+    }
+
+    func activateForPresentedWindow(reason: String) {
+        let activate = { [weak self] in
+            guard let self else { return }
+            self.logger.notice("🧭 Full window presentation requested. reason=\(reason, privacy: .public); isMenuBarOnlyPreference=\(self.isMenuBarOnly, privacy: .public); activationPolicyBefore=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+            AppPresentationPolicy.activateForUserFacingWindow(reason: reason)
         }
 
-        // Post a notification to navigate to the desired destination
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            NotificationCenter.default.post(
-                name: .navigateToDestination,
-                object: nil,
-                userInfo: ["destination": destination]
-            )
+        if Thread.isMainThread {
+            activate()
+        } else {
+            DispatchQueue.main.async(execute: activate)
         }
     }
 
     func openHistoryWindow() {
         guard let modelContainer = modelContainer,
               let engine = engine else {
+            logger.error("🧭 History window requested before MenuBarManager dependencies were configured. hasModelContainer=\((self.modelContainer != nil), privacy: .public); hasEngine=\((self.engine != nil), privacy: .public)")
             return
         }
-        NSApplication.shared.setActivationPolicy(.regular)
-        HistoryWindowController.shared.showHistoryWindow(
-            modelContainer: modelContainer,
-            engine: engine
-        )
+
+        let openWindow = { [weak self] in
+            self?.logger.notice("🧭 History window requested from menu bar. isMenuBarOnly=\(self?.isMenuBarOnly ?? false, privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+            self?.activateForPresentedWindow(reason: "History")
+
+            HistoryWindowController.shared.showHistoryWindow(
+                modelContainer: modelContainer,
+                engine: engine
+            )
+        }
+
+        if Thread.isMainThread {
+            openWindow()
+        } else {
+            DispatchQueue.main.async(execute: openWindow)
+        }
     }
 }

--- a/VoiceInk/MenuBarManager.swift
+++ b/VoiceInk/MenuBarManager.swift
@@ -9,8 +9,7 @@ class MenuBarManager: ObservableObject {
     @Published var isMenuBarOnly: Bool {
         didSet {
             UserDefaults.standard.set(isMenuBarOnly, forKey: "IsMenuBarOnly")
-            logger.notice("🧭 Menu-bar-only preference changed. newValue=\(self.isMenuBarOnly, privacy: .public); activationPolicyBefore=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
-            applyActivationPolicy()
+            applyActivationPolicy(logPreferenceChange: true)
         }
     }
 
@@ -60,9 +59,15 @@ class MenuBarManager: ObservableObject {
         isMenuBarOnly.toggle()
     }
     
-    func applyActivationPolicy() {
+    func applyActivationPolicy(logPreferenceChange: Bool = false) {
+        let changedPreferenceValue = isMenuBarOnly
+
         let applyPolicy = { [weak self] in
             guard let self else { return }
+            if logPreferenceChange {
+                self.logger.notice("🧭 Menu-bar-only preference changed. newValue=\(changedPreferenceValue, privacy: .public); activationPolicyBefore=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+            }
+
             let didSet = NSApplication.shared.setActivationPolicy(self.configuredActivationPolicy)
             self.logger.notice("🧭 Applied menu-bar activation policy. isMenuBarOnly=\(self.isMenuBarOnly, privacy: .public); desiredPolicy=\(WindowDiagnostics.activationPolicyDescription(self.configuredActivationPolicy), privacy: .public); success=\(didSet, privacy: .public); activationPolicyAfter=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public)")
 

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -11,6 +11,7 @@ extension Notification.Name {
     static let licenseStatusChanged = Notification.Name("licenseStatusChanged")
     static let licenseCelebrationRequested = Notification.Name("licenseCelebrationRequested")
     static let navigateToDestination = Notification.Name("navigateToDestination")
+    static let showMainWindowRequested = Notification.Name("showMainWindowRequested")
     static let modeConfigurationApplied = Notification.Name("modeConfigurationApplied")
     static let modeConfigurationsDidChange = Notification.Name("ModeConfigurationsDidChange")
     static let modeShortcutAvailabilityDidChange = Notification.Name("modeShortcutAvailabilityDidChange")

--- a/VoiceInk/Views/ContentView.swift
+++ b/VoiceInk/Views/ContentView.swift
@@ -15,14 +15,30 @@ enum ViewType: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+final class MainWindowNavigation: ObservableObject {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+
+    @Published var selectedView: ViewType = .dashboard
+
+    func navigate(to destination: String) {
+        guard let viewType = ViewType.allCases.first(where: { $0.rawValue == destination }) else {
+            logger.error("🧭 Ignored unknown main-window navigation destination. destination=\(destination, privacy: .public); selectedView=\(self.selectedView.rawValue, privacy: .public)")
+            return
+        }
+
+        logger.notice("🧭 Main-window navigation updated. destination=\(destination, privacy: .public); selectedBefore=\(self.selectedView.rawValue, privacy: .public); selectedAfter=\(viewType.rawValue, privacy: .public)")
+        selectedView = viewType
+    }
+}
+
 struct ContentView: View {
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ContentView")
     private static let detailBackgroundTintOpacity = 0.50
-    @State private var selectedView: ViewType = .dashboard
+    @EnvironmentObject private var navigation: MainWindowNavigation
 
     var body: some View {
         HStack(spacing: 0) {
-            AppSidebar(selectedView: $selectedView)
+            AppSidebar(selectedView: $navigation.selectedView)
 
             detailContent
         }
@@ -35,17 +51,16 @@ struct ContentView: View {
             logger.notice("ContentView disappeared")
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToDestination)) { notification in
-            if let destination = notification.userInfo?["destination"] as? String,
-               let viewType = ViewType.allCases.first(where: { $0.rawValue == destination }) {
+            if let destination = notification.userInfo?["destination"] as? String {
                 logger.notice("navigateToDestination received: \(destination, privacy: .public)")
-                selectedView = viewType
+                navigation.navigate(to: destination)
             }
         }
     }
 
     @ViewBuilder
     private var detailContent: some View {
-        detailView(for: selectedView)
+        detailView(for: navigation.selectedView)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(detailBackground)
     }

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -1,13 +1,18 @@
 import SwiftUI
 import LaunchAtLogin
+import OSLog
 
 struct MenuBarView: View {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+
+    @Environment(\.openWindow) private var openWindow
     @EnvironmentObject var engine: VoiceInkEngine
     @EnvironmentObject var recorderUIManager: RecorderUIManager
     @EnvironmentObject var transcriptionModelManager: TranscriptionModelManager
     @EnvironmentObject var whisperModelManager: WhisperModelManager
     @EnvironmentObject var recordingShortcutManager: RecordingShortcutManager
     @EnvironmentObject var menuBarManager: MenuBarManager
+    @EnvironmentObject var mainWindowNavigation: MainWindowNavigation
     @EnvironmentObject var updaterViewModel: UpdaterViewModel
     @EnvironmentObject var enhancementService: AIEnhancementService
     @EnvironmentObject var aiService: AIService
@@ -29,7 +34,7 @@ struct MenuBarView: View {
     private var onboardingMenu: some View {
         Group {
             Button("Complete Onboarding") {
-                menuBarManager.focusMainWindow()
+                showMainWindow(reason: "Complete Onboarding")
             }
 
             Divider()
@@ -66,11 +71,11 @@ struct MenuBarView: View {
                 Divider()
 
                 Button("Manage Modes") {
-                    menuBarManager.openMainWindowAndNavigate(to: "Modes")
+                    showMainWindowAndNavigate(to: "Modes", reason: "Manage Modes")
                 }
 
                 Button("Manage Models") {
-                    menuBarManager.openMainWindowAndNavigate(to: "AI Models")
+                    showMainWindowAndNavigate(to: "AI Models", reason: "Manage Models")
                 }
             } label: {
                 HStack {
@@ -129,7 +134,12 @@ struct MenuBarView: View {
             .keyboardShortcut("h", modifiers: [.command, .shift])
             
             Button(menuBarManager.isMenuBarOnly ? "Show Dock Icon" : "Hide Dock Icon") {
+                let shouldShowMainWindow = menuBarManager.isMenuBarOnly
                 menuBarManager.toggleMenuBarOnly()
+
+                if shouldShowMainWindow {
+                    showMainWindow(reason: "Show Dock Icon")
+                }
             }
             .keyboardShortcut("d", modifiers: [.command, .shift])
 
@@ -141,7 +151,7 @@ struct MenuBarView: View {
             Divider()
 
             Button("Settings") {
-                menuBarManager.openMainWindowAndNavigate(to: "Settings")
+                showMainWindowAndNavigate(to: "Settings", reason: "Settings")
             }
             .keyboardShortcut(",", modifiers: .command)
 
@@ -154,5 +164,28 @@ struct MenuBarView: View {
                 NSApplication.shared.terminate(nil)
             }
         }
+    }
+
+    private func showMainWindow(reason: String) {
+        let existingWindow = WindowManager.shared.currentMainWindow()
+        logger.notice("🧭 Menu bar requested main window. reason=\(reason, privacy: .public); menuBarOnly=\(self.menuBarManager.isMenuBarOnly, privacy: .public); hasExistingMainWindow=\((existingWindow != nil), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+        menuBarManager.activateForPresentedWindow(reason: reason)
+
+        if existingWindow == nil {
+            WindowManager.shared.prepareForUserRequestedMainWindow()
+            openWindow(id: AppWindowID.main)
+            logger.notice("🧭 Menu bar requested SwiftUI to create/open main window. reason=\(reason, privacy: .public); path=createViaOpenWindow")
+        } else {
+            openWindow(id: AppWindowID.main)
+            WindowManager.shared.showMainWindow()
+            logger.notice("🧭 Menu bar requested SwiftUI to open existing main window and asked WindowManager to present it. reason=\(reason, privacy: .public); path=existingWindow")
+        }
+    }
+
+    private func showMainWindowAndNavigate(to destination: String, reason: String) {
+        logger.notice("🧭 Menu bar navigation requested. reason=\(reason, privacy: .public); destination=\(destination, privacy: .public); selectedBefore=\(self.mainWindowNavigation.selectedView.rawValue, privacy: .public)")
+        mainWindowNavigation.navigate(to: destination)
+        logger.notice("🧭 Menu bar navigation state updated. reason=\(reason, privacy: .public); destination=\(destination, privacy: .public); selectedAfter=\(self.mainWindowNavigation.selectedView.rawValue, privacy: .public)")
+        showMainWindow(reason: reason)
     }
 }

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -19,6 +19,7 @@ struct VoiceInkApp: App {
     @StateObject private var recordingShortcutManager: RecordingShortcutManager
     @StateObject private var updaterViewModel: UpdaterViewModel
     @StateObject private var menuBarManager: MenuBarManager
+    @StateObject private var mainWindowNavigation = MainWindowNavigation()
     @StateObject private var aiService = AIService()
     @StateObject private var enhancementService: AIEnhancementService
     @StateObject private var activeWindowService = ActiveWindowService.shared
@@ -266,7 +267,7 @@ struct VoiceInkApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        Window("VoiceInk", id: AppWindowID.main) {
             Group {
                 if hasCompletedOnboardingV2 {
                     ContentView()
@@ -278,6 +279,7 @@ struct VoiceInkApp: App {
                         .environmentObject(recordingShortcutManager)
                         .environmentObject(updaterViewModel)
                         .environmentObject(menuBarManager)
+                        .environmentObject(mainWindowNavigation)
                         .environmentObject(aiService)
                         .environmentObject(enhancementService)
                         .modelContainer(container)
@@ -299,6 +301,7 @@ struct VoiceInkApp: App {
 
                             // Process any pending open-file request now that the main ContentView is ready.
                             if let pendingURL = appDelegate.pendingOpenFileURL {
+                                Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow").notice("🧭 Processing pending media URL after main ContentView appeared. urlLastPath=\(pendingURL.lastPathComponent, privacy: .private(mask: .hash))")
                                 NotificationCenter.default.post(name: .navigateToDestination, object: nil, userInfo: ["destination": "Transcribe Audio"])
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                                     NotificationCenter.default.post(name: .openFileForTranscription, object: nil, userInfo: ["url": pendingURL])
@@ -351,6 +354,7 @@ struct VoiceInkApp: App {
                 .environmentObject(recorderUIManager)
                 .environmentObject(recordingShortcutManager)
                 .environmentObject(menuBarManager)
+                .environmentObject(mainWindowNavigation)
                 .environmentObject(updaterViewModel)
                 .environmentObject(aiService)
                 .environmentObject(enhancementService)
@@ -363,6 +367,7 @@ struct VoiceInkApp: App {
             }(NSImage(named: "menuBarIcon")!)
 
             Image(nsImage: image)
+                .background(MainWindowRequestBridge(menuBarManager: menuBarManager))
         }
         .menuBarExtraStyle(.menu)
 
@@ -393,6 +398,34 @@ struct VoiceInkApp: App {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
             NSWorkspace.shared.open(url)
         }
+    }
+}
+
+private struct MainWindowRequestBridge: View {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+
+    @Environment(\.openWindow) private var openWindow
+    let menuBarManager: MenuBarManager
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .onReceive(NotificationCenter.default.publisher(for: .showMainWindowRequested)) { _ in
+                let existingWindow = WindowManager.shared.currentMainWindow()
+                logger.notice("🧭 SwiftUI main-window request bridge received request. hasExistingMainWindow=\((existingWindow != nil), privacy: .public); menuBarOnly=\(self.menuBarManager.isMenuBarOnly, privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+
+                if existingWindow == nil {
+                    menuBarManager.activateForPresentedWindow(reason: "SwiftUIBridgeCreateMainWindow")
+                    WindowManager.shared.prepareForUserRequestedMainWindow()
+                    openWindow(id: AppWindowID.main)
+                    logger.notice("🧭 SwiftUI bridge requested main window creation via openWindow.")
+                } else {
+                    menuBarManager.activateForPresentedWindow(reason: "SwiftUIBridgePresentMainWindow")
+                    openWindow(id: AppWindowID.main)
+                    WindowManager.shared.showMainWindow()
+                    logger.notice("🧭 SwiftUI bridge requested existing main window presentation.")
+                }
+            }
     }
 }
 
@@ -436,15 +469,31 @@ struct CheckForUpdatesView: View {
 struct WindowAccessor: NSViewRepresentable {
     let callback: (NSWindow) -> Void
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
-        DispatchQueue.main.async {
-            if let window = view.window {
-                callback(window)
-            }
-        }
+        notifyWindowIfNeeded(for: view, context: context)
         return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        notifyWindowIfNeeded(for: nsView, context: context)
+    }
+
+    private func notifyWindowIfNeeded(for view: NSView, context: Context) {
+        DispatchQueue.main.async {
+            if let window = view.window,
+               context.coordinator.window !== window {
+                context.coordinator.window = window
+                callback(window)
+            }
+        }
+    }
+
+    final class Coordinator {
+        weak var window: NSWindow?
+    }
 }

--- a/VoiceInk/WindowManager.swift
+++ b/VoiceInk/WindowManager.swift
@@ -1,9 +1,115 @@
 import SwiftUI
 import AppKit
+import OSLog
 
 enum AppWindowLayout {
     static let width: CGFloat = 950
     static let minimumHeight: CGFloat = 730
+}
+
+enum AppWindowID {
+    static let main = "main"
+}
+
+enum WindowDiagnostics {
+    static func activationPolicyDescription(_ policy: NSApplication.ActivationPolicy) -> String {
+        switch policy {
+        case .regular:
+            return "regular"
+        case .accessory:
+            return "accessory"
+        case .prohibited:
+            return "prohibited"
+        @unknown default:
+            return "unknown(\(policy.rawValue))"
+        }
+    }
+
+    static func windowDescription(_ window: NSWindow) -> String {
+        let identifier = window.identifier?.rawValue ?? "nil"
+        let title = window.title.isEmpty ? "<empty>" : window.title
+        return "id=\(identifier), title=\(title), visible=\(window.isVisible), key=\(window.isKeyWindow), main=\(window.isMainWindow), miniaturized=\(window.isMiniaturized), level=\(window.level.rawValue), styleMask=\(window.styleMask.rawValue)"
+    }
+
+    static func windowSnapshot() -> String {
+        let windows = NSApplication.shared.windows
+        guard !windows.isEmpty else {
+            return "windows=0"
+        }
+
+        let descriptions = windows
+            .enumerated()
+            .map { index, window in
+                "#\(index){\(windowDescription(window))}"
+            }
+            .joined(separator: " | ")
+
+        return "windows=\(windows.count): \(descriptions)"
+    }
+
+    static func visibleUserFacingWindowSnapshot(excluding excludedWindow: NSWindow? = nil) -> String {
+        let windows = visibleUserFacingWindows(excluding: excludedWindow)
+
+        guard !windows.isEmpty else {
+            return "visibleUserWindows=0"
+        }
+
+        let descriptions = windows
+            .enumerated()
+            .map { index, window in
+                "#\(index){\(windowDescription(window))}"
+            }
+            .joined(separator: " | ")
+
+        return "visibleUserWindows=\(windows.count): \(descriptions)"
+    }
+
+    static func visibleUserFacingWindows(excluding excludedWindow: NSWindow? = nil) -> [NSWindow] {
+        NSApplication.shared.windows.filter { window in
+            if let excludedWindow, window == excludedWindow {
+                return false
+            }
+
+            return window.isVisible &&
+                window.level == .normal &&
+                window.styleMask.contains(.titled)
+        }
+    }
+}
+
+enum AppPresentationPolicy {
+    private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+
+    static func activateForUserFacingWindow(reason: String) {
+        let beforePolicy = NSApplication.shared.activationPolicy()
+        let didSet = NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        Self.logger.notice("🧭 Activated app for user-facing window. reason=\(reason, privacy: .public); menuBarOnlyPreference=\(UserDefaults.standard.bool(forKey: "IsMenuBarOnly"), privacy: .public); activationPolicyBefore=\(WindowDiagnostics.activationPolicyDescription(beforePolicy), privacy: .public); setPolicySuccess=\(didSet, privacy: .public); activationPolicyAfter=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+    }
+
+    static func restoreAccessoryIfNeededAfterUserFacingWindowClosed(reason: String) {
+        DispatchQueue.main.async {
+            let menuBarOnly = UserDefaults.standard.bool(forKey: "IsMenuBarOnly")
+            let hasVisibleUserWindows = !WindowDiagnostics.visibleUserFacingWindows().isEmpty
+            let visibleUserWindows = WindowDiagnostics.visibleUserFacingWindowSnapshot()
+
+            guard menuBarOnly else {
+                Self.logger.notice("🧭 Skipped restoring accessory activation policy because menu-bar-only preference is disabled. reason=\(reason, privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); \(visibleUserWindows, privacy: .public)")
+                return
+            }
+
+            guard !hasVisibleUserWindows else {
+                Self.logger.notice("🧭 Skipped restoring accessory activation policy because another user-facing window is still visible. reason=\(reason, privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); \(visibleUserWindows, privacy: .public)")
+                return
+            }
+
+            let beforePolicy = NSApplication.shared.activationPolicy()
+            let didSet = NSApplication.shared.setActivationPolicy(.accessory)
+            NSApplication.shared.deactivate()
+            Self.logger.notice("🧭 Restored accessory activation policy after closing user-facing windows. reason=\(reason, privacy: .public); activationPolicyBefore=\(WindowDiagnostics.activationPolicyDescription(beforePolicy), privacy: .public); setPolicySuccess=\(didSet, privacy: .public); activationPolicyAfter=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+        }
+    }
 }
 
 class WindowManager: NSObject {
@@ -12,17 +118,36 @@ class WindowManager: NSObject {
     private static let mainWindowIdentifier = NSUserInterfaceItemIdentifier("com.prakashjoshipax.voiceink.mainWindow")
     private static let mainWindowAutosaveName = NSWindow.FrameAutosaveName("VoiceInkMainWindowFrame")
 
-    private var mainWindow: NSWindow?
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MenuBarWindowFlow")
+    private weak var mainWindow: NSWindow?
     private var didApplyInitialPlacement = false
+    private var shouldShowNextConfiguredMainWindow = false
 
     private override init() {
         super.init()
     }
+
+    func prepareForUserRequestedMainWindow() {
+        guard !shouldShowNextConfiguredMainWindow else { return }
+
+        shouldShowNextConfiguredMainWindow = true
+        logger.notice("🧭 Prepared next configured main window for user-requested presentation. menuBarOnly=\(UserDefaults.standard.bool(forKey: "IsMenuBarOnly"), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); storedMainWindow=\(self.mainWindow.map(WindowDiagnostics.windowDescription) ?? "nil", privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+    }
     
     func configureWindow(_ window: NSWindow) {
+        let hadPendingPresentation = shouldShowNextConfiguredMainWindow
+        logger.notice("🧭 Configuring main window. pendingUserPresentation=\(hadPendingPresentation, privacy: .public); menuBarOnly=\(UserDefaults.standard.bool(forKey: "IsMenuBarOnly"), privacy: .public); incoming=\(WindowDiagnostics.windowDescription(window), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+
         if let existingWindow = NSApplication.shared.windows.first(where: { $0.identifier == Self.mainWindowIdentifier && $0 != window }) {
             window.close()
-            existingWindow.makeKeyAndOrderFront(nil)
+            if shouldShowNextConfiguredMainWindow {
+                logger.notice("🧭 Duplicate main window arrived while presentation was pending; presenting existing main window. existing=\(WindowDiagnostics.windowDescription(existingWindow), privacy: .public)")
+                presentMainWindow(existingWindow)
+                shouldShowNextConfiguredMainWindow = false
+            } else {
+                logger.notice("🧭 Duplicate main window arrived without pending presentation; reusing existing main window. existing=\(WindowDiagnostics.windowDescription(existingWindow), privacy: .public)")
+                existingWindow.makeKeyAndOrderFront(nil)
+            }
             return
         }
         
@@ -42,17 +167,32 @@ class WindowManager: NSObject {
         window.setFrameAutosaveName(Self.mainWindowAutosaveName)
         applyInitialPlacementIfNeeded(to: window)
         registerMainWindowIfNeeded(window)
-        window.orderFrontRegardless()
+
+        if shouldShowNextConfiguredMainWindow {
+            shouldShowNextConfiguredMainWindow = false
+            logger.notice("🧭 Presenting newly configured main window for user request. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
+            presentMainWindow(window)
+        } else if UserDefaults.standard.bool(forKey: "IsMenuBarOnly") {
+            logger.notice("🧭 Ordering out newly configured main window because menu-bar-only mode is enabled and no user presentation is pending. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
+            window.orderOut(nil)
+        } else {
+            logger.notice("🧭 Configured main window without pending presentation. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
+        }
     }
     
     func registerMainWindow(_ window: NSWindow) {
         mainWindow = window
         window.identifier = Self.mainWindowIdentifier
         window.delegate = self
+        logger.notice("🧭 Registered main window. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
     }
     
+    @discardableResult
     func showMainWindow() -> NSWindow? {
+        logger.notice("🧭 Show main window requested. storedMainWindow=\(self.mainWindow.map(WindowDiagnostics.windowDescription) ?? "nil", privacy: .public); pendingUserPresentation=\(self.shouldShowNextConfiguredMainWindow, privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+
         guard let window = resolveMainWindow() else {
+            logger.error("🧭 Show main window could not resolve a native window.")
             return nil
         }
 
@@ -60,17 +200,20 @@ class WindowManager: NSObject {
             window.deminiaturize(nil)
         }
 
-        window.makeKeyAndOrderFront(nil)
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        presentMainWindow(window)
         return window
     }
     
     func hideMainWindow() {
+        logger.notice("🧭 Hide main window requested. storedMainWindow=\(self.mainWindow.map(WindowDiagnostics.windowDescription) ?? "nil", privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
+
         guard let window = resolveMainWindow() else {
+            logger.notice("🧭 Hide main window skipped because no native main window is registered yet.")
             return
         }
 
         window.orderOut(nil)
+        logger.notice("🧭 Main window ordered out. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
     }
     
     func currentMainWindow() -> NSWindow? {
@@ -78,7 +221,6 @@ class WindowManager: NSObject {
     }
     
     private func registerMainWindowIfNeeded(_ window: NSWindow) {
-        // Only register the primary content window, identified by the hidden title bar style
         if window.identifier == nil || window.identifier != Self.mainWindowIdentifier {
             registerMainWindow(window)
         }
@@ -121,49 +263,41 @@ class WindowManager: NSObject {
         if let window = NSApplication.shared.windows.first(where: { $0.identifier == Self.mainWindowIdentifier }) {
             mainWindow = window
             window.delegate = self
+            logger.notice("🧭 Recovered main window by identifier. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
             return window
         }
 
         return nil
     }
 
-    private func restoreAccessoryPolicyIfNeededAfterWindowHide() {
-        guard UserDefaults.standard.bool(forKey: "IsMenuBarOnly") else { return }
+    private func presentMainWindow(_ window: NSWindow) {
+        AppPresentationPolicy.activateForUserFacingWindow(reason: "WindowManager.presentMainWindow")
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            let hasVisibleWindows = NSApplication.shared.windows.contains {
-                $0.isVisible && $0.level == .normal && !$0.styleMask.contains(.nonactivatingPanel)
-            }
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
 
-            if !hasVisibleWindows && NSApplication.shared.activationPolicy() != .accessory {
-                NSApplication.shared.setActivationPolicy(.accessory)
-            }
+        window.makeKeyAndOrderFront(nil)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        if !window.isKeyWindow {
+            window.orderFrontRegardless()
+        }
+        logger.notice("🧭 Presented main window. window=\(WindowDiagnostics.windowDescription(window), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public)")
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self, let window else { return }
+            self.logger.notice("🧭 Confirmed main window presentation after runloop. window=\(WindowDiagnostics.windowDescription(window), privacy: .public); activationPolicy=\(WindowDiagnostics.activationPolicyDescription(NSApplication.shared.activationPolicy()), privacy: .public); snapshot=\(WindowDiagnostics.windowSnapshot(), privacy: .public)")
         }
     }
 }
 
 extension WindowManager: NSWindowDelegate {
-    func windowShouldClose(_ sender: NSWindow) -> Bool {
-        guard sender.identifier == Self.mainWindowIdentifier else {
-            return true
-        }
-
-        sender.orderOut(nil)
-        restoreAccessoryPolicyIfNeededAfterWindowHide()
-        return false
-    }
-
     func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
         if window.identifier == Self.mainWindowIdentifier {
+            logger.notice("🧭 Main window will close; clearing stored reference. window=\(WindowDiagnostics.windowDescription(window), privacy: .public)")
             mainWindow = nil
             didApplyInitialPlacement = false
         }
     }
-    
-    func windowDidBecomeKey(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow,
-              window.identifier == Self.mainWindowIdentifier else { return }
-        NSApplication.shared.activate(ignoringOtherApps: true)
-    }
-} 
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the main window presentation flow to reliably create, focus, and show the main window on demand, with correct behavior in menu‑bar‑only mode and when toggling the Dock icon. Dock/app reopen and file‑open now present or create the window via a SwiftUI bridge without duplicating windows.

- **Bug Fixes**
  - Reopen from Dock/app presents the existing window or requests creation via `.showMainWindowRequested`; no duplicate windows.
  - Correct activation policy transitions: switch to regular for user windows; restore accessory after the last user‑facing window closes.
  - Cold‑start file‑open stores the URL, requests the main window, then navigates to Transcribe Audio; running instances focus/present and route in place.
  - Menu bar actions activate the app before presenting windows; enabling “Show Dock Icon” also opens the main window.

- **Refactors**
  - Centralized activation and diagnostics in `AppPresentationPolicy` and `WindowDiagnostics` with structured `OSLog` and window snapshots.
  - Replaced `WindowGroup` with an identified `Window("VoiceInk", id: AppWindowID.main)` and a `MainWindowRequestBridge` that opens/presents on demand.
  - Added `MainWindowNavigation` to manage safe in‑app navigation from menu bar actions.
  - Streamlined `MenuBarManager` (`applyActivationPolicy`, `activateForPresentedWindow`) and deferred preference‑change logging to policy application.
  - `WindowManager` now coordinates presentation (`prepareForUserRequestedMainWindow`, `presentMainWindow`) and orders out unused windows in menu‑bar‑only mode.

<sup>Written for commit ed86cf731968875a6b78fa3f9b30936c99d4a660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

