### PR TITLE
Fix audio interface loopback in dictation input

### DIFF
--- a/VoiceInk/CoreAudioRecorder.swift
+++ b/VoiceInk/CoreAudioRecorder.swift
@@ -5,6 +5,34 @@ import AVFoundation
 import Atomics
 import os
 
+struct AudioInputChannelSelection: Equatable {
+    let deviceChannelIndices: [Int32]
+
+    static func resolve(
+        deviceChannelCount: UInt32,
+        preferredStereoChannels: [UInt32]?
+    ) -> AudioInputChannelSelection {
+        guard deviceChannelCount > 0 else {
+            return AudioInputChannelSelection(deviceChannelIndices: [])
+        }
+
+        let fallback = (0..<min(deviceChannelCount, 2)).map(Int32.init)
+        guard let preferredStereoChannels,
+              !preferredStereoChannels.isEmpty,
+              preferredStereoChannels.allSatisfy({ (1...deviceChannelCount).contains($0) }) else {
+            return AudioInputChannelSelection(deviceChannelIndices: fallback)
+        }
+
+        var seen = Set<UInt32>()
+        let preferred = preferredStereoChannels.compactMap { channel -> Int32? in
+            guard seen.insert(channel).inserted else { return nil }
+            return Int32(channel - 1)
+        }
+
+        return AudioInputChannelSelection(deviceChannelIndices: preferred)
+    }
+}
+
 // MARK: - Core Audio Recorder (AUHAL-based, does not change system default device)
 final class CoreAudioRecorder: @unchecked Sendable {
     private final class InputBufferSlot: @unchecked Sendable {
@@ -38,6 +66,7 @@ final class CoreAudioRecorder: @unchecked Sendable {
 
     // Device format (what the hardware provides)
     private var deviceFormat = AudioStreamBasicDescription()
+    private var captureChannelCount: UInt32 = 1
     // Output format (16kHz mono PCM Int16 for transcription)
     private var outputFormat = AudioStreamBasicDescription()
 
@@ -281,42 +310,23 @@ final class CoreAudioRecorder: @unchecked Sendable {
             throw CoreAudioRecorderError.failedToGetDeviceFormat(status: status)
         }
 
-        // Step 5: Configure callback format for new device
-        var callbackFormat = AudioStreamBasicDescription(
-            mSampleRate: newDeviceFormat.mSampleRate,
-            mFormatID: kAudioFormatLinearPCM,
-            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
-            mBytesPerPacket: UInt32(MemoryLayout<Float32>.size) * newDeviceFormat.mChannelsPerFrame,
-            mFramesPerPacket: 1,
-            mBytesPerFrame: UInt32(MemoryLayout<Float32>.size) * newDeviceFormat.mChannelsPerFrame,
-            mChannelsPerFrame: newDeviceFormat.mChannelsPerFrame,
-            mBitsPerChannel: 32,
-            mReserved: 0
+        // Step 5: Configure callback format and map only the device's preferred input channels.
+        let newCaptureChannelCount = try configureCaptureFormat(
+            deviceID: newDeviceID,
+            deviceFormat: newDeviceFormat
         )
-
-        status = AudioUnitSetProperty(
-            unit,
-            kAudioUnitProperty_StreamFormat,
-            kAudioUnitScope_Output,
-            1,
-            &callbackFormat,
-            UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-        )
-
-        if status != noErr {
-            throw CoreAudioRecorderError.failedToSetFormat(status: status)
-        }
 
         // Step 6: Reallocate buffers if needed
         allocateAudioBuffers(
             maxFrames: renderFrameCapacity(for: newDeviceID),
-            channelCount: newDeviceFormat.mChannelsPerFrame,
+            channelCount: newCaptureChannelCount,
             inputSampleRate: newDeviceFormat.mSampleRate,
             resetQueuedAudio: true
         )
 
         // Update stored format
         deviceFormat = newDeviceFormat
+        captureChannelCount = newCaptureChannelCount
         currentDeviceID = newDeviceID
 
         // Step 7: Reinitialize and restart
@@ -448,32 +458,10 @@ final class CoreAudioRecorder: @unchecked Sendable {
             mReserved: 0
         )
 
-        // Set callback format (Float32 for processing, then convert to Int16 for file)
-        var callbackFormat = AudioStreamBasicDescription(
-            mSampleRate: deviceFormat.mSampleRate,
-            mFormatID: kAudioFormatLinearPCM,
-            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
-            mBytesPerPacket: UInt32(MemoryLayout<Float32>.size) * deviceFormat.mChannelsPerFrame,
-            mFramesPerPacket: 1,
-            mBytesPerFrame: UInt32(MemoryLayout<Float32>.size) * deviceFormat.mChannelsPerFrame,
-            mChannelsPerFrame: deviceFormat.mChannelsPerFrame,
-            mBitsPerChannel: 32,
-            mReserved: 0
+        captureChannelCount = try configureCaptureFormat(
+            deviceID: currentDeviceID,
+            deviceFormat: deviceFormat
         )
-
-        status = AudioUnitSetProperty(
-            audioUnit,
-            kAudioUnitProperty_StreamFormat,
-            kAudioUnitScope_Output,
-            1,
-            &callbackFormat,
-            UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-        )
-
-        if status != noErr {
-            logger.error("Failed to set audio format: \(status, privacy: .public)")
-            throw CoreAudioRecorderError.failedToSetFormat(status: status)
-        }
 
         // Log format details
         let devSampleRate = deviceFormat.mSampleRate
@@ -492,10 +480,73 @@ final class CoreAudioRecorder: @unchecked Sendable {
 
         allocateAudioBuffers(
             maxFrames: renderFrameCapacity(for: currentDeviceID),
-            channelCount: deviceFormat.mChannelsPerFrame,
+            channelCount: captureChannelCount,
             inputSampleRate: deviceFormat.mSampleRate,
             resetQueuedAudio: true
         )
+    }
+
+    private func configureCaptureFormat(
+        deviceID: AudioDeviceID,
+        deviceFormat: AudioStreamBasicDescription
+    ) throws -> UInt32 {
+        guard let audioUnit else {
+            throw CoreAudioRecorderError.audioUnitNotInitialized
+        }
+
+        let selection = AudioInputChannelSelection.resolve(
+            deviceChannelCount: deviceFormat.mChannelsPerFrame,
+            preferredStereoChannels: getPreferredInputChannels(deviceID: deviceID)
+        )
+        let channelCount = UInt32(selection.deviceChannelIndices.count)
+        guard channelCount > 0 else {
+            throw CoreAudioRecorderError.failedToSetFormat(status: kAudio_ParamError)
+        }
+
+        var callbackFormat = AudioStreamBasicDescription(
+            mSampleRate: deviceFormat.mSampleRate,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: UInt32(MemoryLayout<Float32>.size) * channelCount,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: UInt32(MemoryLayout<Float32>.size) * channelCount,
+            mChannelsPerFrame: channelCount,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+
+        var status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioUnitProperty_StreamFormat,
+            kAudioUnitScope_Output,
+            1,
+            &callbackFormat,
+            UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        )
+        guard status == noErr else {
+            logger.error("Failed to set audio format: \(status, privacy: .public)")
+            throw CoreAudioRecorderError.failedToSetFormat(status: status)
+        }
+
+        var channelMap = selection.deviceChannelIndices
+        status = channelMap.withUnsafeMutableBytes { bytes in
+            AudioUnitSetProperty(
+                audioUnit,
+                kAudioOutputUnitProperty_ChannelMap,
+                kAudioUnitScope_Output,
+                1,
+                bytes.baseAddress,
+                UInt32(bytes.count)
+            )
+        }
+        guard status == noErr else {
+            logger.error("Failed to map audio input channels: \(status, privacy: .public)")
+            throw CoreAudioRecorderError.failedToSetFormat(status: status)
+        }
+
+        let mappedChannels = selection.deviceChannelIndices.map { $0 + 1 }
+        logger.notice("🎙️ Capturing device input channels: \(mappedChannels, privacy: .public)")
+        return channelCount
     }
 
     private func allocateAudioBuffers(
@@ -728,7 +779,7 @@ final class CoreAudioRecorder: @unchecked Sendable {
             return noErr
         }
 
-        let channelCount = deviceFormat.mChannelsPerFrame
+        let channelCount = captureChannelCount
         let inputSampleRate = deviceFormat.mSampleRate
         let requiredSamples = inNumberFrames * channelCount
 
@@ -1128,6 +1179,30 @@ final class CoreAudioRecorder: @unchecked Sendable {
         )
 
         return status == noErr ? bufferSize : nil
+    }
+
+    private func getPreferredInputChannels(deviceID: AudioDeviceID) -> [UInt32]? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyPreferredChannelsForStereo,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return nil }
+
+        var channels = [UInt32](repeating: 0, count: 2)
+        var propertySize = UInt32(MemoryLayout<UInt32>.size * channels.count)
+        let status = channels.withUnsafeMutableBytes { bytes in
+            AudioObjectGetPropertyData(
+                deviceID,
+                &address,
+                0,
+                nil,
+                &propertySize,
+                bytes.baseAddress!
+            )
+        }
+
+        return status == noErr ? channels : nil
     }
 
     /// Checks if a device is currently available using Apple's kAudioDevicePropertyDeviceIsAlive

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -9,9 +9,39 @@ import Testing
 @testable import VoiceInk
 
 struct VoiceInkTests {
+    @Test func preferredInputChannelsExcludeLoopbackChannels() {
+        let selection = AudioInputChannelSelection.resolve(
+            deviceChannelCount: 4,
+            preferredStereoChannels: [1, 2]
+        )
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        #expect(selection.deviceChannelIndices == [0, 1])
     }
 
+    @Test func monoInputUsesOneChannel() {
+        let selection = AudioInputChannelSelection.resolve(
+            deviceChannelCount: 1,
+            preferredStereoChannels: [1, 1]
+        )
+
+        #expect(selection.deviceChannelIndices == [0])
+    }
+
+    @Test func missingPreferredChannelsFallBackToFirstTwoInputs() {
+        let selection = AudioInputChannelSelection.resolve(
+            deviceChannelCount: 4,
+            preferredStereoChannels: nil
+        )
+
+        #expect(selection.deviceChannelIndices == [0, 1])
+    }
+
+    @Test func invalidPreferredChannelsFallBackToFirstTwoInputs() {
+        let selection = AudioInputChannelSelection.resolve(
+            deviceChannelCount: 4,
+            preferredStereoChannels: [0, 5]
+        )
+
+        #expect(selection.deviceChannelIndices == [0, 1])
+    }
 }


### PR DESCRIPTION
## Summary

- map AUHAL capture to the input device's preferred input channels
- exclude additional loopback channels exposed by multi-channel audio interfaces
- reapply the channel map when switching recording devices
- fall back safely to the first one or two channels when a device does not publish a valid preferred pair

## Root cause

VoiceInk configured its callback with every input channel exposed by the selected device, then averaged all channels to mono. Interfaces with loopback support expose computer playback as additional input channels, so system audio became part of dictation recordings.

For example, a Scarlett 2i2 4th Gen exposes four input channels: physical inputs 1-2 and loopback inputs 3-4. Core Audio reports 1-2 as the preferred input pair, which this change applies through `kAudioOutputUnitProperty_ChannelMap`.

## Validation

- macOS test build completed successfully
- 4 channel-selection regression tests pass
- live-tested with a Scarlett 2i2 4th Gen while computer audio was playing
- runtime log confirmed `Capturing device input channels: [1, 2]`
- microphone dictation succeeded without capturing the loopback playback


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dictation capturing system audio from multi‑channel interfaces by mapping AUHAL input to the device’s preferred channels and excluding loopback inputs. Applies the channel map on init and device switches, with safe fallbacks and tests.

- **Bug Fixes**
  - Map only preferred input channels via `kAudioOutputUnitProperty_ChannelMap`; ignore loopback channels.
  - Reapply the channel map when switching devices and track `captureChannelCount` in render.
  - Add `AudioInputChannelSelection` with fallbacks to the first one or two channels and tests to cover mono/stereo and invalid prefs.

<sup>Written for commit 4c4b8fec5d346d5549e34e7c1d0595f05eb22723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

