### PR TITLE
Only strip known ASR artifact tokens instead of all bracketed text

### DIFF
--- a/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
+++ b/VoiceInk/Transcription/Processing/TranscriptionOutputFilter.swift
@@ -1,11 +1,34 @@
 import Foundation
 
 struct TranscriptionOutputFilter {
-    private static let hallucinationPatterns = [
-        #"\[.*?\]"#,  // []
-        #"\(.*?\)"#,  // ()
-        #"\{.*?\}"#,  // {}
+    /// Known ASR artifact/placeholder tokens engines emit for non-speech
+    /// segments. ONLY these exact bracketed tokens are stripped; every other
+    /// bracketed string (array[i], func(args), "(as I noted)") passes through
+    /// untouched.
+    private static let artifactTokens = [
+        "[BLANK_AUDIO]",
+        "[SILENCE]", "(silence)",
+        "[NOISE]",
+        "[MUSIC]", "(music)",
+        "[APPLAUSE]", "(applause)",
+        "[LAUGHTER]", "(laughter)",
+        "[INAUDIBLE]", "(inaudible)",
+        "(unintelligible)",
     ]
+
+    /// One case-insensitive alternation, each alternative anchored to a whole
+    /// bracketed token (tolerating internal whitespace, e.g. "[ BLANK_AUDIO ]").
+    private static let artifactTokenRegex: NSRegularExpression? = {
+        let alternatives = artifactTokens.map { token -> String in
+            let open  = NSRegularExpression.escapedPattern(for: String(token.prefix(1)))
+            let close = NSRegularExpression.escapedPattern(for: String(token.suffix(1)))
+            let inner = NSRegularExpression.escapedPattern(for: String(token.dropFirst().dropLast()))
+            return open + #"\s*"# + inner + #"\s*"# + close
+        }
+        return try? NSRegularExpression(
+            pattern: "(?:" + alternatives.joined(separator: "|") + ")",
+            options: .caseInsensitive)
+    }()
 
     static func filter(_ text: String) -> String {
         var filteredText = text
@@ -17,13 +40,12 @@ struct TranscriptionOutputFilter {
             filteredText = regex.stringByReplacingMatches(in: filteredText, options: [], range: range, withTemplate: "")
         }
 
-        // Remove bracketed hallucinations
-        for pattern in hallucinationPatterns {
-            if let regex = try? NSRegularExpression(pattern: pattern) {
-                let range = NSRange(filteredText.startIndex..., in: filteredText)
-                filteredText = regex.stringByReplacingMatches(
-                    in: filteredText, options: [], range: range, withTemplate: "")
-            }
+        // Remove only known ASR artifact tokens (allowlist). Real bracketed
+        // content — code identifiers, prose asides — is preserved.
+        if let regex = artifactTokenRegex {
+            let range = NSRange(filteredText.startIndex..., in: filteredText)
+            filteredText = regex.stringByReplacingMatches(
+                in: filteredText, options: [], range: range, withTemplate: "")
         }
 
         // Remove configured filler words. An empty list is naturally a no-op.


### PR DESCRIPTION
## Problem

`TranscriptionOutputFilter` removes every `[...]`, `(...)` and `{...}` span via greedy regexes (`hallucinationPatterns`) to clean ASR artifacts like `[BLANK_AUDIO]`. Because the patterns match *any* bracketed content, they also silently delete legitimate transcribed text:

- Code dictation: `array[i]` → `array`, `func(args)` → `func`, `{config}` → *(gone)*
- Prose asides: `it works (as I noted) fine` → `it works fine`

The deletion is silent, so users dictating code or parentheticals lose content without warning.

## Fix

Replace the greedy patterns with a small allowlist of tokens speech engines actually emit, each anchored to the whole bracketed token and matched case-insensitively (internal whitespace tolerated, e.g. `[ BLANK_AUDIO ]`):

`[BLANK_AUDIO]`, `[SILENCE]`/`(silence)`, `[NOISE]`, `[MUSIC]`/`(music)`, `[APPLAUSE]`/`(applause)`, `[LAUGHTER]`/`(laughter)`, `[INAUDIBLE]`/`(inaudible)`, `(unintelligible)`

- `{...}` stripping is dropped entirely — no engine emits brace artifacts, and it only endangered code.
- The `<TAG>...</TAG>` remover, filler-word loop and whitespace cleanup are unchanged.
- New artifact tokens are a one-line addition to the `artifactTokens` array.

## Behaviour

| Input | Before | After |
|---|---|---|
| `[BLANK_AUDIO]` / `[ blank_audio ]` | removed | removed |
| `array[i]` | `array` | `array[i]` |
| `func(args)` | `func` | `func(args)` |
| `{config}` | *(deleted)* | `{config}` |
| `it works (as I noted)` | `it works` | `it works (as I noted)` |

Builds cleanly via `make local`. Co-authored with Claude.
