### PR TITLE
Improve Parakeet model transcription finalization

### DIFF
--- a/VoiceInk/Transcription/Engine/TranscriptionSession.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionSession.swift
@@ -123,11 +123,16 @@ final class StreamingTranscriptionSession: TranscriptionSession {
             do {
                 let start = Date()
                 logger.notice("Streaming stop/transcribe started model=\(model.displayName, privacy: .public)")
-                let text = try await streamingService.stopAndGetFinalText()
-                logger.notice(
-                    "Streaming transcript received elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s chars=\(text.count, privacy: .public)"
-                )
-                return text
+                let result = try await streamingService.stopAndFinalize()
+                switch result {
+                case .finalized(let text):
+                    logger.notice(
+                        "Streaming transcript received elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s chars=\(text.count, privacy: .public)"
+                    )
+                    return text
+                case .requiresBatchFallback:
+                    logger.notice("Streaming provider requested full batch transcription")
+                }
             } catch {
                 logger.error("❌ Streaming failed, falling back to batch: \(error, privacy: .public)")
                 startupTask?.cancel()

--- a/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -6,11 +6,11 @@ class FluidAudioTranscriptionService: TranscriptionService {
     private var asrManager: AsrManager?
     private var unifiedAsrManager: UnifiedAsrManager?
     private var nemotronAsrManager: StreamingNemotronMultilingualAsrManager?
-    private var vadManager: VadManager?
     private var activeVersion: AsrModelVersion?
     private var activeNemotronModelName: String?
     private var cachedModels: AsrModels?
     private var loadingTask: (version: AsrModelVersion, task: Task<AsrModels, Error>)?
+    private let audioConverter = AudioConverter()
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "FluidAudioTranscriptionService")
 
     private func version(for model: any TranscriptionModel) -> AsrModelVersion {
@@ -32,7 +32,6 @@ class FluidAudioTranscriptionService: TranscriptionService {
         unifiedAsrManager = nil
         nemotronAsrManager = nil
         asrManager = nil
-        vadManager = nil
         activeVersion = nil
         activeNemotronModelName = nil
     }
@@ -145,7 +144,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
                 throw ASRError.notInitialized
             }
 
-            let speechAudio = try await preparedSpeechAudio(from: audioURL, usesVAD: false)
+            let speechAudio = try loadAudioSamples(from: audioURL)
             let text = try await unifiedAsrManager.transcribe(speechAudio)
             return TextNormalizer.shared.normalizeSentence(text)
         }
@@ -164,7 +163,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
             await nemotronAsrManager.setLanguage(languageHint)
             await nemotronAsrManager.reset()
 
-            var speechAudio = try await preparedSpeechAudio(from: audioURL, usesVAD: true)
+            var speechAudio = try loadAudioSamples(from: audioURL)
             let trailingSilenceSamples = 16_000
             let maxSingleChunkSamples = 240_000
             if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
@@ -187,18 +186,9 @@ class FluidAudioTranscriptionService: TranscriptionService {
             from: context.language,
             model: model
         )
-        var speechAudio = try await preparedSpeechAudio(from: audioURL, usesVAD: true)
-
-        // Pad with 1s of silence to capture final punctuation at sequence boundary
-        let trailingSilenceSamples = 16_000
-        let maxSingleChunkSamples = 240_000
-        if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
-            speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
-        }
-
         var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
         let result = try await asrManager.transcribe(
-            speechAudio,
+            audioURL,
             decoderState: &decoderState,
             language: languageHint
         )
@@ -206,59 +196,11 @@ class FluidAudioTranscriptionService: TranscriptionService {
         return TextNormalizer.shared.normalizeSentence(result.text)
     }
 
-    private func preparedSpeechAudio(from audioURL: URL, usesVAD: Bool) async throws -> [Float] {
-        let audioSamples = try readAudioSamples(from: audioURL)
-        let durationSeconds = Double(audioSamples.count) / 16000.0
-        let isVADEnabled = UserDefaults.standard.bool(forKey: "IsVADEnabled")
-
-        guard usesVAD, durationSeconds >= 20.0, isVADEnabled else {
-            return audioSamples
-        }
-
-        let vadConfig = VadConfig(defaultThreshold: 0.7)
-        if vadManager == nil {
-            do {
-                vadManager = try await VadManager(config: vadConfig)
-            } catch {
-                logger.notice("VAD init failed; falling back to full audio: \(error, privacy: .public)")
-                vadManager = nil
-            }
-        }
-
-        guard let vadManager else {
-            return audioSamples
-        }
-
-        do {
-            let segments = try await vadManager.segmentSpeechAudio(audioSamples)
-            return segments.isEmpty ? audioSamples : segments.flatMap { $0 }
-        } catch {
-            logger.notice("VAD segmentation failed; using full audio: \(error, privacy: .public)")
-            return audioSamples
-        }
+    private func loadAudioSamples(from audioURL: URL) throws -> [Float] {
+        try audioConverter.resampleAudioFile(audioURL)
     }
 
-    private func readAudioSamples(from url: URL) throws -> [Float] {
-        do {
-            let data = try Data(contentsOf: url)
-            guard data.count > 44 else {
-                throw ASRError.invalidAudioData
-            }
-
-            let floats = stride(from: 44, to: data.count, by: 2).map {
-                return data[$0..<$0 + 2].withUnsafeBytes {
-                    let short = Int16(littleEndian: $0.load(as: Int16.self))
-                    return max(-1.0, min(Float(short) / 32767.0, 1.0))
-                }
-            }
-
-            return floats
-        } catch {
-            throw ASRError.invalidAudioData
-        }
-    }
-
-    // Releases ASR/VAD resources but preserves cached models for reuse
+    // Releases ASR resources but preserves cached models for reuse
     func cleanup() async {
         await cleanupLoadedManagers()
     }

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -167,11 +167,8 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         bufferLock.unlock()
 
         // Pad with 1s trailing silence for punctuation capture
-        let maxSingleChunkSamples = 240_000
         let trailingSilenceSamples = 16_000
-        if audioSlice.count + trailingSilenceSamples <= maxSingleChunkSamples {
-            audioSlice += [Float](repeating: 0, count: trailingSilenceSamples)
-        }
+        audioSlice += [Float](repeating: 0, count: trailingSilenceSamples)
 
         guard audioSlice.count >= minimumAudioSamples else { return }
 

--- a/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
+++ b/VoiceInk/Transcription/Streaming/FluidAudioStreamingProvider.swift
@@ -26,8 +26,19 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
     private var transcriptionTask: Task<Void, Never>?
     private var isTranscribing = false
     private var lastTranscribedSampleCount = 0
+    private let confirmationLock = NSLock()
+    private var confirmedSegmentCount = 0
+    private let minimumConfirmedSegmentsForStreamingFinalization = 3
     private let minimumAudioSamples = ASRConstants.minimumRequiredSamples(forSampleRate: ASRConstants.sampleRate)
     private let minNewSamples = ASRConstants.minimumRequiredSamples(forSampleRate: ASRConstants.sampleRate)
+
+    var stopDisposition: StreamingStopDisposition {
+        confirmationLock.lock()
+        defer { confirmationLock.unlock() }
+        return confirmedSegmentCount < minimumConfirmedSegmentsForStreamingFinalization
+            ? .useBatchFallback
+            : .finalizeStreaming
+    }
 
     init(fluidAudioService: FluidAudioTranscriptionService, config: AgreementConfig = AgreementConfig()) {
         self.fluidAudioService = fluidAudioService
@@ -58,6 +69,9 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         audioBuffer = []
         trimmedSampleCount = 0
         lastTranscribedSampleCount = 0
+        confirmationLock.lock()
+        confirmedSegmentCount = 0
+        confirmationLock.unlock()
 
         startTranscriptionLoop()
 
@@ -186,7 +200,12 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
 
             if !agreementResult.newlyConfirmedText.isEmpty {
                 let normalizedConfirmed = TextNormalizer.shared.normalizeSentence(agreementResult.newlyConfirmedText)
-                eventsContinuation?.yield(.committed(text: normalizedConfirmed))
+                if !normalizedConfirmed.isEmpty {
+                    confirmationLock.lock()
+                    confirmedSegmentCount += 1
+                    confirmationLock.unlock()
+                    eventsContinuation?.yield(.committed(text: normalizedConfirmed))
+                }
             }
             if !agreementResult.fullText.isEmpty {
                 eventsContinuation?.yield(.partial(text: agreementResult.fullText))
@@ -231,13 +250,10 @@ final class FluidAudioStreamingProvider: StreamingTranscriptionProvider {
         var samples = Array(audioBuffer[bufferRelativeSeek...])
         bufferLock.unlock()
 
-        guard samples.count >= minimumAudioSamples else { return nil }
-
+        // A short spoken tail still needs enough input for FluidAudio. Padding before
+        // transcription keeps that tail instead of rejecting it for being under 300 ms.
         let trailingSilenceSamples = 16_000
-        let maxSingleChunkSamples = 240_000
-        if samples.count + trailingSilenceSamples <= maxSingleChunkSamples {
-            samples += [Float](repeating: 0, count: trailingSilenceSamples)
-        }
+        samples += [Float](repeating: 0, count: trailingSilenceSamples)
 
         do {
             var state = TdtDecoderState.make(decoderLayers: decoderLayerCount)

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionProvider.swift
@@ -8,6 +8,12 @@ enum StreamingTranscriptionEvent {
     case error(Error)
 }
 
+/// Tells the shared streaming layer how a provider wants to finish the recording.
+enum StreamingStopDisposition {
+    case finalizeStreaming
+    case useBatchFallback
+}
+
 /// Errors specific to streaming transcription
 enum StreamingTranscriptionError: LocalizedError {
     case missingAPIKey
@@ -37,6 +43,9 @@ enum StreamingTranscriptionError: LocalizedError {
 
 /// Protocol for streaming transcription providers.
 protocol StreamingTranscriptionProvider: AnyObject {
+    /// Provider-specific decision made when the user stops recording.
+    var stopDisposition: StreamingStopDisposition { get }
+
     /// Connect to the streaming transcription endpoint
     func connect(model: any TranscriptionModel, language: String?) async throws
 
@@ -51,4 +60,8 @@ protocol StreamingTranscriptionProvider: AnyObject {
 
     /// Stream of transcription events from the provider
     var transcriptionEvents: AsyncStream<StreamingTranscriptionEvent> { get }
+}
+
+extension StreamingTranscriptionProvider {
+    var stopDisposition: StreamingStopDisposition { .finalizeStreaming }
 }

--- a/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
+++ b/VoiceInk/Transcription/Streaming/StreamingTranscriptionService.swift
@@ -102,6 +102,11 @@ enum StreamingState {
     case cancelled
 }
 
+enum StreamingStopResult {
+    case finalized(text: String)
+    case requiresBatchFallback
+}
+
 /// Manages a streaming transcription lifecycle: buffers audio chunks, sends them to the provider, and collects the final text.
 @MainActor
 class StreamingTranscriptionService {
@@ -187,10 +192,17 @@ class StreamingTranscriptionService {
         }
     }
 
-    /// Stops streaming, commits remaining audio, and returns the final transcribed text.
-    func stopAndGetFinalText() async throws -> String {
+    /// Stops streaming and follows the provider's requested finalization path.
+    func stopAndFinalize() async throws -> StreamingStopResult {
         guard let provider = provider, state == .streaming else {
             throw StreamingTranscriptionError.notConnected
+        }
+
+        if provider.stopDisposition == .useBatchFallback {
+            logger.notice("Streaming provider requested full batch fallback")
+            state = .done
+            await cleanupStreaming()
+            return .requiresBatchFallback
         }
 
         state = .committing
@@ -230,7 +242,7 @@ class StreamingTranscriptionService {
         state = .done
         await cleanupStreaming()
 
-        return finalText
+        return .finalized(text: finalText)
     }
 
     /// Cancels the streaming session without waiting for results.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves Parakeet/FluidAudio streaming transcription finalization to avoid clipped endings and trigger batch fallback when confidence is low. Adds provider-driven stop behavior and always pads trailing silence to capture final punctuation.

- New Features
  - Provider-driven stop: new stopDisposition and StreamingStopResult enable finalize or batch fallback.
  - Confidence gate: finalize only after 3 confirmed segments; otherwise request batch.
  - Always pad 1s trailing silence on streaming chunks and final commit to capture last words and punctuation, even for short tails.

- Refactors
  - Removed VAD and custom WAV parsing; use `AudioConverter` for resampling.
  - Renamed stopAndGetFinalText to stopAndFinalize; default stopDisposition keeps other providers working.
  - Only count/emit committed segments after normalization when non-empty.

<sup>Written for commit 35ea001580e2e5fb328f5d06ebc60ecfe883e9ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

