### PR TITLE
Add Dia browser support for URL-based mode triggers

### DIFF
--- a/VoiceInk/Modes/BrowserURLService.swift
+++ b/VoiceInk/Modes/BrowserURLService.swift
@@ -5,6 +5,7 @@ import os
 enum BrowserType {
     case safari
     case arc
+    case dia
     case chrome
     case edge
     case brave
@@ -17,6 +18,7 @@ enum BrowserType {
         switch self {
         case .safari: return "safariURL"
         case .arc: return "arcURL"
+        case .dia: return "diaURL"
         case .chrome: return "chromeURL"
         case .edge: return "edgeURL"
         case .brave: return "braveURL"
@@ -31,6 +33,7 @@ enum BrowserType {
         switch self {
         case .safari: return "com.apple.Safari"
         case .arc: return "company.thebrowser.Browser"
+        case .dia: return "company.thebrowser.dia"
         case .chrome: return "com.google.Chrome"
         case .edge: return "com.microsoft.edgemac"
         case .brave: return "com.brave.Browser"
@@ -45,6 +48,7 @@ enum BrowserType {
         switch self {
         case .safari: return "Safari"
         case .arc: return "Arc"
+        case .dia: return "Dia"
         case .chrome: return "Google Chrome"
         case .edge: return "Microsoft Edge"
         case .brave: return "Brave"
@@ -56,7 +60,7 @@ enum BrowserType {
     }
 
     static var allCases: [BrowserType] {
-        [.safari, .arc, .chrome, .edge, .brave, .opera, .vivaldi, .orion, .yandex]
+        [.safari, .arc, .dia, .chrome, .edge, .brave, .opera, .vivaldi, .orion, .yandex]
     }
 
     static var installedBrowsers: [BrowserType] {

--- a/VoiceInk/Resources/diaURL.scpt
+++ b/VoiceInk/Resources/diaURL.scpt
@@ -1,0 +1,7 @@
+tell application "Dia"
+    tell front window
+        tell active tab
+            return URL
+        end tell
+    end tell
+end tell


### PR DESCRIPTION
## Problem

URL-based mode triggers (Email, AI, Messaging…) don't work in [Dia](https://www.diabrowser.com/), while they work fine in Chrome, Safari, Arc and the other supported browsers.

The Email trigger matches either on an app bundle identifier or on the current page URL (`TriggerTemplateCatalog.swift`). For the URL path, `ActiveWindowService` only queries the frontmost app for its URL when that app matches a known `BrowserType`:

```swift
guard let browserType = BrowserType.allCases.first(where: { $0.bundleIdentifier == bundleIdentifier }) else {
    return Task {}
}
```

Dia wasn't part of the `BrowserType` enum, so this guard returned early and the URL was never read — no website trigger could ever match while browsing in Dia.

## Fix

- Add a `.dia` case to `BrowserType` with bundle identifier `company.thebrowser.dia`.
- Add `VoiceInk/Resources/diaURL.scpt`.

Dia ships a scripting definition (`Dia.app/Contents/Resources/Dia.sdef`) exposing an `active tab` property on `window` and a `URL` property on `tab`, so the script mirrors the existing Arc one:

```applescript
tell application "Dia"
    tell front window
        tell active tab
            return URL
        end tell
    end tell
end tell
```

## Testing

- Verified the AppleScript returns the active tab URL on Dia (build 2026-07, `company.thebrowser.dia`).
- `xcodebuild -scheme VoiceInk build` succeeds, and `diaURL.scpt` is picked up by the synchronized resources group and copied into `VoiceInk.app/Contents/Resources/`.
- Confirmed a website trigger (e.g. `mail.google.com`) now activates the corresponding mode while browsing in Dia.

Note: as with every other browser, macOS will prompt for Automation permission for Dia the first time the script runs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable URL-based mode triggers in Dia so Email/AI/Messaging modes activate while browsing. Adds Dia to `BrowserType` (bundle id `company.thebrowser.dia`) and ships `diaURL.scpt` to read the active tab URL.

<sup>Written for commit bb1b294fb5ec629638eb4052403fd489a125926a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

