### PR TITLE
Fix Apple Speech asset reservation handling

### DIFF
--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -3107,50 +3107,34 @@
         }
       }
     },
-    "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language." : {
+    "Apple Speech could not replace a language reservation automatically. Try again." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Speech kann bis zu 5 Sprachen reservieren. Wähle eine zum Entfernen aus, bevor du die neue Sprache herunterlädst."
+            "value" : "Apple Speech konnte eine Sprachreservierung nicht automatisch ersetzen. Versuche es erneut."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Speech 最多可保留 5 种语言。下载所选语言前，请先选取一种移除。"
+            "value" : "Apple Speech 无法自动替换语言预留。请重试。"
           }
         }
       }
     },
-    "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings." : {
+    "Apple Speech could not reserve language assets for %@. Please try again." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Speech kann bis zu 5 Sprachen reservieren. Verwalte reservierte Sprachen in den Moduseinstellungen."
+            "value" : "Apple Speech konnte die Sprachressourcen für %@ nicht reservieren. Versuche es erneut."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Speech 最多可保留 5 种语言。请在「模式」设置中管理已保留的语言。"
-          }
-        }
-      }
-    },
-    "Apple Speech could not reserve language assets for %@. Manage reserved Apple Speech languages in settings." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech konnte die Sprachressourcen für %@ nicht reservieren. Verwalte reservierte Apple-Speech-Sprachen in den Einstellungen."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Speech 无法为 %@ 预留语言资源。请在设置中管理已预留的 Apple Speech 语言。"
+            "value" : "Apple Speech 无法为 %@ 预留语言资源。请重试。"
           }
         }
       }
@@ -4166,22 +4150,6 @@
         }
       }
     },
-    "Choose a Language to Remove" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache zum Entfernen auswählen"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选取要移除的语言"
-          }
-        }
-      }
-    },
     "Choose a location to save your settings." : {
       "localizations" : {
         "de" : {
@@ -4978,22 +4946,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法连接到服务器。请检查互联网连接后重试。"
-          }
-        }
-      }
-    },
-    "Could not remove %@ from reserved Apple Speech languages." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ konnte nicht aus den reservierten Apple-Speech-Sprachen entfernt werden."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法将 %@ 从 Apple Speech 保留语言中移除。"
           }
         }
       }
@@ -11186,22 +11138,6 @@
         }
       }
     },
-    "No removable language reservations were found." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine entfernbaren Sprachreservierungen gefunden."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到可移除的语言预留。"
-          }
-        }
-      }
-    },
     "No results found" : {
       "localizations" : {
         "de" : {
@@ -13287,22 +13223,6 @@
         }
       }
     },
-    "Remove %@ from reserved Apple Speech languages." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ aus reservierten Apple-Speech-Sprachen entfernen."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将 %@ 从 Apple Speech 保留语言中移除。"
-          }
-        }
-      }
-    },
     "Remove %@ triggers" : {
       "localizations" : {
         "zh-Hans" : {
@@ -13390,22 +13310,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除许可证"
-          }
-        }
-      }
-    },
-    "Remove one reserved language to download %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine reservierte Sprache entfernen, um %@ herunterzuladen."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除一个已保留的语言以下载 %@。"
           }
         }
       }

--- a/VoiceInk/Modes/ModeConfigFormView.swift
+++ b/VoiceInk/Modes/ModeConfigFormView.swift
@@ -285,8 +285,7 @@ struct ModeConfigFormView: View {
                     NativeAppleLanguageAssetControl(
                         localeIdentifier: effectiveLanguage(for: modelInfo),
                         isVisible: true,
-                        startsDownloadAutomatically: true,
-                        allowsReservationReplacement: true
+                        startsDownloadAutomatically: true
                     )
                     .layoutPriority(1)
                     .frame(width: 28, height: 24)

--- a/VoiceInk/Transcription/Native/NativeAppleSpeechAssetManager.swift
+++ b/VoiceInk/Transcription/Native/NativeAppleSpeechAssetManager.swift
@@ -12,7 +12,7 @@ enum NativeAppleSpeechAssetState: Equatable {
     case downloading
     case notSupported
     case assetManagementUnavailable
-    case reservationLimitReached([String])
+    case reservationLimitReached
     case failed(String)
 }
 
@@ -53,11 +53,24 @@ enum NativeAppleSpeechAssetManager {
                 return try await installAssetOnce(for: context)
             } catch {
                 if isReservationLimitError(error) {
-                    let reservedLocales = await reservedLocaleIdentifiers(excluding: localeIdentifier)
+                    if await releaseOneReservation(toMakeRoomFor: localeIdentifier) {
+                        do {
+                            guard let retryContext = await assetContext(for: localeIdentifier) else {
+                                return .notSupported
+                            }
+
+                            return try await installAssetOnce(for: retryContext)
+                        } catch {
+                            if !isReservationLimitError(error) {
+                                return .failed(error.localizedDescription)
+                            }
+                        }
+                    }
+
                     logger.warning(
-                        "Apple Speech asset download hit locale reservation limit for '\(localeIdentifier, privacy: .public)'. Waiting for user to release a reservation."
+                        "Apple Speech asset download still requires reservation replacement for '\(localeIdentifier, privacy: .public)'."
                     )
-                    return .reservationLimitReached(reservedLocales)
+                    return .reservationLimitReached
                 }
 
                 logger.error(
@@ -73,75 +86,28 @@ enum NativeAppleSpeechAssetManager {
         #endif
     }
 
-    static func reservedLocaleIdentifiers(excluding localeIdentifier: String? = nil) async -> [String] {
+    static func prepareAssetForUse(for localeIdentifier: String) async -> NativeAppleSpeechAssetState {
+        let installedState = await installAsset(for: localeIdentifier)
+        guard installedState == .downloaded else {
+            return installedState
+        }
+
         guard #available(macOS 26, *) else {
-            return []
+            return .assetManagementUnavailable
         }
 
         #if canImport(Speech) && ENABLE_NATIVE_SPEECH_ANALYZER
-            let requestedIdentifier: String?
-            if let localeIdentifier {
-                requestedIdentifier =
-                    await supportedLocale(for: localeIdentifier)?.identifier(.bcp47)
-                    ?? Locale(identifier: localeIdentifier).identifier(.bcp47)
-            } else {
-                requestedIdentifier = nil
+            guard let context = await assetContext(for: localeIdentifier) else {
+                return .notSupported
             }
 
-            return await AssetInventory.reservedLocales
-                .map { $0.identifier(.bcp47) }
-                .filter { identifier in
-                    if let requestedIdentifier {
-                        return identifier != requestedIdentifier
-                    }
-                    return true
-                }
-                .sorted {
-                    languageDisplayName(for: $0) < languageDisplayName(for: $1)
-                }
+            guard await reserveLocaleIfNeeded(for: context) else {
+                return .reservationLimitReached
+            }
+
+            return .downloaded
         #else
-            return []
-        #endif
-    }
-
-    static func releaseReservedLocale(
-        _ localeIdentifier: String,
-        toMakeRoomFor requestedLocaleIdentifier: String
-    ) async -> Bool {
-        guard #available(macOS 26, *) else {
-            return false
-        }
-
-        #if canImport(Speech) && ENABLE_NATIVE_SPEECH_ANALYZER
-            let normalizedIdentifier =
-                await supportedLocale(for: localeIdentifier)?.identifier(.bcp47)
-                ?? Locale(identifier: localeIdentifier).identifier(.bcp47)
-            let requestedIdentifier =
-                await supportedLocale(for: requestedLocaleIdentifier)?.identifier(.bcp47)
-                ?? Locale(identifier: requestedLocaleIdentifier).identifier(.bcp47)
-
-            guard
-                let localeToRelease = await AssetInventory.reservedLocales.first(where: {
-                    $0.identifier(.bcp47) == normalizedIdentifier
-                })
-            else {
-                logger.warning(
-                    "Apple Speech locale reservation '\(normalizedIdentifier, privacy: .public)' could not be found while making room for '\(requestedIdentifier, privacy: .public)'."
-                )
-                return false
-            }
-
-            let released = await AssetInventory.release(reservedLocale: localeToRelease)
-
-            if !released {
-                logger.warning(
-                    "Apple Speech failed to release locale reservation '\(normalizedIdentifier, privacy: .public)' while making room for '\(requestedIdentifier, privacy: .public)'."
-                )
-            }
-
-            return released
-        #else
-            return false
+            return .assetManagementUnavailable
         #endif
     }
 
@@ -159,9 +125,14 @@ enum NativeAppleSpeechAssetManager {
             let displayName: String
             let transcriber: SpeechTranscriber
             let status: AssetInventory.Status
+            let isInstalled: Bool
 
             var state: NativeAppleSpeechAssetState {
-                NativeAppleSpeechAssetManager.assetState(for: status)
+                if isInstalled {
+                    return .downloaded
+                }
+
+                return NativeAppleSpeechAssetManager.assetState(for: status)
             }
         }
 
@@ -178,14 +149,26 @@ enum NativeAppleSpeechAssetManager {
                 attributeOptions: []
             )
             let resolvedIdentifier = supportedLocale.identifier(.bcp47)
-            let status = await AssetInventory.status(forModules: [transcriber])
+            let installedLocales = await SpeechTranscriber.installedLocales
+            let isInstalled = installedLocales.contains {
+                $0.identifier(.bcp47) == resolvedIdentifier
+            }
+
+            // Prefer installedLocales because AssetInventory status can become stale.
+            let status: AssetInventory.Status
+            if isInstalled {
+                status = .installed
+            } else {
+                status = await AssetInventory.status(forModules: [transcriber])
+            }
 
             return AssetContext(
                 locale: supportedLocale,
                 localeIdentifier: resolvedIdentifier,
                 displayName: languageDisplayName(for: resolvedIdentifier),
                 transcriber: transcriber,
-                status: status
+                status: status,
+                isInstalled: isInstalled
             )
         }
 
@@ -193,7 +176,7 @@ enum NativeAppleSpeechAssetManager {
         private static func installAssetOnce(
             for context: AssetContext
         ) async throws -> NativeAppleSpeechAssetState {
-            if context.status == .installed || context.status == .unsupported {
+            if context.isInstalled || context.status == .unsupported {
                 return context.state
             }
 
@@ -217,29 +200,54 @@ enum NativeAppleSpeechAssetManager {
                 let reserved = try await AssetInventory.reserve(locale: context.locale)
 
                 guard reserved else {
-                    let finalStatus = await AssetInventory.status(forModules: [context.transcriber])
                     logger.warning(
-                        "Apple Speech asset reservation returned false for '\(context.localeIdentifier, privacy: .public)'. Continuing because the locale is already downloaded. Status: \(String(describing: finalStatus), privacy: .public)."
+                        "Apple Speech asset reservation returned false for '\(context.localeIdentifier, privacy: .public)'. Continuing with the installed language assets."
                     )
                     return true
                 }
 
                 return true
             } catch {
-                let finalStatus = await AssetInventory.status(forModules: [context.transcriber])
-
                 if isReservationLimitError(error) {
                     logger.warning(
-                        "Apple Speech reservation limit reached for '\(context.localeIdentifier, privacy: .public)'. User must release a reserved language in settings. Status: \(String(describing: finalStatus), privacy: .public)."
+                        "Apple Speech reservation limit reached for '\(context.localeIdentifier, privacy: .public)'. Replacing one existing reservation automatically."
                     )
-                } else {
-                    logger.warning(
-                        "Apple Speech asset reservation failed for '\(context.localeIdentifier, privacy: .public)': \(error, privacy: .public). Status: \(String(describing: finalStatus), privacy: .public)."
-                    )
+
+                    guard await releaseOneReservation(toMakeRoomFor: context.localeIdentifier) else {
+                        return false
+                    }
+
+                    do {
+                        try await AssetInventory.reserve(locale: context.locale)
+                        return true
+                    } catch {
+                        return !isReservationLimitError(error)
+                    }
                 }
 
+                logger.warning(
+                    "Apple Speech asset reservation failed for '\(context.localeIdentifier, privacy: .public)': \(error, privacy: .public). Continuing with the installed language assets."
+                )
+                return true
+            }
+        }
+
+        @available(macOS 26, *)
+        private static func releaseOneReservation(toMakeRoomFor localeIdentifier: String) async -> Bool {
+            let reservedLocales = await AssetInventory.reservedLocales
+            let requestedIdentifier =
+                await supportedLocale(for: localeIdentifier)?.identifier(.bcp47)
+                ?? Locale(identifier: localeIdentifier).identifier(.bcp47)
+
+            guard
+                let localeToRelease = reservedLocales.first(where: {
+                    $0.identifier(.bcp47) != requestedIdentifier
+                })
+            else {
                 return false
             }
+
+            return await AssetInventory.release(reservedLocale: localeToRelease)
         }
 
         @available(macOS 26, *)

--- a/VoiceInk/Transcription/Native/NativeAppleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Native/NativeAppleTranscriptionService.swift
@@ -36,7 +36,7 @@ class NativeAppleTranscriptionService: TranscriptionService {
                 return String(
                     format: String(
                         localized:
-                            "Apple Speech could not reserve language assets for %@. Manage reserved Apple Speech languages in settings."
+                            "Apple Speech could not reserve language assets for %@. Please try again."
                     ), displayName)
             case .resultStreamTimedOut:
                 return String(localized: "Apple Speech did not finish returning transcription results.")
@@ -81,24 +81,24 @@ class NativeAppleTranscriptionService: TranscriptionService {
                 throw ServiceError.localeNotSupported
             }
 
-            switch assetContext.status {
-            case .installed:
-                break
-            case .supported, .downloading:
-                logger.error(
-                    "Transcription failed: Assets for '\(assetContext.localeIdentifier, privacy: .public)' are not ready. Status: \(String(describing: assetContext.status), privacy: .public)."
-                )
-                throw ServiceError.assetDownloadRequired(assetContext.displayName)
-            case .unsupported:
-                logger.error(
-                    "Transcription failed: Locale '\(assetContext.localeIdentifier, privacy: .public)' is not supported by SpeechTranscriber."
-                )
-                throw ServiceError.localeNotSupported
-            @unknown default:
-                logger.error(
-                    "Transcription failed: Unknown Apple Speech asset status for '\(assetContext.localeIdentifier, privacy: .public)': \(String(describing: assetContext.status), privacy: .public)."
-                )
-                throw ServiceError.assetDownloadRequired(assetContext.displayName)
+            guard assetContext.isInstalled else {
+                switch assetContext.status {
+                case .unsupported:
+                    logger.error(
+                        "Transcription failed: Locale '\(assetContext.localeIdentifier, privacy: .public)' is not supported by SpeechTranscriber."
+                    )
+                    throw ServiceError.localeNotSupported
+                case .installed, .supported, .downloading:
+                    logger.error(
+                        "Transcription failed: Assets for '\(assetContext.localeIdentifier, privacy: .public)' are not ready. Status: \(String(describing: assetContext.status), privacy: .public)."
+                    )
+                    throw ServiceError.assetDownloadRequired(assetContext.displayName)
+                @unknown default:
+                    logger.error(
+                        "Transcription failed: Unknown Apple Speech asset status for '\(assetContext.localeIdentifier, privacy: .public)': \(String(describing: assetContext.status), privacy: .public)."
+                    )
+                    throw ServiceError.assetDownloadRequired(assetContext.displayName)
+                }
             }
 
             guard await NativeAppleSpeechAssetManager.reserveLocaleIfNeeded(for: assetContext) else {

--- a/VoiceInk/Views/Components/NativeAppleLanguageAssetControl.swift
+++ b/VoiceInk/Views/Components/NativeAppleLanguageAssetControl.swift
@@ -4,23 +4,19 @@ struct NativeAppleLanguageAssetControl: View {
     let localeIdentifier: String
     let isVisible: Bool
     let startsDownloadAutomatically: Bool
-    let allowsReservationReplacement: Bool
 
     init(
         localeIdentifier: String,
         isVisible: Bool,
-        startsDownloadAutomatically: Bool = false,
-        allowsReservationReplacement: Bool = false
+        startsDownloadAutomatically: Bool = false
     ) {
         self.localeIdentifier = localeIdentifier
         self.isVisible = isVisible
         self.startsDownloadAutomatically = startsDownloadAutomatically
-        self.allowsReservationReplacement = allowsReservationReplacement
     }
 
     @State private var state: NativeAppleSpeechAssetState = .checking
     @State private var refreshTask: Task<Void, Never>?
-    @State private var showReservationLimitPopover = false
 
     private var refreshKey: String {
         "\(isVisible)-\(localeIdentifier)"
@@ -36,17 +32,9 @@ struct NativeAppleLanguageAssetControl: View {
         .onChange(of: refreshKey, initial: true) { _, _ in
             refreshAssetState()
         }
-        .onChange(of: state) { _, newState in
-            if case .reservationLimitReached = newState, allowsReservationReplacement {
-                showReservationLimitPopover = true
-            } else {
-                showReservationLimitPopover = false
-            }
-        }
         .onDisappear {
             refreshTask?.cancel()
             refreshTask = nil
-            showReservationLimitPopover = false
         }
     }
 
@@ -89,25 +77,13 @@ struct NativeAppleLanguageAssetControl: View {
                 .foregroundColor(.secondary)
                 .frame(width: 28, height: 24)
         case .reservationLimitReached:
-            if allowsReservationReplacement {
-                Button {
-                    showReservationLimitPopover = true
-                } label: {
-                    Image(systemName: "exclamationmark.circle")
-                        .font(.system(size: 14, weight: .semibold))
-                }
-                .buttonStyle(.plain)
-                .controlSize(.small)
-                .frame(width: 28, height: 24)
-                .popover(isPresented: $showReservationLimitPopover) {
-                    reservationLimitPopover
-                }
-            } else {
+            Button(action: refreshAssetState) {
                 Image(systemName: "exclamationmark.circle")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
-                    .frame(width: 28, height: 24)
             }
+            .buttonStyle(.plain)
+            .controlSize(.small)
+            .frame(width: 28, height: 24)
         case .failed(let message):
             Button(action: downloadAsset) {
                 Image(systemName: "arrow.clockwise.circle.fill")
@@ -134,94 +110,13 @@ struct NativeAppleLanguageAssetControl: View {
         case .assetManagementUnavailable:
             return String(localized: "Apple Speech language downloads are not available on this system.")
         case .reservationLimitReached:
-            if allowsReservationReplacement {
-                return String(
-                    localized:
-                        "Apple Speech can reserve up to 5 languages. Choose one to remove before downloading the selected language."
-                )
-            }
-            return String(
-                localized: "Apple Speech can reserve up to 5 languages. Manage reserved languages in Mode settings.")
+            return String(localized: "Apple Speech could not replace a language reservation automatically. Try again.")
         case .failed(let message):
             return String(
                 format: String(localized: "Apple Speech language download failed: %@"),
                 message
             )
         }
-    }
-
-    private var reservationLimitPopover: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Choose a Language to Remove")
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-
-                Text(
-                    String(
-                        format: String(localized: "Remove one reserved language to download %@."), selectedLanguageName)
-                )
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            }
-
-            let reservedLocaleIdentifiers = reservationLimitLocaleIdentifiers
-            if reservedLocaleIdentifiers.isEmpty {
-                Text("No removable language reservations were found.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            } else {
-                VStack(spacing: 3) {
-                    ForEach(reservedLocaleIdentifiers, id: \.self) { identifier in
-                        reservationLimitRow(for: identifier)
-                    }
-                }
-            }
-        }
-        .padding(14)
-        .frame(width: 280)
-    }
-
-    private func reservationLimitRow(for identifier: String) -> some View {
-        Button {
-            releaseReservationAndRetry(identifier)
-        } label: {
-            HStack(spacing: 8) {
-                Text(languageDisplayName(for: identifier))
-                    .lineLimit(1)
-
-                Spacer(minLength: 10)
-
-                Image(systemName: "minus.circle")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.secondary)
-            }
-            .padding(.vertical, 5)
-            .padding(.horizontal, 7)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(
-            String(
-                format: String(localized: "Remove %@ from reserved Apple Speech languages."),
-                languageDisplayName(for: identifier)))
-    }
-
-    private var reservationLimitLocaleIdentifiers: [String] {
-        guard case .reservationLimitReached(let identifiers) = state else {
-            return []
-        }
-
-        return identifiers
-    }
-
-    private var selectedLanguageName: String {
-        languageDisplayName(for: localeIdentifier)
-    }
-
-    private func languageDisplayName(for localeIdentifier: String) -> String {
-        NativeAppleSpeechAssetManager.languageDisplayName(for: localeIdentifier)
     }
 
     private func refreshAssetState() {
@@ -241,56 +136,17 @@ struct NativeAppleLanguageAssetControl: View {
                 return
             }
 
-            if startsDownloadAutomatically && (resolvedState == .needsDownload || resolvedState == .downloading) {
-                state = .downloading
-                let installedState = await NativeAppleSpeechAssetManager.installAsset(for: localeIdentifier)
+            if startsDownloadAutomatically
+                && (resolvedState == .downloaded || resolvedState == .needsDownload || resolvedState == .downloading)
+            {
+                state = resolvedState == .downloaded ? .checking : .downloading
+                let preparedState = await NativeAppleSpeechAssetManager.prepareAssetForUse(for: localeIdentifier)
 
                 guard !Task.isCancelled else {
                     return
                 }
 
-                state = installedState
-                return
-            }
-
-            state = resolvedState
-        }
-    }
-
-    private func releaseReservationAndRetry(_ reservedLocaleIdentifier: String) {
-        guard #available(macOS 26, *) else {
-            state = .assetManagementUnavailable
-            return
-        }
-
-        let localeIdentifier = localeIdentifier
-        state = .downloading
-        showReservationLimitPopover = false
-        refreshTask?.cancel()
-
-        refreshTask = Task {
-            let released = await NativeAppleSpeechAssetManager.releaseReservedLocale(
-                reservedLocaleIdentifier,
-                toMakeRoomFor: localeIdentifier
-            )
-
-            guard !Task.isCancelled else {
-                return
-            }
-
-            guard released else {
-                state = .failed(
-                    String(
-                        format: String(localized: "Could not remove %@ from reserved Apple Speech languages."),
-                        languageDisplayName(for: reservedLocaleIdentifier)
-                    )
-                )
-                return
-            }
-
-            let resolvedState = await NativeAppleSpeechAssetManager.installAsset(for: localeIdentifier)
-
-            guard !Task.isCancelled else {
+                state = preparedState
                 return
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically handle Apple Speech reservation limits by releasing one existing reservation and retrying, and simplify the asset UI. This reduces failed downloads and removes the manual “choose a language to remove” flow.

- **Bug Fixes**
  - Auto-release one existing reservation when the 5-language limit is hit; retry reserve, fall back to `.reservationLimitReached` only if replacement fails.
  - Prefer `SpeechTranscriber.installedLocales` to avoid stale `AssetInventory` states and treat installed assets as ready.
  - Add `prepareAssetForUse(for:)` to install and reserve in one step; `NativeAppleLanguageAssetControl` uses it for auto-downloads.
  - Simplify UI: remove manual reservation popover and `allowsReservationReplacement`; show a retry button on limit.
  - Update copy and states: `reservationLimitReached` no longer carries locales; refine error strings; `NativeAppleTranscriptionService` checks `isInstalled` and shows a clearer failure message.

<sup>Written for commit a2a9d0002275bf786e6375dd62691cf46298bf14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

