### PR TITLE
Update AI provider models and Gemini integration

### DIFF
--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -43,7 +43,7 @@
       "location" : "https://github.com/Beingpax/LLMkit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "bbfbf5c4cf903d660010ad23f80fbfb7f76ba416"
+        "revision" : "7c32712a286221dab39da7e40d824a6d55e33dad"
       }
     },
     {

--- a/VoiceInk/Services/AIEnhancement/AIChatCompletionService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIChatCompletionService.swift
@@ -13,6 +13,16 @@ extension AIService {
 
         let result: String
         switch provider {
+        case .gemini:
+            result = try await GeminiLLMClient.chatCompletion(
+                apiKey: try chatAPIKey(for: provider, modelName: resolvedModel),
+                model: resolvedModel,
+                messages: messages,
+                systemPrompt: systemPrompt,
+                thinkingLevel: ReasoningConfig.geminiThinkingLevel(for: resolvedModel),
+                store: false,
+                timeout: timeout
+            )
         case .anthropic:
             result = try await AnthropicLLMClient.chatCompletion(
                 apiKey: try chatAPIKey(for: provider, modelName: resolvedModel),

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -252,6 +252,16 @@ class AIEnhancementService: ObservableObject {
         do {
             let result: String
             switch provider {
+            case .gemini:
+                result = try await GeminiLLMClient.chatCompletion(
+                    apiKey: try apiKey(for: provider, modelName: modelName),
+                    model: modelName,
+                    messages: [.user(formattedText)],
+                    systemPrompt: systemMessage,
+                    thinkingLevel: ReasoningConfig.geminiThinkingLevel(for: modelName),
+                    store: false,
+                    timeout: baseTimeout
+                )
             case .anthropic:
                 result = try await AnthropicLLMClient.chatCompletion(
                     apiKey: try apiKey(for: provider, modelName: modelName),

--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -25,7 +25,7 @@ enum AIProvider: String, CaseIterable {
         case .groq:
             return "https://api.groq.com/openai/v1/chat/completions"
         case .gemini:
-            return "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+            return "https://generativelanguage.googleapis.com/v1/interactions"
         case .anthropic:
             return "https://api.anthropic.com/v1/messages"
         case .openAI:
@@ -60,13 +60,13 @@ enum AIProvider: String, CaseIterable {
         case .groq:
             return "openai/gpt-oss-120b"
         case .gemini:
-            return "gemini-3.5-flash"
+            return "gemini-3.6-flash"
         case .anthropic:
-            return "claude-sonnet-4-6"
+            return "claude-sonnet-5"
         case .openAI:
             return "gpt-5.5"
         case .mistral:
-            return "mistral-large-latest"
+            return "mistral-medium-3-5"
         case .elevenLabs:
             return "scribe_v2"
         case .deepgram:
@@ -103,15 +103,17 @@ enum AIProvider: String, CaseIterable {
             ]
         case .gemini:
             return [
+                "gemini-3.6-flash",
+                "gemini-3.5-flash-lite",
                 "gemini-3.5-flash",
                 "gemini-3.1-pro-preview",
                 "gemini-3.1-flash-lite",
+                "gemini-2.5-flash-lite",
             ]
         case .anthropic:
             return [
-                "claude-haiku-4-5",
                 "claude-sonnet-5",
-                "claude-sonnet-4-6",
+                "claude-haiku-4-5",
             ]
         case .openAI:
             return [
@@ -125,9 +127,8 @@ enum AIProvider: String, CaseIterable {
             ]
         case .mistral:
             return [
-                "mistral-large-latest",
-                "mistral-medium-latest",
-                "mistral-small-latest",
+                "mistral-medium-3-5",
+                "mistral-small-2603",
             ]
         case .elevenLabs:
             return ["scribe_v2"]
@@ -462,7 +463,7 @@ class AIService: ObservableObject {
         case .openRouter:
             result = await OpenRouterClient.verifyAPIKey(key, model: verificationModel)
         case .gemini:
-            result = await GeminiTranscriptionClient.verifyAPIKey(key)
+            result = await GeminiLLMClient.verifyAPIKey(key)
         default:
             guard let baseURL = URL(string: provider.baseURL) else {
                 return (false, "Invalid or missing base URL configuration")

--- a/VoiceInk/Services/AIEnhancement/ReasoningConfig.swift
+++ b/VoiceInk/Services/AIEnhancement/ReasoningConfig.swift
@@ -1,18 +1,31 @@
 import Foundation
+import LLMkit
 
 struct ReasoningConfig {
-    static let geminiNoneReasoningModels: Set<String> = []
-
-    // Gemini 3.1 Pro maps "minimal" to "low"; send "low" directly.
-    static let geminiLowReasoningModels: Set<String> = [
-        "gemini-3.1-pro-preview"
-    ]
-
-    // These Gemini models only go down to "minimal".
-    static let geminiMinimalReasoningModels: Set<String> = [
+    // These models support "minimal", optimized for low-latency instruction following.
+    static let geminiMinimalThinkingModels: Set<String> = [
+        "gemini-3.6-flash",
+        "gemini-3.5-flash-lite",
         "gemini-3.5-flash",
         "gemini-3.1-flash-lite",
     ]
+
+    // Gemini 3.1 Pro does not support "minimal".
+    static let geminiLowThinkingModels: Set<String> = [
+        "gemini-3.1-pro-preview",
+    ]
+
+    // Gemini 2.5 Flash-Lite is intentionally omitted because its Interactions
+    // API default has thinking off.
+    static func geminiThinkingLevel(for modelName: String) -> GeminiThinkingLevel? {
+        if geminiMinimalThinkingModels.contains(modelName) {
+            return .minimal
+        }
+        if geminiLowThinkingModels.contains(modelName) {
+            return .low
+        }
+        return nil
+    }
 
     // OpenAI GPT-5 models support explicit "none"; GPT-4.1 models need no param.
     static let openAINoneReasoningModels: Set<String> = [
@@ -40,14 +53,6 @@ struct ReasoningConfig {
 
     static func getReasoningParameter(for provider: AIProvider, modelName: String) -> String? {
         switch provider {
-        case .gemini:
-            if geminiNoneReasoningModels.contains(modelName) {
-                return "none"
-            } else if geminiLowReasoningModels.contains(modelName) {
-                return "low"
-            } else if geminiMinimalReasoningModels.contains(modelName) {
-                return "minimal"
-            }
         case .openAI:
             if openAINoneReasoningModels.contains(modelName) { return "none" }
         case .cerebras:

--- a/VoiceInk/Transcription/Cloud/GeminiProvider.swift
+++ b/VoiceInk/Transcription/Cloud/GeminiProvider.swift
@@ -11,32 +11,12 @@ struct GeminiProvider: CloudProvider {
     var models: [CloudModel] {
         [
             CloudModel(
-                name: "gemini-3.5-flash",
-                displayName: "Gemini 3.5 Flash",
-                description: "Google's current fast model for high-quality transcription",
+                name: "gemini-3.6-flash",
+                displayName: "Gemini 3.6 Flash",
+                description: "Google's latest production model for high-quality transcription",
                 provider: .gemini,
                 speed: 0.92,
                 accuracy: 0.96,
-                isMultilingual: true,
-                supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
-            ),
-            CloudModel(
-                name: "gemini-3.1-flash-lite",
-                displayName: "Gemini 3.1 Flash-Lite",
-                description: "Google's efficient model for lightweight transcription tasks",
-                provider: .gemini,
-                speed: 0.95,
-                accuracy: 0.94,
-                isMultilingual: true,
-                supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
-            ),
-            CloudModel(
-                name: "gemini-3.1-pro-preview",
-                displayName: "Gemini 3.1 Pro",
-                description: "Google's latest model with enhanced transcription capabilities",
-                provider: .gemini,
-                speed: 0.75,
-                accuracy: 0.97,
                 isMultilingual: true,
                 supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .gemini)
             ),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches Gemini to the v1 Interactions API with thinking-level support and updates default models across providers. Improves chat reliability and keeps our model catalog current.

- **New Features**
  - Use the Interactions endpoint for Gemini chat and key verification via GeminiLLMClient.
  - Add Gemini thinking-level mapping (minimal/low) through ReasoningConfig.geminiThinkingLevel.
  - Refresh defaults and model lists: `gemini-3.6-flash` (now default), `claude-sonnet-5`, `mistral-medium-3-5`; Cloud models trimmed to `gemini-3.6-flash`.

- **Dependencies**
  - Bump `LLMkit` to latest main to support the Interactions client.

<sup>Written for commit 6afbd81e1ad385e7464f674adab26d029f33d87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

