### PR TITLE
feat: add per-step onboarding skip controls

### DIFF
--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -14913,6 +14913,7 @@
       }
     },
     "Skip" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -15037,6 +15038,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳过简短转写"
+          }
+        }
+      }
+    },
+    "Skip This Step" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diesen Schritt überspringen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳过此步骤"
           }
         }
       }

--- a/VoiceInk/Views/Onboarding/OnboardingAPIScreen.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingAPIScreen.swift
@@ -29,10 +29,12 @@ struct OnboardingAPIScreen: View {
         } bottomBar: {
             OnboardingBottomBar(
                 leadingTitle: "Back",
-                primaryTitle: primaryButtonTitle,
-                isPrimaryEnabled: isPrimaryEnabled,
+                primaryTitle: "Continue",
+                isPrimaryEnabled: canContinue && isSelectedProviderVerified,
                 onLeading: onBack,
-                onPrimary: primaryAction
+                onPrimary: onContinue,
+                skipTitle: isSelectedProviderVerified ? nil : "Skip This Step",
+                onSkip: isSelectedProviderVerified ? nil : onRequestSkip
             )
         }
         .alert("Skip API setup?", isPresented: $isShowingSkipWarning) {
@@ -42,22 +44,6 @@ struct OnboardingAPIScreen: View {
             }
         } message: {
             Text("Enhancement modes and AI actions will stay off. You can always set it up later in the app.")
-        }
-    }
-
-    private var primaryButtonTitle: String {
-        isSelectedProviderVerified ? "Continue" : "Skip API Setup"
-    }
-
-    private var isPrimaryEnabled: Bool {
-        canContinue || !isSelectedProviderVerified
-    }
-
-    private func primaryAction() {
-        if isSelectedProviderVerified {
-            onContinue()
-        } else {
-            onRequestSkip()
         }
     }
 }

--- a/VoiceInk/Views/Onboarding/OnboardingExperienceScreen.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingExperienceScreen.swift
@@ -13,6 +13,7 @@ struct OnboardingExperienceScreen: View {
     let onContinueIntro: () -> Void
     let onBackFromPractice: () -> Void
     let onAdvance: () -> Void
+    let onSkip: () -> Void
     let onShortcutChanged: () -> Void
     let onAppear: () -> Void
 
@@ -51,7 +52,9 @@ struct OnboardingExperienceScreen: View {
                 primaryTitle: "Continue",
                 isPrimaryEnabled: hasShortcut,
                 onLeading: onBackFromIntro,
-                onPrimary: onContinueIntro
+                onPrimary: onContinueIntro,
+                skipTitle: "Skip This Step",
+                onSkip: onSkip
             )
         }
     }
@@ -77,7 +80,9 @@ struct OnboardingExperienceScreen: View {
                 primaryTitle: isLastStep ? "Continue" : "Next",
                 isPrimaryEnabled: isReady && isComplete,
                 onLeading: onBackFromPractice,
-                onPrimary: onAdvance
+                onPrimary: onAdvance,
+                skipTitle: isComplete ? nil : "Skip This Step",
+                onSkip: isComplete ? nil : onSkip
             )
         }
     }

--- a/VoiceInk/Views/Onboarding/OnboardingFlowController.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingFlowController.swift
@@ -185,6 +185,30 @@ final class OnboardingFlowController {
             return
         }
 
+        continueAfterCurrentExperienceStep(
+            isTranscriptionSetupReady: isTranscriptionSetupReady,
+            enhancementService: enhancementService
+        )
+    }
+
+    func skipCurrentExperienceStep(
+        isTranscriptionSetupReady: Bool,
+        enhancementService: AIEnhancementService
+    ) {
+        guard coordinator.isReadyForExperience(isTranscriptionSetupReady: isTranscriptionSetupReady) else {
+            return
+        }
+
+        continueAfterCurrentExperienceStep(
+            isTranscriptionSetupReady: isTranscriptionSetupReady,
+            enhancementService: enhancementService
+        )
+    }
+
+    private func continueAfterCurrentExperienceStep(
+        isTranscriptionSetupReady: Bool,
+        enhancementService: AIEnhancementService
+    ) {
         if coordinator.shouldShowContextAwarenessAfterCurrentExperience {
             goToContextAwarenessStep(isTranscriptionSetupReady: isTranscriptionSetupReady)
         } else if coordinator.isLastExperienceStep {

--- a/VoiceInk/Views/Onboarding/OnboardingSections.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingSections.swift
@@ -95,14 +95,13 @@ struct OnboardingBottomBar: View {
     var body: some View {
         switch placement {
         case .split:
-            ZStack {
-                HStack(spacing: 0) {
-                    leadingSlot
-                    Spacer(minLength: 0)
-                    primaryButton
-                }
-
+            HStack(spacing: 0) {
+                leadingSlot
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 skipButton
+                    .frame(maxWidth: .infinity, alignment: .center)
+                primaryButton
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
         case .centered:
             HStack(spacing: 0) {
@@ -140,6 +139,9 @@ struct OnboardingBottomBar: View {
                     .foregroundColor(AppTheme.Text.secondary)
                     .padding(.horizontal, 4)
                     .frame(height: 20)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .allowsTightening(true)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)

--- a/VoiceInk/Views/Onboarding/OnboardingSections.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingSections.swift
@@ -82,6 +82,8 @@ struct OnboardingBottomBar: View {
     var placement: OnboardingBottomBarPlacement = .split
     let onLeading: (() -> Void)?
     let onPrimary: () -> Void
+    var skipTitle: String? = nil
+    var onSkip: (() -> Void)? = nil
 
     private enum Metrics {
         static let controlButtonWidth: CGFloat = 132
@@ -89,19 +91,23 @@ struct OnboardingBottomBar: View {
         static let primaryButtonHorizontalPadding: CGFloat = 20
     }
 
+    @ViewBuilder
     var body: some View {
-        HStack(spacing: 0) {
-            switch placement {
-            case .split:
-                leadingSlot
-                Spacer(minLength: 0)
-            case .centered:
-                Spacer(minLength: 0)
+        switch placement {
+        case .split:
+            ZStack {
+                HStack(spacing: 0) {
+                    leadingSlot
+                    Spacer(minLength: 0)
+                    primaryButton
+                }
+
+                skipButton
             }
-
-            primaryButton
-
-            if case .centered = placement {
+        case .centered:
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                primaryButton
                 Spacer(minLength: 0)
             }
         }
@@ -122,6 +128,21 @@ struct OnboardingBottomBar: View {
             AppTheme.Surface.clear
                 .frame(width: Metrics.controlButtonWidth, height: Metrics.buttonHeight)
                 .accessibilityHidden(true)
+        }
+    }
+
+    @ViewBuilder
+    private var skipButton: some View {
+        if let skipTitle, let onSkip {
+            Button(action: onSkip) {
+                Text(LocalizedStringKey(skipTitle))
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(AppTheme.Text.secondary)
+                    .padding(.horizontal, 4)
+                    .frame(height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
     }
 

--- a/VoiceInk/Views/Onboarding/OnboardingView.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingView.swift
@@ -136,6 +136,12 @@ struct OnboardingView: View {
                                 enhancementService: enhancementService
                             )
                         },
+                        onSkip: {
+                            coordinator.flow.skipCurrentExperienceStep(
+                                isTranscriptionSetupReady: isTranscriptionSetupReady,
+                                enhancementService: enhancementService
+                            )
+                        },
                         onShortcutChanged: {
                             coordinator.flow.refreshExperienceModeState(enhancementService: enhancementService)
                         },
@@ -293,7 +299,7 @@ struct OnboardingView: View {
         Button {
             isShowingSkipOnboardingConfirmation = true
         } label: {
-            Text("Skip")
+            Text("Skip Onboarding")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(AppTheme.Text.secondary)
                 .padding(.horizontal, 9)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds per-step skip controls to onboarding so users can bypass API setup and experience steps when needed. Updates the bottom bar with a split layout and a dedicated, contextual Skip button.

- **New Features**
  - Adds optional “Skip This Step” on API setup and experience screens; shows only when the step isn’t complete or the provider isn’t verified.
  - Introduces `skipCurrentExperienceStep` to advance without requiring completion, using the same continuation path.
  - Refines bottom bar: split layout with Back on the left, optional Skip centered, and primary action on the right.
  - Adds localization for “Skip This Step” (de, zh-Hans).
  - Renames global “Skip” to “Skip Onboarding” for clarity.

<sup>Written for commit d51548ab12eb1523e30bbb3188aed0684f67c61d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

