### PR TITLE
fix: surface enhancement failure diagnostics

### DIFF
--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -12757,6 +12757,22 @@
         }
       }
     },
+    "Re-enhancement failed: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneute Verbesserung fehlgeschlagen: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新润色失败：%@"
+          }
+        }
+      }
+    },
     "Re-enhancement successful" : {
       "localizations" : {
         "de" : {
@@ -16965,6 +16981,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "转写模型"
+          }
+        }
+      }
+    },
+    "Transcription saved, but enhancement failed: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transkription gespeichert, aber Verbesserung fehlgeschlagen: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转写已保存，但润色失败：%@"
           }
         }
       }

--- a/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIEnhancementService.swift
@@ -453,6 +453,13 @@ class AIEnhancementService: ObservableObject {
             let duration = endTime.timeIntervalSince(startTime)
             return (result, duration, promptName)
         } catch {
+            let errorDescription = EnhancementFailureFormatter.description(for: error)
+            let providerName = configuration.provider?.rawValue ?? "Unconfigured"
+            let modelName = configuration.modelName ?? configuration.provider?.defaultModel ?? "Unconfigured"
+            let duration = Date().timeIntervalSince(startTime)
+            logger.error(
+                "Enhancement failed provider=\(providerName, privacy: .public) model=\(modelName, privacy: .public) duration=\(duration, format: .fixed(precision: 3), privacy: .public)s: \(errorDescription, privacy: .public)"
+            )
             throw error
         }
     }

--- a/VoiceInk/Services/AIEnhancement/EnhancementFailureFormatter.swift
+++ b/VoiceInk/Services/AIEnhancement/EnhancementFailureFormatter.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum EnhancementFailureFormatter {
+    static func description(for error: Error) -> String {
+        if let localizedDescription = (error as? LocalizedError)?.errorDescription?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !localizedDescription.isEmpty
+        {
+            return localizedDescription
+        }
+
+        let fallbackDescription = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !fallbackDescription.isEmpty {
+            return fallbackDescription
+        }
+
+        return String(localized: "AI enhancement failed to process the text.")
+    }
+
+    static func message(for error: Error) -> String {
+        message(description: description(for: error))
+    }
+
+    static func message(description: String) -> String {
+        String(format: String(localized: "Enhancement failed: %@"), description)
+    }
+
+    static func reEnhancementMessage(description: String) -> String {
+        String(format: String(localized: "Re-enhancement failed: %@"), description)
+    }
+
+    static func transcriptionSavedMessage(description: String) -> String {
+        String(format: String(localized: "Transcription saved, but enhancement failed: %@"), description)
+    }
+}

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -233,11 +233,11 @@ class AudioTranscriptionManager: ObservableObject {
                         modeEmoji: modeMetadata.emoji
                     )
                 } catch {
-                    logger.error("Enhancement failed: \(error, privacy: .public)")
+                    let failureMessage = EnhancementFailureFormatter.message(for: error)
                     transcription = Transcription(
                         text: cleanedText,
                         duration: duration,
-                        enhancedText: String(localized: "Enhancement failed: \(error.localizedDescription)"),
+                        enhancedText: failureMessage,
                         audioFileURL: permanentURL.absoluteString,
                         transcriptionModelName: currentModel.displayName,
                         promptName: nil,

--- a/VoiceInk/Services/AudioFileTranscriptionService.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionService.swift
@@ -4,6 +4,11 @@ import SwiftData
 import SwiftUI
 import os
 
+struct AudioRetranscriptionResult {
+    let transcription: Transcription
+    let enhancementFailure: String?
+}
+
 @MainActor
 class AudioTranscriptionService: ObservableObject {
     @Published var isTranscribing = false
@@ -39,7 +44,7 @@ class AudioTranscriptionService: ObservableObject {
     }
 
     func retranscribeAudio(from url: URL, using model: any TranscriptionModel, mode: ModeConfig? = nil) async throws
-        -> Transcription
+        -> AudioRetranscriptionResult
     {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw TranscriptionError.noAudioFile
@@ -150,11 +155,17 @@ class AudioTranscriptionService: ObservableObject {
                         isTranscribing = false
                     }
 
-                    return newTranscription
+                    return AudioRetranscriptionResult(
+                        transcription: newTranscription,
+                        enhancementFailure: nil
+                    )
                 } catch {
+                    let failureDescription = EnhancementFailureFormatter.description(for: error)
+                    let failureMessage = EnhancementFailureFormatter.message(description: failureDescription)
                     let newTranscription = Transcription(
                         text: originalText,
                         duration: duration,
+                        enhancedText: failureMessage,
                         audioFileURL: permanentURLString,
                         transcriptionModelName: model.displayName,
                         promptName: nil,
@@ -175,7 +186,10 @@ class AudioTranscriptionService: ObservableObject {
                         isTranscribing = false
                     }
 
-                    return newTranscription
+                    return AudioRetranscriptionResult(
+                        transcription: newTranscription,
+                        enhancementFailure: failureDescription
+                    )
                 }
             } else {
                 let newTranscription = Transcription(
@@ -200,7 +214,10 @@ class AudioTranscriptionService: ObservableObject {
                     isTranscribing = false
                 }
 
-                return newTranscription
+                return AudioRetranscriptionResult(
+                    transcription: newTranscription,
+                    enhancementFailure: nil
+                )
             }
         } catch {
             logger.error("❌ Transcription failed: \(error, privacy: .public)")

--- a/VoiceInk/Services/LastTranscriptionService.swift
+++ b/VoiceInk/Services/LastTranscriptionService.swift
@@ -133,20 +133,30 @@ class LastTranscriptionService: ObservableObject {
                 enhancementService: enhancementService
             )
             do {
-                let newTranscription = try await transcriptionService.retranscribeAudio(
+                let result = try await transcriptionService.retranscribeAudio(
                     from: audioURL,
                     using: transcriptionConfiguration.model
                 )
+                let newTranscription = result.transcription
 
                 let textToCopy =
-                    newTranscription.enhancedText?.isEmpty == false
+                    result.enhancementFailure == nil && newTranscription.enhancedText?.isEmpty == false
                     ? newTranscription.enhancedText! : newTranscription.text
                 ClipboardManager.copyToClipboard(textToCopy)
 
-                NotificationManager.shared.showNotification(
-                    title: String(localized: "Copied to clipboard"),
-                    type: .success
-                )
+                if let enhancementFailure = result.enhancementFailure {
+                    NotificationManager.shared.showNotification(
+                        title: EnhancementFailureFormatter.transcriptionSavedMessage(
+                            description: enhancementFailure
+                        ),
+                        type: .warning
+                    )
+                } else {
+                    NotificationManager.shared.showNotification(
+                        title: String(localized: "Copied to clipboard"),
+                        type: .success
+                    )
+                }
             } catch {
                 NotificationManager.shared.showNotification(
                     title: String(format: String(localized: "Retry failed: %@"), error.localizedDescription),

--- a/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionPipeline.swift
@@ -203,15 +203,13 @@ class TranscriptionPipeline {
                         transcription.aiRequestUserMessage = enhancementService.lastUserMessageSent
                         finalText = enhancedText
                     } catch {
-                        let errorDescription =
-                            (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                        transcription.enhancedText = String(
-                            format: String(localized: "Enhancement failed: %@"), errorDescription)
+                        let errorDescription = EnhancementFailureFormatter.description(for: error)
+                        let failureMessage = EnhancementFailureFormatter.message(description: errorDescription)
+                        transcription.enhancedText = failureMessage
                         responseError = errorDescription
-                        let shortReason = String(errorDescription.prefix(80))
                         await MainActor.run {
                             NotificationManager.shared.showNotification(
-                                title: String(format: String(localized: "Enhancement failed: %@"), shortReason),
+                                title: failureMessage,
                                 type: .warning
                             )
                         }

--- a/VoiceInk/Views/AudioPlayerView.swift
+++ b/VoiceInk/Views/AudioPlayerView.swift
@@ -617,11 +617,13 @@ struct AudioPlayerView: View {
                     showSuccessFeedback(.reEnhanceSuccess, title: String(localized: "Re-enhancement successful"))
                 }
             } catch {
+                let errorDescription = EnhancementFailureFormatter.description(for: error)
+                let failureMessage = EnhancementFailureFormatter.reEnhancementMessage(
+                    description: errorDescription
+                )
                 await MainActor.run {
                     isReEnhancing = false
-                    showErrorNotification(
-                        error.localizedDescription.isEmpty
-                            ? String(localized: "Re-enhancement failed") : error.localizedDescription)
+                    showErrorNotification(failureMessage)
                 }
             }
         }
@@ -648,14 +650,26 @@ struct AudioPlayerView: View {
 
         Task {
             do {
-                let _ = try await transcriptionService.retranscribeAudio(
+                let result = try await transcriptionService.retranscribeAudio(
                     from: url,
                     using: transcriptionConfiguration.model,
                     mode: selectedMode
                 )
                 await MainActor.run {
                     isRetranscribing = false
-                    showSuccessFeedback(.retranscribeSuccess, title: String(localized: "Retranscription successful"))
+                    if let enhancementFailure = result.enhancementFailure {
+                        NotificationManager.shared.showNotification(
+                            title: EnhancementFailureFormatter.transcriptionSavedMessage(
+                                description: enhancementFailure
+                            ),
+                            type: .warning
+                        )
+                    } else {
+                        showSuccessFeedback(
+                            .retranscribeSuccess,
+                            title: String(localized: "Retranscription successful")
+                        )
+                    }
                 }
             } catch {
                 await MainActor.run {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve enhancement failure diagnostics across the app. Users now see clear, localized reasons when enhancement, re-enhancement, or retranscription enhancement fails, while transcriptions still save.

- **Bug Fixes**
  - Added `EnhancementFailureFormatter` to produce consistent, concise error text.
  - Show specific failure messages in notifications and UI, including re-enhancement and retranscription.
  - Save transcription with `enhancedText` set to “Enhancement failed: …” when enhancement fails.
  - Updated `retranscribeAudio` to return `AudioRetranscriptionResult` with optional `enhancementFailure` for warnings.
  - Improved logging with provider, model, and duration for failed enhancements.
  - Added localized strings for “Re-enhancement failed: %@" and “Transcription saved, but enhancement failed: %@”.

<sup>Written for commit 91a10d85f9bc3f14586bafe1c4b3f8e7f173bcd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

