### PR TITLE
Send custom vocabulary as biasing prompt to custom transcription endpoints

### DIFF
--- a/VoiceInk/Transcription/Cloud/CloudTranscriptionService.swift
+++ b/VoiceInk/Transcription/Cloud/CloudTranscriptionService.swift
@@ -57,7 +57,8 @@ class CloudTranscriptionService: TranscriptionService {
                     throw CloudTranscriptionError.unsupportedProvider
                 }
                 return try await openAICompatibleService.transcribe(
-                    audioURL: audioURL, model: customModel, context: context)
+                    audioURL: audioURL, model: customModel, context: context,
+                    customVocabulary: getCustomDictionaryTerms())
             }
 
             guard let cloudProvider = CloudProviderRegistry.provider(for: model.provider) else {

--- a/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
+++ b/VoiceInk/Transcription/Cloud/OpenAICompatibleTranscriptionService.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 class OpenAICompatibleTranscriptionService {
-    func transcribe(audioURL: URL, model: CustomCloudModel, context: TranscriptionRequestContext) async throws -> String
-    {
+    func transcribe(
+        audioURL: URL, model: CustomCloudModel, context: TranscriptionRequestContext,
+        customVocabulary: [String] = []
+    ) async throws -> String {
         guard let url = URL(string: model.apiEndpoint) else {
             throw NSError(
                 domain: "CustomWhisperTranscriptionService", code: -1,
@@ -16,7 +18,8 @@ class OpenAICompatibleTranscriptionService {
         request.setValue("Bearer \(model.apiKey)", forHTTPHeaderField: "Authorization")
 
         let body = try buildRequestBody(
-            audioURL: audioURL, modelName: model.modelName, boundary: boundary, context: context)
+            audioURL: audioURL, modelName: model.modelName, boundary: boundary, context: context,
+            customVocabulary: customVocabulary)
         // Ephemeral session per request: the shared session persists Alt-Svc and upgrades
         // new connections to HTTP/3, but QUIC bulk uploads blackhole behind VPNs that drop
         // full-size UDP datagrams (e.g. GlobalProtect), timing out large audio uploads.
@@ -41,7 +44,8 @@ class OpenAICompatibleTranscriptionService {
     }
 
     private func buildRequestBody(
-        audioURL: URL, modelName: String, boundary: String, context: TranscriptionRequestContext
+        audioURL: URL, modelName: String, boundary: String, context: TranscriptionRequestContext,
+        customVocabulary: [String]
     ) throws -> Data {
         guard let audioData = try? Data(contentsOf: audioURL) else {
             throw CloudTranscriptionError.audioFileNotFound
@@ -71,6 +75,11 @@ class OpenAICompatibleTranscriptionService {
 
         if selectedLanguage != "auto" && !selectedLanguage.isEmpty {
             field("language", selectedLanguage)
+        }
+
+        let promptText = VocabularyBiasingPrompt.build(existing: context.prompt, vocabulary: customVocabulary)
+        if !promptText.isEmpty {
+            field("prompt", promptText)
         }
 
         append("--\(boundary)--\(crlf)")

--- a/VoiceInk/Transcription/Cloud/VocabularyBiasingPrompt.swift
+++ b/VoiceInk/Transcription/Cloud/VocabularyBiasingPrompt.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum VocabularyBiasingPrompt {
+    static func build(existing: String? = nil, vocabulary: [String]) -> String {
+        var seen = Set<String>()
+        var terms: [String] = []
+        for term in vocabulary {
+            let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let key = trimmed.lowercased()
+            if seen.insert(key).inserted {
+                terms.append(trimmed)
+            }
+            if terms.count >= 200 { break }
+        }
+
+        var segments: [String] = []
+        if let existing = existing?.trimmingCharacters(in: .whitespacesAndNewlines), !existing.isEmpty {
+            segments.append(existing)
+        }
+        if !terms.isEmpty {
+            segments.append(
+                "The audio may reference the following names, products, and technical terms — "
+                    + "transcribe any occurrences using these exact spellings: "
+                    + terms.joined(separator: ", ") + ".")
+        }
+        return segments.joined(separator: " ")
+    }
+}


### PR DESCRIPTION
## Problem

The custom dictionary (Vocabulary) is passed to the built-in cloud providers, but the custom OpenAI-compatible path never receives it. Users running models like `gpt-4o-transcribe` on custom or Azure OpenAI endpoints get no transcription-time term biasing — every technical term, product name, or proper noun in their dictionary is ignored until post-hoc word replacement, which can't fix words the model never produced.

## Change

- New shared helper `VocabularyBiasingPrompt` builds a framed instruction from the vocabulary — *"The audio may reference the following names, products, and technical terms — transcribe any occurrences using these exact spellings: …"* — rather than a bare comma list (a bare list gives instruction-following transcription models no guidance on what to do with it). Terms are trimmed, case-insensitively deduped, and capped at 200 to stay inside prompt budgets.
- `OpenAICompatibleTranscriptionService` emits the result as the multipart `prompt` field — only when there is something to send.
- `CloudTranscriptionService` passes the dictionary terms into the custom-model path (it already fetched them for built-in providers).

The helper is deliberately shared so other providers can adopt the same biasing format.

## Relationship to the prompt-scoping change

This intentionally does **not** reintroduce the user's free-form TranscriptionPrompt on custom endpoints: [cde93d3](https://github.com/Beingpax/VoiceInk/commit/cde93d3f80b38eae946733d2c7eedf0ed01cb806) ("Scope transcription prompts to Whisper models") nils `context.prompt` at the source for non-Whisper models, and that stays exactly as is. What's sent here is a different, narrower thing — a short app-constructed instruction derived only from the user's Vocabulary entries; with an empty dictionary the field is not sent and the request is byte-identical to today's.

`prompt` is part of the OpenAI transcription API spec, so OpenAI-compatible endpoints are expected to accept (or ignore) the field; if you'd rather make this opt-in per custom model, happy to add a toggle.

## Testing

Verified against an Azure OpenAI `gpt-4o-transcribe` deployment: a product name the model consistently mis-heard is transcribed with the exact expected spelling once added to the Vocabulary, and the empty-dictionary case was confirmed to send no `prompt` field.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass custom vocabulary to OpenAI-compatible transcription endpoints as a biasing `prompt` so custom models like `gpt-4o-transcribe` use exact term spellings during transcription. No `prompt` is sent when the dictionary is empty.

- **New Features**
  - Added `VocabularyBiasingPrompt` to build a short instruction from trimmed, deduped terms (max 200).
  - `OpenAICompatibleTranscriptionService` sends it as the multipart `prompt` when non-empty; otherwise unchanged.
  - `CloudTranscriptionService` now forwards vocabulary to custom models; this does not re-enable free-form user prompts for non-Whisper models.

<sup>Written for commit 92c5d9866befa4de1777bc7fdc852f4a32933138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

