### PR TITLE
feat: add gpt-5.6 models

### DIFF
--- a/VoiceInk/Services/AIEnhancement/AIService.swift
+++ b/VoiceInk/Services/AIEnhancement/AIService.swift
@@ -117,6 +117,9 @@ enum AIProvider: String, CaseIterable {
             ]
         case .openAI:
             return [
+                "gpt-5.6-luna",
+                "gpt-5.6-terra",
+                "gpt-5.6-sol",
                 "gpt-5.5",
                 "gpt-5.4",
                 "gpt-5.4-mini",

--- a/VoiceInk/Services/AIEnhancement/ReasoningConfig.swift
+++ b/VoiceInk/Services/AIEnhancement/ReasoningConfig.swift
@@ -29,6 +29,9 @@ struct ReasoningConfig {
 
     // OpenAI GPT-5 models support explicit "none"; GPT-4.1 models need no param.
     static let openAINoneReasoningModels: Set<String> = [
+        "gpt-5.6-luna",
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",


### PR DESCRIPTION
Fixes #851 

This adds the gpt-5.6 models to the ai enhancement.

If you want to implement it yourself / close the PR since you seem to not accept any, that is fine.

Just want to help out making this software better and this is a really small change.