### PR TITLE
Make "Pause Media While Recording" actually pause

### DIFF
--- a/VoiceInk/PlaybackController.swift
+++ b/VoiceInk/PlaybackController.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import MediaRemoteAdapter
 import SwiftUI
+import os
 
 class PlaybackController: ObservableObject {
     static let shared = PlaybackController()
@@ -12,6 +13,29 @@ class PlaybackController: ObservableObject {
     private var lastKnownTrackInfo: TrackInfo?
     private var originalMediaAppBundleId: String?
     private var resumeTask: Task<Void, Never>?
+
+    /// MediaRemote intermittently emits a full track event with no client identity
+    /// (bundleIdentifier/applicationName/PID all absent) while still reporting
+    /// isPlaying. Tracking the id separately keeps those events from erasing which
+    /// app we are controlling.
+    private var lastKnownBundleId: String?
+
+    private var listenerRestartAttempts = 0
+    private static let maxListenerRestartAttempts = 5
+
+    /// Bumped whenever a pause or resume starts, so an in-flight pause retry loop
+    /// can tell that it has been superseded and stop.
+    private var pauseGeneration = 0
+
+    /// Verification window after each pause attempt. The last one is longer on
+    /// purpose: by then every attempt has already been sent, so the extra time does
+    /// not make the pause more likely to land – it stops us reporting failure for a
+    /// command that was about to take effect.
+    private static let pauseConfirmationDelays: [UInt64] = [300_000_000, 300_000_000, 400_000_000]
+    private static var maxPauseAttempts: Int { pauseConfirmationDelays.count }
+
+    private let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink", category: "PlaybackController")
 
     @Published var isPauseMediaEnabled: Bool = UserDefaults.standard.bool(forKey: "isPauseMediaEnabled") {
         didSet {
@@ -37,14 +61,47 @@ class PlaybackController: ObservableObject {
 
     private func setupMediaControllerCallbacks() {
         mediaController.onTrackInfoReceived = { [weak self] trackInfo in
-            self?.isMediaPlaying = trackInfo?.payload.isPlaying ?? false
-            self?.lastKnownTrackInfo = trackInfo
+            guard let self = self else { return }
+            self.listenerRestartAttempts = 0
+            self.isMediaPlaying = trackInfo?.payload.isPlaying ?? false
+            self.lastKnownTrackInfo = trackInfo
+
+            if trackInfo == nil {
+                // Nothing is playing at all – forget the app we were tracking.
+                self.lastKnownBundleId = nil
+            } else if let bundleId = trackInfo?.payload.bundleIdentifier {
+                self.lastKnownBundleId = bundleId
+            }
+            // else: identity-less event, keep the previously known bundle id.
         }
 
-        mediaController.onListenerTerminated = {}
+        mediaController.onListenerTerminated = { [weak self] in
+            self?.handleListenerTermination()
+        }
+    }
+
+    /// The listener is a child process. If it dies nothing else restarts it, and the
+    /// feature goes silently dead until the app is relaunched.
+    private func handleListenerTermination() {
+        guard isPauseMediaEnabled else { return }
+
+        listenerRestartAttempts += 1
+        guard listenerRestartAttempts <= Self.maxListenerRestartAttempts else {
+            logger.error("Media listener terminated; restart limit reached, giving up")
+            return
+        }
+
+        let attempt = listenerRestartAttempts
+        logger.warning("Media listener terminated; restarting (attempt \(attempt, privacy: .public))")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double(attempt)) { [weak self] in
+            guard let self = self, self.isPauseMediaEnabled else { return }
+            self.mediaController.startListening()
+        }
     }
 
     private func startMediaTracking() {
+        listenerRestartAttempts = 0
         mediaController.startListening()
     }
 
@@ -52,6 +109,8 @@ class PlaybackController: ObservableObject {
         mediaController.stopListening()
         isMediaPlaying = false
         lastKnownTrackInfo = nil
+        lastKnownBundleId = nil
+        listenerRestartAttempts = 0
         wasPlayingWhenRecordingStarted = false
         originalMediaAppBundleId = nil
     }
@@ -59,28 +118,66 @@ class PlaybackController: ObservableObject {
     func pauseMedia() async {
         resumeTask?.cancel()
         resumeTask = nil
+        pauseGeneration += 1
+        let generation = pauseGeneration
 
         wasPlayingWhenRecordingStarted = false
         originalMediaAppBundleId = nil
 
-        guard isPauseMediaEnabled,
-            isMediaPlaying,
-            lastKnownTrackInfo?.payload.isPlaying == true,
-            let bundleId = lastKnownTrackInfo?.payload.bundleIdentifier
-        else {
+        guard isPauseMediaEnabled else { return }
+
+        // The pause command targets whatever macOS reports as Now Playing, so a known
+        // bundle id is not required to issue it – only to verify the app on resume.
+        guard isMediaPlaying, lastKnownTrackInfo?.payload.isPlaying == true else {
+            logger.notice(
+                "pauseMedia: nothing to pause (isMediaPlaying=\(self.isMediaPlaying, privacy: .public), lastKnownIsPlaying=\(String(describing: self.lastKnownTrackInfo?.payload.isPlaying), privacy: .public))"
+            )
             return
         }
 
         wasPlayingWhenRecordingStarted = true
-        originalMediaAppBundleId = bundleId
+        originalMediaAppBundleId = lastKnownBundleId
+
+        logger.notice("pauseMedia: pausing \(self.lastKnownBundleId ?? "unknown app", privacy: .public)")
 
         try? await Task.sleep(nanoseconds: 50_000_000)
-        guard !Task.isCancelled else { return }
+        guard !Task.isCancelled, pauseGeneration == generation else { return }
 
-        mediaController.pause()
+        // MediaRemote reports success for a command it merely dispatched, not one the
+        // player acted on, and the first command after an idle gap is routinely
+        // dropped. So confirm the player actually stopped and re-issue if it did not.
+        // `pause` is idempotent (unlike the play/pause toggle used to resume), so a
+        // redundant retry is harmless.
+        for attempt in 1...Self.maxPauseAttempts {
+            mediaController.pause()
+
+            try? await Task.sleep(nanoseconds: Self.pauseConfirmationDelays[attempt - 1])
+
+            // A resume (or another recording) started while we were retrying – stop,
+            // otherwise we would pause playback the user has already resumed.
+            guard pauseGeneration == generation else {
+                logger.notice("pauseMedia: superseded, abandoning retry")
+                return
+            }
+
+            if lastKnownTrackInfo?.payload.isPlaying != true {
+                if attempt > 1 {
+                    logger.notice("pauseMedia: took \(attempt, privacy: .public) attempts to land")
+                }
+                return
+            }
+
+            logger.warning("pauseMedia: still playing after attempt \(attempt, privacy: .public)")
+        }
+
+        logger.error("pauseMedia: gave up after \(Self.maxPauseAttempts, privacy: .public) attempts")
     }
 
     func resumeMedia() async {
+        // Supersede any pause retry still in flight, so a late retry cannot pause
+        // playback again after we have decided to resume it.
+        pauseGeneration += 1
+
         let shouldResume = wasPlayingWhenRecordingStarted
         let originalBundleId = originalMediaAppBundleId
         let delay = MediaController.shared.audioResumptionDelay
@@ -90,24 +187,31 @@ class PlaybackController: ObservableObject {
             originalMediaAppBundleId = nil
         }
 
-        guard isPauseMediaEnabled,
-            shouldResume,
-            let bundleId = originalBundleId
-        else {
+        guard isPauseMediaEnabled, shouldResume else { return }
+
+        // If the app was identified when we paused, verify it is still the one we
+        // would be resuming. If MediaRemote never told us who it was, fall back to
+        // "we paused it and it is still paused" rather than silently doing nothing.
+        if let bundleId = originalBundleId {
+            guard isAppStillRunning(bundleId: bundleId) else {
+                logger.notice("resumeMedia: \(bundleId, privacy: .public) is no longer running")
+                return
+            }
+
+            if let currentBundleId = lastKnownBundleId, currentBundleId != bundleId {
+                logger.notice(
+                    "resumeMedia: now playing app changed (\(bundleId, privacy: .public) -> \(currentBundleId, privacy: .public))"
+                )
+                return
+            }
+        }
+
+        guard lastKnownTrackInfo?.payload.isPlaying == false else {
+            logger.notice("resumeMedia: media is not paused, nothing to resume")
             return
         }
 
-        guard isAppStillRunning(bundleId: bundleId) else {
-            return
-        }
-
-        guard let currentTrackInfo = lastKnownTrackInfo,
-            let currentBundleId = currentTrackInfo.payload.bundleIdentifier,
-            currentBundleId == bundleId,
-            currentTrackInfo.payload.isPlaying == false
-        else {
-            return
-        }
+        logger.notice("resumeMedia: resuming \(originalBundleId ?? "unknown app", privacy: .public)")
 
         let task = Task {
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))


### PR DESCRIPTION
Pause Media While Recording currently fails in three separate ways, all of them silently. Diagnosed on macOS 15.6 with Spotify, but none of it is app- or device-specific.

## 1. The pause was never issued

`pauseMedia()` required a bundle identifier before sending the command:

```swift
guard isPauseMediaEnabled,
    isMediaPlaying,
    lastKnownTrackInfo?.payload.isPlaying == true,
    let bundleId = lastKnownTrackInfo?.payload.bundleIdentifier
else { return }
```

MediaRemote intermittently emits a **full** track event (`diff=false`) with no client identity at all — `bundleIdentifier`, `applicationName` and `PID` all absent — while still correctly reporting `isPlaying`. Captured example:

```
album=…  artist=…  isPlaying=True  playbackRate=1  elapsedTimeMicros=167501000
bundleIdentifier: ABSENT
```

`onTrackInfoReceived` stored that event wholesale, erasing the app being controlled. And since the listener only emits on state change, steady playback produced no corrective event — so pause stayed dead indefinitely.

The bundle id was never needed to pause: the command targets whatever macOS reports as Now Playing. It is only needed to verify the app on resume. This tracks the id separately and keeps the last known value.

## 2. A dead listener is never restarted

```swift
mediaController.onListenerTerminated = {}
```

The listener is a child process. When it died, nothing restarted it and the feature was silently dead until relaunch. Found this on an app instance with 64 days uptime — the helper process was simply gone. Now restarts with a bounded, increasing backoff.

## 3. The first command after an idle gap is dropped

With the above fixed, pause still failed on the first press after roughly 5+ seconds of no activity, then worked on the next press.

Instrumented the helper to log every invocation and its exit status. Every one launched and exited 0, in 20–34ms — the command was dispatched, and Spotify ignored it. Verified against the real player state: on the failing press Spotify never paused, not during the recording and not afterwards. Sending the identical command from a shell landed 3/3 times cold, so the command path itself is sound.

MediaRemote reports success for a command it *dispatched*, not one the player *acted on*. So this confirms playback actually stopped and re-issues if not, up to 3 attempts (300/300/400ms). `pause` is idempotent — unlike the play/pause toggle used to resume — so a redundant retry is harmless. A generation counter lets a resume supersede an in-flight retry, preventing a late retry from re-pausing media the user already resumed.

Measured over 11 cycles after the fix: 6 landed first attempt, 4 needed a second, 1 needed a third, 0 failed.

## Logging

The class had none, which is why all three failures were invisible — every layer reported success because every layer had succeeded at its own job. Each early return now says which condition rejected it.

## Note on verification

This has been running on a v1.79 build for several hours across dozens of cycles. The change here is that same code re-applied to current `main`, differing only in comment wrapping — I could not compile against `main` on this machine, as it now requires Swift tools 6.3.0 (via mlx-swift 0.31.6) and I have 6.2.4. Worth a CI build before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “Pause Media While Recording” reliably pause the current Now Playing app and recover from listener crashes. Also adds lightweight logging so failures are visible.

- **Bug Fixes**
  - Removed the bundle-id requirement to pause; track a `lastKnownBundleId` only for resume checks.
  - Auto-restart the media listener on termination with bounded backoff (up to 5 attempts).
  - Verify pause actually landed; retry up to 3 times (300/300/400ms). Use a generation counter to cancel stale retries when a resume starts.

- **Logging**
  - Added clear log lines for early returns and key state changes to aid diagnosis.

<sup>Written for commit 207ebc1d4bea6087abfdad3e8f6fe8df5a87901f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

