### PR TITLE
Add independent Dock and menu bar icon controls

### DIFF
--- a/VoiceInk/AppDefaults.swift
+++ b/VoiceInk/AppDefaults.swift
@@ -49,7 +49,8 @@ enum AppDefaults {
             CleanupSettingsKeys.audioRetentionPeriod: 7,
 
             // UI & Behavior
-            "IsMenuBarOnly": false,
+            AppPreferenceKey.isMenuBarOnly: false,
+            AppPreferenceKey.showMenuBarIcon: true,
             AppAppearancePreference.userDefaultsKey: AppAppearancePreference.system.rawValue,
             AppLanguagePreference.userDefaultsKey: AppLanguagePreference.systemValue,
             // Shortcuts

--- a/VoiceInk/AppDelegate.swift
+++ b/VoiceInk/AppDelegate.swift
@@ -1,26 +1,53 @@
 import Cocoa
+import Carbon.HIToolbox
 import SwiftUI
 import UniformTypeIdentifiers
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     weak var menuBarManager: MenuBarManager?
+    private var launchedAsLoginItem = false
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        launchedAsLoginItem = Self.isLoginItemLaunch(NSAppleEventManager.shared().currentAppleEvent)
+
+        guard !launchedAsLoginItem, Self.areBothIconsHidden else { return }
+        AppPresentationPolicy.activateForUserFacingWindow()
+        WindowManager.shared.prepareForUserRequestedMainWindow()
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        menuBarManager?.applyActivationPolicy()
+        guard !launchedAsLoginItem, Self.areBothIconsHidden else {
+            menuBarManager?.applyActivationPolicy()
+            return
+        }
+
+        menuBarManager?.activateForPresentedWindow()
+        if WindowManager.shared.showMainWindow() == nil {
+            WindowManager.shared.prepareForUserRequestedMainWindow()
+        }
+    }
+
+    private static func isLoginItemLaunch(_ event: NSAppleEventDescriptor?) -> Bool {
+        return event?.eventID == kAEOpenApplication
+            && event?.paramDescriptor(forKeyword: keyAEPropData)?.enumCodeValue == keyAELaunchedAsLogInItem
+    }
+
+    private static var areBothIconsHidden: Bool {
+        let defaults = UserDefaults.standard
+        return AppIconVisibility(
+            isDockIconHidden: defaults.bool(forKey: AppPreferenceKey.isMenuBarOnly),
+            isMenuBarIconHidden: !defaults.bool(forKey: AppPreferenceKey.showMenuBarIcon)
+        ).areBothIconsHidden
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if let menuBarManager, !menuBarManager.isMenuBarOnly {
-            if WindowManager.shared.currentMainWindow() != nil {
-                WindowManager.shared.showMainWindow()
-                return false
-            }
-
-            WindowManager.shared.prepareForUserRequestedMainWindow()
-            NotificationCenter.default.post(name: .showMainWindowRequested, object: nil)
+        if WindowManager.shared.currentMainWindow() != nil {
+            WindowManager.shared.showMainWindow()
             return false
         }
 
+        WindowManager.shared.prepareForUserRequestedMainWindow()
+        NotificationCenter.default.post(name: .showMainWindowRequested, object: nil)
         return true
     }
 

--- a/VoiceInk/AppIconVisibility.swift
+++ b/VoiceInk/AppIconVisibility.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum AppPreferenceKey {
+    static let isMenuBarOnly = "IsMenuBarOnly"
+    static let showMenuBarIcon = "ShowMenuBarIcon"
+}
+
+struct AppIconVisibility: Equatable {
+    var isDockIconHidden: Bool
+    var isMenuBarIconHidden: Bool
+
+    var areBothIconsHidden: Bool {
+        isDockIconHidden && isMenuBarIconHidden
+    }
+
+    func applying(_ change: AppIconVisibilityChange) -> AppIconVisibility {
+        var updated = self
+
+        switch change {
+        case .setDockIconHidden(let isHidden):
+            updated.isDockIconHidden = isHidden
+        case .setMenuBarIconHidden(let isHidden):
+            updated.isMenuBarIconHidden = isHidden
+        }
+
+        return updated
+    }
+
+    func decision(for change: AppIconVisibilityChange) -> AppIconVisibilityDecision {
+        AppIconVisibilityDecision(current: self, requested: applying(change))
+    }
+
+    static func afterImport(_ general: GeneralBackup?, current: AppIconVisibility) -> AppIconVisibility {
+        guard let general else { return current }
+
+        return AppIconVisibility(
+            isDockIconHidden: general.isMenuBarOnly ?? current.isDockIconHidden,
+            isMenuBarIconHidden: general.showMenuBarIcon.map { !$0 } ?? current.isMenuBarIconHidden
+        )
+    }
+}
+
+enum AppIconVisibilityChange: Equatable {
+    case setDockIconHidden(Bool)
+    case setMenuBarIconHidden(Bool)
+}
+
+struct AppIconVisibilityDecision: Equatable {
+    let current: AppIconVisibility
+    let requested: AppIconVisibility
+
+    var requiresConfirmation: Bool {
+        !current.areBothIconsHidden && requested.areBothIconsHidden
+    }
+}
+
+enum BackupIconVisibilityPreflight {
+    static func decision(
+        for backup: BackupFile, categories: Set<BackupCategory>, current: AppIconVisibility
+    ) -> AppIconVisibilityDecision? {
+        guard categories.contains(.general), let general = backup.generalSettings else {
+            return nil
+        }
+
+        return AppIconVisibilityDecision(
+            current: current,
+            requested: .afterImport(general, current: current)
+        )
+    }
+
+    static func resultsInBothIconsHidden(
+        for backup: BackupFile, categories: Set<BackupCategory>, current: AppIconVisibility
+    ) -> Bool {
+        decision(for: backup, categories: categories, current: current)?.requested.areBothIconsHidden == true
+    }
+}

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -8509,6 +8509,12 @@
         }
       }
     },
+    "Hide Both" : {
+
+    },
+    "Hide Both App Icons?" : {
+
+    },
     "Hide Dock Icon" : {
       "localizations" : {
         "de" : {
@@ -8524,6 +8530,9 @@
           }
         }
       }
+    },
+    "Hide Menu Bar Icon" : {
+
     },
     "History" : {
       "localizations" : {
@@ -18501,6 +18510,9 @@
           }
         }
       }
+    },
+    "VoiceInk keeps running and can be reopened from Applications or Spotlight." : {
+
     },
     "VoiceInk is also open source, so you can inspect every single line of code." : {
       "localizations" : {

--- a/VoiceInk/MenuBarManager.swift
+++ b/VoiceInk/MenuBarManager.swift
@@ -5,7 +5,7 @@ import SwiftUI
 class MenuBarManager: ObservableObject {
     @Published var isMenuBarOnly: Bool {
         didSet {
-            UserDefaults.standard.set(isMenuBarOnly, forKey: "IsMenuBarOnly")
+            UserDefaults.standard.set(isMenuBarOnly, forKey: AppPreferenceKey.isMenuBarOnly)
             applyActivationPolicy()
         }
     }
@@ -17,7 +17,7 @@ class MenuBarManager: ObservableObject {
     }
 
     init() {
-        self.isMenuBarOnly = UserDefaults.standard.bool(forKey: "IsMenuBarOnly")
+        self.isMenuBarOnly = UserDefaults.standard.bool(forKey: AppPreferenceKey.isMenuBarOnly)
         applyActivationPolicy()
 
         NotificationCenter.default.addObserver(

--- a/VoiceInk/Services/BackupImporter.swift
+++ b/VoiceInk/Services/BackupImporter.swift
@@ -154,6 +154,9 @@ enum BackupImporter {
         if let launch = general.launchAtLoginEnabled {
             LaunchAtLoginManager.shared.setEnabled(launch)
         }
+        if let showMenuBarIcon = general.showMenuBarIcon {
+            UserDefaults.standard.set(showMenuBarIcon, forKey: AppPreferenceKey.showMenuBarIcon)
+        }
         if let menuOnly = general.isMenuBarOnly {
             menuBarManager.isMenuBarOnly = menuOnly
         }

--- a/VoiceInk/Services/BackupTypes.swift
+++ b/VoiceInk/Services/BackupTypes.swift
@@ -83,6 +83,7 @@ struct GeneralBackup: Codable {
     let middleClickActivationDelay: Int?
     let launchAtLoginEnabled: Bool?
     let isMenuBarOnly: Bool?
+    let showMenuBarIcon: Bool?
     let recorderType: String?
     let appAppearancePreference: String?
     let appLanguagePreference: String?

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -170,6 +170,7 @@ class ImportExportService {
             middleClickActivationDelay: recordingShortcutManager.middleClickActivationDelay,
             launchAtLoginEnabled: launchAtLoginEnabled,
             isMenuBarOnly: menuBarManager.isMenuBarOnly,
+            showMenuBarIcon: UserDefaults.standard.bool(forKey: AppPreferenceKey.showMenuBarIcon),
             recorderType: recorderUIManager.recorderPanelStyle.rawValue,
             appAppearancePreference: AppAppearancePreference.stored.rawValue,
             appLanguagePreference: AppLanguagePreference.storedRawValue,
@@ -303,6 +304,21 @@ class ImportExportService {
                 return
             }
 
+            let currentIconVisibility = AppIconVisibility(
+                isDockIconHidden: menuBarManager.isMenuBarOnly,
+                isMenuBarIconHidden: !UserDefaults.standard.bool(forKey: AppPreferenceKey.showMenuBarIcon)
+            )
+            if BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: backup, categories: selectedCategories, current: currentIconVisibility
+            ),
+                !confirmHidingBothAppIcons()
+            {
+                showAlert(
+                    title: String(localized: "Import Canceled"),
+                    message: String(localized: "No settings were imported."))
+                return
+            }
+
             try BackupImporter.apply(
                 backup,
                 categories: selectedCategories,
@@ -349,6 +365,17 @@ class ImportExportService {
         }
 
         return accessory.selectedCategories
+    }
+
+    private func confirmHidingBothAppIcons() -> Bool {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Hide Both App Icons?")
+        alert.informativeText = String(
+            localized: "VoiceInk keeps running and can be reopened from Applications or Spotlight.")
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        alert.addButton(withTitle: String(localized: "Hide Both"))
+        return alert.runModal() == .alertSecondButtonReturn
     }
 
     private func categorySummary(for categories: Set<BackupCategory>) -> String {

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -23,8 +23,10 @@ struct SettingsView: View {
     @AppStorage(AppLanguagePreference.userDefaultsKey) private var appLanguagePreference = AppLanguagePreference
         .systemValue
     @AppStorage(RecorderDisplaySettingsKeys.showLiveTranscript) private var showLiveTranscript = true
+    @AppStorage(AppPreferenceKey.showMenuBarIcon) private var showMenuBarIcon = true
     @State private var showResetOnboardingAlert = false
     @State private var showLanguageRestartAlert = false
+    @State private var pendingIconVisibilityChange: AppIconVisibilityChange?
     @State private var hasCancelRecordingShortcut = ShortcutStore.shortcut(for: .cancelRecorder) != nil
     @State private var cancelRecordingShortcutRecorderResetID = 0
 
@@ -234,7 +236,21 @@ struct SettingsView: View {
             }
 
             Section("General") {
-                Toggle("Hide Dock Icon", isOn: $menuBarManager.isMenuBarOnly)
+                Toggle(
+                    "Hide Dock Icon",
+                    isOn: Binding(
+                        get: { menuBarManager.isMenuBarOnly },
+                        set: { requestIconVisibilityChange(.setDockIconHidden($0)) }
+                    )
+                )
+
+                Toggle(
+                    "Hide Menu Bar Icon",
+                    isOn: Binding(
+                        get: { !showMenuBarIcon },
+                        set: { requestIconVisibilityChange(.setMenuBarIconHidden($0)) }
+                    )
+                )
 
                 Toggle(
                     String(localized: "Launch at Login"),
@@ -330,6 +346,50 @@ struct SettingsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Your language change will take full effect after you quit and reopen VoiceInk.")
+        }
+        .alert("Hide Both App Icons?", isPresented: isHideBothConfirmationPresented) {
+            Button("Cancel", role: .cancel) {}
+            Button("Hide Both", role: .destructive) {
+                guard let change = pendingIconVisibilityChange else { return }
+                applyIconVisibilityChange(change)
+            }
+        } message: {
+            Text("VoiceInk keeps running and can be reopened from Applications or Spotlight.")
+        }
+    }
+
+    private var iconVisibility: AppIconVisibility {
+        AppIconVisibility(
+            isDockIconHidden: menuBarManager.isMenuBarOnly,
+            isMenuBarIconHidden: !showMenuBarIcon
+        )
+    }
+
+    private var isHideBothConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { pendingIconVisibilityChange != nil },
+            set: { isPresented in
+                if !isPresented {
+                    pendingIconVisibilityChange = nil
+                }
+            }
+        )
+    }
+
+    private func requestIconVisibilityChange(_ change: AppIconVisibilityChange) {
+        if iconVisibility.decision(for: change).requiresConfirmation {
+            pendingIconVisibilityChange = change
+        } else {
+            applyIconVisibilityChange(change)
+        }
+    }
+
+    private func applyIconVisibilityChange(_ change: AppIconVisibilityChange) {
+        switch change {
+        case .setDockIconHidden(let isHidden):
+            menuBarManager.isMenuBarOnly = isHidden
+        case .setMenuBarIconHidden(let isHidden):
+            showMenuBarIcon = !isHidden
         }
     }
 

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -25,7 +25,7 @@ struct VoiceInkApp: App {
     @StateObject private var activeWindowService = ActiveWindowService.shared
     @AppStorage("hasCompletedOnboardingV2") private var hasCompletedOnboardingV2 = false
     @AppStorage("enableAnnouncements") private var enableAnnouncements = true
-    @State private var showMenuBarIcon = true
+    @AppStorage(AppPreferenceKey.showMenuBarIcon) private var showMenuBarIcon = true
     @State private var didShowLaunchReminders = false
 
     // Audio cleanup manager for automatic deletion of old audio files
@@ -352,6 +352,7 @@ struct VoiceInkApp: App {
                 }
             }
             .confettiCelebrationPresenter()
+            .background(MainWindowRequestBridge(menuBarManager: menuBarManager))
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: AppWindowLayout.width, height: AppWindowLayout.minimumHeight)

--- a/VoiceInk/WindowManager.swift
+++ b/VoiceInk/WindowManager.swift
@@ -30,7 +30,7 @@ enum AppPresentationPolicy {
 
     static func restoreAccessoryIfNeededAfterUserFacingWindowClosed() {
         DispatchQueue.main.async {
-            let menuBarOnly = UserDefaults.standard.bool(forKey: "IsMenuBarOnly")
+            let menuBarOnly = UserDefaults.standard.bool(forKey: AppPreferenceKey.isMenuBarOnly)
             let hasVisibleUserWindows = !WindowDiagnostics.visibleUserFacingWindows().isEmpty
 
             guard menuBarOnly else { return }
@@ -97,7 +97,7 @@ class WindowManager: NSObject {
         if shouldShowNextConfiguredMainWindow {
             shouldShowNextConfiguredMainWindow = false
             presentMainWindow(window)
-        } else if UserDefaults.standard.bool(forKey: "IsMenuBarOnly") {
+        } else if UserDefaults.standard.bool(forKey: AppPreferenceKey.isMenuBarOnly) {
             window.orderOut(nil)
         }
     }

--- a/VoiceInkTests/VoiceInkTests.swift
+++ b/VoiceInkTests/VoiceInkTests.swift
@@ -1,17 +1,183 @@
-//
-//  VoiceInkTests.swift
-//  VoiceInkTests
-//
-//  Created by Prakash Joshi on 15/10/2024.
-//
-
+import Foundation
 import Testing
 @testable import VoiceInk
 
-struct VoiceInkTests {
+struct AppIconVisibilityTests {
+    @Test func warningDetectionCoversEveryVisibilityAndToggleCombination() {
+        for isDockIconHidden in [false, true] {
+            for isMenuBarIconHidden in [false, true] {
+                let current = AppIconVisibility(
+                    isDockIconHidden: isDockIconHidden,
+                    isMenuBarIconHidden: isMenuBarIconHidden
+                )
+                let changes: [AppIconVisibilityChange] = [
+                    .setDockIconHidden(false),
+                    .setDockIconHidden(true),
+                    .setMenuBarIconHidden(false),
+                    .setMenuBarIconHidden(true),
+                ]
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+                for change in changes {
+                    let decision = current.decision(for: change)
+                    let expected = !current.areBothIconsHidden && decision.requested.areBothIconsHidden
+                    #expect(decision.requiresConfirmation == expected)
+                }
+            }
+        }
     }
 
+    @Test func cancelAndConfirmHidingMenuBarAsLastIcon() {
+        let current = AppIconVisibility(isDockIconHidden: true, isMenuBarIconHidden: false)
+        let decision = current.decision(for: .setMenuBarIconHidden(true))
+
+        #expect(decision.requiresConfirmation)
+    }
+
+    @Test func cancelAndConfirmHidingDockAsLastIcon() {
+        let current = AppIconVisibility(isDockIconHidden: false, isMenuBarIconHidden: true)
+        let decision = current.decision(for: .setDockIconHidden(true))
+
+        #expect(decision.requiresConfirmation)
+    }
+}
+
+struct MenuBarIconPreferenceTests {
+    @Test func menuBarIconDefaultsToVisible() {
+        AppDefaults.registerDefaults()
+
+        let registeredDefaults = UserDefaults.standard.volatileDomain(forName: UserDefaults.registrationDomain)
+        #expect(registeredDefaults[AppPreferenceKey.showMenuBarIcon] as? Bool == true)
+    }
+}
+
+struct GeneralBackupIconVisibilityTests {
+    @Test func oldBackupWithoutMenuBarFieldLeavesVisibilityUnchanged() throws {
+        let backup = try decodeBackup("""
+            {
+              "version": "1.0.0",
+              "generalSettings": {
+                "isMenuBarOnly": true
+              }
+            }
+            """)
+        let current = AppIconVisibility(isDockIconHidden: false, isMenuBarIconHidden: true)
+
+        #expect(backup.generalSettings?.showMenuBarIcon == nil)
+        #expect(
+            AppIconVisibility.afterImport(backup.generalSettings, current: current).isMenuBarIconHidden
+                == current.isMenuBarIconHidden
+        )
+    }
+
+    @Test(arguments: [true, false])
+    func menuBarVisibilityRoundTrips(showMenuBarIcon: Bool) throws {
+        let backup = try decodeBackup("""
+            {
+              "version": "1.0.0",
+              "generalSettings": {
+                "showMenuBarIcon": \(showMenuBarIcon)
+              }
+            }
+            """)
+        let encoded = try JSONEncoder().encode(backup)
+        let decoded = try JSONDecoder().decode(BackupFile.self, from: encoded)
+
+        #expect(decoded.generalSettings?.showMenuBarIcon == showMenuBarIcon)
+    }
+
+    @Test func importPreflightWarnsOnlyWhenSelectedGeneralWouldHideBothIcons() throws {
+        let bothHiddenBackup = try decodeBackup("""
+            {
+              "version": "1.0.0",
+              "generalSettings": {
+                "isMenuBarOnly": true,
+                "showMenuBarIcon": false
+              }
+            }
+            """)
+        let visible = AppIconVisibility(isDockIconHidden: false, isMenuBarIconHidden: false)
+
+        #expect(
+            BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: bothHiddenBackup, categories: [.general], current: visible
+            )
+        )
+        #expect(
+            !BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: bothHiddenBackup, categories: [.modes], current: visible
+            )
+        )
+    }
+
+    @Test func importPreflightUsesCurrentDockStateWhenBackupOmitsIt() throws {
+        let menuHiddenBackup = try decodeBackup("""
+            {
+              "version": "1.0.0",
+              "generalSettings": {
+                "showMenuBarIcon": false
+              }
+            }
+            """)
+
+        let dockHidden = AppIconVisibility(isDockIconHidden: true, isMenuBarIconHidden: false)
+        let dockVisible = AppIconVisibility(isDockIconHidden: false, isMenuBarIconHidden: false)
+
+        #expect(
+            BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: menuHiddenBackup, categories: [.general], current: dockHidden
+            )
+        )
+        #expect(
+            !BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: menuHiddenBackup, categories: [.general], current: dockVisible
+            )
+        )
+    }
+
+    @Test func oldBackupPreflightUsesCurrentMenuBarVisibility() throws {
+        let oldBackup = try decodeBackup("""
+            {
+              "version": "1.0.0",
+              "generalSettings": {
+                "isMenuBarOnly": true
+              }
+            }
+            """)
+        let menuBarHidden = AppIconVisibility(isDockIconHidden: false, isMenuBarIconHidden: true)
+        let iconsVisible = AppIconVisibility(isDockIconHidden: false, isMenuBarIconHidden: false)
+
+        #expect(
+            BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: oldBackup, categories: [.general], current: menuBarHidden
+            )
+        )
+        #expect(
+            !BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: oldBackup, categories: [.general], current: iconsVisible
+            )
+        )
+    }
+
+    @Test func importPreflightWarnsAgainWhenCurrentStateAlreadyHasBothIconsHidden() throws {
+        let bothHiddenBackup = try decodeBackup("""
+            {
+              "version": "1.0.0",
+              "generalSettings": {
+                "isMenuBarOnly": true,
+                "showMenuBarIcon": false
+              }
+            }
+            """)
+        let bothHidden = AppIconVisibility(isDockIconHidden: true, isMenuBarIconHidden: true)
+
+        #expect(
+            BackupIconVisibilityPreflight.resultsInBothIconsHidden(
+                for: bothHiddenBackup, categories: [.general], current: bothHidden
+            )
+        )
+    }
+
+    private func decodeBackup(_ json: String) throws -> BackupFile {
+        try JSONDecoder().decode(BackupFile.self, from: Data(json.utf8))
+    }
 }


### PR DESCRIPTION
## Summary

- Add independent Settings controls for hiding the Dock and menu bar icons.
- Require explicit confirmation when a Settings change or selected backup import would hide both icons.
- Persist, export, and import menu bar visibility while preserving compatibility with older backups.
- Keep login-item launches background-only and restore access to the main window through normal launch and reopen flows.

## Relationship to #753

This is an alternative to #753. Instead of forcing the Dock icon visible when the menu bar icon is hidden, it allows either icon—or both—to be hidden, requires explicit confirmation for the both-hidden state, and adds recovery handling.

## Testing

- Added Swift Testing coverage for visibility transitions, registered defaults, backup round-trips, legacy backups, and import preflight decisions.
- `git diff --check origin/main...HEAD` passes.
- Focused `VoiceInkTests` could not execute in this environment: SwiftPM dependency resolution stopped before compilation because nested package sandbox initialization is unavailable (`sandbox-exec: sandbox_apply: Operation not permitted`).
- Manual verification remains pending for toggle confirmation, backup import confirmation, login-item behavior, and reopening through Applications or Spotlight with both icons hidden.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds separate toggles for hiding the Dock and menu bar icons, with a confirmation to prevent unintentionally hiding both. Persists and import/exports menu bar visibility (backward compatible) and refines launch/reopen so login-item launches stay background-only while normal launch/reopen restores the main window.

- **New Features**
  - Independent toggles for Dock and menu bar icons.
  - Confirmation when a setting or import would hide both icons (import preflight included).
  - Backups now include `showMenuBarIcon` and remain compatible with older files.
  - Login-item launches are background-only; normal launch/reopen shows the main window.

- **Migration**
  - No action needed; existing backups work and the menu bar icon defaults to visible.
  - If both icons are hidden, reopen from Applications or Spotlight.

<sup>Written for commit b03c2004a3085418f567059a5c6dbb67ff826faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

