### PR TITLE
Add Cohere Transcribe support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ playground.xcworkspace
 .build/
 build/
 .local-build/
+*.profraw
 
 # CocoaPods
 #
@@ -99,4 +100,4 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk 
+.apdisk

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,10 +9,11 @@ Before you begin, ensure you have:
 - Xcode (latest version recommended)
 - Swift (latest version recommended)
 - Git (for cloning repositories)
+- CMake (`brew install cmake`)
 
 ## Quick Start with Makefile (Recommended)
 
-The easiest way to build VoiceInk is using the included Makefile, which automates the entire build process including building and linking the whisper framework.
+The easiest way to build VoiceInk is using the included Makefile. It builds the local Whisper framework; Xcode resolves Swift packages automatically.
 
 ### Simple Build Commands
 
@@ -32,7 +33,7 @@ make dev
 
 - `make check` or `make healthcheck` - Verify all required tools are installed
 - `make whisper` - Clone and build whisper.cpp XCFramework automatically
-- `make setup` - Prepare the whisper framework for linking
+- `make setup` - Prepare the local Whisper framework
 - `make build` - Build the VoiceInk Xcode project
 - `make local` - Build for local use (no Apple Developer certificate needed)
 - `make run` - Launch the built VoiceInk app
@@ -44,9 +45,9 @@ make dev
 ### How the Makefile Helps
 
 The Makefile automatically:
-1. **Manages Dependencies**: Creates a dedicated `~/VoiceInk-Dependencies` directory for all external frameworks
-2. **Builds Whisper Framework**: Clones whisper.cpp and builds the XCFramework with the correct configuration
-3. **Handles Framework Linking**: Sets up the whisper.xcframework in the proper location for Xcode to find
+1. **Manages Whisper**: Creates `~/VoiceInk-Dependencies` for the local framework
+2. **Builds Whisper**: Clones whisper.cpp and builds its XCFramework
+3. **Uses SwiftPM**: Xcode downloads and verifies package dependencies, including TranscribeCpp
 4. **Verifies Prerequisites**: Checks that git, xcodebuild, and swift are installed before building
 5. **Streamlines Development**: Provides convenient shortcuts for common development tasks
 
@@ -78,6 +79,30 @@ Your normal `make all` / `make build` commands are completely unaffected.
 
 ---
 
+## Transcription dependencies
+
+Whisper is built locally outside the source checkout:
+
+```text
+~/VoiceInk-Dependencies/whisper.cpp
+```
+
+Prepare it with:
+
+```bash
+make setup
+```
+
+TranscribeCpp is a remote Swift package pinned by the Xcode project:
+
+```text
+https://github.com/Beingpax/Transcribe-cpp-swift.git
+0.2.0-dev.856d7c1
+```
+
+SwiftPM downloads the checksummed native artifact automatically. No local
+transcribe.cpp checkout or manual framework setup is required.
+
 ## Manual Build Process (Alternative)
 
 If you prefer to build manually or need more control over the build process, follow these steps:
@@ -100,9 +125,8 @@ git clone https://github.com/Beingpax/VoiceInk.git
 cd VoiceInk
 ```
 
-2. Add the whisper.xcframework to your project:
-   - Drag and drop `../whisper.cpp/build-apple/whisper.xcframework` into the project navigator, or
-   - Add it manually in the "Frameworks, Libraries, and Embedded Content" section of project settings
+2. Run `make setup` for Whisper. Xcode resolves TranscribeCpp and the remaining
+   Swift packages; no drag-and-drop setup is required.
 
 3. Build and Run
    - Build the project using Cmd+B or Product > Build
@@ -115,9 +139,8 @@ cd VoiceInk
    - Install any required Xcode Command Line Tools
 
 2. **Dependencies**
-   - The project uses [whisper.cpp](https://github.com/ggerganov/whisper.cpp) for transcription
-   - Ensure the whisper.xcframework is properly linked in your Xcode project
-   - Test the whisper.cpp installation independently before proceeding
+   - The project uses [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and [TranscribeCpp for Swift](https://github.com/Beingpax/Transcribe-cpp-swift)
+   - Ensure Whisper is built and Xcode has resolved Swift packages
 
 3. **Building for Development**
    - Use the Debug configuration for development
@@ -134,6 +157,6 @@ If you encounter any build issues:
 2. Clean the build cache (Cmd+Shift+K twice)
 3. Check Xcode and macOS versions
 4. Verify all dependencies are properly installed
-5. Make sure whisper.xcframework is properly built and linked
+5. Run `make setup` to rebuild Whisper and reset Xcode package caches if needed
 
 For more help, please check the [issues](https://github.com/Beingpax/VoiceInk/issues) section or create a new issue.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Define a directory for dependencies in the user's home folder
 DEPS_DIR := $(HOME)/VoiceInk-Dependencies
 WHISPER_CPP_DIR := $(DEPS_DIR)/whisper.cpp
-FRAMEWORK_PATH := $(WHISPER_CPP_DIR)/build-apple/whisper.xcframework
+WHISPER_FRAMEWORK_PATH := $(WHISPER_CPP_DIR)/build-apple/whisper.xcframework
 LOCAL_DERIVED_DATA := $(CURDIR)/.local-build
 
 .PHONY: all clean whisper setup build local check healthcheck help dev run release release-setup
@@ -18,6 +18,7 @@ check:
 	@command -v git >/dev/null 2>&1 || { echo "git is not installed"; exit 1; }
 	@command -v xcodebuild >/dev/null 2>&1 || { echo "xcodebuild is not installed (need Xcode)"; exit 1; }
 	@command -v swift >/dev/null 2>&1 || { echo "swift is not installed"; exit 1; }
+	@command -v cmake >/dev/null 2>&1 || { echo "cmake is not installed (run: brew install cmake ninja)"; exit 1; }
 	@echo "Prerequisites OK"
 
 healthcheck: check
@@ -25,7 +26,7 @@ healthcheck: check
 # Build process
 whisper:
 	@mkdir -p $(DEPS_DIR)
-	@if [ ! -d "$(FRAMEWORK_PATH)" ]; then \
+	@if [ ! -d "$(WHISPER_FRAMEWORK_PATH)" ]; then \
 		echo "Building whisper.xcframework in $(DEPS_DIR)..."; \
 		if [ ! -d "$(WHISPER_CPP_DIR)" ]; then \
 			git clone https://github.com/ggerganov/whisper.cpp.git $(WHISPER_CPP_DIR); \
@@ -38,8 +39,8 @@ whisper:
 	fi
 
 setup: whisper
-	@echo "Whisper framework is ready at $(FRAMEWORK_PATH)"
-	@echo "Please ensure your Xcode project references the framework from this new location."
+	@echo "Whisper framework is ready at $(WHISPER_FRAMEWORK_PATH)"
+	@echo "Swift package dependencies are resolved by Xcode."
 
 build: setup
 	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug CODE_SIGN_IDENTITY="" build
@@ -116,7 +117,7 @@ help:
 	@echo "Available targets:"
 	@echo "  check/healthcheck  Check if required CLI tools are installed"
 	@echo "  whisper            Clone and build whisper.cpp XCFramework"
-	@echo "  setup              Copy whisper XCFramework to VoiceInk project"
+	@echo "  setup              Prepare the local Whisper framework"
 	@echo "  build              Build the VoiceInk Xcode project"
 	@echo "  local              Build for local use (no Apple Developer certificate needed)"
 	@echo "  run                Launch the built VoiceInk app"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you encounter any issues or have questions, please:
 ### Core Technology
 - [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - High-performance inference of OpenAI's Whisper model
 - [FluidAudio](https://github.com/FluidInference/FluidAudio) - Used for Parakeet model implementation
+- [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp) - Local GGUF inference for Cohere Transcribe
 
 ### Essential Dependencies
 - [Sparkle](https://github.com/sparkle-project/Sparkle) - Keeping VoiceInk up to date

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you encounter any issues or have questions, please:
 ### Core Technology
 - [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - High-performance inference of OpenAI's Whisper model
 - [FluidAudio](https://github.com/FluidInference/FluidAudio) - Used for Parakeet model implementation
-- [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp) - Local GGUF inference for Cohere Transcribe
+- [TranscribeCpp for Swift](https://github.com/Beingpax/Transcribe-cpp-swift) - SwiftPM distribution of [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp), used for Cohere Transcribe
 
 ### Essential Dependencies
 - [Sparkle](https://github.com/sparkle-project/Sparkle) - Keeping VoiceInk up to date

--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -388,7 +388,7 @@
 				E1F900012FA6000000000001 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				E1F900022FA6000000000001 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
 				E1F900032FA6000000000001 /* XCRemoteSwiftPackageReference "swift-transformers" */,
-				E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "transcribe-cpp-swift" */,
+				E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -857,6 +857,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Beingpax/Transcribe-cpp-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = "0.2.0-dev.856d7c1";
+			};
+		};
 		E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-atomics.git";
@@ -879,14 +887,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.6.4;
-			};
-		};
-		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "transcribe-cpp-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/altic-dev/transcribe-cpp-swift.git";
-			requirement = {
-				kind = exactVersion;
-				version = 0.1.2;
 			};
 		};
 		E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */ = {
@@ -958,6 +958,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */;
+			productName = TranscribeCpp;
+		};
 		E1342C1E2EB4844800CED8A2 /* Atomics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */;
@@ -972,11 +977,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1ADD45D2CC544F100303ECB /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
-		};
-		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "transcribe-cpp-swift" */;
-			productName = TranscribeCpp;
 		};
 		E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		E13461ED2FD1CCCD005B6A81 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = E13461EC2FD1CCCD005B6A81 /* MarkdownUI */; };
 		E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E161D4A02F41ECB90086F83D /* CloudKit.framework */; };
 		E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD45E2CC544F100303ECB /* Sparkle */; };
+		E1C0A0022FA8000000000001 /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = E1C0A0012FA8000000000001 /* TranscribeCpp */; };
 		E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; };
 		E1D7EF9A2E35E19B00640029 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD1EE02FA1D7D30020AF3B /* Zip */; };
@@ -148,6 +149,7 @@
 				E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */,
 				E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */,
 				E1DD20DE2FA20AD90020AF3B /* FluidAudio in Frameworks */,
+				E1C0A0022FA8000000000001 /* TranscribeCpp in Frameworks */,
 				E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */,
 				E13461ED2FD1CCCD005B6A81 /* MarkdownUI in Frameworks */,
 				E1DD20E12FA20AEE0020AF3B /* LLMkit in Frameworks */,
@@ -255,6 +257,7 @@
 				E1342C1E2EB4844800CED8A2 /* Atomics */,
 				E1DD1EE02FA1D7D30020AF3B /* Zip */,
 				E1DD20DD2FA20AD90020AF3B /* FluidAudio */,
+				E1C0A0012FA8000000000001 /* TranscribeCpp */,
 				E1DD20E02FA20AEE0020AF3B /* LLMkit */,
 				E1F511032FA3B47000F00001 /* SelectedTextKit */,
 				E13461EC2FD1CCCD005B6A81 /* MarkdownUI */,
@@ -385,6 +388,7 @@
 				E1F900012FA6000000000001 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				E1F900022FA6000000000001 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
 				E1F900032FA6000000000001 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+				E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "transcribe-cpp-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -622,6 +626,7 @@
 				CURRENT_PROJECT_VERSION = 210;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"VoiceInk/Preview Content\"";
+				DEVELOPMENT_TEAM = V6J6A3VWY2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -656,6 +661,7 @@
 				CURRENT_PROJECT_VERSION = 210;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"VoiceInk/Preview Content\"";
+				DEVELOPMENT_TEAM = V6J6A3VWY2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -875,6 +881,14 @@
 				minimumVersion = 2.6.4;
 			};
 		};
+		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "transcribe-cpp-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/altic-dev/transcribe-cpp-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.1.2;
+			};
+		};
 		E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Beingpax/mediaremote-adapter";
@@ -958,6 +972,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1ADD45D2CC544F100303ECB /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "transcribe-cpp-swift" */;
+			productName = TranscribeCpp;
 		};
 		E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -226,6 +226,15 @@
       }
     },
     {
+      "identity" : "transcribe-cpp-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/altic-dev/transcribe-cpp-swift.git",
+      "state" : {
+        "revision" : "a16df2905f9c715344374fd2d8dd97c2712a6d96",
+        "version" : "0.1.2"
+      }
+    },
+    {
       "identity" : "yyjson",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ibireme/yyjson.git",

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92f23ea9771bf7c4e072587ae3f8c003da396a7e6291a65c2ad4acb671979963",
+  "originHash" : "a16b09e2c0e3fee7d86fbd260972eb0b946296e1771f315691d250410632fd8c",
   "pins" : [
     {
       "identity" : "axswift",
@@ -228,10 +228,10 @@
     {
       "identity" : "transcribe-cpp-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/altic-dev/transcribe-cpp-swift.git",
+      "location" : "https://github.com/Beingpax/Transcribe-cpp-swift.git",
       "state" : {
-        "revision" : "a16df2905f9c715344374fd2d8dd97c2712a6d96",
-        "version" : "0.1.2"
+        "revision" : "fb1c1ad99e8939a69fcfb613417d9635fb77ef42",
+        "version" : "0.2.0-dev.856d7c1"
       }
     },
     {

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -17458,19 +17458,19 @@
         }
       }
     },
-    "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization." : {
+    "Turn this on if local transcriptions take longer than expected. It prepares the selected model in the background when the app launches or wakes." : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktiviere diese Option, wenn Transkriptionen mit lokalen Modellen länger als erwartet dauern. Führt beim App-Start und Aufwachen im Hintergrund stille Transkriptionen aus, um die Optimierung anzustoßen."
+            "value" : "Aktiviere diese Option, wenn lokale Transkriptionen länger als erwartet dauern. Das ausgewählte Modell wird beim Start oder Aufwachen der App im Hintergrund vorbereitet."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "如果本地模型转写耗时超出预期，请开启此选项。App 在启动和唤醒时会静默运行后台转写，以触发优化。"
+            "value" : "如果本地转写耗时超出预期，请开启此选项。App 启动或唤醒时会在后台准备所选模型。"
           }
         }
       }

--- a/VoiceInk/Models/LanguageDictionary.swift
+++ b/VoiceInk/Models/LanguageDictionary.swift
@@ -130,6 +130,10 @@ enum LanguageDictionary {
         "zh-CN": "Mandarin Chinese",
     ]
 
+    static let cohereTranscribe = forCodes([
+        "ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh",
+    ])
+
     private static func languages(matching codes: Set<String>) -> [String: String] {
         all.filter { codes.contains($0.key) }
     }

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -4,6 +4,7 @@ import Foundation
 enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case whisper = "Whisper"
     case fluidAudio = "Parakeet"
+    case transcribeCpp = "TranscribeCpp"
     case groq = "Groq"
     case elevenLabs = "ElevenLabs"
     case deepgram = "Deepgram"
@@ -20,9 +21,13 @@ enum ModelProvider: String, Codable, Hashable, CaseIterable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)
-        // "Local" was the raw value before renaming to "Whisper"
+        // Preserve previously stored provider values across provider renames.
         if raw == "Local" {
             self = .whisper
+            return
+        }
+        if raw == "Cohere" {
+            self = .transcribeCpp
             return
         }
         guard let value = ModelProvider(rawValue: raw) else {
@@ -101,6 +106,23 @@ struct FluidAudioModel: TranscriptionModel {
         self.supportsStreaming = supportsStreaming
         self.supportedLanguages = supportedLanguages
     }
+}
+
+/// A local GGUF transcription model served by the reusable transcribe.cpp backend.
+struct TranscribeCppModel: TranscriptionModel, Sendable {
+    let id = UUID()
+    let name: String
+    let displayName: String
+    let description: String
+    let provider: ModelProvider = .transcribeCpp
+    let size: String
+    let speed: Double
+    let accuracy: Double
+    let ramUsage: Double
+    let publisher: String
+    let supportedLanguages: [String: String]
+
+    var isMultilingualModel: Bool { supportedLanguages.count > 1 }
 }
 
 // A new struct for cloud models

--- a/VoiceInk/Models/TranscriptionModelRegistry.swift
+++ b/VoiceInk/Models/TranscriptionModelRegistry.swift
@@ -74,6 +74,18 @@ enum TranscriptionModelRegistry {
                 supportedLanguages: LanguageDictionary.nemotronMultilingual
             ),
 
+            TranscribeCppModel(
+                name: "cohere-transcribe",
+                displayName: "Cohere Transcribe",
+                description: "Accurate multilingual transcription that runs privately on your Mac",
+                size: "1.56 GB",
+                speed: 0.98,
+                accuracy: 0.99,
+                ramUsage: 2.5,
+                publisher: "Cohere",
+                supportedLanguages: LanguageDictionary.cohereTranscribe
+            ),
+
             // Local Models
             WhisperModel(
                 name: "ggml-tiny",

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -7,6 +7,7 @@ extension Notification.Name {
     static let toggleRecorderPanel = Notification.Name("toggleRecorderPanel")
     static let dismissRecorderPanel = Notification.Name("dismissRecorderPanel")
     static let didChangeModel = Notification.Name("didChangeModel")
+    static let transcribeCppModelDeleted = Notification.Name("transcribeCppModelDeleted")
     static let aiProviderKeyChanged = Notification.Name("aiProviderKeyChanged")
     static let licenseCelebrationRequested = Notification.Name("licenseCelebrationRequested")
     static let navigateToDestination = Notification.Name("navigateToDestination")

--- a/VoiceInk/Services/ModelPrewarmService.swift
+++ b/VoiceInk/Services/ModelPrewarmService.swift
@@ -112,7 +112,8 @@ final class ModelPrewarmService: ObservableObject {
             return false
         }
 
-        // Only prewarm local models (Parakeet and Whisper need ANE compilation)
+        // Only prewarm local models. This prepares their runtime before the user
+        // starts a transcription, while each service remains responsible for cleanup.
         guard
             let model = ModeRuntimeResolver.transcriptionConfiguration(
                 transcriptionModelManager: transcriptionModelManager
@@ -122,7 +123,7 @@ final class ModelPrewarmService: ObservableObject {
         }
 
         switch model.provider {
-        case .whisper, .fluidAudio:
+        case .whisper, .fluidAudio, .transcribeCpp:
             return true
         default:
             logger.notice("Skipping prewarm - cloud models don't need it")

--- a/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
@@ -9,6 +9,7 @@ class TranscriptionModelManager: ObservableObject {
 
     private weak var whisperModelManager: WhisperModelManager?
     private weak var fluidAudioModelManager: FluidAudioModelManager?
+    private let transcribeCppModelManager = TranscribeCppModelManager.shared
 
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionModelManager")
 
@@ -23,12 +24,18 @@ class TranscriptionModelManager: ObservableObject {
         fluidAudioModelManager.onModelDeleted = { [weak self] modelName in
             self?.handleModelDeleted(modelName)
         }
+        transcribeCppModelManager.onModelDeleted = { [weak self] modelName in
+            self?.handleModelDeleted(modelName)
+        }
 
         // Wire up "models changed" callbacks so this manager rebuilds allAvailableModels.
         whisperModelManager.onModelsChanged = { [weak self] in
             self?.refreshAllAvailableModels()
         }
         fluidAudioModelManager.onModelsChanged = { [weak self] in
+            self?.refreshAllAvailableModels()
+        }
+        transcribeCppModelManager.onModelsChanged = { [weak self] in
             self?.refreshAllAvailableModels()
         }
     }
@@ -42,6 +49,8 @@ class TranscriptionModelManager: ObservableObject {
                 return whisperModelManager?.availableModels.contains { $0.name == model.name } ?? false
             case .fluidAudio:
                 return fluidAudioModelManager?.isFluidAudioModelDownloaded(named: model.name) ?? false
+            case .transcribeCpp:
+                return transcribeCppModelManager.isModelDownloaded(named: model.name)
             case .nativeApple:
                 if #available(macOS 26, *) { return true } else { return false }
             case .custom:
@@ -146,7 +155,7 @@ class TranscriptionModelManager: ObservableObject {
 
     // MARK: - Handle model deletion callback
 
-    /// Called by WhisperModelManager.onModelDeleted or FluidAudioModelManager.onModelDeleted.
+    /// Called when one of the local model managers deletes a model.
     func handleModelDeleted(_ modelName: String) {
         if currentTranscriptionModel?.name == modelName {
             currentTranscriptionModel = nil

--- a/VoiceInk/Transcription/Engine/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionServiceRegistry.swift
@@ -17,6 +17,16 @@ class TranscriptionServiceRegistry {
     private(set) lazy var cloudTranscriptionService = CloudTranscriptionService(modelContext: modelContext)
     private(set) lazy var nativeAppleTranscriptionService = NativeAppleTranscriptionService()
     private(set) lazy var fluidAudioTranscriptionService = FluidAudioTranscriptionService()
+    private var cachedTranscribeCppTranscriptionService: TranscribeCppTranscriptionService?
+
+    var transcribeCppTranscriptionService: TranscribeCppTranscriptionService {
+        if let cachedTranscribeCppTranscriptionService {
+            return cachedTranscribeCppTranscriptionService
+        }
+        let service = TranscribeCppTranscriptionService()
+        cachedTranscribeCppTranscriptionService = service
+        return service
+    }
 
     init(modelProvider: any WhisperModelProvider, modelsDirectory: URL, modelContext: ModelContext) {
         self.modelProvider = modelProvider
@@ -30,6 +40,8 @@ class TranscriptionServiceRegistry {
             return localTranscriptionService
         case .fluidAudio:
             return fluidAudioTranscriptionService
+        case .transcribeCpp:
+            return transcribeCppTranscriptionService
         case .nativeApple:
             return nativeAppleTranscriptionService
         default:
@@ -73,5 +85,6 @@ class TranscriptionServiceRegistry {
 
     func cleanup() async {
         await fluidAudioTranscriptionService.cleanup()
+        cachedTranscribeCppTranscriptionService?.cleanup()
     }
 }

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -383,6 +383,9 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                 } else if let fluidAudioModel = currentModel as? FluidAudioModel {
                                     try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(
                                         for: fluidAudioModel)
+                                } else if let transcribeCppModel = currentModel as? TranscribeCppModel {
+                                    try? await self.serviceRegistry.transcribeCppTranscriptionService.loadModel(
+                                        for: transcribeCppModel)
                                 }
 
                             }

--- a/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
@@ -1,0 +1,353 @@
+import FluidAudio
+import Dispatch
+import Foundation
+import TranscribeCpp
+import os
+
+final class CohereTranscriptionService: TranscriptionService, @unchecked Sendable {
+    private struct LoadedState {
+        let modelName: String
+        let model: Model
+    }
+
+    private struct LoadingState {
+        let id: UUID
+        let modelName: String
+        let task: Task<Model, Error>
+    }
+
+    private enum LoadResolution {
+        case loaded(Model)
+        case loading(LoadingState)
+    }
+
+    private static let backendInitializationLock = NSLock()
+    private static var backendsInitialized = false
+
+    private let stateLock = NSLock()
+    private var loadedState: LoadedState?
+    private var loadingState: LoadingState?
+    private var notificationObservers: [NSObjectProtocol] = []
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
+    private let audioConverter = AudioConverter()
+    private let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "CohereTranscriptionService"
+    )
+
+    init() {
+        let center = NotificationCenter.default
+        notificationObservers.append(
+            center.addObserver(forName: .didChangeModel, object: nil, queue: nil) { [weak self] notification in
+                guard let modelName = notification.userInfo?["modelName"] as? String else { return }
+                self?.unloadModel(unlessSelectedModelIs: modelName)
+            }
+        )
+        notificationObservers.append(
+            center.addObserver(forName: .transcribeCppModelDeleted, object: nil, queue: nil) { [weak self] notification in
+                guard let modelName = notification.userInfo?["modelName"] as? String else {
+                    self?.unloadModel()
+                    return
+                }
+                self?.unloadModel(named: modelName)
+            }
+        )
+
+        let pressureSource = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .global(qos: .utility)
+        )
+        pressureSource.setEventHandler { [weak self] in
+            self?.unloadModel()
+        }
+        pressureSource.resume()
+        memoryPressureSource = pressureSource
+    }
+
+    deinit {
+        memoryPressureSource?.cancel()
+        for observer in notificationObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        unloadModel()
+    }
+
+    private var backend: Backend {
+        #if arch(arm64)
+        return .metal
+        #else
+        return .cpu
+        #endif
+    }
+
+    func loadModel(for model: TranscribeCppModel) async throws {
+        _ = try await getOrLoadModel(for: model)
+    }
+
+    func transcribe(
+        audioURL: URL,
+        model: any TranscriptionModel,
+        context: TranscriptionRequestContext
+    ) async throws -> String {
+        guard let transcribeCppModel = model as? TranscribeCppModel else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported transcription model"]
+            )
+        }
+        let artifact = TranscribeCppModelCatalog.cohereTranscribe
+        guard transcribeCppModel.name == artifact.modelName else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
+            )
+        }
+
+        let nativeModel = try await getOrLoadModel(for: transcribeCppModel)
+        defer { unloadModel(named: transcribeCppModel.name) }
+
+        let samples = try audioConverter.resampleAudioFile(audioURL)
+        let language = selectedLanguage(context.language, for: transcribeCppModel)
+        let options = RunOptions(timestamps: .none, language: language)
+        let chunks = samples.energyAwareChunks(
+            maximumCount: artifact.maximumChunkSeconds * 16_000,
+            boundarySearchCount: artifact.boundarySearchSeconds * 16_000,
+            energyWindowCount: artifact.boundaryEnergyWindowSamples
+        )
+
+        let startedAt = ContinuousClock.now
+        var texts: [String] = []
+        texts.reserveCapacity(chunks.count)
+
+        for chunk in chunks {
+            try Task.checkCancellation()
+            let session = try nativeModel.session()
+            let transcript = try await session.run(chunk, options: options)
+            let text = transcript.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                texts.append(text)
+            }
+        }
+
+        logger.notice(
+            "\(transcribeCppModel.displayName, privacy: .public) completed in \(startedAt.duration(to: .now).formatted(.units(allowed: [.seconds], width: .narrow)), privacy: .public) for \(samples.count, privacy: .public) samples"
+        )
+        return TextNormalizer.shared.normalizeSentence(texts.joined(separator: languageUsesSpaces(language) ? " " : ""))
+    }
+
+    func cleanup() {
+        unloadModel()
+    }
+
+    func unloadModel() {
+        let didUnload = stateLock.withLock {
+            let hadRuntime = loadedState != nil || loadingState != nil
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+            return hadRuntime
+        }
+        if didUnload {
+            logger.notice("transcribe.cpp runtime unloaded")
+        }
+    }
+
+    private func getOrLoadModel(for model: TranscribeCppModel) async throws -> Model {
+        let artifact = TranscribeCppModelCatalog.cohereTranscribe
+        guard model.name == artifact.modelName else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
+            )
+        }
+
+        let resolvedState: LoadResolution = stateLock.withLock {
+            if let loadedState, loadedState.modelName == model.name {
+                return .loaded(loadedState.model)
+            }
+            if let loadingState, loadingState.modelName == model.name {
+                return .loading(loadingState)
+            }
+
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+
+            let loadID = UUID()
+            let backend = backend
+            let task = Task.detached(priority: .userInitiated) {
+                guard let modelURL = artifact.installedModelFileURL else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+
+                try Self.initializeBackendsIfNeeded()
+                guard Transcribe.backendAvailable(backend) else {
+                    throw TranscribeError.backend("The requested transcribe.cpp backend is unavailable")
+                }
+
+                return try Model(
+                    path: modelURL.path,
+                    options: ModelOptions(backend: backend)
+                )
+            }
+            let state = LoadingState(id: loadID, modelName: model.name, task: task)
+            loadingState = state
+            return .loading(state)
+        }
+
+        if case .loaded(let loadedModel) = resolvedState {
+            return loadedModel
+        }
+
+        guard case .loading(let loading) = resolvedState else {
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        let startedAt = ContinuousClock.now
+        do {
+            let loadedModel = try await loading.task.value
+            if let architectureHint = artifact.architectureHint {
+                guard loadedModel.arch.localizedCaseInsensitiveContains(architectureHint) else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+            }
+
+            let loadIsCurrent = stateLock.withLock {
+                if
+                    let currentState = loadedState,
+                    currentState.modelName == model.name,
+                    currentState.model === loadedModel
+                {
+                    return true
+                }
+                guard loadingState?.id == loading.id else { return false }
+                loadedState = LoadedState(modelName: model.name, model: loadedModel)
+                loadingState = nil
+                return true
+            }
+            guard loadIsCurrent else { throw CancellationError() }
+
+            logger.notice(
+                "\(model.displayName, privacy: .public) loaded with \(loadedModel.backend, privacy: .public) in \(startedAt.duration(to: .now).formatted(.units(allowed: [.seconds], width: .narrow)), privacy: .public)"
+            )
+            return loadedModel
+        } catch {
+            stateLock.withLock {
+                if loadingState?.id == loading.id {
+                    loadingState = nil
+                }
+            }
+            throw error
+        }
+    }
+
+    private func unloadModel(named modelName: String) {
+        let didUnload = stateLock.withLock {
+            guard loadedState?.modelName == modelName || loadingState?.modelName == modelName else {
+                return false
+            }
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+            return true
+        }
+        if didUnload {
+            logger.notice("transcribe.cpp runtime unloaded")
+        }
+    }
+
+    private func unloadModel(unlessSelectedModelIs modelName: String) {
+        let didUnload = stateLock.withLock {
+            let hasDifferentLoadedModel = loadedState != nil && loadedState?.modelName != modelName
+            let hasDifferentLoadingModel = loadingState != nil && loadingState?.modelName != modelName
+            guard hasDifferentLoadedModel || hasDifferentLoadingModel else { return false }
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+            return true
+        }
+        if didUnload {
+            logger.notice("transcribe.cpp runtime unloaded")
+        }
+    }
+
+    private func selectedLanguage(_ language: String?, for model: TranscribeCppModel) -> String {
+        let compatibleLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(language, for: model)
+        return compatibleLanguage.split(separator: "-").first.map(String.init)?.lowercased() ?? "en"
+    }
+
+    private func languageUsesSpaces(_ language: String) -> Bool {
+        language != "ja" && language != "zh"
+    }
+
+    private static func initializeBackendsIfNeeded() throws {
+        try backendInitializationLock.withLock {
+            guard !backendsInitialized else { return }
+            try Transcribe.initBackends()
+            backendsInitialized = true
+        }
+    }
+}
+
+private extension Array where Element == Float {
+    /// Matches Cohere's reference long-form splitter. The final part of each
+    /// possible 35-second chunk is a boundary-search region, not audio overlap.
+    func energyAwareChunks(
+        maximumCount: Int,
+        boundarySearchCount: Int,
+        energyWindowCount: Int
+    ) -> [[Float]] {
+        guard maximumCount > 0, count > maximumCount else { return [self] }
+
+        let safeBoundarySearch = Swift.max(1, Swift.min(boundarySearchCount, maximumCount))
+        let safeEnergyWindow = Swift.max(1, energyWindowCount)
+        var chunks: [[Float]] = []
+        var start = 0
+
+        while start < count {
+            let maximumEnd = Swift.min(start + maximumCount, count)
+            if maximumEnd == count {
+                chunks.append(Array(self[start..<maximumEnd]))
+                break
+            }
+
+            let searchStart = Swift.max(start, maximumEnd - safeBoundarySearch)
+            let splitPoint = quietestWindowStart(
+                from: searchStart,
+                to: maximumEnd,
+                windowCount: safeEnergyWindow
+            )
+            let safeSplitPoint = Swift.max(start + 1, Swift.min(splitPoint, count))
+            chunks.append(Array(self[start..<safeSplitPoint]))
+            start = safeSplitPoint
+        }
+
+        return chunks
+    }
+
+    private func quietestWindowStart(from start: Int, to end: Int, windowCount: Int) -> Int {
+        guard end - start > windowCount else { return (start + end) / 2 }
+
+        var quietestStart = start
+        var lowestEnergy = Double.infinity
+        let finalWindowStart = end - windowCount
+
+        for windowStart in stride(from: start, to: finalWindowStart, by: windowCount) {
+            var squaredSampleSum = 0.0
+            for sample in self[windowStart..<(windowStart + windowCount)] {
+                let value = Double(sample)
+                squaredSampleSum += value * value
+            }
+            let meanSquaredEnergy = squaredSampleSum / Double(windowCount)
+            if meanSquaredEnergy < lowestEnergy {
+                lowestEnergy = meanSquaredEnergy
+                quietestStart = windowStart
+            }
+        }
+
+        return quietestStart
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct TranscribeCppModelArtifact: Sendable {
+    let modelName: String
+    let fileName: String
+    let repository: String
+    let repositoryRevision: String
+    let expectedFileSize: Int64
+    let expectedSHA256: String
+    let architectureHint: String?
+    let maximumChunkSeconds: Int
+    let boundarySearchSeconds: Int
+    let boundaryEnergyWindowSamples: Int
+    let legacyDirectoryName: String?
+
+    var downloadURL: URL {
+        URL(
+            string: "https://huggingface.co/\(repository)/resolve/\(repositoryRevision)/\(fileName)"
+        )!
+    }
+
+    var modelDirectory: URL {
+        Self.applicationSupportDirectory
+            .appendingPathComponent("TranscribeCpp", isDirectory: true)
+            .appendingPathComponent(modelName, isDirectory: true)
+    }
+
+    var modelFileURL: URL {
+        modelDirectory.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    var checksumFileURL: URL {
+        modelDirectory.appendingPathComponent(".\(fileName).sha256", isDirectory: false)
+    }
+
+    var installedModelFileURL: URL? {
+        if modelFileIsValid(in: modelDirectory) {
+            return modelFileURL
+        }
+
+        guard let legacyDirectory else { return nil }
+        let legacyModelURL = legacyDirectory.appendingPathComponent(fileName, isDirectory: false)
+        return modelFileIsValid(in: legacyDirectory) ? legacyModelURL : nil
+    }
+
+    func modelFileIsValid(in directory: URL) -> Bool {
+        let fileURL = directory.appendingPathComponent(fileName, isDirectory: false)
+        let checksumURL = directory.appendingPathComponent(".\(fileName).sha256", isDirectory: false)
+
+        guard
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+            values.isRegularFile == true,
+            let size = values.fileSize,
+            Int64(size) == expectedFileSize
+        else {
+            return false
+        }
+
+        let installedChecksum = try? String(contentsOf: checksumURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return installedChecksum == expectedSHA256
+    }
+
+    func removeInstalledFiles() {
+        try? FileManager.default.removeItem(at: modelDirectory)
+        if let legacyDirectory {
+            try? FileManager.default.removeItem(at: legacyDirectory)
+        }
+    }
+
+    private var legacyDirectory: URL? {
+        guard let legacyDirectoryName else { return nil }
+        return Self.applicationSupportDirectory.appendingPathComponent(legacyDirectoryName, isDirectory: true)
+    }
+
+    private static var applicationSupportDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.prakashjoshipax.VoiceInk", isDirectory: true)
+    }
+}
+
+enum TranscribeCppModelCatalog {
+    static let cohereTranscribe = TranscribeCppModelArtifact(
+        modelName: "cohere-transcribe",
+        fileName: "cohere-transcribe-03-2026-Q4_K_M.gguf",
+        repository: "handy-computer/cohere-transcribe-03-2026-gguf",
+        repositoryRevision: "dfa4adebb64f3076b7b6b90b721275cc069cb421",
+        expectedFileSize: 1_558_162_944,
+        expectedSHA256: "0ea56826d8bd5d74b7143a4a04e022dc1bb75452cfae49d98b6acb0c1d16a1fb",
+        architectureHint: "cohere",
+        maximumChunkSeconds: 35,
+        boundarySearchSeconds: 5,
+        boundaryEnergyWindowSamples: 1_600,
+        legacyDirectoryName: "CohereTranscribe"
+    )
+
+    private static let artifactsByModelName = [
+        cohereTranscribe.modelName: cohereTranscribe
+    ]
+
+    static func artifact(for modelName: String) -> TranscribeCppModelArtifact? {
+        artifactsByModelName[modelName]
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
@@ -1,0 +1,290 @@
+import AppKit
+import CryptoKit
+import Foundation
+import os
+
+struct TranscribeCppDownloadStatus: Sendable {
+    let fractionCompleted: Double
+    let message: String
+    let isIndeterminate: Bool
+}
+
+private final class TranscribeCppDownloadOperation: @unchecked Sendable {
+    private let destinationURL: URL
+    private let expectedByteCount: Int64
+    private let progressHandler: @Sendable (Double) -> Void
+    private let lock = NSLock()
+    private var task: URLSessionDownloadTask?
+    private var observation: NSKeyValueObservation?
+    private var continuation: CheckedContinuation<HTTPURLResponse, Error>?
+    private var isCancelled = false
+    private var isCompleted = false
+
+    init(
+        destinationURL: URL,
+        expectedByteCount: Int64,
+        progressHandler: @escaping @Sendable (Double) -> Void
+    ) {
+        self.destinationURL = destinationURL
+        self.expectedByteCount = expectedByteCount
+        self.progressHandler = progressHandler
+    }
+
+    func start(from sourceURL: URL) async throws -> HTTPURLResponse {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = URLSession.shared.downloadTask(with: sourceURL) { [weak self] temporaryURL, response, error in
+                    self?.finishDownload(temporaryURL: temporaryURL, response: response, error: error)
+                }
+                let observation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+                    guard let self else { return }
+                    let reportedTotal = progress.totalUnitCount
+                    let total = reportedTotal > 0 ? reportedTotal : expectedByteCount
+                    guard total > 0 else { return }
+                    let fraction = Double(progress.completedUnitCount) / Double(total)
+                    progressHandler(min(max(fraction, 0), 1))
+                }
+
+                let shouldStart = lock.withLock {
+                    guard !isCancelled, !isCompleted else { return false }
+                    self.task = task
+                    self.observation = observation
+                    self.continuation = continuation
+                    return true
+                }
+
+                if shouldStart {
+                    task.resume()
+                } else {
+                    observation.invalidate()
+                    task.cancel()
+                    continuation.resume(throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            self.cancel()
+        }
+    }
+
+    private func finishDownload(temporaryURL: URL?, response: URLResponse?, error: Error?) {
+        let result: Result<HTTPURLResponse, Error>
+
+        if let error {
+            result = .failure(error)
+        } else if
+            let httpResponse = response as? HTTPURLResponse,
+            (200...299).contains(httpResponse.statusCode),
+            let temporaryURL
+        {
+            do {
+                try? FileManager.default.removeItem(at: destinationURL)
+                try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
+                result = .success(httpResponse)
+            } catch {
+                result = .failure(error)
+            }
+        } else {
+            result = .failure(URLError(.badServerResponse))
+        }
+
+        finish(with: result)
+    }
+
+    private func finish(with result: Result<HTTPURLResponse, Error>) {
+        let resolution = lock.withLock {
+            guard !isCompleted else {
+                return (nil as CheckedContinuation<HTTPURLResponse, Error>?, nil as NSKeyValueObservation?)
+            }
+
+            isCompleted = true
+            let continuation = self.continuation
+            let observation = self.observation
+            self.continuation = nil
+            self.observation = nil
+            task = nil
+            return (continuation, observation)
+        }
+
+        resolution.1?.invalidate()
+        resolution.0?.resume(with: result)
+    }
+
+    private func cancel() {
+        let task = lock.withLock {
+            isCancelled = true
+            return self.task
+        }
+        task?.cancel()
+    }
+}
+
+@MainActor
+final class TranscribeCppModelManager: ObservableObject {
+    static let shared = TranscribeCppModelManager()
+
+    @Published private var downloadStatuses: [String: TranscribeCppDownloadStatus] = [:]
+
+    var onModelDeleted: ((String) -> Void)?
+    var onModelsChanged: (() -> Void)?
+
+    private var activeDownloadIDs: [String: UUID] = [:]
+    private let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "TranscribeCppModelManager"
+    )
+
+    private init() {}
+
+    func isModelDownloaded(_ model: TranscribeCppModel) -> Bool {
+        isModelDownloaded(named: model.name)
+    }
+
+    func isModelDownloaded(named modelName: String) -> Bool {
+        TranscribeCppModelCatalog.artifact(for: modelName)?.installedModelFileURL != nil
+    }
+
+    func isModelDownloading(_ model: TranscribeCppModel) -> Bool {
+        activeDownloadIDs[model.name] != nil
+    }
+
+    func downloadStatus(for model: TranscribeCppModel) -> TranscribeCppDownloadStatus? {
+        downloadStatuses[model.name]
+    }
+
+    func downloadModel(_ model: TranscribeCppModel) async {
+        guard
+            let artifact = TranscribeCppModelCatalog.artifact(for: model.name),
+            activeDownloadIDs[model.name] == nil,
+            !isModelDownloaded(model)
+        else {
+            return
+        }
+
+        let downloadID = UUID()
+        activeDownloadIDs[model.name] = downloadID
+        downloadStatuses[model.name] = TranscribeCppDownloadStatus(
+            fractionCompleted: 0,
+            message: String(localized: "Downloading..."),
+            isIndeterminate: false
+        )
+
+        defer {
+            if activeDownloadIDs[model.name] == downloadID {
+                activeDownloadIDs[model.name] = nil
+                downloadStatuses[model.name] = nil
+                onModelsChanged?()
+            }
+        }
+
+        let partialURL = artifact.modelDirectory.appendingPathComponent("\(artifact.fileName).partial")
+        let modelName = model.name
+
+        do {
+            try FileManager.default.createDirectory(at: artifact.modelDirectory, withIntermediateDirectories: true)
+            try? FileManager.default.removeItem(at: partialURL)
+
+            let operation = TranscribeCppDownloadOperation(
+                destinationURL: partialURL,
+                expectedByteCount: artifact.expectedFileSize
+            ) { [weak self] fraction in
+                Task { @MainActor [weak self] in
+                    self?.updateDownloadProgress(fraction, for: modelName, downloadID: downloadID)
+                }
+            }
+            _ = try await operation.start(from: artifact.downloadURL)
+            try Task.checkCancellation()
+
+            downloadStatuses[model.name] = TranscribeCppDownloadStatus(
+                fractionCompleted: 1,
+                message: String(localized: "Verifying..."),
+                isIndeterminate: true
+            )
+
+            let values = try partialURL.resourceValues(forKeys: [.fileSizeKey])
+            guard Int64(values.fileSize ?? 0) == artifact.expectedFileSize else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            let checksum = try await Task.detached(priority: .utility) {
+                try Self.sha256(of: partialURL)
+            }.value
+            guard checksum == artifact.expectedSHA256 else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            try? FileManager.default.removeItem(at: artifact.modelFileURL)
+            try FileManager.default.moveItem(at: partialURL, to: artifact.modelFileURL)
+            try artifact.expectedSHA256.write(
+                to: artifact.checksumFileURL,
+                atomically: true,
+                encoding: .utf8
+            )
+
+            guard artifact.installedModelFileURL != nil else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            logger.notice("\(model.displayName, privacy: .public) installed successfully")
+        } catch is CancellationError {
+            try? FileManager.default.removeItem(at: partialURL)
+            logger.notice("\(model.displayName, privacy: .public) download cancelled")
+        } catch {
+            try? FileManager.default.removeItem(at: partialURL)
+            if !artifact.modelFileIsValid(in: artifact.modelDirectory) {
+                try? FileManager.default.removeItem(at: artifact.modelFileURL)
+                try? FileManager.default.removeItem(at: artifact.checksumFileURL)
+            }
+            logger.error("\(model.displayName, privacy: .public) download failed: \(error, privacy: .public)")
+            NotificationManager.shared.showNotification(
+                title: "\(model.displayName) download failed",
+                type: .error
+            )
+        }
+    }
+
+    func deleteModel(_ model: TranscribeCppModel) {
+        guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name) else { return }
+        artifact.removeInstalledFiles()
+        NotificationCenter.default.post(
+            name: .transcribeCppModelDeleted,
+            object: nil,
+            userInfo: ["modelName": model.name]
+        )
+        onModelDeleted?(model.name)
+        onModelsChanged?()
+    }
+
+    func showModelInFinder(_ model: TranscribeCppModel) {
+        guard
+            let artifact = TranscribeCppModelCatalog.artifact(for: model.name),
+            let modelFileURL = artifact.installedModelFileURL
+        else {
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([modelFileURL])
+    }
+
+    private func updateDownloadProgress(_ fraction: Double, for modelName: String, downloadID: UUID) {
+        guard activeDownloadIDs[modelName] == downloadID, fraction.isFinite else { return }
+        let currentFraction = downloadStatuses[modelName]?.fractionCompleted ?? 0
+        guard fraction > currentFraction else { return }
+        guard fraction == 1 || fraction - currentFraction >= 0.005 else { return }
+
+        downloadStatuses[modelName] = TranscribeCppDownloadStatus(
+            fractionCompleted: fraction,
+            message: String(localized: "Downloading..."),
+            isIndeterminate: false
+        )
+    }
+
+    nonisolated private static func sha256(of fileURL: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 8 * 1_024 * 1_024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Routes transcribe.cpp-backed models to their model-specific service.
+/// Shared provider wiring stays stable as additional transcribe.cpp model
+/// families are added.
+final class TranscribeCppTranscriptionService: TranscriptionService, @unchecked Sendable {
+    private let cohereService = CohereTranscriptionService()
+
+    func loadModel(for model: TranscribeCppModel) async throws {
+        switch model.name {
+        case TranscribeCppModelCatalog.cohereTranscribe.modelName:
+            try await cohereService.loadModel(for: model)
+        default:
+            throw unsupportedModelError(model.name)
+        }
+    }
+
+    func transcribe(
+        audioURL: URL,
+        model: any TranscriptionModel,
+        context: TranscriptionRequestContext
+    ) async throws -> String {
+        guard let transcribeCppModel = model as? TranscribeCppModel else {
+            throw NSError(
+                domain: "TranscribeCppTranscriptionService",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported transcription model"]
+            )
+        }
+
+        switch transcribeCppModel.name {
+        case TranscribeCppModelCatalog.cohereTranscribe.modelName:
+            return try await cohereService.transcribe(
+                audioURL: audioURL,
+                model: transcribeCppModel,
+                context: context
+            )
+        default:
+            throw unsupportedModelError(transcribeCppModel.name)
+        }
+    }
+
+    func cleanup() {
+        cohereService.cleanup()
+    }
+
+    private func unsupportedModelError(_ modelName: String) -> NSError {
+        NSError(
+            domain: "TranscribeCppTranscriptionService",
+            code: -2,
+            userInfo: [NSLocalizedDescriptionKey: "No transcribe.cpp service is registered for \(modelName)"]
+        )
+    }
+}

--- a/VoiceInk/Views/AI Models/ModelCardView.swift
+++ b/VoiceInk/Views/AI Models/ModelCardView.swift
@@ -42,6 +42,10 @@ struct ModelCardView: View {
                         fluidAudioModelManager: fluidAudioModelManager
                     )
                 }
+            case .transcribeCpp:
+                if let transcribeCppModel = model as? TranscribeCppModel {
+                    TranscribeCppModelCardView(model: transcribeCppModel)
+                }
             case .nativeApple:
                 if let nativeAppleModel = model as? NativeAppleModel {
                     NativeAppleModelCardView(

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -349,7 +349,8 @@ struct ModelManagementView: View {
 
     private var localModels: [any TranscriptionModel] {
         transcriptionModelManager.allAvailableModels.filter {
-            ($0.provider == .whisper || $0.provider == .nativeApple || $0.provider == .fluidAudio)
+            ($0.provider == .whisper || $0.provider == .nativeApple || $0.provider == .fluidAudio
+                || $0.provider == .transcribeCpp)
                 && transcriptionModelManager.isAvailableOnCurrentOS($0)
         }
     }

--- a/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
+++ b/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
@@ -166,7 +166,7 @@ private struct AdvancedModelSettingsSection: View {
                 HStack(spacing: 4) {
                     Text("Prewarm model (Experimental)")
                     InfoTip(
-                        "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization."
+                        "Turn this on if local transcriptions take longer than expected. It prepares the selected model in the background when the app launches or wakes."
                     )
                 }
             }

--- a/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
+++ b/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct TranscribeCppModelCardView: View {
+    let model: TranscribeCppModel
+    @ObservedObject private var modelManager = TranscribeCppModelManager.shared
+
+    private var isDownloaded: Bool { modelManager.isModelDownloaded(model) }
+    private var isDownloading: Bool { modelManager.isModelDownloading(model) }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(model.displayName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(Color(.labelColor))
+
+                HStack(spacing: 12) {
+                    Label(model.language, systemImage: "globe")
+                    Label(model.size, systemImage: "internaldrive")
+                    HStack(spacing: 3) {
+                        Text("Speed")
+                        progressDotsWithNumber(value: model.speed * 10)
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                    HStack(spacing: 3) {
+                        Text("Accuracy")
+                        progressDotsWithNumber(value: model.accuracy * 10)
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(Color(.secondaryLabelColor))
+                .lineLimit(1)
+
+                Text(model.description)
+                    .font(.system(size: 11))
+                    .foregroundColor(Color(.secondaryLabelColor))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
+
+                progressSection
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            actionSection
+        }
+        .padding(16)
+        .background(AppMaterialCardBackground())
+    }
+
+    @ViewBuilder
+    private var progressSection: some View {
+        if let status = modelManager.downloadStatus(for: model) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(status.message)
+                        .lineLimit(1)
+
+                    if status.isIndeterminate {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.65)
+                    }
+
+                    Spacer()
+
+                    Text(status.fractionCompleted, format: .percent.precision(.fractionLength(0)))
+                        .fontDesign(.monospaced)
+                }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color(.secondaryLabelColor))
+
+                ProgressView(value: status.fractionCompleted)
+                    .progressViewStyle(.linear)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 8)
+            .animation(.smooth, value: status.fractionCompleted)
+        }
+    }
+
+    private var actionSection: some View {
+        HStack(spacing: 8) {
+            if isDownloaded && !isDownloading {
+                modelStatusPill("Downloaded", systemImage: "checkmark.circle")
+
+                Menu {
+                    Button(role: .destructive) {
+                        modelManager.deleteModel(model)
+                    } label: {
+                        Label("Delete Model", systemImage: "trash")
+                    }
+
+                    Button {
+                        modelManager.showModelInFinder(model)
+                    } label: {
+                        Label("Show in Finder", systemImage: "folder")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.system(size: 14))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 20, height: 20)
+            } else {
+                Button {
+                    Task { await modelManager.downloadModel(model) }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(LocalizedStringKey(isDownloading ? "Downloading..." : "Download"))
+                        Image(systemName: "arrow.down.circle")
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(AppTheme.Accent.primary))
+                }
+                .buttonStyle(.plain)
+                .disabled(isDownloading)
+            }
+        }
+    }
+}

--- a/VoiceInk/Views/Dashboard/ModelInsightComponents.swift
+++ b/VoiceInk/Views/Dashboard/ModelInsightComponents.swift
@@ -348,6 +348,9 @@ private struct ModelProviderIdentity {
         if let model = TranscriptionModelRegistry.models.first(where: { model in
             namesMatch(model.displayName, trimmedName) || namesMatch(model.name, trimmedName)
         }) {
+            if let transcribeCppModel = model as? TranscribeCppModel {
+                return transcribeCppIdentity(publisher: transcribeCppModel.publisher)
+            }
             return identity(for: model.provider)
         }
 
@@ -355,6 +358,10 @@ private struct ModelProviderIdentity {
             || trimmedName.localizedCaseInsensitiveContains("nemotron")
         {
             return identity(for: .fluidAudio)
+        }
+
+        if trimmedName.localizedCaseInsensitiveContains("cohere") {
+            return transcribeCppIdentity(publisher: "Cohere")
         }
 
         if trimmedName.localizedCaseInsensitiveContains("apple") {
@@ -429,6 +436,10 @@ private struct ModelProviderIdentity {
             displayName = "Parakeet"
             providerKey = "Parakeet"
             fallbackSystemImage = "waveform"
+        case .transcribeCpp:
+            displayName = "On-Device"
+            providerKey = "On-Device"
+            fallbackSystemImage = "waveform.badge.magnifyingglass"
         case .nativeApple:
             displayName = "Apple Speech"
             providerKey = "Native Apple"
@@ -452,6 +463,14 @@ private struct ModelProviderIdentity {
                 cloudProvider: cloudProvider
             ),
             fallbackSystemImage: fallbackSystemImage
+        )
+    }
+
+    private static func transcribeCppIdentity(publisher: String) -> ModelProviderIdentity {
+        ModelProviderIdentity(
+            providerName: publisher,
+            descriptor: descriptor(displayName: publisher, providerKey: publisher),
+            fallbackSystemImage: "waveform.badge.magnifyingglass"
         )
     }
 

--- a/VoiceInk/VoiceInk.entitlements
+++ b/VoiceInk/VoiceInk.entitlements
@@ -16,8 +16,6 @@
 	<false/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>

--- a/VoiceInk/VoiceInk.entitlements
+++ b/VoiceInk/VoiceInk.entitlements
@@ -16,6 +16,8 @@
 	<false/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>


### PR DESCRIPTION
## What changed

- adds Cohere Transcribe through the official TranscribeCpp Swift API
- uses `Beingpax/Transcribe-cpp-swift` at `0.2.0-dev.856d7c1`
- removes manual transcribe.cpp framework setup from VoiceInk
- keeps model download, language selection, chunking, and lifecycle handling in VoiceInk

## Package provenance

The package and XCFramework are built from `handy-computer/transcribe.cpp`
commit `856d7c10a1a864b900e066b7c9801edf373f5148` and runtime version `0.2.0`.

## Validation

- remote release checksum verified
- package resolved from its public GitHub tag
- Swift wrapper and isolated consumer compiled
- native runtime loaded as `0.2.0 (856d7c1)`
- upstream package tests: 56 executed, 41 model-dependent skips, 0 failures
- Xcode project and package lockfile syntax checked

The complete VoiceInk application was not built or launched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds on-device Cohere Transcribe powered by transcribe.cpp via the `TranscribeCpp` Swift package, including model download, verification, and lifecycle managed in VoiceInk. This introduces a new local model option with energy-aware chunking and language support, and removes the manual transcribe.cpp framework setup.

- **New Features**
  - New `TranscribeCppModel` and catalog entry for Cohere Transcribe (`cohere-transcribe`).
  - Cohere service with Metal/CPU backend init, energy-aware chunking, language selection, and runtime unload on memory pressure or model changes.
  - Model manager for download, SHA-256 verify, install, delete, and “Show in Finder”.
  - UI: model card with download progress; provider identity; listed among local models.
  - Engine, service registry, and prewarm support for `transcribeCpp`.

- **Dependencies**
  - Added `Transcribe-cpp-swift` pinned to `0.2.0-dev.856d7c1` (runtime 0.2.0); Xcode resolves the native artifact.
  - Docs updated to remove manual transcribe.cpp framework steps and clarify Whisper local build.
  - Makefile adds a `cmake` check and simplifies `setup` messaging; README references `TranscribeCpp for Swift`.

<sup>Written for commit 0bd363316273277e9a95de3bebae08689bb23cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

