### PR TITLE
Cohere transcribe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you encounter any issues or have questions, please:
 ### Core Technology
 - [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - High-performance inference of OpenAI's Whisper model
 - [FluidAudio](https://github.com/FluidInference/FluidAudio) - Used for Parakeet model implementation
+- [TranscribeCpp for Swift](https://github.com/Beingpax/Transcribe-cpp-swift) - SwiftPM distribution of [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp), used for Cohere Transcribe
 
 ### Essential Dependencies
 - [Sparkle](https://github.com/sparkle-project/Sparkle) - Keeping VoiceInk up to date

--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		E13461ED2FD1CCCD005B6A81 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = E13461EC2FD1CCCD005B6A81 /* MarkdownUI */; };
 		E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E161D4A02F41ECB90086F83D /* CloudKit.framework */; };
 		E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD45E2CC544F100303ECB /* Sparkle */; };
+		E1C0A0022FA8000000000001 /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = E1C0A0012FA8000000000001 /* TranscribeCpp */; };
 		E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; };
 		E1D7EF9A2E35E19B00640029 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD1EE02FA1D7D30020AF3B /* Zip */; };
@@ -148,6 +149,7 @@
 				E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */,
 				E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */,
 				E1DD20DE2FA20AD90020AF3B /* FluidAudio in Frameworks */,
+				E1C0A0022FA8000000000001 /* TranscribeCpp in Frameworks */,
 				E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */,
 				E13461ED2FD1CCCD005B6A81 /* MarkdownUI in Frameworks */,
 				E1DD20E12FA20AEE0020AF3B /* LLMkit in Frameworks */,
@@ -255,6 +257,7 @@
 				E1342C1E2EB4844800CED8A2 /* Atomics */,
 				E1DD1EE02FA1D7D30020AF3B /* Zip */,
 				E1DD20DD2FA20AD90020AF3B /* FluidAudio */,
+				E1C0A0012FA8000000000001 /* TranscribeCpp */,
 				E1DD20E02FA20AEE0020AF3B /* LLMkit */,
 				E1F511032FA3B47000F00001 /* SelectedTextKit */,
 				E13461EC2FD1CCCD005B6A81 /* MarkdownUI */,
@@ -385,6 +388,7 @@
 				E1F900012FA6000000000001 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				E1F900022FA6000000000001 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
 				E1F900032FA6000000000001 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+				E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -622,6 +626,7 @@
 				CURRENT_PROJECT_VERSION = 210;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"VoiceInk/Preview Content\"";
+				DEVELOPMENT_TEAM = V6J6A3VWY2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -656,6 +661,7 @@
 				CURRENT_PROJECT_VERSION = 210;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"VoiceInk/Preview Content\"";
+				DEVELOPMENT_TEAM = V6J6A3VWY2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -851,6 +857,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Beingpax/Transcribe-cpp-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = "0.2.0-dev.856d7c1";
+			};
+		};
 		E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-atomics.git";
@@ -944,6 +958,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */;
+			productName = TranscribeCpp;
+		};
 		E1342C1E2EB4844800CED8A2 /* Atomics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */;

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92f23ea9771bf7c4e072587ae3f8c003da396a7e6291a65c2ad4acb671979963",
+  "originHash" : "a16b09e2c0e3fee7d86fbd260972eb0b946296e1771f315691d250410632fd8c",
   "pins" : [
     {
       "identity" : "axswift",
@@ -223,6 +223,15 @@
       "state" : {
         "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "transcribe-cpp-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Beingpax/Transcribe-cpp-swift.git",
+      "state" : {
+        "revision" : "fb1c1ad99e8939a69fcfb613417d9635fb77ef42",
+        "version" : "0.2.0-dev.856d7c1"
       }
     },
     {

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -17458,19 +17458,19 @@
         }
       }
     },
-    "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization." : {
+    "Turn this on if local transcriptions take longer than expected. It prepares the selected model in the background when the app launches or wakes." : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktiviere diese Option, wenn Transkriptionen mit lokalen Modellen länger als erwartet dauern. Führt beim App-Start und Aufwachen im Hintergrund stille Transkriptionen aus, um die Optimierung anzustoßen."
+            "value" : "Aktiviere diese Option, wenn lokale Transkriptionen länger als erwartet dauern. Das ausgewählte Modell wird beim Start oder Aufwachen der App im Hintergrund vorbereitet."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "如果本地模型转写耗时超出预期，请开启此选项。App 在启动和唤醒时会静默运行后台转写，以触发优化。"
+            "value" : "如果本地转写耗时超出预期，请开启此选项。App 启动或唤醒时会在后台准备所选模型。"
           }
         }
       }

--- a/VoiceInk/Models/LanguageDictionary.swift
+++ b/VoiceInk/Models/LanguageDictionary.swift
@@ -130,6 +130,10 @@ enum LanguageDictionary {
         "zh-CN": "Mandarin Chinese",
     ]
 
+    static let cohereTranscribe = forCodes([
+        "ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh",
+    ])
+
     private static func languages(matching codes: Set<String>) -> [String: String] {
         all.filter { codes.contains($0.key) }
     }

--- a/VoiceInk/Models/TranscriptionModel.swift
+++ b/VoiceInk/Models/TranscriptionModel.swift
@@ -4,6 +4,7 @@ import Foundation
 enum ModelProvider: String, Codable, Hashable, CaseIterable {
     case whisper = "Whisper"
     case fluidAudio = "Parakeet"
+    case transcribeCpp = "TranscribeCpp"
     case groq = "Groq"
     case elevenLabs = "ElevenLabs"
     case deepgram = "Deepgram"
@@ -20,9 +21,13 @@ enum ModelProvider: String, Codable, Hashable, CaseIterable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)
-        // "Local" was the raw value before renaming to "Whisper"
+        // Preserve previously stored provider values across provider renames.
         if raw == "Local" {
             self = .whisper
+            return
+        }
+        if raw == "Cohere" {
+            self = .transcribeCpp
             return
         }
         guard let value = ModelProvider(rawValue: raw) else {
@@ -101,6 +106,23 @@ struct FluidAudioModel: TranscriptionModel {
         self.supportsStreaming = supportsStreaming
         self.supportedLanguages = supportedLanguages
     }
+}
+
+/// A local GGUF transcription model served by the reusable transcribe.cpp backend.
+struct TranscribeCppModel: TranscriptionModel, Sendable {
+    let id = UUID()
+    let name: String
+    let displayName: String
+    let description: String
+    let provider: ModelProvider = .transcribeCpp
+    let size: String
+    let speed: Double
+    let accuracy: Double
+    let ramUsage: Double
+    let publisher: String
+    let supportedLanguages: [String: String]
+
+    var isMultilingualModel: Bool { supportedLanguages.count > 1 }
 }
 
 // A new struct for cloud models

--- a/VoiceInk/Models/TranscriptionModelRegistry.swift
+++ b/VoiceInk/Models/TranscriptionModelRegistry.swift
@@ -79,8 +79,8 @@ enum TranscriptionModelRegistry {
                 displayName: "Cohere Transcribe",
                 description: "Accurate multilingual transcription that runs privately on your Mac",
                 size: "1.56 GB",
-                speed: 0.98,
-                accuracy: 0.99,
+                speed: 0.75,
+                accuracy: 0.95,
                 ramUsage: 2.5,
                 publisher: "Cohere",
                 supportedLanguages: LanguageDictionary.cohereTranscribe

--- a/VoiceInk/Models/TranscriptionModelRegistry.swift
+++ b/VoiceInk/Models/TranscriptionModelRegistry.swift
@@ -74,6 +74,18 @@ enum TranscriptionModelRegistry {
                 supportedLanguages: LanguageDictionary.nemotronMultilingual
             ),
 
+            TranscribeCppModel(
+                name: "cohere-transcribe",
+                displayName: "Cohere Transcribe",
+                description: "Accurate multilingual transcription that runs privately on your Mac",
+                size: "1.56 GB",
+                speed: 0.98,
+                accuracy: 0.99,
+                ramUsage: 2.5,
+                publisher: "Cohere",
+                supportedLanguages: LanguageDictionary.cohereTranscribe
+            ),
+
             // Local Models
             WhisperModel(
                 name: "ggml-tiny",

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -7,6 +7,7 @@ extension Notification.Name {
     static let toggleRecorderPanel = Notification.Name("toggleRecorderPanel")
     static let dismissRecorderPanel = Notification.Name("dismissRecorderPanel")
     static let didChangeModel = Notification.Name("didChangeModel")
+    static let transcribeCppModelDeleted = Notification.Name("transcribeCppModelDeleted")
     static let aiProviderKeyChanged = Notification.Name("aiProviderKeyChanged")
     static let licenseCelebrationRequested = Notification.Name("licenseCelebrationRequested")
     static let navigateToDestination = Notification.Name("navigateToDestination")

--- a/VoiceInk/Services/ModelPrewarmService.swift
+++ b/VoiceInk/Services/ModelPrewarmService.swift
@@ -112,7 +112,8 @@ final class ModelPrewarmService: ObservableObject {
             return false
         }
 
-        // Only prewarm local models (Parakeet and Whisper need ANE compilation)
+        // Only prewarm local models. This prepares their runtime before the user
+        // starts a transcription, while each service remains responsible for cleanup.
         guard
             let model = ModeRuntimeResolver.transcriptionConfiguration(
                 transcriptionModelManager: transcriptionModelManager
@@ -122,7 +123,7 @@ final class ModelPrewarmService: ObservableObject {
         }
 
         switch model.provider {
-        case .whisper, .fluidAudio:
+        case .whisper, .fluidAudio, .transcribeCpp:
             return true
         default:
             logger.notice("Skipping prewarm - cloud models don't need it")

--- a/VoiceInk/Services/ModelPrewarmService.swift
+++ b/VoiceInk/Services/ModelPrewarmService.swift
@@ -112,8 +112,7 @@ final class ModelPrewarmService: ObservableObject {
             return false
         }
 
-        // Only prewarm local models. This prepares their runtime before the user
-        // starts a transcription, while each service remains responsible for cleanup.
+        // Prewarm only local runtimes that benefit from retained preparation.
         guard
             let model = ModeRuntimeResolver.transcriptionConfiguration(
                 transcriptionModelManager: transcriptionModelManager
@@ -123,7 +122,7 @@ final class ModelPrewarmService: ObservableObject {
         }
 
         switch model.provider {
-        case .whisper, .fluidAudio, .transcribeCpp:
+        case .whisper, .fluidAudio:
             return true
         default:
             logger.notice("Skipping prewarm - cloud models don't need it")

--- a/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionModelManager.swift
@@ -9,6 +9,7 @@ class TranscriptionModelManager: ObservableObject {
 
     private weak var whisperModelManager: WhisperModelManager?
     private weak var fluidAudioModelManager: FluidAudioModelManager?
+    private let transcribeCppModelManager = TranscribeCppModelManager.shared
 
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionModelManager")
 
@@ -23,12 +24,18 @@ class TranscriptionModelManager: ObservableObject {
         fluidAudioModelManager.onModelDeleted = { [weak self] modelName in
             self?.handleModelDeleted(modelName)
         }
+        transcribeCppModelManager.onModelDeleted = { [weak self] modelName in
+            self?.handleModelDeleted(modelName)
+        }
 
         // Wire up "models changed" callbacks so this manager rebuilds allAvailableModels.
         whisperModelManager.onModelsChanged = { [weak self] in
             self?.refreshAllAvailableModels()
         }
         fluidAudioModelManager.onModelsChanged = { [weak self] in
+            self?.refreshAllAvailableModels()
+        }
+        transcribeCppModelManager.onModelsChanged = { [weak self] in
             self?.refreshAllAvailableModels()
         }
     }
@@ -42,6 +49,8 @@ class TranscriptionModelManager: ObservableObject {
                 return whisperModelManager?.availableModels.contains { $0.name == model.name } ?? false
             case .fluidAudio:
                 return fluidAudioModelManager?.isFluidAudioModelDownloaded(named: model.name) ?? false
+            case .transcribeCpp:
+                return transcribeCppModelManager.isModelDownloaded(named: model.name)
             case .nativeApple:
                 if #available(macOS 26, *) { return true } else { return false }
             case .custom:
@@ -146,7 +155,7 @@ class TranscriptionModelManager: ObservableObject {
 
     // MARK: - Handle model deletion callback
 
-    /// Called by WhisperModelManager.onModelDeleted or FluidAudioModelManager.onModelDeleted.
+    /// Called when one of the local model managers deletes a model.
     func handleModelDeleted(_ modelName: String) {
         if currentTranscriptionModel?.name == modelName {
             currentTranscriptionModel = nil

--- a/VoiceInk/Transcription/Engine/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionServiceRegistry.swift
@@ -17,6 +17,16 @@ class TranscriptionServiceRegistry {
     private(set) lazy var cloudTranscriptionService = CloudTranscriptionService(modelContext: modelContext)
     private(set) lazy var nativeAppleTranscriptionService = NativeAppleTranscriptionService()
     private(set) lazy var fluidAudioTranscriptionService = FluidAudioTranscriptionService()
+    private var cachedTranscribeCppTranscriptionService: TranscribeCppTranscriptionService?
+
+    var transcribeCppTranscriptionService: TranscribeCppTranscriptionService {
+        if let cachedTranscribeCppTranscriptionService {
+            return cachedTranscribeCppTranscriptionService
+        }
+        let service = TranscribeCppTranscriptionService()
+        cachedTranscribeCppTranscriptionService = service
+        return service
+    }
 
     init(modelProvider: any WhisperModelProvider, modelsDirectory: URL, modelContext: ModelContext) {
         self.modelProvider = modelProvider
@@ -30,6 +40,8 @@ class TranscriptionServiceRegistry {
             return localTranscriptionService
         case .fluidAudio:
             return fluidAudioTranscriptionService
+        case .transcribeCpp:
+            return transcribeCppTranscriptionService
         case .nativeApple:
             return nativeAppleTranscriptionService
         default:
@@ -73,5 +85,6 @@ class TranscriptionServiceRegistry {
 
     func cleanup() async {
         await fluidAudioTranscriptionService.cleanup()
+        cachedTranscribeCppTranscriptionService?.cleanup()
     }
 }

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -383,6 +383,9 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                 } else if let fluidAudioModel = currentModel as? FluidAudioModel {
                                     try? await self.serviceRegistry.fluidAudioTranscriptionService.loadModel(
                                         for: fluidAudioModel)
+                                } else if let transcribeCppModel = currentModel as? TranscribeCppModel {
+                                    try? await self.serviceRegistry.transcribeCppTranscriptionService.loadModel(
+                                        for: transcribeCppModel)
                                 }
 
                             }

--- a/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
@@ -22,11 +22,13 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     }
 
     private static let backendInitializationLock = NSLock()
+    private static let modelInitializationLock = NSLock()
     private static var backendsInitialized = false
 
     private let stateLock = NSLock()
     private var loadedState: LoadedState?
     private var loadingState: LoadingState?
+    private var activeTranscriptionCount = 0
     private var notificationObservers: [NSObjectProtocol] = []
     private var memoryPressureSource: DispatchSourceMemoryPressure?
     private let audioConverter = AudioConverter()
@@ -81,7 +83,8 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     }
 
     func loadModel(for model: TranscribeCppModel) async throws {
-        _ = try await getOrLoadModel(for: model)
+        let artifact = try resolveArtifact(for: model)
+        _ = try await getOrLoadModel(for: model, artifact: artifact)
     }
 
     func transcribe(
@@ -96,17 +99,11 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
                 userInfo: [NSLocalizedDescriptionKey: "Unsupported transcription model"]
             )
         }
-        let artifact = TranscribeCppModelCatalog.cohereTranscribe
-        guard transcribeCppModel.name == artifact.modelName else {
-            throw NSError(
-                domain: "CohereTranscriptionService",
-                code: -2,
-                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
-            )
-        }
+        let artifact = try resolveArtifact(for: transcribeCppModel)
 
-        let nativeModel = try await getOrLoadModel(for: transcribeCppModel)
-        defer { unloadModel(named: transcribeCppModel.name) }
+        let nativeModel = try await getOrLoadModel(for: transcribeCppModel, artifact: artifact)
+        retainModel(nativeModel, named: transcribeCppModel.name)
+        defer { releaseModel(named: transcribeCppModel.name) }
 
         let samples = try audioConverter.resampleAudioFile(audioURL)
         let language = selectedLanguage(context.language, for: transcribeCppModel)
@@ -142,28 +139,13 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     }
 
     func unloadModel() {
-        let didUnload = stateLock.withLock {
-            let hadRuntime = loadedState != nil || loadingState != nil
-            loadingState?.task.cancel()
-            loadingState = nil
-            loadedState = nil
-            return hadRuntime
-        }
-        if didUnload {
-            logger.notice("transcribe.cpp runtime unloaded")
-        }
+        unloadModel { _ in true }
     }
 
-    private func getOrLoadModel(for model: TranscribeCppModel) async throws -> Model {
-        let artifact = TranscribeCppModelCatalog.cohereTranscribe
-        guard model.name == artifact.modelName else {
-            throw NSError(
-                domain: "CohereTranscriptionService",
-                code: -2,
-                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
-            )
-        }
-
+    private func getOrLoadModel(
+        for model: TranscribeCppModel,
+        artifact: TranscribeCppModelArtifact
+    ) async throws -> Model {
         let resolvedState: LoadResolution = stateLock.withLock {
             if let loadedState, loadedState.modelName == model.name {
                 return .loaded(loadedState.model)
@@ -179,6 +161,7 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
             let loadID = UUID()
             let backend = backend
             let task = Task.detached(priority: .userInitiated) {
+                try Task.checkCancellation()
                 guard let modelURL = artifact.installedModelFileURL else {
                     throw CocoaError(.fileNoSuchFile)
                 }
@@ -188,10 +171,16 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
                     throw TranscribeError.backend("The requested transcribe.cpp backend is unavailable")
                 }
 
-                return try Model(
-                    path: modelURL.path,
-                    options: ModelOptions(backend: backend)
-                )
+                // Serialize non-cancellable native construction to prevent overlapping model loads.
+                return try Self.modelInitializationLock.withLock {
+                    try Task.checkCancellation()
+                    let loadedModel = try Model(
+                        path: modelURL.path,
+                        options: ModelOptions(backend: backend)
+                    )
+                    try Task.checkCancellation()
+                    return loadedModel
+                }
             }
             let state = LoadingState(id: loadID, modelName: model.name, task: task)
             loadingState = state
@@ -245,8 +234,19 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     }
 
     private func unloadModel(named modelName: String) {
+        unloadModel { $0 == modelName }
+    }
+
+    private func unloadModel(unlessSelectedModelIs modelName: String) {
+        unloadModel { $0 != modelName }
+    }
+
+    private func unloadModel(where shouldUnload: (String) -> Bool) {
         let didUnload = stateLock.withLock {
-            guard loadedState?.modelName == modelName || loadingState?.modelName == modelName else {
+            guard let activeModelName = loadedState?.modelName ?? loadingState?.modelName,
+                shouldUnload(activeModelName),
+                activeTranscriptionCount == 0
+            else {
                 return false
             }
             loadingState?.task.cancel()
@@ -259,11 +259,25 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
         }
     }
 
-    private func unloadModel(unlessSelectedModelIs modelName: String) {
+    private func retainModel(_ model: Model, named modelName: String) {
+        stateLock.withLock {
+            // Restore an acquired model after a racing unload and cancel its replacement load.
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = LoadedState(modelName: modelName, model: model)
+            activeTranscriptionCount += 1
+        }
+    }
+
+    private func releaseModel(named modelName: String) {
         let didUnload = stateLock.withLock {
-            let hasDifferentLoadedModel = loadedState != nil && loadedState?.modelName != modelName
-            let hasDifferentLoadingModel = loadingState != nil && loadingState?.modelName != modelName
-            guard hasDifferentLoadedModel || hasDifferentLoadingModel else { return false }
+            guard activeTranscriptionCount > 0 else { return false }
+            activeTranscriptionCount -= 1
+            guard activeTranscriptionCount == 0,
+                loadedState?.modelName == modelName || loadingState?.modelName == modelName
+            else {
+                return false
+            }
             loadingState?.task.cancel()
             loadingState = nil
             loadedState = nil
@@ -272,6 +286,19 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
         if didUnload {
             logger.notice("transcribe.cpp runtime unloaded")
         }
+    }
+
+    private func resolveArtifact(for model: TranscribeCppModel) throws -> TranscribeCppModelArtifact {
+        guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name),
+            artifact.modelName == TranscribeCppModelCatalog.cohereTranscribe.modelName
+        else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
+            )
+        }
+        return artifact
     }
 
     private func selectedLanguage(_ language: String?, for model: TranscribeCppModel) -> String {
@@ -293,8 +320,7 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
 }
 
 private extension Array where Element == Float {
-    /// Matches Cohere's reference long-form splitter. The final part of each
-    /// possible 35-second chunk is a boundary-search region, not audio overlap.
+    /// Matches Cohere's long-form splitter, using the chunk tail for boundary search rather than overlap.
     func energyAwareChunks(
         maximumCount: Int,
         boundarySearchCount: Int,
@@ -334,8 +360,12 @@ private extension Array where Element == Float {
         var quietestStart = start
         var lowestEnergy = Double.infinity
         let finalWindowStart = end - windowCount
+        var candidateStarts = Array(stride(from: start, through: finalWindowStart, by: windowCount))
+        if candidateStarts.last != finalWindowStart {
+            candidateStarts.append(finalWindowStart)
+        }
 
-        for windowStart in stride(from: start, to: finalWindowStart, by: windowCount) {
+        for windowStart in candidateStarts {
             var squaredSampleSum = 0.0
             for sample in self[windowStart..<(windowStart + windowCount)] {
                 let value = Double(sample)

--- a/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
@@ -360,7 +360,7 @@ private extension Array where Element == Float {
         var quietestStart = start
         var lowestEnergy = Double.infinity
         let finalWindowStart = end - windowCount
-        var candidateStarts = Array(stride(from: start, through: finalWindowStart, by: windowCount))
+        var candidateStarts = [Int](stride(from: start, through: finalWindowStart, by: windowCount))
         if candidateStarts.last != finalWindowStart {
             candidateStarts.append(finalWindowStart)
         }

--- a/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/Cohere/CohereTranscriptionService.swift
@@ -1,0 +1,353 @@
+import FluidAudio
+import Dispatch
+import Foundation
+import TranscribeCpp
+import os
+
+final class CohereTranscriptionService: TranscriptionService, @unchecked Sendable {
+    private struct LoadedState {
+        let modelName: String
+        let model: Model
+    }
+
+    private struct LoadingState {
+        let id: UUID
+        let modelName: String
+        let task: Task<Model, Error>
+    }
+
+    private enum LoadResolution {
+        case loaded(Model)
+        case loading(LoadingState)
+    }
+
+    private static let backendInitializationLock = NSLock()
+    private static var backendsInitialized = false
+
+    private let stateLock = NSLock()
+    private var loadedState: LoadedState?
+    private var loadingState: LoadingState?
+    private var notificationObservers: [NSObjectProtocol] = []
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
+    private let audioConverter = AudioConverter()
+    private let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "CohereTranscriptionService"
+    )
+
+    init() {
+        let center = NotificationCenter.default
+        notificationObservers.append(
+            center.addObserver(forName: .didChangeModel, object: nil, queue: nil) { [weak self] notification in
+                guard let modelName = notification.userInfo?["modelName"] as? String else { return }
+                self?.unloadModel(unlessSelectedModelIs: modelName)
+            }
+        )
+        notificationObservers.append(
+            center.addObserver(forName: .transcribeCppModelDeleted, object: nil, queue: nil) { [weak self] notification in
+                guard let modelName = notification.userInfo?["modelName"] as? String else {
+                    self?.unloadModel()
+                    return
+                }
+                self?.unloadModel(named: modelName)
+            }
+        )
+
+        let pressureSource = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .global(qos: .utility)
+        )
+        pressureSource.setEventHandler { [weak self] in
+            self?.unloadModel()
+        }
+        pressureSource.resume()
+        memoryPressureSource = pressureSource
+    }
+
+    deinit {
+        memoryPressureSource?.cancel()
+        for observer in notificationObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        unloadModel()
+    }
+
+    private var backend: Backend {
+        #if arch(arm64)
+        return .metal
+        #else
+        return .cpu
+        #endif
+    }
+
+    func loadModel(for model: TranscribeCppModel) async throws {
+        _ = try await getOrLoadModel(for: model)
+    }
+
+    func transcribe(
+        audioURL: URL,
+        model: any TranscriptionModel,
+        context: TranscriptionRequestContext
+    ) async throws -> String {
+        guard let transcribeCppModel = model as? TranscribeCppModel else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported transcription model"]
+            )
+        }
+        let artifact = TranscribeCppModelCatalog.cohereTranscribe
+        guard transcribeCppModel.name == artifact.modelName else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
+            )
+        }
+
+        let nativeModel = try await getOrLoadModel(for: transcribeCppModel)
+        defer { unloadModel(named: transcribeCppModel.name) }
+
+        let samples = try audioConverter.resampleAudioFile(audioURL)
+        let language = selectedLanguage(context.language, for: transcribeCppModel)
+        let options = RunOptions(timestamps: .none, language: language)
+        let chunks = samples.energyAwareChunks(
+            maximumCount: artifact.maximumChunkSeconds * 16_000,
+            boundarySearchCount: artifact.boundarySearchSeconds * 16_000,
+            energyWindowCount: artifact.boundaryEnergyWindowSamples
+        )
+
+        let startedAt = ContinuousClock.now
+        var texts: [String] = []
+        texts.reserveCapacity(chunks.count)
+
+        for chunk in chunks {
+            try Task.checkCancellation()
+            let session = try nativeModel.session()
+            let transcript = try await session.run(chunk, options: options)
+            let text = transcript.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                texts.append(text)
+            }
+        }
+
+        logger.notice(
+            "\(transcribeCppModel.displayName, privacy: .public) completed in \(startedAt.duration(to: .now).formatted(.units(allowed: [.seconds], width: .narrow)), privacy: .public) for \(samples.count, privacy: .public) samples"
+        )
+        return TextNormalizer.shared.normalizeSentence(texts.joined(separator: languageUsesSpaces(language) ? " " : ""))
+    }
+
+    func cleanup() {
+        unloadModel()
+    }
+
+    func unloadModel() {
+        let didUnload = stateLock.withLock {
+            let hadRuntime = loadedState != nil || loadingState != nil
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+            return hadRuntime
+        }
+        if didUnload {
+            logger.notice("transcribe.cpp runtime unloaded")
+        }
+    }
+
+    private func getOrLoadModel(for model: TranscribeCppModel) async throws -> Model {
+        let artifact = TranscribeCppModelCatalog.cohereTranscribe
+        guard model.name == artifact.modelName else {
+            throw NSError(
+                domain: "CohereTranscriptionService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
+            )
+        }
+
+        let resolvedState: LoadResolution = stateLock.withLock {
+            if let loadedState, loadedState.modelName == model.name {
+                return .loaded(loadedState.model)
+            }
+            if let loadingState, loadingState.modelName == model.name {
+                return .loading(loadingState)
+            }
+
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+
+            let loadID = UUID()
+            let backend = backend
+            let task = Task.detached(priority: .userInitiated) {
+                guard let modelURL = artifact.installedModelFileURL else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+
+                try Self.initializeBackendsIfNeeded()
+                guard Transcribe.backendAvailable(backend) else {
+                    throw TranscribeError.backend("The requested transcribe.cpp backend is unavailable")
+                }
+
+                return try Model(
+                    path: modelURL.path,
+                    options: ModelOptions(backend: backend)
+                )
+            }
+            let state = LoadingState(id: loadID, modelName: model.name, task: task)
+            loadingState = state
+            return .loading(state)
+        }
+
+        if case .loaded(let loadedModel) = resolvedState {
+            return loadedModel
+        }
+
+        guard case .loading(let loading) = resolvedState else {
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        let startedAt = ContinuousClock.now
+        do {
+            let loadedModel = try await loading.task.value
+            if let architectureHint = artifact.architectureHint {
+                guard loadedModel.arch.localizedCaseInsensitiveContains(architectureHint) else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+            }
+
+            let loadIsCurrent = stateLock.withLock {
+                if
+                    let currentState = loadedState,
+                    currentState.modelName == model.name,
+                    currentState.model === loadedModel
+                {
+                    return true
+                }
+                guard loadingState?.id == loading.id else { return false }
+                loadedState = LoadedState(modelName: model.name, model: loadedModel)
+                loadingState = nil
+                return true
+            }
+            guard loadIsCurrent else { throw CancellationError() }
+
+            logger.notice(
+                "\(model.displayName, privacy: .public) loaded with \(loadedModel.backend, privacy: .public) in \(startedAt.duration(to: .now).formatted(.units(allowed: [.seconds], width: .narrow)), privacy: .public)"
+            )
+            return loadedModel
+        } catch {
+            stateLock.withLock {
+                if loadingState?.id == loading.id {
+                    loadingState = nil
+                }
+            }
+            throw error
+        }
+    }
+
+    private func unloadModel(named modelName: String) {
+        let didUnload = stateLock.withLock {
+            guard loadedState?.modelName == modelName || loadingState?.modelName == modelName else {
+                return false
+            }
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+            return true
+        }
+        if didUnload {
+            logger.notice("transcribe.cpp runtime unloaded")
+        }
+    }
+
+    private func unloadModel(unlessSelectedModelIs modelName: String) {
+        let didUnload = stateLock.withLock {
+            let hasDifferentLoadedModel = loadedState != nil && loadedState?.modelName != modelName
+            let hasDifferentLoadingModel = loadingState != nil && loadingState?.modelName != modelName
+            guard hasDifferentLoadedModel || hasDifferentLoadingModel else { return false }
+            loadingState?.task.cancel()
+            loadingState = nil
+            loadedState = nil
+            return true
+        }
+        if didUnload {
+            logger.notice("transcribe.cpp runtime unloaded")
+        }
+    }
+
+    private func selectedLanguage(_ language: String?, for model: TranscribeCppModel) -> String {
+        let compatibleLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(language, for: model)
+        return compatibleLanguage.split(separator: "-").first.map(String.init)?.lowercased() ?? "en"
+    }
+
+    private func languageUsesSpaces(_ language: String) -> Bool {
+        language != "ja" && language != "zh"
+    }
+
+    private static func initializeBackendsIfNeeded() throws {
+        try backendInitializationLock.withLock {
+            guard !backendsInitialized else { return }
+            try Transcribe.initBackends()
+            backendsInitialized = true
+        }
+    }
+}
+
+private extension Array where Element == Float {
+    /// Matches Cohere's reference long-form splitter. The final part of each
+    /// possible 35-second chunk is a boundary-search region, not audio overlap.
+    func energyAwareChunks(
+        maximumCount: Int,
+        boundarySearchCount: Int,
+        energyWindowCount: Int
+    ) -> [[Float]] {
+        guard maximumCount > 0, count > maximumCount else { return [self] }
+
+        let safeBoundarySearch = Swift.max(1, Swift.min(boundarySearchCount, maximumCount))
+        let safeEnergyWindow = Swift.max(1, energyWindowCount)
+        var chunks: [[Float]] = []
+        var start = 0
+
+        while start < count {
+            let maximumEnd = Swift.min(start + maximumCount, count)
+            if maximumEnd == count {
+                chunks.append(Array(self[start..<maximumEnd]))
+                break
+            }
+
+            let searchStart = Swift.max(start, maximumEnd - safeBoundarySearch)
+            let splitPoint = quietestWindowStart(
+                from: searchStart,
+                to: maximumEnd,
+                windowCount: safeEnergyWindow
+            )
+            let safeSplitPoint = Swift.max(start + 1, Swift.min(splitPoint, count))
+            chunks.append(Array(self[start..<safeSplitPoint]))
+            start = safeSplitPoint
+        }
+
+        return chunks
+    }
+
+    private func quietestWindowStart(from start: Int, to end: Int, windowCount: Int) -> Int {
+        guard end - start > windowCount else { return (start + end) / 2 }
+
+        var quietestStart = start
+        var lowestEnergy = Double.infinity
+        let finalWindowStart = end - windowCount
+
+        for windowStart in stride(from: start, to: finalWindowStart, by: windowCount) {
+            var squaredSampleSum = 0.0
+            for sample in self[windowStart..<(windowStart + windowCount)] {
+                let value = Double(sample)
+                squaredSampleSum += value * value
+            }
+            let meanSquaredEnergy = squaredSampleSum / Double(windowCount)
+            if meanSquaredEnergy < lowestEnergy {
+                lowestEnergy = meanSquaredEnergy
+                quietestStart = windowStart
+            }
+        }
+
+        return quietestStart
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct TranscribeCppModelArtifact: Sendable {
+    let modelName: String
+    let fileName: String
+    let repository: String
+    let repositoryRevision: String
+    let expectedFileSize: Int64
+    let expectedSHA256: String
+    let architectureHint: String?
+    let maximumChunkSeconds: Int
+    let boundarySearchSeconds: Int
+    let boundaryEnergyWindowSamples: Int
+    let legacyDirectoryName: String?
+
+    var downloadURL: URL {
+        URL(
+            string: "https://huggingface.co/\(repository)/resolve/\(repositoryRevision)/\(fileName)"
+        )!
+    }
+
+    var modelDirectory: URL {
+        Self.applicationSupportDirectory
+            .appendingPathComponent("TranscribeCpp", isDirectory: true)
+            .appendingPathComponent(modelName, isDirectory: true)
+    }
+
+    var modelFileURL: URL {
+        modelDirectory.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    var checksumFileURL: URL {
+        modelDirectory.appendingPathComponent(".\(fileName).sha256", isDirectory: false)
+    }
+
+    var installedModelFileURL: URL? {
+        if modelFileIsValid(in: modelDirectory) {
+            return modelFileURL
+        }
+
+        guard let legacyDirectory else { return nil }
+        let legacyModelURL = legacyDirectory.appendingPathComponent(fileName, isDirectory: false)
+        return modelFileIsValid(in: legacyDirectory) ? legacyModelURL : nil
+    }
+
+    func modelFileIsValid(in directory: URL) -> Bool {
+        let fileURL = directory.appendingPathComponent(fileName, isDirectory: false)
+        let checksumURL = directory.appendingPathComponent(".\(fileName).sha256", isDirectory: false)
+
+        guard
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+            values.isRegularFile == true,
+            let size = values.fileSize,
+            Int64(size) == expectedFileSize
+        else {
+            return false
+        }
+
+        let installedChecksum = try? String(contentsOf: checksumURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return installedChecksum == expectedSHA256
+    }
+
+    func removeInstalledFiles() {
+        try? FileManager.default.removeItem(at: modelDirectory)
+        if let legacyDirectory {
+            try? FileManager.default.removeItem(at: legacyDirectory)
+        }
+    }
+
+    private var legacyDirectory: URL? {
+        guard let legacyDirectoryName else { return nil }
+        return Self.applicationSupportDirectory.appendingPathComponent(legacyDirectoryName, isDirectory: true)
+    }
+
+    private static var applicationSupportDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.prakashjoshipax.VoiceInk", isDirectory: true)
+    }
+}
+
+enum TranscribeCppModelCatalog {
+    static let cohereTranscribe = TranscribeCppModelArtifact(
+        modelName: "cohere-transcribe",
+        fileName: "cohere-transcribe-03-2026-Q4_K_M.gguf",
+        repository: "handy-computer/cohere-transcribe-03-2026-gguf",
+        repositoryRevision: "dfa4adebb64f3076b7b6b90b721275cc069cb421",
+        expectedFileSize: 1_558_162_944,
+        expectedSHA256: "0ea56826d8bd5d74b7143a4a04e022dc1bb75452cfae49d98b6acb0c1d16a1fb",
+        architectureHint: "cohere",
+        maximumChunkSeconds: 35,
+        boundarySearchSeconds: 5,
+        boundaryEnergyWindowSamples: 1_600,
+        legacyDirectoryName: "CohereTranscribe"
+    )
+
+    private static let artifactsByModelName = [
+        cohereTranscribe.modelName: cohereTranscribe
+    ]
+
+    static func artifact(for modelName: String) -> TranscribeCppModelArtifact? {
+        artifactsByModelName[modelName]
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
@@ -11,7 +11,6 @@ struct TranscribeCppModelArtifact: Sendable {
     let maximumChunkSeconds: Int
     let boundarySearchSeconds: Int
     let boundaryEnergyWindowSamples: Int
-    let legacyDirectoryName: String?
 
     var downloadURL: URL {
         URL(
@@ -34,13 +33,7 @@ struct TranscribeCppModelArtifact: Sendable {
     }
 
     var installedModelFileURL: URL? {
-        if modelFileIsValid(in: modelDirectory) {
-            return modelFileURL
-        }
-
-        guard let legacyDirectory else { return nil }
-        let legacyModelURL = legacyDirectory.appendingPathComponent(fileName, isDirectory: false)
-        return modelFileIsValid(in: legacyDirectory) ? legacyModelURL : nil
+        modelFileIsValid(in: modelDirectory) ? modelFileURL : nil
     }
 
     func modelFileIsValid(in directory: URL) -> Bool {
@@ -63,14 +56,6 @@ struct TranscribeCppModelArtifact: Sendable {
 
     func removeInstalledFiles() {
         try? FileManager.default.removeItem(at: modelDirectory)
-        if let legacyDirectory {
-            try? FileManager.default.removeItem(at: legacyDirectory)
-        }
-    }
-
-    private var legacyDirectory: URL? {
-        guard let legacyDirectoryName else { return nil }
-        return Self.applicationSupportDirectory.appendingPathComponent(legacyDirectoryName, isDirectory: true)
     }
 
     private static var applicationSupportDirectory: URL {
@@ -90,8 +75,7 @@ enum TranscribeCppModelCatalog {
         architectureHint: "cohere",
         maximumChunkSeconds: 35,
         boundarySearchSeconds: 5,
-        boundaryEnergyWindowSamples: 1_600,
-        legacyDirectoryName: "CohereTranscribe"
+        boundaryEnergyWindowSamples: 1_600
     )
 
     private static let artifactsByModelName = [

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
@@ -1,0 +1,290 @@
+import AppKit
+import CryptoKit
+import Foundation
+import os
+
+struct TranscribeCppDownloadStatus: Sendable {
+    let fractionCompleted: Double
+    let message: String
+    let isIndeterminate: Bool
+}
+
+private final class TranscribeCppDownloadOperation: @unchecked Sendable {
+    private let destinationURL: URL
+    private let expectedByteCount: Int64
+    private let progressHandler: @Sendable (Double) -> Void
+    private let lock = NSLock()
+    private var task: URLSessionDownloadTask?
+    private var observation: NSKeyValueObservation?
+    private var continuation: CheckedContinuation<HTTPURLResponse, Error>?
+    private var isCancelled = false
+    private var isCompleted = false
+
+    init(
+        destinationURL: URL,
+        expectedByteCount: Int64,
+        progressHandler: @escaping @Sendable (Double) -> Void
+    ) {
+        self.destinationURL = destinationURL
+        self.expectedByteCount = expectedByteCount
+        self.progressHandler = progressHandler
+    }
+
+    func start(from sourceURL: URL) async throws -> HTTPURLResponse {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = URLSession.shared.downloadTask(with: sourceURL) { [weak self] temporaryURL, response, error in
+                    self?.finishDownload(temporaryURL: temporaryURL, response: response, error: error)
+                }
+                let observation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+                    guard let self else { return }
+                    let reportedTotal = progress.totalUnitCount
+                    let total = reportedTotal > 0 ? reportedTotal : expectedByteCount
+                    guard total > 0 else { return }
+                    let fraction = Double(progress.completedUnitCount) / Double(total)
+                    progressHandler(min(max(fraction, 0), 1))
+                }
+
+                let shouldStart = lock.withLock {
+                    guard !isCancelled, !isCompleted else { return false }
+                    self.task = task
+                    self.observation = observation
+                    self.continuation = continuation
+                    return true
+                }
+
+                if shouldStart {
+                    task.resume()
+                } else {
+                    observation.invalidate()
+                    task.cancel()
+                    continuation.resume(throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            self.cancel()
+        }
+    }
+
+    private func finishDownload(temporaryURL: URL?, response: URLResponse?, error: Error?) {
+        let result: Result<HTTPURLResponse, Error>
+
+        if let error {
+            result = .failure(error)
+        } else if
+            let httpResponse = response as? HTTPURLResponse,
+            (200...299).contains(httpResponse.statusCode),
+            let temporaryURL
+        {
+            do {
+                try? FileManager.default.removeItem(at: destinationURL)
+                try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
+                result = .success(httpResponse)
+            } catch {
+                result = .failure(error)
+            }
+        } else {
+            result = .failure(URLError(.badServerResponse))
+        }
+
+        finish(with: result)
+    }
+
+    private func finish(with result: Result<HTTPURLResponse, Error>) {
+        let resolution = lock.withLock {
+            guard !isCompleted else {
+                return (nil as CheckedContinuation<HTTPURLResponse, Error>?, nil as NSKeyValueObservation?)
+            }
+
+            isCompleted = true
+            let continuation = self.continuation
+            let observation = self.observation
+            self.continuation = nil
+            self.observation = nil
+            task = nil
+            return (continuation, observation)
+        }
+
+        resolution.1?.invalidate()
+        resolution.0?.resume(with: result)
+    }
+
+    private func cancel() {
+        let task = lock.withLock {
+            isCancelled = true
+            return self.task
+        }
+        task?.cancel()
+    }
+}
+
+@MainActor
+final class TranscribeCppModelManager: ObservableObject {
+    static let shared = TranscribeCppModelManager()
+
+    @Published private var downloadStatuses: [String: TranscribeCppDownloadStatus] = [:]
+
+    var onModelDeleted: ((String) -> Void)?
+    var onModelsChanged: (() -> Void)?
+
+    private var activeDownloadIDs: [String: UUID] = [:]
+    private let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "TranscribeCppModelManager"
+    )
+
+    private init() {}
+
+    func isModelDownloaded(_ model: TranscribeCppModel) -> Bool {
+        isModelDownloaded(named: model.name)
+    }
+
+    func isModelDownloaded(named modelName: String) -> Bool {
+        TranscribeCppModelCatalog.artifact(for: modelName)?.installedModelFileURL != nil
+    }
+
+    func isModelDownloading(_ model: TranscribeCppModel) -> Bool {
+        activeDownloadIDs[model.name] != nil
+    }
+
+    func downloadStatus(for model: TranscribeCppModel) -> TranscribeCppDownloadStatus? {
+        downloadStatuses[model.name]
+    }
+
+    func downloadModel(_ model: TranscribeCppModel) async {
+        guard
+            let artifact = TranscribeCppModelCatalog.artifact(for: model.name),
+            activeDownloadIDs[model.name] == nil,
+            !isModelDownloaded(model)
+        else {
+            return
+        }
+
+        let downloadID = UUID()
+        activeDownloadIDs[model.name] = downloadID
+        downloadStatuses[model.name] = TranscribeCppDownloadStatus(
+            fractionCompleted: 0,
+            message: String(localized: "Downloading..."),
+            isIndeterminate: false
+        )
+
+        defer {
+            if activeDownloadIDs[model.name] == downloadID {
+                activeDownloadIDs[model.name] = nil
+                downloadStatuses[model.name] = nil
+                onModelsChanged?()
+            }
+        }
+
+        let partialURL = artifact.modelDirectory.appendingPathComponent("\(artifact.fileName).partial")
+        let modelName = model.name
+
+        do {
+            try FileManager.default.createDirectory(at: artifact.modelDirectory, withIntermediateDirectories: true)
+            try? FileManager.default.removeItem(at: partialURL)
+
+            let operation = TranscribeCppDownloadOperation(
+                destinationURL: partialURL,
+                expectedByteCount: artifact.expectedFileSize
+            ) { [weak self] fraction in
+                Task { @MainActor [weak self] in
+                    self?.updateDownloadProgress(fraction, for: modelName, downloadID: downloadID)
+                }
+            }
+            _ = try await operation.start(from: artifact.downloadURL)
+            try Task.checkCancellation()
+
+            downloadStatuses[model.name] = TranscribeCppDownloadStatus(
+                fractionCompleted: 1,
+                message: String(localized: "Verifying..."),
+                isIndeterminate: true
+            )
+
+            let values = try partialURL.resourceValues(forKeys: [.fileSizeKey])
+            guard Int64(values.fileSize ?? 0) == artifact.expectedFileSize else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            let checksum = try await Task.detached(priority: .utility) {
+                try Self.sha256(of: partialURL)
+            }.value
+            guard checksum == artifact.expectedSHA256 else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            try? FileManager.default.removeItem(at: artifact.modelFileURL)
+            try FileManager.default.moveItem(at: partialURL, to: artifact.modelFileURL)
+            try artifact.expectedSHA256.write(
+                to: artifact.checksumFileURL,
+                atomically: true,
+                encoding: .utf8
+            )
+
+            guard artifact.installedModelFileURL != nil else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            logger.notice("\(model.displayName, privacy: .public) installed successfully")
+        } catch is CancellationError {
+            try? FileManager.default.removeItem(at: partialURL)
+            logger.notice("\(model.displayName, privacy: .public) download cancelled")
+        } catch {
+            try? FileManager.default.removeItem(at: partialURL)
+            if !artifact.modelFileIsValid(in: artifact.modelDirectory) {
+                try? FileManager.default.removeItem(at: artifact.modelFileURL)
+                try? FileManager.default.removeItem(at: artifact.checksumFileURL)
+            }
+            logger.error("\(model.displayName, privacy: .public) download failed: \(error, privacy: .public)")
+            NotificationManager.shared.showNotification(
+                title: "\(model.displayName) download failed",
+                type: .error
+            )
+        }
+    }
+
+    func deleteModel(_ model: TranscribeCppModel) {
+        guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name) else { return }
+        artifact.removeInstalledFiles()
+        NotificationCenter.default.post(
+            name: .transcribeCppModelDeleted,
+            object: nil,
+            userInfo: ["modelName": model.name]
+        )
+        onModelDeleted?(model.name)
+        onModelsChanged?()
+    }
+
+    func showModelInFinder(_ model: TranscribeCppModel) {
+        guard
+            let artifact = TranscribeCppModelCatalog.artifact(for: model.name),
+            let modelFileURL = artifact.installedModelFileURL
+        else {
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([modelFileURL])
+    }
+
+    private func updateDownloadProgress(_ fraction: Double, for modelName: String, downloadID: UUID) {
+        guard activeDownloadIDs[modelName] == downloadID, fraction.isFinite else { return }
+        let currentFraction = downloadStatuses[modelName]?.fractionCompleted ?? 0
+        guard fraction > currentFraction else { return }
+        guard fraction == 1 || fraction - currentFraction >= 0.005 else { return }
+
+        downloadStatuses[modelName] = TranscribeCppDownloadStatus(
+            fractionCompleted: fraction,
+            message: String(localized: "Downloading..."),
+            isIndeterminate: false
+        )
+    }
+
+    nonisolated private static func sha256(of fileURL: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 8 * 1_024 * 1_024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
@@ -9,14 +9,40 @@ struct TranscribeCppDownloadStatus: Sendable {
     let isIndeterminate: Bool
 }
 
-private final class TranscribeCppDownloadOperation: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+private func regularFileSize(at url: URL) -> Int64 {
+    let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+    guard values?.isRegularFile == true else { return 0 }
+    return Int64(values?.fileSize ?? 0)
+}
+
+private enum TranscribeCppDownloadError: LocalizedError {
+    case httpStatus(Int)
+    case invalidRangeResponse
+    case incompleteDownload(received: Int64, expected: Int64)
+
+    var errorDescription: String? {
+        switch self {
+        case .httpStatus(let statusCode):
+            return "Model download returned HTTP status \(statusCode)."
+        case .invalidRangeResponse:
+            return "The model server returned an invalid resume response."
+        case .incompleteDownload(let received, let expected):
+            return "The model download ended after \(received) of \(expected) bytes."
+        }
+    }
+}
+
+private final class TranscribeCppDownloadOperation: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     private let destinationURL: URL
     private let expectedByteCount: Int64
     private let progressHandler: @Sendable (Double) -> Void
     private let lock = NSLock()
     private var session: URLSession?
-    private var task: URLSessionDownloadTask?
+    private var fileHandle: FileHandle?
     private var continuation: CheckedContinuation<HTTPURLResponse, Error>?
+    private var response: HTTPURLResponse?
+    private var totalBytesWritten: Int64 = 0
+    private var lastReportedFraction = 0.0
     private var isCancelled = false
     private var isCompleted = false
 
@@ -33,18 +59,25 @@ private final class TranscribeCppDownloadOperation: NSObject, URLSessionDownload
     func start(from sourceURL: URL) async throws -> HTTPURLResponse {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
+                let resumeOffset = regularFileSize(at: destinationURL)
+                var request = URLRequest(url: sourceURL)
+                if resumeOffset > 0 {
+                    request.setValue("bytes=\(resumeOffset)-", forHTTPHeaderField: "Range")
+                }
+
                 let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-                let task = session.downloadTask(with: sourceURL)
+                let task = session.dataTask(with: request)
 
                 let shouldStart = lock.withLock {
                     guard !isCancelled, !isCompleted else { return false }
                     self.session = session
-                    self.task = task
                     self.continuation = continuation
+                    totalBytesWritten = resumeOffset
                     return true
                 }
 
                 if shouldStart {
+                    reportProgress(for: resumeOffset)
                     task.resume()
                 } else {
                     session.invalidateAndCancel()
@@ -58,40 +91,71 @@ private final class TranscribeCppDownloadOperation: NSObject, URLSessionDownload
 
     func urlSession(
         _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
-        totalBytesWritten: Int64,
-        totalBytesExpectedToWrite: Int64
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
     ) {
-        let total = expectedByteCount > 0 ? expectedByteCount : totalBytesExpectedToWrite
-        guard total > 0 else { return }
-
-        let fraction = Double(totalBytesWritten) / Double(total)
-        progressHandler(min(max(fraction, 0), 1))
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo temporaryURL: URL
-    ) {
-        let result: Result<HTTPURLResponse, Error>
-
-        if let httpResponse = downloadTask.response as? HTTPURLResponse,
-            (200...299).contains(httpResponse.statusCode)
-        {
-            do {
-                try? FileManager.default.removeItem(at: destinationURL)
-                try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
-                result = .success(httpResponse)
-            } catch {
-                result = .failure(error)
-            }
-        } else {
-            result = .failure(URLError(.badServerResponse))
+        guard let httpResponse = response as? HTTPURLResponse else {
+            completionHandler(.cancel)
+            finish(with: .failure(URLError(.badServerResponse)))
+            return
         }
 
-        finish(with: result)
+        guard (200...299).contains(httpResponse.statusCode) else {
+            completionHandler(.cancel)
+            finish(with: .failure(TranscribeCppDownloadError.httpStatus(httpResponse.statusCode)))
+            return
+        }
+
+        let requestedOffset = lock.withLock { totalBytesWritten }
+        let shouldAppend: Bool
+        if requestedOffset > 0 && httpResponse.statusCode == 206 {
+            guard Self.contentRange(in: httpResponse, startsAt: requestedOffset) else {
+                completionHandler(.cancel)
+                finish(with: .failure(TranscribeCppDownloadError.invalidRangeResponse))
+                return
+            }
+            shouldAppend = true
+        } else {
+            // A 200 response means Range was ignored, so restart instead of appending duplicates.
+            shouldAppend = false
+        }
+
+        do {
+            let handle = try Self.openFile(at: destinationURL, appending: shouldAppend)
+            lock.withLock {
+                self.response = httpResponse
+                fileHandle = handle
+                if !shouldAppend {
+                    totalBytesWritten = 0
+                    lastReportedFraction = 0
+                }
+            }
+            if requestedOffset > 0 && !shouldAppend {
+                progressHandler(0)
+            }
+            completionHandler(.allow)
+        } catch {
+            completionHandler(.cancel)
+            finish(with: .failure(error))
+        }
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        do {
+            let progress = try lock.withLock { () throws -> Double? in
+                guard !isCompleted, let fileHandle else { return nil }
+                try fileHandle.write(contentsOf: data)
+                totalBytesWritten += Int64(data.count)
+                return progressToReport(for: totalBytesWritten)
+            }
+            if let progress {
+                progressHandler(progress)
+            }
+        } catch {
+            dataTask.cancel()
+            finish(with: .failure(error))
+        }
     }
 
     func urlSession(
@@ -101,24 +165,50 @@ private final class TranscribeCppDownloadOperation: NSObject, URLSessionDownload
     ) {
         if let error {
             finish(with: .failure(error))
+            return
         }
+
+        let completion = lock.withLock { (response: self.response, byteCount: totalBytesWritten) }
+        guard let response = completion.response else {
+            finish(with: .failure(URLError(.badServerResponse)))
+            return
+        }
+        guard completion.byteCount == expectedByteCount else {
+            finish(
+                with: .failure(
+                    TranscribeCppDownloadError.incompleteDownload(
+                        received: completion.byteCount,
+                        expected: expectedByteCount
+                    )
+                )
+            )
+            return
+        }
+        reportProgress(for: completion.byteCount)
+        finish(with: .success(response))
     }
 
     private func finish(with result: Result<HTTPURLResponse, Error>) {
         let resolution = lock.withLock {
             guard !isCompleted else {
-                return (nil as CheckedContinuation<HTTPURLResponse, Error>?, nil as URLSession?)
+                return (
+                    nil as CheckedContinuation<HTTPURLResponse, Error>?,
+                    nil as URLSession?,
+                    nil as FileHandle?
+                )
             }
 
             isCompleted = true
             let continuation = self.continuation
             let session = self.session
+            let fileHandle = self.fileHandle
             self.continuation = nil
             self.session = nil
-            task = nil
-            return (continuation, session)
+            self.fileHandle = nil
+            return (continuation, session, fileHandle)
         }
 
+        try? resolution.2?.close()
         resolution.1?.finishTasksAndInvalidate()
         resolution.0?.resume(with: result)
     }
@@ -130,14 +220,50 @@ private final class TranscribeCppDownloadOperation: NSObject, URLSessionDownload
         }
         session?.invalidateAndCancel()
     }
+
+    private func reportProgress(for byteCount: Int64) {
+        let progress = lock.withLock { progressToReport(for: byteCount) }
+        if let progress {
+            progressHandler(progress)
+        }
+    }
+
+    private func progressToReport(for byteCount: Int64) -> Double? {
+        guard expectedByteCount > 0 else { return nil }
+        let fraction = min(max(Double(byteCount) / Double(expectedByteCount), 0), 1)
+        guard fraction == 1 || fraction - lastReportedFraction >= 0.005 else { return nil }
+        lastReportedFraction = fraction
+        return fraction
+    }
+
+    private static func openFile(at url: URL, appending: Bool) throws -> FileHandle {
+        if !appending {
+            guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        if appending {
+            try handle.seekToEnd()
+        }
+        return handle
+    }
+
+    private static func contentRange(in response: HTTPURLResponse, startsAt offset: Int64) -> Bool {
+        guard let contentRange = response.value(forHTTPHeaderField: "Content-Range")?.lowercased() else {
+            return false
+        }
+        return contentRange.hasPrefix("bytes \(offset)-")
+    }
+
 }
 
 @MainActor
 final class TranscribeCppModelManager: ObservableObject {
     static let shared = TranscribeCppModelManager()
+    private static let maximumDownloadAttempts = 3
 
     @Published private var downloadStatuses: [String: TranscribeCppDownloadStatus] = [:]
-    @Published private var modelStateRevision = 0
 
     var onModelDeleted: ((String) -> Void)?
     var onModelsChanged: (() -> Void)?
@@ -196,7 +322,85 @@ final class TranscribeCppModelManager: ObservableObject {
 
         do {
             try FileManager.default.createDirectory(at: artifact.modelDirectory, withIntermediateDirectories: true)
+            if regularFileSize(at: partialURL) > artifact.expectedFileSize {
+                try? FileManager.default.removeItem(at: partialURL)
+            }
+
+            if regularFileSize(at: partialURL) < artifact.expectedFileSize {
+                try await downloadArtifact(
+                    artifact,
+                    to: partialURL,
+                    modelName: modelName,
+                    downloadID: downloadID
+                )
+            }
+            try Task.checkCancellation()
+        } catch is CancellationError {
+            logger.notice("\(model.displayName, privacy: .public) download paused")
+            return
+        } catch {
+            reportFailure(error, for: model)
+            return
+        }
+
+        downloadStatuses[model.name] = TranscribeCppDownloadStatus(
+            fractionCompleted: 1,
+            message: String(localized: "Verifying..."),
+            isIndeterminate: true
+        )
+
+        do {
+            guard regularFileSize(at: partialURL) == artifact.expectedFileSize else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            let checksum = try await Task.detached(priority: .utility) {
+                try Self.sha256(of: partialURL)
+            }.value
+            try Task.checkCancellation()
+            guard checksum == artifact.expectedSHA256 else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+        } catch is CancellationError {
+            logger.notice("\(model.displayName, privacy: .public) verification paused")
+            return
+        } catch {
             try? FileManager.default.removeItem(at: partialURL)
+            reportFailure(error, for: model)
+            return
+        }
+
+        do {
+            // Commit the checksum first so the final model move makes the installation visible atomically.
+            try artifact.expectedSHA256.write(
+                to: artifact.checksumFileURL,
+                atomically: true,
+                encoding: .utf8
+            )
+            try? FileManager.default.removeItem(at: artifact.modelFileURL)
+            try FileManager.default.moveItem(at: partialURL, to: artifact.modelFileURL)
+            guard artifact.installedModelFileURL != nil else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            logger.notice("\(model.displayName, privacy: .public) installed successfully")
+        } catch {
+            if !artifact.modelFileIsValid(in: artifact.modelDirectory) {
+                try? FileManager.default.removeItem(at: artifact.modelFileURL)
+                try? FileManager.default.removeItem(at: artifact.checksumFileURL)
+            }
+            reportFailure(error, for: model)
+        }
+    }
+
+    private func downloadArtifact(
+        _ artifact: TranscribeCppModelArtifact,
+        to partialURL: URL,
+        modelName: String,
+        downloadID: UUID
+    ) async throws {
+        var attempt = 1
+
+        while true {
+            try Task.checkCancellation()
 
             let operation = TranscribeCppDownloadOperation(
                 destinationURL: partialURL,
@@ -206,61 +410,42 @@ final class TranscribeCppModelManager: ObservableObject {
                     self?.updateDownloadProgress(fraction, for: modelName, downloadID: downloadID)
                 }
             }
-            _ = try await operation.start(from: artifact.downloadURL)
-            try Task.checkCancellation()
 
-            downloadStatuses[model.name] = TranscribeCppDownloadStatus(
-                fractionCompleted: 1,
-                message: String(localized: "Verifying..."),
-                isIndeterminate: true
-            )
+            do {
+                _ = try await operation.start(from: artifact.downloadURL)
+                return
+            } catch {
+                if Task.isCancelled || (error as? URLError)?.code == .cancelled {
+                    throw CancellationError()
+                }
 
-            let values = try partialURL.resourceValues(forKeys: [.fileSizeKey])
-            guard Int64(values.fileSize ?? 0) == artifact.expectedFileSize else {
-                throw CocoaError(.fileReadCorruptFile)
+                if let downloadError = error as? TranscribeCppDownloadError,
+                    case .invalidRangeResponse = downloadError
+                {
+                    try? FileManager.default.removeItem(at: partialURL)
+                    updateDownloadProgress(0, for: modelName, downloadID: downloadID)
+                } else if regularFileSize(at: partialURL) > artifact.expectedFileSize {
+                    try? FileManager.default.removeItem(at: partialURL)
+                    updateDownloadProgress(0, for: modelName, downloadID: downloadID)
+                }
+
+                guard attempt < Self.maximumDownloadAttempts, Self.isRetryableDownloadError(error) else {
+                    throw error
+                }
+
+                logger.warning(
+                    "Model download attempt \(attempt, privacy: .public) failed; resuming: \(error.localizedDescription, privacy: .public)"
+                )
+                try await Task.sleep(for: .seconds(attempt))
+                attempt += 1
             }
-
-            let checksum = try await Task.detached(priority: .utility) {
-                try Self.sha256(of: partialURL)
-            }.value
-            guard checksum == artifact.expectedSHA256 else {
-                throw CocoaError(.fileReadCorruptFile)
-            }
-
-            try? FileManager.default.removeItem(at: artifact.modelFileURL)
-            try FileManager.default.moveItem(at: partialURL, to: artifact.modelFileURL)
-            try artifact.expectedSHA256.write(
-                to: artifact.checksumFileURL,
-                atomically: true,
-                encoding: .utf8
-            )
-
-            guard artifact.installedModelFileURL != nil else {
-                throw CocoaError(.fileReadCorruptFile)
-            }
-
-            logger.notice("\(model.displayName, privacy: .public) installed successfully")
-        } catch is CancellationError {
-            try? FileManager.default.removeItem(at: partialURL)
-            logger.notice("\(model.displayName, privacy: .public) download cancelled")
-        } catch {
-            try? FileManager.default.removeItem(at: partialURL)
-            if !artifact.modelFileIsValid(in: artifact.modelDirectory) {
-                try? FileManager.default.removeItem(at: artifact.modelFileURL)
-                try? FileManager.default.removeItem(at: artifact.checksumFileURL)
-            }
-            logger.error("\(model.displayName, privacy: .public) download failed: \(error, privacy: .public)")
-            NotificationManager.shared.showNotification(
-                title: "\(model.displayName) download failed",
-                type: .error
-            )
         }
     }
 
     func deleteModel(_ model: TranscribeCppModel) {
         guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name) else { return }
+        objectWillChange.send()
         artifact.removeInstalledFiles()
-        modelStateRevision += 1
         NotificationCenter.default.post(
             name: .transcribeCppModelDeleted,
             object: nil,
@@ -281,16 +466,42 @@ final class TranscribeCppModelManager: ObservableObject {
     }
 
     private func updateDownloadProgress(_ fraction: Double, for modelName: String, downloadID: UUID) {
-        guard activeDownloadIDs[modelName] == downloadID, fraction.isFinite else { return }
+        guard activeDownloadIDs[modelName] == downloadID,
+            fraction.isFinite,
+            (0...1).contains(fraction)
+        else {
+            return
+        }
         let currentFraction = downloadStatuses[modelName]?.fractionCompleted ?? 0
-        guard fraction > currentFraction else { return }
-        guard fraction == 1 || fraction - currentFraction >= 0.005 else { return }
+        guard fraction == 0 || fraction > currentFraction else { return }
 
         downloadStatuses[modelName] = TranscribeCppDownloadStatus(
             fractionCompleted: fraction,
             message: String(localized: "Downloading..."),
             isIndeterminate: false
         )
+    }
+
+    private func reportFailure(_ error: Error, for model: TranscribeCppModel) {
+        logger.error("\(model.displayName, privacy: .public) download failed: \(error, privacy: .public)")
+        NotificationManager.shared.showNotification(
+            title: "\(model.displayName) download failed",
+            type: .error
+        )
+    }
+
+    nonisolated private static func isRetryableDownloadError(_ error: Error) -> Bool {
+        if let downloadError = error as? TranscribeCppDownloadError {
+            switch downloadError {
+            case .invalidRangeResponse, .incompleteDownload:
+                return true
+            case .httpStatus(let statusCode):
+                return statusCode == 408 || statusCode == 429 || (500...599).contains(statusCode)
+            }
+        }
+
+        // Retry non-cancellation URL failures while retaining downloaded bytes.
+        return error is URLError
     }
 
     nonisolated private static func sha256(of fileURL: URL) throws -> String {

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelManager.swift
@@ -9,13 +9,13 @@ struct TranscribeCppDownloadStatus: Sendable {
     let isIndeterminate: Bool
 }
 
-private final class TranscribeCppDownloadOperation: @unchecked Sendable {
+private final class TranscribeCppDownloadOperation: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
     private let destinationURL: URL
     private let expectedByteCount: Int64
     private let progressHandler: @Sendable (Double) -> Void
     private let lock = NSLock()
+    private var session: URLSession?
     private var task: URLSessionDownloadTask?
-    private var observation: NSKeyValueObservation?
     private var continuation: CheckedContinuation<HTTPURLResponse, Error>?
     private var isCancelled = false
     private var isCompleted = false
@@ -33,22 +33,13 @@ private final class TranscribeCppDownloadOperation: @unchecked Sendable {
     func start(from sourceURL: URL) async throws -> HTTPURLResponse {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                let task = URLSession.shared.downloadTask(with: sourceURL) { [weak self] temporaryURL, response, error in
-                    self?.finishDownload(temporaryURL: temporaryURL, response: response, error: error)
-                }
-                let observation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
-                    guard let self else { return }
-                    let reportedTotal = progress.totalUnitCount
-                    let total = reportedTotal > 0 ? reportedTotal : expectedByteCount
-                    guard total > 0 else { return }
-                    let fraction = Double(progress.completedUnitCount) / Double(total)
-                    progressHandler(min(max(fraction, 0), 1))
-                }
+                let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+                let task = session.downloadTask(with: sourceURL)
 
                 let shouldStart = lock.withLock {
                     guard !isCancelled, !isCompleted else { return false }
+                    self.session = session
                     self.task = task
-                    self.observation = observation
                     self.continuation = continuation
                     return true
                 }
@@ -56,8 +47,7 @@ private final class TranscribeCppDownloadOperation: @unchecked Sendable {
                 if shouldStart {
                     task.resume()
                 } else {
-                    observation.invalidate()
-                    task.cancel()
+                    session.invalidateAndCancel()
                     continuation.resume(throwing: CancellationError())
                 }
             }
@@ -66,15 +56,29 @@ private final class TranscribeCppDownloadOperation: @unchecked Sendable {
         }
     }
 
-    private func finishDownload(temporaryURL: URL?, response: URLResponse?, error: Error?) {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let total = expectedByteCount > 0 ? expectedByteCount : totalBytesExpectedToWrite
+        guard total > 0 else { return }
+
+        let fraction = Double(totalBytesWritten) / Double(total)
+        progressHandler(min(max(fraction, 0), 1))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo temporaryURL: URL
+    ) {
         let result: Result<HTTPURLResponse, Error>
 
-        if let error {
-            result = .failure(error)
-        } else if
-            let httpResponse = response as? HTTPURLResponse,
-            (200...299).contains(httpResponse.statusCode),
-            let temporaryURL
+        if let httpResponse = downloadTask.response as? HTTPURLResponse,
+            (200...299).contains(httpResponse.statusCode)
         {
             do {
                 try? FileManager.default.removeItem(at: destinationURL)
@@ -90,31 +94,41 @@ private final class TranscribeCppDownloadOperation: @unchecked Sendable {
         finish(with: result)
     }
 
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error {
+            finish(with: .failure(error))
+        }
+    }
+
     private func finish(with result: Result<HTTPURLResponse, Error>) {
         let resolution = lock.withLock {
             guard !isCompleted else {
-                return (nil as CheckedContinuation<HTTPURLResponse, Error>?, nil as NSKeyValueObservation?)
+                return (nil as CheckedContinuation<HTTPURLResponse, Error>?, nil as URLSession?)
             }
 
             isCompleted = true
             let continuation = self.continuation
-            let observation = self.observation
+            let session = self.session
             self.continuation = nil
-            self.observation = nil
+            self.session = nil
             task = nil
-            return (continuation, observation)
+            return (continuation, session)
         }
 
-        resolution.1?.invalidate()
+        resolution.1?.finishTasksAndInvalidate()
         resolution.0?.resume(with: result)
     }
 
     private func cancel() {
-        let task = lock.withLock {
+        let session = lock.withLock {
             isCancelled = true
-            return self.task
+            return self.session
         }
-        task?.cancel()
+        session?.invalidateAndCancel()
     }
 }
 
@@ -123,6 +137,7 @@ final class TranscribeCppModelManager: ObservableObject {
     static let shared = TranscribeCppModelManager()
 
     @Published private var downloadStatuses: [String: TranscribeCppDownloadStatus] = [:]
+    @Published private var modelStateRevision = 0
 
     var onModelDeleted: ((String) -> Void)?
     var onModelsChanged: (() -> Void)?
@@ -245,6 +260,7 @@ final class TranscribeCppModelManager: ObservableObject {
     func deleteModel(_ model: TranscribeCppModel) {
         guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name) else { return }
         artifact.removeInstalledFiles()
+        modelStateRevision += 1
         NotificationCenter.default.post(
             name: .transcribeCppModelDeleted,
             object: nil,

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Routes transcribe.cpp-backed models to their model-specific service.
+/// Shared provider wiring stays stable as additional transcribe.cpp model
+/// families are added.
+final class TranscribeCppTranscriptionService: TranscriptionService, @unchecked Sendable {
+    private let cohereService = CohereTranscriptionService()
+
+    func loadModel(for model: TranscribeCppModel) async throws {
+        switch model.name {
+        case TranscribeCppModelCatalog.cohereTranscribe.modelName:
+            try await cohereService.loadModel(for: model)
+        default:
+            throw unsupportedModelError(model.name)
+        }
+    }
+
+    func transcribe(
+        audioURL: URL,
+        model: any TranscriptionModel,
+        context: TranscriptionRequestContext
+    ) async throws -> String {
+        guard let transcribeCppModel = model as? TranscribeCppModel else {
+            throw NSError(
+                domain: "TranscribeCppTranscriptionService",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported transcription model"]
+            )
+        }
+
+        switch transcribeCppModel.name {
+        case TranscribeCppModelCatalog.cohereTranscribe.modelName:
+            return try await cohereService.transcribe(
+                audioURL: audioURL,
+                model: transcribeCppModel,
+                context: context
+            )
+        default:
+            throw unsupportedModelError(transcribeCppModel.name)
+        }
+    }
+
+    func cleanup() {
+        cohereService.cleanup()
+    }
+
+    private func unsupportedModelError(_ modelName: String) -> NSError {
+        NSError(
+            domain: "TranscribeCppTranscriptionService",
+            code: -2,
+            userInfo: [NSLocalizedDescriptionKey: "No transcribe.cpp service is registered for \(modelName)"]
+        )
+    }
+}

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 /// Routes transcribe.cpp-backed models to their model-specific service.
-/// Shared provider wiring stays stable as additional transcribe.cpp model
-/// families are added.
 final class TranscribeCppTranscriptionService: TranscriptionService, @unchecked Sendable {
     private let cohereService = CohereTranscriptionService()
 

--- a/VoiceInk/Views/AI Models/ModelCardView.swift
+++ b/VoiceInk/Views/AI Models/ModelCardView.swift
@@ -42,6 +42,10 @@ struct ModelCardView: View {
                         fluidAudioModelManager: fluidAudioModelManager
                     )
                 }
+            case .transcribeCpp:
+                if let transcribeCppModel = model as? TranscribeCppModel {
+                    TranscribeCppModelCardView(model: transcribeCppModel)
+                }
             case .nativeApple:
                 if let nativeAppleModel = model as? NativeAppleModel {
                     NativeAppleModelCardView(

--- a/VoiceInk/Views/AI Models/ModelManagementView.swift
+++ b/VoiceInk/Views/AI Models/ModelManagementView.swift
@@ -349,7 +349,8 @@ struct ModelManagementView: View {
 
     private var localModels: [any TranscriptionModel] {
         transcriptionModelManager.allAvailableModels.filter {
-            ($0.provider == .whisper || $0.provider == .nativeApple || $0.provider == .fluidAudio)
+            ($0.provider == .whisper || $0.provider == .nativeApple || $0.provider == .fluidAudio
+                || $0.provider == .transcribeCpp)
                 && transcriptionModelManager.isAvailableOnCurrentOS($0)
         }
     }

--- a/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
+++ b/VoiceInk/Views/AI Models/ModelSettingsPanel.swift
@@ -166,7 +166,7 @@ private struct AdvancedModelSettingsSection: View {
                 HStack(spacing: 4) {
                     Text("Prewarm model (Experimental)")
                     InfoTip(
-                        "Turn this on if transcriptions with local models are taking longer than expected. Runs silent background transcription on app launch and wake to trigger optimization."
+                        "Turn this on if local transcriptions take longer than expected. It prepares the selected model in the background when the app launches or wakes."
                     )
                 }
             }

--- a/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
+++ b/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct TranscribeCppModelCardView: View {
+    let model: TranscribeCppModel
+    @ObservedObject private var modelManager = TranscribeCppModelManager.shared
+
+    private var isDownloaded: Bool { modelManager.isModelDownloaded(model) }
+    private var isDownloading: Bool { modelManager.isModelDownloading(model) }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(model.displayName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(Color(.labelColor))
+
+                HStack(spacing: 12) {
+                    Label(model.language, systemImage: "globe")
+                    Label(model.size, systemImage: "internaldrive")
+                    HStack(spacing: 3) {
+                        Text("Speed")
+                        progressDotsWithNumber(value: model.speed * 10)
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                    HStack(spacing: 3) {
+                        Text("Accuracy")
+                        progressDotsWithNumber(value: model.accuracy * 10)
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(Color(.secondaryLabelColor))
+                .lineLimit(1)
+
+                Text(model.description)
+                    .font(.system(size: 11))
+                    .foregroundColor(Color(.secondaryLabelColor))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
+
+                progressSection
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            actionSection
+        }
+        .padding(16)
+        .background(AppMaterialCardBackground())
+    }
+
+    @ViewBuilder
+    private var progressSection: some View {
+        if let status = modelManager.downloadStatus(for: model) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(status.message)
+                        .lineLimit(1)
+
+                    if status.isIndeterminate {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.65)
+                    }
+
+                    Spacer()
+
+                    Text(status.fractionCompleted, format: .percent.precision(.fractionLength(0)))
+                        .fontDesign(.monospaced)
+                }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color(.secondaryLabelColor))
+
+                ProgressView(value: status.fractionCompleted)
+                    .progressViewStyle(.linear)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 8)
+            .animation(.smooth, value: status.fractionCompleted)
+        }
+    }
+
+    private var actionSection: some View {
+        HStack(spacing: 8) {
+            if isDownloaded && !isDownloading {
+                modelStatusPill("Downloaded", systemImage: "checkmark.circle")
+
+                Menu {
+                    Button(role: .destructive) {
+                        modelManager.deleteModel(model)
+                    } label: {
+                        Label("Delete Model", systemImage: "trash")
+                    }
+
+                    Button {
+                        modelManager.showModelInFinder(model)
+                    } label: {
+                        Label("Show in Finder", systemImage: "folder")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.system(size: 14))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 20, height: 20)
+            } else {
+                Button {
+                    Task { await modelManager.downloadModel(model) }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(LocalizedStringKey(isDownloading ? "Downloading..." : "Download"))
+                        Image(systemName: "arrow.down.circle")
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(AppTheme.Accent.primary))
+                }
+                .buttonStyle(.plain)
+                .disabled(isDownloading)
+            }
+        }
+    }
+}

--- a/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
+++ b/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
@@ -10,9 +10,20 @@ struct TranscribeCppModelCardView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
-                Text(model.displayName)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(Color(.labelColor))
+                HStack(alignment: .firstTextBaseline) {
+                    Text(model.displayName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(Color(.labelColor))
+
+                    Text("Experimental")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.black)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color(red: 0.96, green: 0.79, blue: 0.63)))
+
+                    Spacer()
+                }
 
                 HStack(spacing: 12) {
                     Label(model.language, systemImage: "globe")

--- a/VoiceInk/Views/Dashboard/ModelInsightComponents.swift
+++ b/VoiceInk/Views/Dashboard/ModelInsightComponents.swift
@@ -348,6 +348,9 @@ private struct ModelProviderIdentity {
         if let model = TranscriptionModelRegistry.models.first(where: { model in
             namesMatch(model.displayName, trimmedName) || namesMatch(model.name, trimmedName)
         }) {
+            if let transcribeCppModel = model as? TranscribeCppModel {
+                return transcribeCppIdentity(publisher: transcribeCppModel.publisher)
+            }
             return identity(for: model.provider)
         }
 
@@ -355,6 +358,10 @@ private struct ModelProviderIdentity {
             || trimmedName.localizedCaseInsensitiveContains("nemotron")
         {
             return identity(for: .fluidAudio)
+        }
+
+        if trimmedName.localizedCaseInsensitiveContains("cohere") {
+            return transcribeCppIdentity(publisher: "Cohere")
         }
 
         if trimmedName.localizedCaseInsensitiveContains("apple") {
@@ -429,6 +436,10 @@ private struct ModelProviderIdentity {
             displayName = "Parakeet"
             providerKey = "Parakeet"
             fallbackSystemImage = "waveform"
+        case .transcribeCpp:
+            displayName = "On-Device"
+            providerKey = "On-Device"
+            fallbackSystemImage = "waveform.badge.magnifyingglass"
         case .nativeApple:
             displayName = "Apple Speech"
             providerKey = "Native Apple"
@@ -452,6 +463,14 @@ private struct ModelProviderIdentity {
                 cloudProvider: cloudProvider
             ),
             fallbackSystemImage: fallbackSystemImage
+        )
+    }
+
+    private static func transcribeCppIdentity(publisher: String) -> ModelProviderIdentity {
+        ModelProviderIdentity(
+            providerName: publisher,
+            descriptor: descriptor(displayName: publisher, providerKey: publisher),
+            fallbackSystemImage: "waveform.badge.magnifyingglass"
         )
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add on-device Cohere Transcribe support via the `TranscribeCpp` backend, including model download/verification and full engine integration. Users can run Cohere Transcribe privately on Mac with resumable downloads, a memory-aware runtime, and an Experimental badge in the UI.

- New Features
  - Added `.transcribeCpp` provider and TranscribeCppModel with a Cohere Transcribe catalog entry (multilingual, ~1.56 GB).
  - Implemented TranscribeCppModelManager: resumable downloads with Range requests, SHA256 verification, retries, pause/resume, delete, “Show in Finder,” and progress UI with accurate reporting.
  - Added TranscribeCppTranscriptionService and CohereTranscriptionService: backend init (Metal on arm64, CPU otherwise), energy-aware chunking, language auto-selection, and automatic unload on memory pressure or model changes.
  - Wired into engine and UI: service registry routing, model availability checks, engine model loading, new `transcribeCppModelDeleted` notification, TranscribeCppModelCardView with Experimental badge, Model Management filtering, and dashboard identity for Cohere.
  - Expanded language support for Cohere Transcribe and updated prewarm tooltip copy.
  - Updated displayed speed/accuracy ratings for Cohere Transcribe.

- Dependencies
  - Added SwiftPM package `Transcribe-cpp-swift` and linked `TranscribeCpp`; updated README to reference the project.

<sup>Written for commit cf5611793fa9c3ca87f8a2fb9d06d9106c06eb2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

