### PR TITLE
Show Sparkle updates from dashboard

### DIFF
--- a/VoiceInk/Info.plist
+++ b/VoiceInk/Info.plist
@@ -11,7 +11,7 @@
 	<key>LSUIElement</key>
 	<false/>
 	<key>SUEnableAutomaticChecks</key>
-	<true/>
+	<false/>
 	<key>SUScheduledCheckInterval</key>
 	<integer>14400</integer>
 	<key>NSMicrophoneUsageDescription</key>

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -3562,11 +3562,28 @@
       }
     },
     "Auto-check Updates" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Updates automatisch prüfen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动检查更新"
+          }
+        }
+      }
+    },
+    "Automatically Check for Updates" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatisch nach Updates suchen"
           }
         },
         "zh-Hans" : {
@@ -12076,6 +12093,22 @@
         }
       }
     },
+    "Open the VoiceInk %@ update" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VoiceInk-Update %@ öffnen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 VoiceInk %@ 更新"
+          }
+        }
+      }
+    },
     "OpenAI Compatible" : {
       "localizations" : {
         "de" : {
@@ -12088,6 +12121,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OpenAI 兼容"
+          }
+        }
+      }
+    },
+    "Opens the update window" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffnet das Updatefenster"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开更新窗口"
           }
         }
       }
@@ -17552,6 +17601,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持的提供商"
+          }
+        }
+      }
+    },
+    "Update Available" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update verfügbar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有可用更新"
           }
         }
       }

--- a/VoiceInk/Services/UpdaterViewModel.swift
+++ b/VoiceInk/Services/UpdaterViewModel.swift
@@ -1,0 +1,162 @@
+import Combine
+import Foundation
+import Sparkle
+import SwiftUI
+
+@MainActor
+final class UpdaterViewModel: NSObject, ObservableObject, SPUUpdaterDelegate {
+    struct AvailableUpdate: Equatable {
+        let versionIdentifier: String
+        let displayVersion: String
+    }
+
+    private enum DefaultsKey {
+        // Keep the existing persisted key strings so current user preferences migrate automatically.
+        static let automaticUpdateChecks = "VoiceInkChecksForUpdatesOnLaunch"
+        static let interactedUpdateVersions = "VoiceInkInteractedUpdateVersions"
+        static let sparkleAutomaticChecks = "SUEnableAutomaticChecks"
+    }
+
+    private let defaults: UserDefaults
+    private var isUserInitiatedUpdateCheck = false
+    private lazy var updaterController = SPUStandardUpdaterController(
+        startingUpdater: false,
+        updaterDelegate: self,
+        userDriverDelegate: nil
+    )
+
+    @Published var canCheckForUpdates = false
+    @Published private(set) var checksForUpdatesWhenDashboardAppears = false
+    @Published private(set) var availableUpdate: AvailableUpdate?
+
+    override init() {
+        let defaults = UserDefaults.standard
+        self.defaults = defaults
+        checksForUpdatesWhenDashboardAppears = Self.initialAutomaticCheckPreference(in: defaults)
+        super.init()
+
+        let updater = updaterController.updater
+
+        // VoiceInk owns automatic discovery through Sparkle's non-presenting probe.
+        // Keeping Sparkle's scheduler disabled prevents it from showing an update
+        // window independently of the Dashboard button.
+        updater.automaticallyChecksForUpdates = false
+        updaterController.startUpdater()
+
+        canCheckForUpdates = updater.canCheckForUpdates
+        updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+
+    func setChecksForUpdatesWhenDashboardAppears(_ value: Bool) {
+        guard checksForUpdatesWhenDashboardAppears != value else { return }
+
+        checksForUpdatesWhenDashboardAppears = value
+        defaults.set(value, forKey: DefaultsKey.automaticUpdateChecks)
+
+        if value {
+            checkForUpdateInformationIfPossible()
+        } else {
+            availableUpdate = nil
+        }
+    }
+
+    func checkForUpdatesIfDue() {
+        guard checksForUpdatesWhenDashboardAppears else { return }
+
+        let updater = updaterController.updater
+        guard !updater.sessionInProgress else { return }
+
+        if let lastCheckDate = updater.lastUpdateCheckDate {
+            let elapsed = Date().timeIntervalSince(lastCheckDate)
+            guard elapsed < 0 || elapsed >= updater.updateCheckInterval else { return }
+        }
+
+        checkForUpdateInformationIfPossible()
+    }
+
+    func checkForUpdates() {
+        guard canCheckForUpdates else { return }
+
+        // Any explicit check is interaction with the currently advertised update.
+        // Persist it before presenting Sparkle so dismissing or closing the native
+        // window cannot make the Dashboard button reappear for the same build.
+        if let availableUpdate {
+            rememberInteraction(with: availableUpdate.versionIdentifier)
+            self.availableUpdate = nil
+        }
+
+        if !updaterController.updater.sessionInProgress {
+            isUserInitiatedUpdateCheck = true
+        }
+        updaterController.checkForUpdates(nil)
+    }
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        let update = AvailableUpdate(
+            versionIdentifier: item.versionString,
+            displayVersion: item.displayVersionString
+        )
+
+        if isUserInitiatedUpdateCheck {
+            rememberInteraction(with: update.versionIdentifier)
+            availableUpdate = nil
+        } else if checksForUpdatesWhenDashboardAppears && !hasInteracted(with: update.versionIdentifier) {
+            availableUpdate = update
+        } else {
+            availableUpdate = nil
+        }
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        availableUpdate = nil
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: Error?
+    ) {
+        isUserInitiatedUpdateCheck = false
+    }
+
+    private func checkForUpdateInformationIfPossible() {
+        let updater = updaterController.updater
+        guard !updater.sessionInProgress else { return }
+        updater.checkForUpdateInformation()
+    }
+
+    private func hasInteracted(with versionIdentifier: String) -> Bool {
+        defaults.stringArray(forKey: DefaultsKey.interactedUpdateVersions)?
+            .contains(versionIdentifier) == true
+    }
+
+    private func rememberInteraction(with versionIdentifier: String) {
+        var versions = defaults.stringArray(forKey: DefaultsKey.interactedUpdateVersions) ?? []
+        guard !versions.contains(versionIdentifier) else { return }
+        versions.append(versionIdentifier)
+        defaults.set(versions, forKey: DefaultsKey.interactedUpdateVersions)
+    }
+
+    private static func initialAutomaticCheckPreference(in defaults: UserDefaults) -> Bool {
+        if let preference = defaults.object(forKey: DefaultsKey.automaticUpdateChecks) as? Bool {
+            return preference
+        }
+
+        // Preserve an explicit choice made through VoiceInk's previous Sparkle-backed
+        // setting. With no saved choice, keep VoiceInk's existing opt-in default.
+        let preference = (defaults.object(forKey: DefaultsKey.sparkleAutomaticChecks) as? Bool) ?? true
+
+        defaults.set(preference, forKey: DefaultsKey.automaticUpdateChecks)
+        return preference
+    }
+}
+
+struct CheckForUpdatesView: View {
+    @ObservedObject var updaterViewModel: UpdaterViewModel
+
+    var body: some View {
+        Button("Check for Updates…", action: updaterViewModel.checkForUpdates)
+            .disabled(!updaterViewModel.canCheckForUpdates)
+    }
+}

--- a/VoiceInk/Views/Dashboard/DashboardContent.swift
+++ b/VoiceInk/Views/Dashboard/DashboardContent.swift
@@ -31,6 +31,7 @@ struct DashboardContent: View {
     @State private var isInsightsViewPresented = false
     @State private var selectedInsightPeriod: DashboardInsightPeriod = .allTime
     @State private var isAccessibilityEnabled = AXIsProcessTrusted()
+    @EnvironmentObject private var updaterViewModel: UpdaterViewModel
     @ObservedObject private var modeManager = ModeManager.shared
     @ObservedObject private var starPrompt = GitHubStarPromptCoordinator.shared
     @State private var isSystemInfoCopied = false
@@ -92,7 +93,10 @@ struct DashboardContent: View {
         .task {
             await scheduleDashboardStatsRefresh(allowSkipWhenFresh: hasLoadedStatsSnapshot)
         }
-        .onAppear(perform: refreshAccessibilityStatus)
+        .onAppear {
+            refreshAccessibilityStatus()
+            updaterViewModel.checkForUpdatesIfDue()
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshAccessibilityStatus()
         }
@@ -574,6 +578,24 @@ struct DashboardContent: View {
                 .animation(.easeInOut(duration: 0.15), value: starPrompt.openFailed)
             }
 
+            if let availableUpdate = updaterViewModel.availableUpdate {
+                Button(action: updaterViewModel.checkForUpdates) {
+                    footerActionLabel(
+                        icon: "arrow.down.circle.fill",
+                        title: "Update Available",
+                        color: AppTheme.Status.infoStrong
+                    )
+                }
+                .buttonStyle(.plain)
+                .fixedSize(horizontal: true, vertical: true)
+                .disabled(!updaterViewModel.canCheckForUpdates)
+                .help("Open the VoiceInk \(availableUpdate.displayVersion) update")
+                .accessibilityLabel("Update Available")
+                .accessibilityValue(Text(verbatim: availableUpdate.displayVersion))
+                .accessibilityHint("Opens the update window")
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+
             Button(action: copySystemInfo) {
                 footerActionLabel(
                     icon: isSystemInfoCopied ? "checkmark" : "doc.on.doc",
@@ -585,6 +607,7 @@ struct DashboardContent: View {
             .fixedSize(horizontal: true, vertical: true)
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSystemInfoCopied)
         }
+        .animation(.easeOut(duration: 0.2), value: updaterViewModel.availableUpdate)
     }
 
     @ViewBuilder

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -246,10 +246,10 @@ struct SettingsView: View {
                 .disabled(launchAtLoginManager.isUpdating)
 
                 Toggle(
-                    "Auto-check Updates",
+                    "Automatically Check for Updates",
                     isOn: Binding(
-                        get: { updaterViewModel.automaticallyChecksForUpdates },
-                        set: { updaterViewModel.setAutomaticallyChecksForUpdates($0) }
+                        get: { updaterViewModel.checksForUpdatesWhenDashboardAppears },
+                        set: { updaterViewModel.setChecksForUpdatesWhenDashboardAppears($0) }
                     ))
 
                 Toggle("Show Announcements", isOn: $enableAnnouncements)

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -2,7 +2,6 @@ import AppIntents
 import AppKit
 import FluidAudio
 import OSLog
-import Sparkle
 import SwiftData
 import SwiftUI
 
@@ -460,44 +459,6 @@ private struct MainWindowRequestBridge: View {
                     WindowManager.shared.showMainWindow()
                 }
             }
-    }
-}
-
-class UpdaterViewModel: ObservableObject {
-    private let updaterController: SPUStandardUpdaterController
-
-    @Published var canCheckForUpdates = false
-    @Published var automaticallyChecksForUpdates = false
-
-    init() {
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
-
-        automaticallyChecksForUpdates = updaterController.updater.automaticallyChecksForUpdates
-
-        updaterController.updater.publisher(for: \.canCheckForUpdates)
-            .assign(to: &$canCheckForUpdates)
-
-        updaterController.updater.publisher(for: \.automaticallyChecksForUpdates)
-            .assign(to: &$automaticallyChecksForUpdates)
-    }
-
-    func setAutomaticallyChecksForUpdates(_ value: Bool) {
-        updaterController.updater.automaticallyChecksForUpdates = value
-    }
-
-    func checkForUpdates() {
-        // This is for manual checks - will show UI
-        updaterController.checkForUpdates(nil)
-    }
-}
-
-struct CheckForUpdatesView: View {
-    @ObservedObject var updaterViewModel: UpdaterViewModel
-
-    var body: some View {
-        Button("Check for Updates…", action: updaterViewModel.checkForUpdates)
-            .disabled(!updaterViewModel.canCheckForUpdates)
     }
 }
 

--- a/VoiceInk/WindowManager.swift
+++ b/VoiceInk/WindowManager.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 enum AppWindowLayout {
     static let width: CGFloat = 950
-    static let minimumHeight: CGFloat = 730
+    static let minimumHeight: CGFloat = 750
 }
 
 enum AppWindowID {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show update availability in the dashboard and manage checks in-app. Disables `Sparkle` auto checks and adds a user toggle to probe for updates when the dashboard opens.

- **New Features**
  - Dashboard shows an "Update Available" action when a new version is found; clicking opens the `Sparkle` updater.
  - Settings toggle renamed to "Automatically Check for Updates" and now probes on dashboard appear (respects check interval); localized for de and zh-Hans.
  - Tracks interacted update versions so the banner won’t reappear for the same build.

- **Refactors**
  - Introduced `UpdaterViewModel` using non-presenting `Sparkle` probes; avoids overlapping sessions and exposes minimal state.
  - Disabled `SUEnableAutomaticChecks` in Info.plist and removed old updater code from `VoiceInk.swift`.
  - Preserves existing user preference by migrating previous keys.
  - Increased dashboard window minimum height to 750 to accommodate the update banner.

<sup>Written for commit 3bebec6979b9e4ab0d610691d54b4609cbecda48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

