### PR TITLE
Fix microphone fallback when MacBook lid closes

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -857,14 +857,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Beingpax/Transcribe-cpp-swift.git";
-			requirement = {
-				kind = exactVersion;
-				version = "0.2.0-dev.856d7c1";
-			};
-		};
 		E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-atomics.git";
@@ -887,6 +879,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.6.4;
+			};
+		};
+		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Beingpax/Transcribe-cpp-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = "0.2.0-dev.856d7c1";
 			};
 		};
 		E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */ = {
@@ -958,11 +958,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */;
-			productName = TranscribeCpp;
-		};
 		E1342C1E2EB4844800CED8A2 /* Atomics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */;
@@ -977,6 +972,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1ADD45D2CC544F100303ECB /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */;
+			productName = TranscribeCpp;
 		};
 		E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -3519,6 +3519,22 @@
         }
       }
     },
+    "Audio Settings" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audioeinstellungen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音频设置"
+          }
+        }
+      }
+    },
     "AudioUnit not initialized" : {
       "localizations" : {
         "de" : {
@@ -11588,6 +11604,22 @@
         }
       }
     },
+    "No usable microphone is available. Choose a microphone in Audio Settings." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es ist kein verwendbares Mikrofon verfügbar. Wähle unter „Audioeinstellungen“ ein Mikrofon aus."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的麦克风。请在“音频设置”中选择一个麦克风。"
+          }
+        }
+      }
+    },
     "No Websites" : {
       "localizations" : {
         "de" : {
@@ -13282,6 +13314,7 @@
       }
     },
     "Recording Failed: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -18212,6 +18245,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "VoiceInk 可以根据你正在使用的 App 和你配置的规则选择合适的模式。"
+          }
+        }
+      }
+    },
+    "VoiceInk could not switch to another microphone." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VoiceInk konnte nicht zu einem anderen Mikrofon wechseln."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VoiceInk 无法切换到其他麦克风。"
           }
         }
       }

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -11620,6 +11620,22 @@
         }
       }
     },
+    "No usable microphone is available. Open the lid or connect an external microphone." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es ist kein verwendbares Mikrofon verfügbar. Öffne den Deckel oder schließe ein externes Mikrofon an."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的麦克风。请打开上盖或连接外接麦克风。"
+          }
+        }
+      }
+    },
     "No Websites" : {
       "localizations" : {
         "de" : {

--- a/VoiceInk/Modes/ModeSetupNavigator.swift
+++ b/VoiceInk/Modes/ModeSetupNavigator.swift
@@ -3,14 +3,22 @@ import Foundation
 /// Opens a main-window tab from contexts with no view hierarchy, such as a notification action.
 enum ModeSetupNavigator {
     static func openModesSettings() {
-        open(destination: .modes)
+        MainWindowNavigator.open(destination: .modes)
     }
 
     static func openModelsSettings() {
-        open(destination: .models)
+        MainWindowNavigator.open(destination: .models)
     }
+}
 
-    private static func open(destination: ViewType) {
+enum AudioSetupNavigator {
+    static func openAudioSettings() {
+        MainWindowNavigator.open(destination: .audio)
+    }
+}
+
+private enum MainWindowNavigator {
+    static func open(destination: ViewType) {
         MainWindowNavigation.shared.navigate(to: destination)
 
         if WindowManager.shared.currentMainWindow() == nil {

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -20,5 +20,5 @@ extension Notification.Name {
     static let transcriptionDeleted = Notification.Name("transcriptionDeleted")
     static let sessionMetricsDidChange = Notification.Name("sessionMetricsDidChange")
     static let openFileForTranscription = Notification.Name("openFileForTranscription")
-    static let audioDeviceSwitchRequired = Notification.Name("audioDeviceSwitchRequired")
+    static let recordingDeviceChangeRequired = Notification.Name("recordingDeviceChangeRequired")
 }

--- a/VoiceInk/Recorder+RecordingDeviceSetup.swift
+++ b/VoiceInk/Recorder+RecordingDeviceSetup.swift
@@ -1,0 +1,114 @@
+import CoreAudio
+import Foundation
+import os
+
+extension Recorder {
+    func setupRecordingDeviceChangeObserver() {
+        recordingDeviceChangeObserver = NotificationCenter.default.addObserver(
+            forName: .recordingDeviceChangeRequired,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task {
+                await self?.handleRecordingDeviceChange(notification)
+            }
+        }
+    }
+
+    func startHardwareRecording(
+        _ recorder: CoreAudioRecorder,
+        to url: URL,
+        deviceID: AudioDeviceID
+    ) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            audioSetupQueue.async {
+                do {
+                    try recorder.startRecording(toOutputFile: url, deviceID: deviceID)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func showRecordingDeviceNotification(
+        for deviceID: AudioDeviceID,
+        resolution: RecordingDeviceResolution
+    ) {
+        guard let deviceName = deviceManager.availableDevices.first(where: { $0.id == deviceID })?.name else {
+            return
+        }
+
+        if resolution.fellBackFromClosedBuiltInMicrophone {
+            NotificationManager.shared.showNotification(
+                title: String(format: String(localized: "Using: %@"), deviceName),
+                type: .info
+            )
+            return
+        }
+
+        let lastDeviceID = UserDefaults.standard.string(forKey: "lastUsedMicrophoneDeviceID")
+        guard String(deviceID) != lastDeviceID else { return }
+        NotificationManager.shared.showNotification(
+            title: String(format: String(localized: "Using: %@"), deviceName),
+            type: .info
+        )
+    }
+
+    private func handleRecordingDeviceChange(_ notification: Notification) async {
+        guard let request = notification.object as? RecordingDeviceChangeRequest else { return }
+        guard let fallbackDeviceID = request.fallbackDeviceID else {
+            deviceManager.recordingDeviceChangeFinished()
+            showNoFallbackNotification()
+            return
+        }
+        guard let recorder else {
+            deviceManager.recordingDeviceChangeFinished()
+            return
+        }
+
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                audioSetupQueue.async {
+                    do {
+                        try recorder.switchDevice(to: fallbackDeviceID)
+                        continuation.resume()
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+
+            deviceManager.recordingDeviceChangeFinished(activeDeviceID: fallbackDeviceID)
+            UserDefaults.standard.set(
+                String(fallbackDeviceID),
+                forKey: "lastUsedMicrophoneDeviceID"
+            )
+            if let deviceName = deviceManager.availableDevices.first(where: { $0.id == fallbackDeviceID })?.name {
+                NotificationManager.shared.showNotification(
+                    title: String(format: String(localized: "Switched to: %@"), deviceName),
+                    type: .info
+                )
+            }
+        } catch {
+            deviceManager.recordingDeviceChangeFinished()
+            logger.error("Failed to switch recording devices: \(error, privacy: .public)")
+            NotificationManager.shared.showNotification(
+                title: String(localized: "VoiceInk could not switch to another microphone."),
+                type: .error,
+                duration: 7.0
+            )
+        }
+    }
+
+    private func showNoFallbackNotification() {
+        NotificationManager.shared.showNotification(
+            title: String(localized: "No usable microphone is available. Choose a microphone in Audio Settings."),
+            type: .error,
+            duration: 7.0,
+            actionButton: (String(localized: "Audio Settings"), AudioSetupNavigator.openAudioSettings)
+        )
+    }
+
+}

--- a/VoiceInk/Recorder+RecordingDeviceSetup.swift
+++ b/VoiceInk/Recorder+RecordingDeviceSetup.swift
@@ -60,7 +60,7 @@ extension Recorder {
         guard let request = notification.object as? RecordingDeviceChangeRequest else { return }
         guard let fallbackDeviceID = request.fallbackDeviceID else {
             deviceManager.recordingDeviceChangeFinished()
-            showNoFallbackNotification()
+            showNoFallbackNotification(reason: request.reason)
             return
         }
         guard let recorder else {
@@ -102,12 +102,15 @@ extension Recorder {
         }
     }
 
-    private func showNoFallbackNotification() {
+    private func showNoFallbackNotification(reason: RecordingDeviceChangeReason) {
+        let presentation = AudioInputFailurePresentation.noUsableMicrophone(
+            builtInBlockedByClosedLid: reason == .closedLid
+        )
         NotificationManager.shared.showNotification(
-            title: String(localized: "No usable microphone is available. Choose a microphone in Audio Settings."),
+            title: presentation.title,
             type: .error,
             duration: 7.0,
-            actionButton: (String(localized: "Audio Settings"), AudioSetupNavigator.openAudioSettings)
+            actionButton: (presentation.actionLabel, presentation.action)
         )
     }
 

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -5,16 +5,15 @@ import os
 
 @MainActor
 class Recorder: NSObject, ObservableObject {
-    private var recorder: CoreAudioRecorder?
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "Recorder")
-    private let deviceManager = AudioDeviceManager.shared
-    private var deviceSwitchObserver: NSObjectProtocol?
+    var recorder: CoreAudioRecorder?
+    let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "Recorder")
+    let deviceManager = AudioDeviceManager.shared
     private var audioDeviceChangedObserver: NSObjectProtocol?
-    private var isReconfiguring = false
+    var recordingDeviceChangeObserver: NSObjectProtocol?
     private let mediaController = MediaController.shared
     private let playbackController = PlaybackController.shared
     /// Dedicated serial queue for hardware setup.
-    private let audioSetupQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.audioSetup", qos: .userInitiated)
+    let audioSetupQueue = DispatchQueue(label: "com.prakashjoshipax.voiceink.audioSetup", qos: .userInitiated)
     private let recordingAudioActionDelayNanoseconds: UInt64 = 220_000_000
     private var audioMuteTask: Task<Void, Never>?
     private var mediaPauseTask: Task<Void, Never>?
@@ -31,25 +30,14 @@ class Recorder: NSObject, ObservableObject {
 
     enum RecorderError: Error {
         case couldNotStartRecording
+        case noUsableMicrophone(builtInBlockedByClosedLid: Bool)
     }
 
     override init() {
         super.init()
-        setupDeviceSwitchObserver()
         setupAudioDeviceChangedObserver()
+        setupRecordingDeviceChangeObserver()
         schedulePrepareForCurrentDevice(reason: "init")
-    }
-
-    private func setupDeviceSwitchObserver() {
-        deviceSwitchObserver = NotificationCenter.default.addObserver(
-            forName: .audioDeviceSwitchRequired,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            Task {
-                await self?.handleDeviceSwitchRequired(notification)
-            }
-        }
     }
 
     private func setupAudioDeviceChangedObserver() {
@@ -65,69 +53,15 @@ class Recorder: NSObject, ObservableObject {
         }
     }
 
-    private func handleDeviceSwitchRequired(_ notification: Notification) async {
-        guard !isReconfiguring else { return }
-        guard let recorder = recorder else { return }
-        guard let userInfo = notification.userInfo,
-            let newDeviceID = userInfo["newDeviceID"] as? AudioDeviceID
-        else {
-            logger.error("Device switch notification missing newDeviceID")
-            return
-        }
-
-        // Prevent concurrent device switches and handleDeviceChange() interference
-        isReconfiguring = true
-        defer { isReconfiguring = false }
-
-        logger.notice("🎙️ Device switch required: switching to device \(newDeviceID, privacy: .public)")
-
-        do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                audioSetupQueue.async {
-                    do {
-                        try recorder.switchDevice(to: newDeviceID)
-                        continuation.resume()
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-
-            // Notify user about the switch
-            if let deviceName = deviceManager.availableDevices.first(where: { $0.id == newDeviceID })?.name {
-                await MainActor.run {
-                    NotificationManager.shared.showNotification(
-                        title: String(format: String(localized: "Switched to: %@"), deviceName),
-                        type: .info
-                    )
-                }
-            }
-
-            logger.notice("🎙️ Successfully switched recording to device \(newDeviceID, privacy: .public)")
-        } catch {
-            logger.error("❌ Failed to switch device: \(error, privacy: .public)")
-
-            // If switch fails, stop recording and notify user
-            await handleRecordingError(error)
-        }
-    }
-
     func startRecording(toOutputFile url: URL) async throws {
-        deviceManager.isRecordingActive = true
-
-        let currentDeviceID = deviceManager.getCurrentDevice()
-        let lastDeviceID = UserDefaults.standard.string(forKey: "lastUsedMicrophoneDeviceID")
-        if String(currentDeviceID) != lastDeviceID {
-            if let deviceName = deviceManager.availableDevices.first(where: { $0.id == currentDeviceID })?.name {
-                NotificationManager.shared.showNotification(
-                    title: String(format: String(localized: "Using: %@"), deviceName),
-                    type: .info
-                )
-            }
+        var resolution = deviceManager.resolveCurrentRecordingDevice()
+        guard var deviceID = resolution.deviceID else {
+            throw RecorderError.noUsableMicrophone(
+                builtInBlockedByClosedLid: resolution.builtInBlockedByClosedLid
+            )
         }
-        UserDefaults.standard.set(String(currentDeviceID), forKey: "lastUsedMicrophoneDeviceID")
 
-        let deviceID = currentDeviceID
+        deviceManager.beginRecordingSetup(deviceID: deviceID)
 
         audioRestorationTask?.cancel()
         audioRestorationTask = nil
@@ -139,18 +73,26 @@ class Recorder: NSObject, ObservableObject {
         recorder = coreAudioRecorder
 
         do {
-            // Offload hardware start to avoid shortcut lag.
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                audioSetupQueue.async {
-                    do {
-                        try coreAudioRecorder.startRecording(toOutputFile: url, deviceID: deviceID)
-                        continuation.resume()
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
+            do {
+                try await startHardwareRecording(coreAudioRecorder, to: url, deviceID: deviceID)
+            } catch {
+                let retryResolution = deviceManager.resolveCurrentRecordingDevice(excluding: deviceID)
+                guard deviceManager.isClamshellClosed,
+                    deviceManager.isBuiltInDevice(deviceID),
+                    let fallbackDeviceID = retryResolution.deviceID
+                else {
+                    throw error
                 }
+
+                deviceID = fallbackDeviceID
+                resolution = retryResolution
+                deviceManager.beginRecordingSetup(deviceID: fallbackDeviceID)
+                try await startHardwareRecording(coreAudioRecorder, to: url, deviceID: fallbackDeviceID)
             }
 
+            deviceManager.recordingDidStart(deviceID: deviceID)
+            showRecordingDeviceNotification(for: deviceID, resolution: resolution)
+            UserDefaults.standard.set(String(deviceID), forKey: "lastUsedMicrophoneDeviceID")
             resetAudioMeter()
         } catch {
             logger.error(
@@ -184,7 +126,7 @@ class Recorder: NSObject, ObservableObject {
             await mediaController.unmuteSystemAudio()
             await playbackController.resumeMedia()
         }
-        deviceManager.isRecordingActive = false
+        deviceManager.recordingDidStop()
     }
 
     private func muteSystemAudio() {
@@ -202,21 +144,6 @@ class Recorder: NSObject, ObservableObject {
         mediaPauseTask = Task { [weak self] in
             guard let self else { return }
             await self.playbackController.pauseMedia()
-        }
-    }
-
-    private func handleRecordingError(_ error: Error) async {
-        logger.error("❌ Recording error occurred: \(error, privacy: .public)")
-
-        // Stop the recording
-        await stopRecording()
-
-        // Notify the user about the recording failure
-        await MainActor.run {
-            NotificationManager.shared.showNotification(
-                title: String(format: String(localized: "Recording Failed: %@"), error.localizedDescription),
-                type: .error
-            )
         }
     }
 
@@ -303,10 +230,10 @@ class Recorder: NSObject, ObservableObject {
         audioMuteTask?.cancel()
         mediaPauseTask?.cancel()
         audioRestorationTask?.cancel()
-        if let observer = deviceSwitchObserver {
+        if let observer = audioDeviceChangedObserver {
             NotificationCenter.default.removeObserver(observer)
         }
-        if let observer = audioDeviceChangedObserver {
+        if let observer = recordingDeviceChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         recorder?.teardown()

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -56,6 +56,7 @@ class Recorder: NSObject, ObservableObject {
     func startRecording(toOutputFile url: URL) async throws {
         var resolution = deviceManager.resolveCurrentRecordingDevice()
         guard var deviceID = resolution.deviceID else {
+            onAudioChunk = nil
             throw RecorderError.noUsableMicrophone(
                 builtInBlockedByClosedLid: resolution.builtInBlockedByClosedLid
             )

--- a/VoiceInk/Services/AudioDeviceManager+RecordingRouting.swift
+++ b/VoiceInk/Services/AudioDeviceManager+RecordingRouting.swift
@@ -1,0 +1,162 @@
+import CoreAudio
+import Foundation
+import os
+
+struct RecordingDeviceResolution {
+    let deviceID: AudioDeviceID?
+    let builtInBlockedByClosedLid: Bool
+    let fellBackFromClosedBuiltInMicrophone: Bool
+}
+
+struct RecordingDeviceSession {
+    var isActive = false
+    var activeDeviceID: AudioDeviceID?
+    var isDeviceChangePending = false
+}
+
+enum RecordingDeviceChangeReason: Equatable {
+    case closedLid
+    case deviceUnavailable
+}
+
+struct RecordingDeviceChangeRequest {
+    let fallbackDeviceID: AudioDeviceID?
+    let reason: RecordingDeviceChangeReason
+}
+
+extension AudioDeviceManager {
+    func setupRecordingDeviceRouting() {
+        clamshellStateMonitor = ClamshellStateMonitor { [weak self] isClosed in
+            self?.handleClamshellChange(isClosed: isClosed)
+        }
+    }
+
+    func beginRecordingSetup(deviceID: AudioDeviceID) {
+        recordingDeviceSession.isActive = true
+        recordingDeviceSession.activeDeviceID = deviceID
+    }
+
+    func recordingDidStart(deviceID: AudioDeviceID) {
+        recordingDeviceSession.isActive = true
+        recordingDeviceSession.activeDeviceID = deviceID
+    }
+
+    func recordingDeviceChangeFinished(activeDeviceID: AudioDeviceID? = nil) {
+        if let activeDeviceID {
+            recordingDeviceSession.activeDeviceID = activeDeviceID
+        }
+        recordingDeviceSession.isDeviceChangePending = false
+    }
+
+    func recordingDidStop() {
+        recordingDeviceSession = RecordingDeviceSession()
+    }
+
+    func resolveCurrentRecordingDevice(
+        excluding excludedDeviceID: AudioDeviceID? = nil
+    ) -> RecordingDeviceResolution {
+        let preferredCandidates = preferredRecordingDeviceIDs()
+        let preferredAvailableDevice = preferredCandidates.first(where: isOperationalInputDevice)
+        let builtInBlockedByClosedLid = isClamshellClosed
+            && preferredAvailableDevice.map(isBuiltInDevice) == true
+
+        var seen = Set<AudioDeviceID>()
+        let candidates = (preferredCandidates + fallbackRecordingDeviceIDs()).filter { deviceID in
+            guard deviceID != excludedDeviceID else { return false }
+            return seen.insert(deviceID).inserted
+        }
+        let resolvedDeviceID = candidates.first(where: isDeviceUsableForRecording)
+
+        return RecordingDeviceResolution(
+            deviceID: resolvedDeviceID,
+            builtInBlockedByClosedLid: builtInBlockedByClosedLid,
+            fellBackFromClosedBuiltInMicrophone: builtInBlockedByClosedLid
+                && resolvedDeviceID != preferredAvailableDevice
+        )
+    }
+
+    func getCurrentDevice() -> AudioDeviceID {
+        resolveCurrentRecordingDevice().deviceID ?? 0
+    }
+
+    func findBestAvailableDevice() -> AudioDeviceID? {
+        fallbackRecordingDeviceIDs().first(where: isDeviceUsableForRecording)
+    }
+
+    func isBuiltInDevice(_ deviceID: AudioDeviceID) -> Bool {
+        let transportType = getUInt32DeviceProperty(
+            deviceID: deviceID,
+            selector: kAudioDevicePropertyTransportType
+        )
+        return transportType == kAudioDeviceTransportTypeBuiltIn
+    }
+
+    func isDeviceUsableForRecording(_ deviceID: AudioDeviceID) -> Bool {
+        isOperationalInputDevice(deviceID)
+            && !(isClamshellClosed && isBuiltInDevice(deviceID))
+    }
+
+    private func preferredRecordingDeviceIDs() -> [AudioDeviceID] {
+        switch inputMode {
+        case .systemDefault:
+            return getSystemDefaultDevice().map { [$0] } ?? []
+        case .custom:
+            let savedUID = UserDefaults.standard.selectedAudioDeviceUID ?? ""
+            let savedModelUID = UserDefaults.standard.selectedAudioDeviceModelUID
+            var candidates = findAvailableDevice(uid: savedUID, modelUID: savedModelUID).map { [$0.id] } ?? []
+            if let selectedDeviceID, !candidates.contains(selectedDeviceID) {
+                candidates.append(selectedDeviceID)
+            }
+            return candidates
+        case .prioritized:
+            return prioritizedDevices.sorted { $0.priority < $1.priority }.compactMap { device in
+                findAvailableDevice(uid: device.id, modelUID: device.modelUID)?.id
+            }
+        }
+    }
+
+    private func fallbackRecordingDeviceIDs() -> [AudioDeviceID] {
+        let builtIn = availableDevices.filter { isBuiltInDevice($0.id) }.map { $0.id }
+        let external = availableDevices.filter { !isBuiltInDevice($0.id) }.map { $0.id }
+        return isClamshellClosed ? external + builtIn : builtIn + external
+    }
+
+    func isOperationalInputDevice(_ deviceID: AudioDeviceID) -> Bool {
+        availableDevices.contains { $0.id == deviceID }
+    }
+
+    private func handleClamshellChange(isClosed: Bool) {
+        logger.notice("Clamshell state changed: \(isClosed ? "closed" : "open", privacy: .public)")
+
+        guard isRecordingActive else {
+            notifyDeviceChange()
+            return
+        }
+        guard isClosed,
+            let activeRecordingDeviceID,
+            isBuiltInDevice(activeRecordingDeviceID)
+        else {
+            return
+        }
+
+        requestRecordingDeviceChange(reason: .closedLid)
+    }
+
+    func requestRecordingDeviceChange(reason: RecordingDeviceChangeReason) {
+        guard let activeDeviceID = activeRecordingDeviceID,
+            !recordingDeviceSession.isDeviceChangePending
+        else {
+            return
+        }
+
+        recordingDeviceSession.isDeviceChangePending = true
+        let request = RecordingDeviceChangeRequest(
+            fallbackDeviceID: resolveCurrentRecordingDevice(excluding: activeDeviceID).deviceID,
+            reason: reason
+        )
+        NotificationCenter.default.post(
+            name: .recordingDeviceChangeRequired,
+            object: request
+        )
+    }
+}

--- a/VoiceInk/Services/AudioDeviceManager.swift
+++ b/VoiceInk/Services/AudioDeviceManager.swift
@@ -17,13 +17,18 @@ enum AudioInputMode: String, CaseIterable {
 }
 
 class AudioDeviceManager: ObservableObject {
-    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "AudioDeviceManager")
+    let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "AudioDeviceManager")
     @Published var availableDevices: [(id: AudioDeviceID, uid: String, name: String)] = []
     @Published var selectedDeviceID: AudioDeviceID?
     @Published var inputMode: AudioInputMode = .custom
     @Published var prioritizedDevices: [PrioritizedDevice] = []
 
-    var isRecordingActive: Bool = false
+    var recordingDeviceSession = RecordingDeviceSession()
+    var clamshellStateMonitor: ClamshellStateMonitor?
+
+    var isRecordingActive: Bool { recordingDeviceSession.isActive }
+    var activeRecordingDeviceID: AudioDeviceID? { recordingDeviceSession.activeDeviceID }
+    var isClamshellClosed: Bool { clamshellStateMonitor?.isClosed == true }
 
     static let shared = AudioDeviceManager()
 
@@ -37,6 +42,8 @@ class AudioDeviceManager: ObservableObject {
         } else {
             inputMode = .systemDefault
         }
+
+        setupRecordingDeviceRouting()
 
         loadAvailableDevices { [weak self] in
             self?.initializeSelectedDevice()
@@ -117,20 +124,6 @@ class AudioDeviceManager: ObservableObject {
         notifyDeviceChange()
     }
 
-    func findBestAvailableDevice() -> AudioDeviceID? {
-        if let device = availableDevices.first(where: { isBuiltInDevice($0.id) }) {
-            return device.id
-        }
-        return availableDevices.first?.id
-    }
-
-    private func isBuiltInDevice(_ deviceID: AudioDeviceID) -> Bool {
-        guard let uid = getDeviceUID(deviceID: deviceID) else {
-            return false
-        }
-        return uid.contains("BuiltIn")
-    }
-
     func loadAvailableDevices(completion: (() -> Void)? = nil) {
         var propertySize: UInt32 = 0
         var address = AudioObjectPropertyAddress(
@@ -192,13 +185,13 @@ class AudioDeviceManager: ObservableObject {
     }
 
     func getDeviceName(deviceID: AudioDeviceID) -> String? {
-        let name: CFString? = getDeviceProperty(
+        let name = getCFStringDeviceProperty(
             deviceID: deviceID,
             selector: kAudioDevicePropertyDeviceNameCFString)
         return name as String?
     }
 
-    private func isValidInputDevice(deviceID: AudioDeviceID) -> Bool {
+    func isValidInputDevice(deviceID: AudioDeviceID) -> Bool {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyStreamConfiguration,
             mScope: kAudioDevicePropertyScopeInput,
@@ -220,8 +213,12 @@ class AudioDeviceManager: ObservableObject {
             return false
         }
 
-        let bufferList = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: Int(propertySize))
-        defer { bufferList.deallocate() }
+        let bufferListStorage = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(propertySize),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { bufferListStorage.deallocate() }
+        let bufferList = bufferListStorage.assumingMemoryBound(to: AudioBufferList.self)
 
         result = AudioObjectGetPropertyData(
             deviceID,
@@ -239,8 +236,9 @@ class AudioDeviceManager: ObservableObject {
             return false
         }
 
-        let bufferCount = Int(bufferList.pointee.mNumberBuffers)
-        return bufferCount > 0
+        return UnsafeMutableAudioBufferListPointer(bufferList).contains {
+            $0.mNumberChannels > 0
+        }
     }
 
     func selectDevice(id: AudioDeviceID) {
@@ -295,26 +293,6 @@ class AudioDeviceManager: ObservableObject {
         }
 
         notifyDeviceChange()
-    }
-
-    func getCurrentDevice() -> AudioDeviceID {
-        switch inputMode {
-        case .systemDefault:
-            return getSystemDefaultDevice() ?? findBestAvailableDevice() ?? 0
-        case .custom:
-            if let id = selectedDeviceID, isDeviceAvailable(id) {
-                return id
-            }
-            return findBestAvailableDevice() ?? 0
-        case .prioritized:
-            let sortedDevices = prioritizedDevices.sorted { $0.priority < $1.priority }
-            for device in sortedDevices {
-                if let available = availableDevices.first(where: { $0.uid == device.id }) {
-                    return available.id
-                }
-            }
-            return findBestAvailableDevice() ?? 0
-        }
     }
 
     private func loadPrioritizedDevices() {
@@ -375,6 +353,7 @@ class AudioDeviceManager: ObservableObject {
             guard let found = findAvailableDevice(uid: saved.id, modelUID: saved.modelUID) else {
                 continue
             }
+            guard isDeviceUsableForRecording(found.id) else { continue }
             selectedDeviceID = found.id
             if found.uid != saved.id || saved.modelUID == nil {
                 rebindPrioritizedDevice(
@@ -418,46 +397,18 @@ class AudioDeviceManager: ObservableObject {
         loadAvailableDevices { [weak self] in
             guard let self = self else { return }
 
-            if self.inputMode == .systemDefault {
-                self.notifyDeviceChange()
+            if self.isRecordingActive {
+                guard let activeDeviceID = self.activeRecordingDeviceID,
+                    !self.isOperationalInputDevice(activeDeviceID)
+                else {
+                    return
+                }
+                self.requestRecordingDeviceChange(reason: .deviceUnavailable)
                 return
             }
 
-            if self.isRecordingActive {
-                guard let currentID = self.selectedDeviceID else { return }
-
-                if !self.isDeviceAvailable(currentID) {
-                    self.logger.warning(
-                        "🎙️ Recording device \(currentID, privacy: .public) no longer available - requesting switch")
-
-                    let newDeviceID: AudioDeviceID?
-                    if self.inputMode == .prioritized {
-                        let sortedDevices = self.prioritizedDevices.sorted { $0.priority < $1.priority }
-                        let priorityDeviceID = sortedDevices.compactMap { device in
-                            self.availableDevices.first(where: { $0.uid == device.id })?.id
-                        }.first
-
-                        if let deviceID = priorityDeviceID {
-                            newDeviceID = deviceID
-                        } else {
-                            newDeviceID = self.findBestAvailableDevice()
-                        }
-                    } else {
-                        newDeviceID = self.findBestAvailableDevice()
-                    }
-
-                    if let deviceID = newDeviceID {
-                        self.selectedDeviceID = deviceID
-                        NotificationCenter.default.post(
-                            name: .audioDeviceSwitchRequired,
-                            object: nil,
-                            userInfo: ["newDeviceID": deviceID]
-                        )
-                    } else {
-                        self.logger.error("No audio input devices available!")
-                        NotificationCenter.default.post(name: .toggleRecorderPanel, object: nil)
-                    }
-                }
+            if self.inputMode == .systemDefault {
+                self.notifyDeviceChange()
                 return
             }
 
@@ -470,20 +421,20 @@ class AudioDeviceManager: ObservableObject {
     }
 
     private func getDeviceUID(deviceID: AudioDeviceID) -> String? {
-        let uid: CFString? = getDeviceProperty(
+        let uid = getCFStringDeviceProperty(
             deviceID: deviceID,
             selector: kAudioDevicePropertyDeviceUID)
         return uid as String?
     }
 
     func getDeviceModelUID(deviceID: AudioDeviceID) -> String? {
-        let uid: CFString? = getDeviceProperty(
+        let uid = getCFStringDeviceProperty(
             deviceID: deviceID,
             selector: kAudioDevicePropertyModelUID)
         return uid as String?
     }
 
-    private func findAvailableDevice(uid: String, modelUID: String?) -> (id: AudioDeviceID, uid: String, name: String)?
+    func findAvailableDevice(uid: String, modelUID: String?) -> (id: AudioDeviceID, uid: String, name: String)?
     {
         if !uid.isEmpty, let found = availableDevices.first(where: { $0.uid == uid }) {
             return found
@@ -545,6 +496,7 @@ class AudioDeviceManager: ObservableObject {
             },
             UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         )
+
     }
 
     private func createPropertyAddress(
@@ -559,16 +511,16 @@ class AudioDeviceManager: ObservableObject {
         )
     }
 
-    private func getDeviceProperty<T>(
+    private func getCFStringDeviceProperty(
         deviceID: AudioDeviceID,
         selector: AudioObjectPropertySelector,
         scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal
-    ) -> T? {
+    ) -> CFString? {
         guard deviceID != 0 else { return nil }
 
         var address = createPropertyAddress(selector: selector, scope: scope)
-        var propertySize = UInt32(MemoryLayout<T>.size)
-        var property: T? = nil
+        var propertySize = UInt32(MemoryLayout<CFString?>.size)
+        var property: CFString?
 
         let status = AudioObjectGetPropertyData(
             deviceID,
@@ -589,7 +541,30 @@ class AudioDeviceManager: ObservableObject {
         return property
     }
 
-    private func notifyDeviceChange() {
+    func getUInt32DeviceProperty(
+        deviceID: AudioDeviceID,
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal
+    ) -> UInt32? {
+        guard deviceID != 0 else { return nil }
+
+        var address = createPropertyAddress(selector: selector, scope: scope)
+        var propertySize = UInt32(MemoryLayout<UInt32>.size)
+        var property: UInt32 = 0
+
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &propertySize,
+            &property
+        )
+        guard status == noErr else { return nil }
+        return property
+    }
+
+    func notifyDeviceChange() {
         NotificationCenter.default.post(name: NSNotification.Name("AudioDeviceChanged"), object: nil)
     }
 }

--- a/VoiceInk/Services/ClamshellStateMonitor.swift
+++ b/VoiceInk/Services/ClamshellStateMonitor.swift
@@ -1,0 +1,87 @@
+import Foundation
+import IOKit
+import os
+
+final class ClamshellStateMonitor {
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ClamshellStateMonitor")
+    private let onChange: (Bool) -> Void
+
+    private var rootDomain: io_registry_entry_t = 0
+    private var notificationPort: IONotificationPortRef?
+    private var notifier: io_object_t = 0
+
+    private(set) var isClosed = false
+
+    init(onChange: @escaping (Bool) -> Void) {
+        self.onChange = onChange
+        startMonitoring()
+    }
+
+    private func startMonitoring() {
+        rootDomain = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPMrootDomain")
+        )
+        guard rootDomain != 0 else {
+            logger.warning("Unable to access IOPMrootDomain")
+            return
+        }
+
+        refresh(notify: false)
+
+        guard let port = IONotificationPortCreate(kIOMainPortDefault) else {
+            logger.warning("Unable to create clamshell notification port")
+            return
+        }
+        notificationPort = port
+        IONotificationPortSetDispatchQueue(port, DispatchQueue.main)
+
+        let status = IOServiceAddInterestNotification(
+            port,
+            rootDomain,
+            kIOGeneralInterest,
+            { userData, _, _, _ in
+                guard let userData else { return }
+                let monitor = Unmanaged<ClamshellStateMonitor>.fromOpaque(userData).takeUnretainedValue()
+                monitor.refresh(notify: true)
+            },
+            UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()),
+            &notifier
+        )
+
+        if status != kIOReturnSuccess {
+            logger.error("Failed to monitor clamshell state: \(status, privacy: .public)")
+        }
+    }
+
+    private func refresh(notify: Bool) {
+        guard rootDomain != 0,
+            let value = IORegistryEntryCreateCFProperty(
+                rootDomain,
+                "AppleClamshellState" as CFString,
+                kCFAllocatorDefault,
+                0
+            )?.takeRetainedValue() as? Bool,
+            value != isClosed
+        else {
+            return
+        }
+
+        isClosed = value
+        if notify {
+            onChange(value)
+        }
+    }
+
+    deinit {
+        if notifier != 0 {
+            IOObjectRelease(notifier)
+        }
+        if let notificationPort {
+            IONotificationPortDestroy(notificationPort)
+        }
+        if rootDomain != 0 {
+            IOObjectRelease(rootDomain)
+        }
+    }
+}

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine+AudioInputFailure.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine+AudioInputFailure.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension VoiceInkEngine {
+    @MainActor
+    func recordingAudioFailure(
+        for error: Error
+    ) -> (title: String, actionLabel: String, action: () -> Void)? {
+        guard let recorderError = error as? Recorder.RecorderError,
+            case .noUsableMicrophone = recorderError
+        else {
+            return nil
+        }
+
+        return (
+            String(localized: "No usable microphone is available. Choose a microphone in Audio Settings."),
+            String(localized: "Audio Settings"),
+            AudioSetupNavigator.openAudioSettings
+        )
+    }
+}

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine+AudioInputFailure.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine+AudioInputFailure.swift
@@ -1,20 +1,43 @@
 import Foundation
 
+struct AudioInputFailurePresentation {
+    let title: String
+    let actionLabel: String
+    let action: () -> Void
+
+    @MainActor
+    static func noUsableMicrophone(
+        builtInBlockedByClosedLid: Bool
+    ) -> AudioInputFailurePresentation {
+        let title = builtInBlockedByClosedLid
+            ? String(
+                localized:
+                    "No usable microphone is available. Open the lid or connect an external microphone."
+            )
+            : String(localized: "No usable microphone is available. Choose a microphone in Audio Settings.")
+
+        return AudioInputFailurePresentation(
+            title: title,
+            actionLabel: String(localized: "Audio Settings"),
+            action: AudioSetupNavigator.openAudioSettings
+        )
+    }
+}
+
 extension VoiceInkEngine {
     @MainActor
     func recordingAudioFailure(
         for error: Error
     ) -> (title: String, actionLabel: String, action: () -> Void)? {
         guard let recorderError = error as? Recorder.RecorderError,
-            case .noUsableMicrophone = recorderError
+            case .noUsableMicrophone(let builtInBlockedByClosedLid) = recorderError
         else {
             return nil
         }
 
-        return (
-            String(localized: "No usable microphone is available. Choose a microphone in Audio Settings."),
-            String(localized: "Audio Settings"),
-            AudioSetupNavigator.openAudioSettings
+        let presentation = AudioInputFailurePresentation.noUsableMicrophone(
+            builtInBlockedByClosedLid: builtInBlockedByClosedLid
         )
+        return (presentation.title, presentation.actionLabel, presentation.action)
     }
 }

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -393,7 +393,10 @@ class VoiceInkEngine: NSObject, ObservableObject {
                         } catch {
                             activeModeTask.cancel()
                             self.logger.error("Recording failed to start: \(error, privacy: .public)")
-                            await self.recorder.stopRecording()
+                            let audioFailure = self.recordingAudioFailure(for: error)
+                            if audioFailure == nil {
+                                await self.recorder.stopRecording()
+                            }
                             self.cancelCurrentSession()
                             if let recordedFile = self.recordedFile {
                                 try? FileManager.default.removeItem(at: recordedFile)
@@ -403,8 +406,17 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             self.activeRecordingStartID = nil
                             self.clearActiveRecordingContext()
                             await self.cleanupResources()
-                            NotificationManager.shared.showNotification(
-                                title: String(localized: "Recording failed to start"), type: .error)
+                            if let failure = audioFailure {
+                                NotificationManager.shared.showNotification(
+                                    title: failure.title,
+                                    type: .error,
+                                    duration: 7.0,
+                                    actionButton: (failure.actionLabel, failure.action)
+                                )
+                            } else {
+                                NotificationManager.shared.showNotification(
+                                    title: String(localized: "Recording failed to start"), type: .error)
+                            }
                             await self.recorderUIManager?.dismissRecorderPanel()
                         }
                     }
@@ -418,8 +430,6 @@ class VoiceInkEngine: NSObject, ObservableObject {
     private func requestRecordPermission(response: @escaping (Bool) -> Void) {
         response(true)
     }
-
-    // MARK: - Recording Preflight
 
     @MainActor
     private func recordingModelFailure(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically switches to a usable microphone when the MacBook lid closes and the built‑in mic becomes unavailable. Adds clearer failure guidance for closed lids with an action to open Audio Settings, plus more reliable routing at start and mid‑session.

- **New Features**
  - Detects clamshell state and auto‑routes to the best available mic; avoids built‑in when the lid is closed and retries start on a fallback device if needed.
  - Shows “Using/Switched to” notifications; when no mic works, error copy now tells you to open the lid or connect an external mic, with an “Audio Settings” action.

- **Bug Fixes**
  - Prevents start and in‑progress recording failures on lid‑close and device removal by performing safe device switches.
  - Improves built‑in detection via `kAudioDevicePropertyTransportType`, fixes CoreAudio buffer handling, and renames `audioDeviceSwitchRequired` to `recordingDeviceChangeRequired` with isolated routing logic.

<sup>Written for commit e36cdd178a4106ec5480b6b3928e16ec49688dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

