### PR TITLE
Fall back to batch when a streaming session finalizes an empty transcript

### DIFF
--- a/VoiceInk/Transcription/Engine/TranscriptionSession.swift
+++ b/VoiceInk/Transcription/Engine/TranscriptionSession.swift
@@ -125,11 +125,18 @@ final class StreamingTranscriptionSession: TranscriptionSession {
                 logger.notice("Streaming stop/transcribe started model=\(model.displayName, privacy: .public)")
                 let result = try await streamingService.stopAndFinalize()
                 switch result {
-                case .finalized(let text):
+                case .finalized(let text)
+                where !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
                     logger.notice(
                         "Streaming transcript received elapsed=\(Date().timeIntervalSince(start), format: .fixed(precision: 3), privacy: .public)s chars=\(text.count, privacy: .public)"
                     )
                     return text
+                case .finalized:
+                    // The session finalized with nothing to show for it, e.g. it stopped
+                    // producing text and the commit acknowledgement timed out. Take the same
+                    // batch path as .requiresBatchFallback rather than discarding a recording
+                    // that is still on disk.
+                    logger.error("Streaming finalized an empty transcript, falling back to batch")
                 case .requiresBatchFallback:
                     logger.notice("Streaming provider requested full batch transcription")
                 }


### PR DESCRIPTION
### The problem

`stopAndFinalize()` returns `.finalized` even when the session produced no text at all. If the provider stops emitting segments and the commit acknowledgement never arrives, `waitForFinalCommit` gives up after its 10s timeout and returns `""` — still reported as a successful finalization.

`StreamingTranscriptionSession.transcribe` takes that at face value:

```swift
case .finalized(let text):
    logger.notice("Streaming transcript received ...")
    return text
```

So it returns an empty string, the batch fallback below it never runs, and the recording is discarded — even though the complete audio file is sitting on disk and `fallbackService.transcribe(audioURL:)` could still transcribe it. From the user's side nothing is pasted and the dictation is simply gone.

### The fix

Route the empty case down the same path as `.requiresBatchFallback`, which already re-transcribes the recorded file:

```swift
case .finalized(let text)
where !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
    return text
case .finalized:
    logger.error("Streaming finalized an empty transcript, falling back to batch")
case .requiresBatchFallback:
    ...
```

The happy path is untouched. The only behavioural change is in a case that previously produced nothing at all, where the cost is one batch pass over audio that has already been recorded.

### Scope and testing

Built and running locally on macOS (Parakeet V3); the happy path is unaffected in normal use. I have **not** reproduced the empty-finalize path on demand — it is derived from reading the code, and I could not deliberately trigger the commit-acknowledgement timeout. If you would rather see a reproduction before merging, that is fair; I would still argue the current behaviour (discarding a recording that is on disk) is not the outcome you want in either case.

An earlier revision of this PR also marked the session `.failed` on every `.error` event. [Review feedback](https://github.com/Beingpax/VoiceInk/pull/872#pullrequestreview-4915639552) correctly pointed out that `FluidAudioStreamingProvider` emits `.error` for transient per-pass failures the session recovers from, so that change would have aborted recoverable sessions and forced needless full re-transcriptions. It has been dropped; this PR is now a single-file change.
