### PR TITLE
Improve transcript cleanup workflow

### DIFF
--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -33,6 +33,90 @@
         }
       }
     },
+    "Delete Old Transcript History?" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Alten Transkriptverlauf löschen?" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除旧的转写历史记录？" } }
+      }
+    },
+    "Delete Old Transcripts" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Alte Transkripte löschen" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除旧转写记录" } }
+      }
+    },
+    "Deleted 1 transcript." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "1 Transkript wurde gelöscht." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已删除 1 条转写记录。" } }
+      }
+    },
+    "Deleted 1 transcript, but couldn't delete its saved audio file. Try again or export logs from Settings." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "1 Transkript wurde gelöscht, die zugehörige Audiodatei konnte jedoch nicht gelöscht werden. Versuche es erneut oder exportiere die Protokolle in den Einstellungen." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已删除 1 条转写记录，但无法删除其保存的音频文件。请重试或从“设置”中导出日志。" } }
+      }
+    },
+    "Deleted %lld transcripts." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "%lld Transkripte wurden gelöscht." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已删除 %lld 条转写记录。" } }
+      }
+    },
+    "Deleted %1$lld transcripts, but couldn't delete %2$lld saved audio files. Try again or export logs from Settings." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "%1$lld Transkripte wurden gelöscht, %2$lld gespeicherte Audiodateien konnten jedoch nicht gelöscht werden. Versuche es erneut oder exportiere die Protokolle in den Einstellungen." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已删除 %1$lld 条转写记录，但无法删除 %2$lld 个保存的音频文件。请重试或从“设置”中导出日志。" } }
+      }
+    },
+    "Deleting Transcript History..." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Transkriptverlauf wird gelöscht …" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在删除转写历史记录…" } }
+      }
+    },
+    "Enable Auto-Delete" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Automatisches Löschen aktivieren" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "启用自动删除" } }
+      }
+    },
+    "Enable Transcript Auto-Delete?" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Transkripte automatisch löschen?" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "启用转写记录自动删除？" } }
+      }
+    },
+    "Existing transcripts older than the selected retention period and their saved audio files will be permanently deleted. This action cannot be undone." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Vorhandene Transkripte, die älter als die gewählte Aufbewahrungsfrist sind, und die zugehörigen Audiodateien werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "超过所选保留期限的现有转写记录及其保存的音频文件将被永久删除。此操作无法撤销。" } }
+      }
+    },
+    "No transcripts were old enough to delete." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Keine Transkripte sind alt genug, um gelöscht zu werden." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "没有达到删除期限的转写记录。" } }
+      }
+    },
+    "This will permanently delete transcripts older than the selected retention period and their saved audio files. This action cannot be undone." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Dadurch werden Transkripte, die älter als die gewählte Aufbewahrungsfrist sind, und die zugehörigen Audiodateien dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "这将永久删除超过所选保留期限的转写记录及其保存的音频文件。此操作无法撤销。" } }
+      }
+    },
+    "Transcript auto-delete is turned off." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Das automatische Löschen von Transkripten ist deaktiviert." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "转写记录自动删除已关闭。" } }
+      }
+    },
+    "VoiceInk couldn't delete transcript history. Try again or export logs from Settings." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "VoiceInk konnte den Transkriptverlauf nicht löschen. Versuche es erneut oder exportiere die Protokolle in den Einstellungen." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "VoiceInk 无法删除转写历史记录。请重试或从“设置”中导出日志。" } }
+      }
+    },
     " (drag to reorder)" : {
       "localizations" : {
         "de" : {

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -71,7 +71,7 @@
     },
     "Deleting Transcript History..." : {
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Transkriptverlauf wird gelöscht …" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Transkriptverlauf wird gelöscht …" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在删除转写历史记录…" } }
       }
     },
@@ -111,10 +111,10 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "转写记录自动删除已关闭。" } }
       }
     },
-    "VoiceInk couldn't delete transcript history. Try again or export logs from Settings." : {
+    "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings." : {
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "VoiceInk konnte den Transkriptverlauf nicht löschen. Versuche es erneut oder exportiere die Protokolle in den Einstellungen." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "VoiceInk 无法删除转写历史记录。请重试或从“设置”中导出日志。" } }
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "VoiceInk konnte das Löschen des Transkriptverlaufs nicht abschließen. Versuche es erneut oder exportiere die Protokolle in den Einstellungen." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "VoiceInk 无法完成转写历史记录的删除。请重试或从“设置”中导出日志。" } }
       }
     },
     " (drag to reorder)" : {

--- a/VoiceInk/Notifications/AppNotifications.swift
+++ b/VoiceInk/Notifications/AppNotifications.swift
@@ -22,3 +22,21 @@ extension Notification.Name {
     static let openFileForTranscription = Notification.Name("openFileForTranscription")
     static let recordingDeviceChangeRequired = Notification.Name("recordingDeviceChangeRequired")
 }
+
+extension Notification {
+    private static let deletedTranscriptionIDsKey = "deletedTranscriptionIDs"
+
+    static func postTranscriptionDeleted(ids: Set<UUID>) {
+        guard !ids.isEmpty else { return }
+        NotificationCenter.default.post(
+            name: .transcriptionDeleted,
+            object: nil,
+            userInfo: [deletedTranscriptionIDsKey: Array(ids)]
+        )
+    }
+
+    var deletedTranscriptionIDs: Set<UUID>? {
+        guard let ids = userInfo?[Self.deletedTranscriptionIDsKey] as? [UUID] else { return nil }
+        return Set(ids)
+    }
+}

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -2,11 +2,161 @@ import Foundation
 import OSLog
 import SwiftData
 
-class TranscriptionAutoCleanupService {
+struct TranscriptionCleanupResult: Sendable {
+    let deletedCount: Int
+    let audioFileErrorCount: Int
+    let errorMessage: String?
+}
+
+@ModelActor
+private actor TranscriptionCleanupWorker {
+    private static let batchSize = 1_000
+    private static let referenceBatchSize = 10_000
+
+    private let logger = Logger(
+        subsystem: "com.prakashjoshipax.voiceink",
+        category: "TranscriptionAutoCleanupService"
+    )
+
+    func sweep(cutoffDate: Date) throws -> (deletedCount: Int, audioFileErrorCount: Int) {
+        var deletedCount = 0
+        var audioFileErrorCount = 0
+
+        while true {
+            let batchResult = try autoreleasepool { () throws -> (deletedCount: Int, audioFileErrorCount: Int) in
+                let batchContext = ModelContext(modelContainer)
+                var descriptor = FetchDescriptor<Transcription>(
+                    predicate: #Predicate<Transcription> { transcription in
+                        transcription.timestamp < cutoffDate
+                    }
+                )
+                descriptor.fetchLimit = Self.batchSize
+
+                let transcriptions = try batchContext.fetch(descriptor)
+                let audioURLs = transcriptions.compactMap { transcription -> URL? in
+                    guard let urlString = transcription.audioFileURL else { return nil }
+                    return URL(string: urlString)
+                }
+
+                for transcription in transcriptions {
+                    batchContext.delete(transcription)
+                }
+
+                if !transcriptions.isEmpty {
+                    try batchContext.save()
+                }
+
+                var batchAudioFileErrorCount = 0
+                for audioURL in audioURLs where FileManager.default.fileExists(atPath: audioURL.path) {
+                    do {
+                        try FileManager.default.removeItem(at: audioURL)
+                    } catch {
+                        batchAudioFileErrorCount += 1
+                        logger.error(
+                            "Failed to delete audio file during transcript cleanup: \(error, privacy: .public)"
+                        )
+                    }
+                }
+
+                return (
+                    deletedCount: transcriptions.count,
+                    audioFileErrorCount: batchAudioFileErrorCount
+                )
+            }
+
+            deletedCount += batchResult.deletedCount
+            audioFileErrorCount += batchResult.audioFileErrorCount
+
+            if batchResult.deletedCount < Self.batchSize {
+                break
+            }
+        }
+
+        return (
+            deletedCount: deletedCount,
+            audioFileErrorCount: audioFileErrorCount
+        )
+    }
+
+    /// Removes only stale, unreferenced recordings. The age check protects active recordings
+    /// and files that have been created for an in-progress transcription.
+    func cleanupOrphanAudioFiles(in recordingsDirectory: URL, olderThan cutoffDate: Date) {
+        do {
+            var referencedFiles = Set<String>()
+            var fetchOffset = 0
+
+            while true {
+                let batch = try autoreleasepool { () throws -> (fetchedCount: Int, fileNames: [String]) in
+                    let batchContext = ModelContext(modelContainer)
+                    var descriptor = FetchDescriptor<Transcription>(
+                        sortBy: [SortDescriptor(\.id)]
+                    )
+                    descriptor.propertiesToFetch = [\.audioFileURL]
+                    descriptor.fetchLimit = Self.referenceBatchSize
+                    descriptor.fetchOffset = fetchOffset
+
+                    let transcriptions = try batchContext.fetch(descriptor)
+                    let fileNames = transcriptions.compactMap { transcription in
+                        guard let urlString = transcription.audioFileURL,
+                            let url = URL(string: urlString)
+                        else { return nil }
+                        return url.lastPathComponent
+                    }
+                    return (transcriptions.count, fileNames)
+                }
+
+                referencedFiles.formUnion(batch.fileNames)
+                fetchOffset += batch.fetchedCount
+
+                if batch.fetchedCount < Self.referenceBatchSize {
+                    break
+                }
+            }
+
+            guard FileManager.default.fileExists(atPath: recordingsDirectory.path) else { return }
+            guard let files = FileManager.default.enumerator(
+                at: recordingsDirectory,
+                includingPropertiesForKeys: [.contentModificationDateKey, .creationDateKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+            ) else { return }
+
+            var deletedCount = 0
+            for case let fileURL as URL in files
+            where !referencedFiles.contains(fileURL.lastPathComponent) {
+                let values = try fileURL.resourceValues(
+                    forKeys: [.contentModificationDateKey, .creationDateKey, .isRegularFileKey]
+                )
+                guard values.isRegularFile == true,
+                    let fileDate = values.contentModificationDate ?? values.creationDate,
+                    fileDate < cutoffDate
+                else { continue }
+
+                do {
+                    try FileManager.default.removeItem(at: fileURL)
+                    deletedCount += 1
+                } catch {
+                    logger.error("Failed to delete orphan audio file: \(error, privacy: .public)")
+                }
+            }
+
+            if deletedCount > 0 {
+                logger.notice("Cleaned up \(deletedCount, privacy: .public) stale orphan audio file(s)")
+            }
+        } catch {
+            logger.error("Failed during orphan audio cleanup: \(error, privacy: .public)")
+        }
+    }
+}
+
+@MainActor
+final class TranscriptionAutoCleanupService {
     static let shared = TranscriptionAutoCleanupService()
+
+    private static let orphanFileGracePeriod: TimeInterval = 7 * 24 * 60 * 60
 
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "TranscriptionAutoCleanupService")
     private var modelContext: ModelContext?
+    private var cleanupWorker: TranscriptionCleanupWorker?
 
     private var recordingsDirectory: URL {
         FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -18,6 +168,7 @@ class TranscriptionAutoCleanupService {
 
     func startMonitoring(modelContext: ModelContext) {
         self.modelContext = modelContext
+        cleanupWorker = TranscriptionCleanupWorker(modelContainer: modelContext.container)
 
         NotificationCenter.default.addObserver(
             self,
@@ -28,8 +179,8 @@ class TranscriptionAutoCleanupService {
 
         if UserDefaults.standard.bool(forKey: CleanupSettingsKeys.isTranscriptionCleanupEnabled) {
             Task { [weak self] in
-                guard let self = self, let modelContext = self.modelContext else { return }
-                await self.sweepOldTranscriptions(modelContext: modelContext)
+                guard let self, let modelContext = self.modelContext else { return }
+                _ = await self.sweepOldTranscriptions(modelContext: modelContext)
                 await self.cleanupOrphanAudioFiles(modelContext: modelContext)
             }
         }
@@ -39,7 +190,7 @@ class TranscriptionAutoCleanupService {
         NotificationCenter.default.removeObserver(self, name: .transcriptionCompleted, object: nil)
     }
 
-    func runManualCleanup(modelContext: ModelContext) async {
+    func runManualCleanup(modelContext: ModelContext) async -> TranscriptionCleanupResult {
         await sweepOldTranscriptions(modelContext: modelContext)
     }
 
@@ -50,9 +201,9 @@ class TranscriptionAutoCleanupService {
         let minutes = UserDefaults.standard.integer(forKey: CleanupSettingsKeys.transcriptionRetentionMinutes)
         if minutes > 0 {
             if let modelContext = self.modelContext {
-                Task { [weak self] in
+                Task { @MainActor [weak self] in
                     guard let self = self else { return }
-                    await self.sweepOldTranscriptions(modelContext: modelContext)
+                    _ = await self.sweepOldTranscriptions(modelContext: modelContext)
                 }
             }
             return
@@ -65,29 +216,32 @@ class TranscriptionAutoCleanupService {
             return
         }
 
-        if let urlString = transcription.audioFileURL,
-            let url = URL(string: urlString)
-        {
-            do {
-                try FileManager.default.removeItem(at: url)
-            } catch {
-                logger.error("Failed to delete audio file: \(error, privacy: .public)")
-            }
-        }
+        let audioURL = transcription.audioFileURL.flatMap(URL.init(string:))
 
         modelContext.delete(transcription)
 
         do {
             try modelContext.save()
+            if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
+                do {
+                    try FileManager.default.removeItem(at: audioURL)
+                } catch {
+                    logger.error("Failed to delete audio file: \(error, privacy: .public)")
+                }
+            }
             NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
         } catch {
             logger.error("Failed to save after transcription deletion: \(error, privacy: .public)")
         }
     }
 
-    private func sweepOldTranscriptions(modelContext: ModelContext) async {
+    private func sweepOldTranscriptions(modelContext: ModelContext) async -> TranscriptionCleanupResult {
         guard UserDefaults.standard.bool(forKey: CleanupSettingsKeys.isTranscriptionCleanupEnabled) else {
-            return
+            return TranscriptionCleanupResult(
+                deletedCount: 0,
+                audioFileErrorCount: 0,
+                errorMessage: String(localized: "Transcript auto-delete is turned off.")
+            )
         }
 
         let retentionMinutes = UserDefaults.standard.integer(forKey: CleanupSettingsKeys.transcriptionRetentionMinutes)
@@ -95,37 +249,27 @@ class TranscriptionAutoCleanupService {
 
         let cutoffDate = Date().addingTimeInterval(TimeInterval(-effectiveMinutes * 60))
 
-        let modelContainer = await MainActor.run { modelContext.container }
+        let worker = cleanupWorker ?? TranscriptionCleanupWorker(modelContainer: modelContext.container)
+        cleanupWorker = worker
 
         do {
-            let backgroundContext = ModelContext(modelContainer)
-
-            let descriptor = FetchDescriptor<Transcription>(
-                predicate: #Predicate<Transcription> { transcription in
-                    transcription.timestamp < cutoffDate
-                }
+            let result = try await worker.sweep(cutoffDate: cutoffDate)
+            if result.deletedCount > 0 {
+                logger.notice("Cleaned up \(result.deletedCount, privacy: .public) old transcription(s)")
+                NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
+            }
+            return TranscriptionCleanupResult(
+                deletedCount: result.deletedCount,
+                audioFileErrorCount: result.audioFileErrorCount,
+                errorMessage: nil
             )
-            let items = try backgroundContext.fetch(descriptor)
-            var deletedCount = 0
-            for transcription in items {
-                if let urlString = transcription.audioFileURL,
-                    let url = URL(string: urlString),
-                    FileManager.default.fileExists(atPath: url.path)
-                {
-                    try? FileManager.default.removeItem(at: url)
-                }
-                backgroundContext.delete(transcription)
-                deletedCount += 1
-            }
-            if deletedCount > 0 {
-                try backgroundContext.save()
-                logger.notice("Cleaned up \(deletedCount, privacy: .public) old transcription(s)")
-                await MainActor.run {
-                    NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
-                }
-            }
         } catch {
             logger.error("Failed during transcription cleanup: \(error, privacy: .public)")
+            return TranscriptionCleanupResult(
+                deletedCount: 0,
+                audioFileErrorCount: 0,
+                errorMessage: String(localized: "VoiceInk couldn't delete transcript history. Try again or export logs from Settings.")
+            )
         }
     }
 
@@ -135,43 +279,9 @@ class TranscriptionAutoCleanupService {
             return
         }
 
-        let modelContainer = await MainActor.run { modelContext.container }
-
-        do {
-            let backgroundContext = ModelContext(modelContainer)
-
-            var descriptor = FetchDescriptor<Transcription>()
-            descriptor.propertiesToFetch = [\.audioFileURL]
-
-            let transcriptions = try backgroundContext.fetch(descriptor)
-            let referencedFiles = Set(
-                transcriptions.compactMap { transcription -> String? in
-                    guard let urlString = transcription.audioFileURL,
-                        let url = URL(string: urlString)
-                    else { return nil }
-                    return url.lastPathComponent
-                })
-
-            guard FileManager.default.fileExists(atPath: recordingsDirectory.path) else { return }
-            let filesInDirectory = try FileManager.default.contentsOfDirectory(
-                at: recordingsDirectory,
-                includingPropertiesForKeys: nil
-            )
-
-            var deletedCount = 0
-            for fileURL in filesInDirectory {
-                let fileName = fileURL.lastPathComponent
-                if !referencedFiles.contains(fileName) {
-                    try? FileManager.default.removeItem(at: fileURL)
-                    deletedCount += 1
-                }
-            }
-
-            if deletedCount > 0 {
-                logger.notice("Cleaned up \(deletedCount, privacy: .public) orphan audio file(s)")
-            }
-        } catch {
-            logger.error("Failed during orphan audio cleanup: \(error, privacy: .public)")
-        }
+        let worker = cleanupWorker ?? TranscriptionCleanupWorker(modelContainer: modelContext.container)
+        cleanupWorker = worker
+        let cutoffDate = Date().addingTimeInterval(-Self.orphanFileGracePeriod)
+        await worker.cleanupOrphanAudioFiles(in: recordingsDirectory, olderThan: cutoffDate)
     }
 }

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -16,17 +16,6 @@ private struct TranscriptionSweepResult: Sendable {
 
 private struct TranscriptionBatchSaveError: Error {
     let audioFileErrorCount: Int
-    let underlyingError: Error
-}
-
-private func stageAudioFile(at url: URL) throws -> URL {
-    let stagedURL = url.appendingPathExtension("cleanup")
-    try FileManager.default.moveItem(at: url, to: stagedURL)
-    return stagedURL
-}
-
-private func restoreAudioFile(from stagedURL: URL, to originalURL: URL) {
-    try? FileManager.default.moveItem(at: stagedURL, to: originalURL)
 }
 
 @ModelActor
@@ -59,15 +48,13 @@ private actor TranscriptionCleanupWorker {
                     let transcriptions = try batchContext.fetch(descriptor)
                     var deletedIDs = Set<UUID>()
                     var audioFileErrorCount = 0
-                    var stagedAudioFiles = [(original: URL, staged: URL)]()
 
                     for transcription in transcriptions {
                         if let audioURL = transcription.audioFileURL.flatMap(URL.init(string:)),
                             FileManager.default.fileExists(atPath: audioURL.path)
                         {
                             do {
-                                let stagedURL = try stageAudioFile(at: audioURL)
-                                stagedAudioFiles.append((audioURL, stagedURL))
+                                try FileManager.default.removeItem(at: audioURL)
                             } catch {
                                 audioFileErrorCount += 1
                                 logger.error(
@@ -85,18 +72,13 @@ private actor TranscriptionCleanupWorker {
                         do {
                             try batchContext.save()
                         } catch {
-                            for file in stagedAudioFiles {
-                                restoreAudioFile(from: file.staged, to: file.original)
-                            }
+                            logger.error(
+                                "Failed to save a transcript cleanup batch: \(error, privacy: .public)"
+                            )
                             throw TranscriptionBatchSaveError(
-                                audioFileErrorCount: audioFileErrorCount,
-                                underlyingError: error
+                                audioFileErrorCount: audioFileErrorCount
                             )
                         }
-                    }
-
-                    for file in stagedAudioFiles {
-                        try? FileManager.default.removeItem(at: file.staged)
                     }
 
                     return (transcriptions.count, deletedIDs, audioFileErrorCount)
@@ -111,9 +93,6 @@ private actor TranscriptionCleanupWorker {
                 }
             } catch let error as TranscriptionBatchSaveError {
                 result.audioFileErrorCount += error.audioFileErrorCount
-                logger.error(
-                    "Failed to save a transcript cleanup batch: \(error.underlyingError, privacy: .public)"
-                )
                 result.errorMessage = String(
                     localized: "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings."
                 )
@@ -249,10 +228,9 @@ final class TranscriptionAutoCleanupService {
         let audioURL = transcription.audioFileURL.flatMap(URL.init(string:))
         let transcriptionID = transcription.id
 
-        var stagedAudioURL: URL?
         if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
             do {
-                stagedAudioURL = try stageAudioFile(at: audioURL)
+                try FileManager.default.removeItem(at: audioURL)
             } catch {
                 logger.error("Failed to delete audio file: \(error, privacy: .public)")
                 return
@@ -262,15 +240,9 @@ final class TranscriptionAutoCleanupService {
         modelContext.delete(transcription)
         do {
             try modelContext.save()
-            if let stagedAudioURL {
-                try? FileManager.default.removeItem(at: stagedAudioURL)
-            }
             Notification.postTranscriptionDeleted(ids: [transcriptionID])
         } catch {
             modelContext.rollback()
-            if let audioURL, let stagedAudioURL {
-                restoreAudioFile(from: stagedAudioURL, to: audioURL)
-            }
             logger.error("Failed to save after transcription deletion: \(error, privacy: .public)")
         }
     }

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -8,110 +8,117 @@ struct TranscriptionCleanupResult: Sendable {
     let errorMessage: String?
 }
 
+private struct TranscriptionSweepResult: Sendable {
+    var deletedIDs = Set<UUID>()
+    var audioFileErrorCount = 0
+    var errorMessage: String?
+}
+
+private struct TranscriptionBatchSaveError: Error {
+    let audioFileErrorCount: Int
+}
+
 @ModelActor
 private actor TranscriptionCleanupWorker {
     private static let batchSize = 1_000
-    private static let referenceBatchSize = 10_000
 
     private let logger = Logger(
         subsystem: "com.prakashjoshipax.voiceink",
         category: "TranscriptionAutoCleanupService"
     )
 
-    func sweep(cutoffDate: Date) throws -> (deletedCount: Int, audioFileErrorCount: Int) {
-        var deletedCount = 0
-        var audioFileErrorCount = 0
+    func sweep(cutoffDate: Date) -> TranscriptionSweepResult {
+        var result = TranscriptionSweepResult()
+        var failedRecordCount = 0
 
         while true {
-            let batchResult = try autoreleasepool { () throws -> (deletedCount: Int, audioFileErrorCount: Int) in
-                let batchContext = ModelContext(modelContainer)
-                var descriptor = FetchDescriptor<Transcription>(
-                    predicate: #Predicate<Transcription> { transcription in
-                        transcription.timestamp < cutoffDate
+            do {
+                let batchResult = try autoreleasepool {
+                    () throws -> (fetchedCount: Int, deletedIDs: Set<UUID>, audioFileErrorCount: Int) in
+                    let batchContext = ModelContext(modelContainer)
+                    var descriptor = FetchDescriptor<Transcription>(
+                        predicate: #Predicate<Transcription> { transcription in
+                            transcription.timestamp < cutoffDate
+                        },
+                        sortBy: [SortDescriptor(\.id)]
+                    )
+                    descriptor.fetchLimit = Self.batchSize
+                    descriptor.fetchOffset = failedRecordCount
+
+                    let transcriptions = try batchContext.fetch(descriptor)
+                    var deletedIDs = Set<UUID>()
+                    var audioFileErrorCount = 0
+
+                    for transcription in transcriptions {
+                        if let audioURL = transcription.audioFileURL.flatMap(URL.init(string:)),
+                            FileManager.default.fileExists(atPath: audioURL.path)
+                        {
+                            do {
+                                try FileManager.default.removeItem(at: audioURL)
+                            } catch {
+                                audioFileErrorCount += 1
+                                logger.error(
+                                    "Failed to delete audio file during transcript cleanup: \(error, privacy: .public)"
+                                )
+                                continue
+                            }
+                        }
+
+                        deletedIDs.insert(transcription.id)
+                        batchContext.delete(transcription)
                     }
-                )
-                descriptor.fetchLimit = Self.batchSize
 
-                let transcriptions = try batchContext.fetch(descriptor)
-                let audioURLs = transcriptions.compactMap { transcription -> URL? in
-                    guard let urlString = transcription.audioFileURL else { return nil }
-                    return URL(string: urlString)
-                }
-
-                for transcription in transcriptions {
-                    batchContext.delete(transcription)
-                }
-
-                if !transcriptions.isEmpty {
-                    try batchContext.save()
-                }
-
-                var batchAudioFileErrorCount = 0
-                for audioURL in audioURLs where FileManager.default.fileExists(atPath: audioURL.path) {
-                    do {
-                        try FileManager.default.removeItem(at: audioURL)
-                    } catch {
-                        batchAudioFileErrorCount += 1
-                        logger.error(
-                            "Failed to delete audio file during transcript cleanup: \(error, privacy: .public)"
-                        )
+                    if !deletedIDs.isEmpty {
+                        do {
+                            try batchContext.save()
+                        } catch {
+                            throw TranscriptionBatchSaveError(
+                                audioFileErrorCount: audioFileErrorCount
+                            )
+                        }
                     }
+
+                    return (transcriptions.count, deletedIDs, audioFileErrorCount)
                 }
 
-                return (
-                    deletedCount: transcriptions.count,
-                    audioFileErrorCount: batchAudioFileErrorCount
+                result.deletedIDs.formUnion(batchResult.deletedIDs)
+                result.audioFileErrorCount += batchResult.audioFileErrorCount
+                failedRecordCount += batchResult.audioFileErrorCount
+
+                if batchResult.fetchedCount < Self.batchSize {
+                    return result
+                }
+            } catch let error as TranscriptionBatchSaveError {
+                result.audioFileErrorCount += error.audioFileErrorCount
+                logger.error("Failed to save a transcript cleanup batch: \(error, privacy: .public)")
+                result.errorMessage = String(
+                    localized: "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings."
                 )
-            }
-
-            deletedCount += batchResult.deletedCount
-            audioFileErrorCount += batchResult.audioFileErrorCount
-
-            if batchResult.deletedCount < Self.batchSize {
-                break
+                return result
+            } catch {
+                logger.error("Failed to fetch a transcript cleanup batch: \(error, privacy: .public)")
+                result.errorMessage = String(
+                    localized: "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings."
+                )
+                return result
             }
         }
-
-        return (
-            deletedCount: deletedCount,
-            audioFileErrorCount: audioFileErrorCount
-        )
     }
 
     /// Removes only stale, unreferenced recordings. The age check protects active recordings
     /// and files that have been created for an in-progress transcription.
     func cleanupOrphanAudioFiles(in recordingsDirectory: URL, olderThan cutoffDate: Date) {
         do {
-            var referencedFiles = Set<String>()
-            var fetchOffset = 0
-
-            while true {
-                let batch = try autoreleasepool { () throws -> (fetchedCount: Int, fileNames: [String]) in
-                    let batchContext = ModelContext(modelContainer)
-                    var descriptor = FetchDescriptor<Transcription>(
-                        sortBy: [SortDescriptor(\.id)]
-                    )
-                    descriptor.propertiesToFetch = [\.audioFileURL]
-                    descriptor.fetchLimit = Self.referenceBatchSize
-                    descriptor.fetchOffset = fetchOffset
-
-                    let transcriptions = try batchContext.fetch(descriptor)
-                    let fileNames = transcriptions.compactMap { transcription in
-                        guard let urlString = transcription.audioFileURL,
-                            let url = URL(string: urlString)
-                        else { return nil }
-                        return url.lastPathComponent
-                    }
-                    return (transcriptions.count, fileNames)
-                }
-
-                referencedFiles.formUnion(batch.fileNames)
-                fetchOffset += batch.fetchedCount
-
-                if batch.fetchedCount < Self.referenceBatchSize {
-                    break
-                }
-            }
+            let referenceContext = ModelContext(modelContainer)
+            var descriptor = FetchDescriptor<Transcription>()
+            descriptor.propertiesToFetch = [\.audioFileURL]
+            let transcriptions = try referenceContext.fetch(descriptor)
+            let referencedFiles = Set(transcriptions.compactMap { transcription -> String? in
+                guard let urlString = transcription.audioFileURL,
+                    let url = URL(string: urlString)
+                else { return nil }
+                return url.lastPathComponent
+            })
 
             guard FileManager.default.fileExists(atPath: recordingsDirectory.path) else { return }
             guard let files = FileManager.default.enumerator(
@@ -123,19 +130,19 @@ private actor TranscriptionCleanupWorker {
             var deletedCount = 0
             for case let fileURL as URL in files
             where !referencedFiles.contains(fileURL.lastPathComponent) {
-                let values = try fileURL.resourceValues(
-                    forKeys: [.contentModificationDateKey, .creationDateKey, .isRegularFileKey]
-                )
-                guard values.isRegularFile == true,
-                    let fileDate = values.contentModificationDate ?? values.creationDate,
-                    fileDate < cutoffDate
-                else { continue }
-
                 do {
+                    let values = try fileURL.resourceValues(
+                        forKeys: [.contentModificationDateKey, .creationDateKey, .isRegularFileKey]
+                    )
+                    guard values.isRegularFile == true,
+                        let fileDate = values.contentModificationDate ?? values.creationDate,
+                        fileDate < cutoffDate
+                    else { continue }
+
                     try FileManager.default.removeItem(at: fileURL)
                     deletedCount += 1
                 } catch {
-                    logger.error("Failed to delete orphan audio file: \(error, privacy: .public)")
+                    logger.error("Failed to inspect or delete orphan audio file: \(error, privacy: .public)")
                 }
             }
 
@@ -217,20 +224,23 @@ final class TranscriptionAutoCleanupService {
         }
 
         let audioURL = transcription.audioFileURL.flatMap(URL.init(string:))
+        let transcriptionID = transcription.id
+
+        if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
+            do {
+                try FileManager.default.removeItem(at: audioURL)
+            } catch {
+                logger.error("Failed to delete audio file: \(error, privacy: .public)")
+                return
+            }
+        }
 
         modelContext.delete(transcription)
-
         do {
             try modelContext.save()
-            if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
-                do {
-                    try FileManager.default.removeItem(at: audioURL)
-                } catch {
-                    logger.error("Failed to delete audio file: \(error, privacy: .public)")
-                }
-            }
-            NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
+            Notification.postTranscriptionDeleted(ids: [transcriptionID])
         } catch {
+            modelContext.rollback()
             logger.error("Failed to save after transcription deletion: \(error, privacy: .public)")
         }
     }
@@ -252,25 +262,16 @@ final class TranscriptionAutoCleanupService {
         let worker = cleanupWorker ?? TranscriptionCleanupWorker(modelContainer: modelContext.container)
         cleanupWorker = worker
 
-        do {
-            let result = try await worker.sweep(cutoffDate: cutoffDate)
-            if result.deletedCount > 0 {
-                logger.notice("Cleaned up \(result.deletedCount, privacy: .public) old transcription(s)")
-                NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
-            }
-            return TranscriptionCleanupResult(
-                deletedCount: result.deletedCount,
-                audioFileErrorCount: result.audioFileErrorCount,
-                errorMessage: nil
-            )
-        } catch {
-            logger.error("Failed during transcription cleanup: \(error, privacy: .public)")
-            return TranscriptionCleanupResult(
-                deletedCount: 0,
-                audioFileErrorCount: 0,
-                errorMessage: String(localized: "VoiceInk couldn't delete transcript history. Try again or export logs from Settings.")
-            )
+        let result = await worker.sweep(cutoffDate: cutoffDate)
+        if !result.deletedIDs.isEmpty {
+            logger.notice("Cleaned up \(result.deletedIDs.count, privacy: .public) old transcription(s)")
+            Notification.postTranscriptionDeleted(ids: result.deletedIDs)
         }
+        return TranscriptionCleanupResult(
+            deletedCount: result.deletedIDs.count,
+            audioFileErrorCount: result.audioFileErrorCount,
+            errorMessage: result.errorMessage
+        )
     }
 
     /// Deletes audio files in Recordings directory that have no corresponding Transcription record

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -14,10 +14,6 @@ private struct TranscriptionSweepResult: Sendable {
     var errorMessage: String?
 }
 
-private struct TranscriptionBatchSaveError: Error {
-    let audioFileErrorCount: Int
-}
-
 @ModelActor
 private actor TranscriptionCleanupWorker {
     private static let batchSize = 1_000
@@ -29,7 +25,6 @@ private actor TranscriptionCleanupWorker {
 
     func sweep(cutoffDate: Date) -> TranscriptionSweepResult {
         var result = TranscriptionSweepResult()
-        var failedRecordCount = 0
 
         while true {
             do {
@@ -43,40 +38,29 @@ private actor TranscriptionCleanupWorker {
                         sortBy: [SortDescriptor(\.id)]
                     )
                     descriptor.fetchLimit = Self.batchSize
-                    descriptor.fetchOffset = failedRecordCount
 
                     let transcriptions = try batchContext.fetch(descriptor)
-                    var deletedIDs = Set<UUID>()
-                    var audioFileErrorCount = 0
+                    let deletedIDs = Set(transcriptions.map(\.id))
+                    let audioURLs = transcriptions.compactMap {
+                        $0.audioFileURL.flatMap(URL.init(string:))
+                    }
 
                     for transcription in transcriptions {
-                        if let audioURL = transcription.audioFileURL.flatMap(URL.init(string:)),
-                            FileManager.default.fileExists(atPath: audioURL.path)
-                        {
-                            do {
-                                try FileManager.default.removeItem(at: audioURL)
-                            } catch {
-                                audioFileErrorCount += 1
-                                logger.error(
-                                    "Failed to delete audio file during transcript cleanup: \(error, privacy: .public)"
-                                )
-                                continue
-                            }
-                        }
-
-                        deletedIDs.insert(transcription.id)
                         batchContext.delete(transcription)
                     }
 
                     if !deletedIDs.isEmpty {
+                        try batchContext.save()
+                    }
+
+                    var audioFileErrorCount = 0
+                    for audioURL in audioURLs where FileManager.default.fileExists(atPath: audioURL.path) {
                         do {
-                            try batchContext.save()
+                            try FileManager.default.removeItem(at: audioURL)
                         } catch {
+                            audioFileErrorCount += 1
                             logger.error(
-                                "Failed to save a transcript cleanup batch: \(error, privacy: .public)"
-                            )
-                            throw TranscriptionBatchSaveError(
-                                audioFileErrorCount: audioFileErrorCount
+                                "Failed to delete audio file during transcript cleanup: \(error, privacy: .public)"
                             )
                         }
                     }
@@ -86,19 +70,12 @@ private actor TranscriptionCleanupWorker {
 
                 result.deletedIDs.formUnion(batchResult.deletedIDs)
                 result.audioFileErrorCount += batchResult.audioFileErrorCount
-                failedRecordCount += batchResult.audioFileErrorCount
 
                 if batchResult.fetchedCount < Self.batchSize {
                     return result
                 }
-            } catch let error as TranscriptionBatchSaveError {
-                result.audioFileErrorCount += error.audioFileErrorCount
-                result.errorMessage = String(
-                    localized: "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings."
-                )
-                return result
             } catch {
-                logger.error("Failed to fetch a transcript cleanup batch: \(error, privacy: .public)")
+                logger.error("Failed to fetch or save a transcript cleanup batch: \(error, privacy: .public)")
                 result.errorMessage = String(
                     localized: "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings."
                 )
@@ -228,18 +205,16 @@ final class TranscriptionAutoCleanupService {
         let audioURL = transcription.audioFileURL.flatMap(URL.init(string:))
         let transcriptionID = transcription.id
 
-        if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
-            do {
-                try FileManager.default.removeItem(at: audioURL)
-            } catch {
-                logger.error("Failed to delete audio file: \(error, privacy: .public)")
-                return
-            }
-        }
-
         modelContext.delete(transcription)
         do {
             try modelContext.save()
+            if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
+                do {
+                    try FileManager.default.removeItem(at: audioURL)
+                } catch {
+                    logger.error("Failed to delete audio file: \(error, privacy: .public)")
+                }
+            }
             Notification.postTranscriptionDeleted(ids: [transcriptionID])
         } catch {
             modelContext.rollback()

--- a/VoiceInk/Services/TranscriptionAutoCleanupService.swift
+++ b/VoiceInk/Services/TranscriptionAutoCleanupService.swift
@@ -16,6 +16,17 @@ private struct TranscriptionSweepResult: Sendable {
 
 private struct TranscriptionBatchSaveError: Error {
     let audioFileErrorCount: Int
+    let underlyingError: Error
+}
+
+private func stageAudioFile(at url: URL) throws -> URL {
+    let stagedURL = url.appendingPathExtension("cleanup")
+    try FileManager.default.moveItem(at: url, to: stagedURL)
+    return stagedURL
+}
+
+private func restoreAudioFile(from stagedURL: URL, to originalURL: URL) {
+    try? FileManager.default.moveItem(at: stagedURL, to: originalURL)
 }
 
 @ModelActor
@@ -48,13 +59,15 @@ private actor TranscriptionCleanupWorker {
                     let transcriptions = try batchContext.fetch(descriptor)
                     var deletedIDs = Set<UUID>()
                     var audioFileErrorCount = 0
+                    var stagedAudioFiles = [(original: URL, staged: URL)]()
 
                     for transcription in transcriptions {
                         if let audioURL = transcription.audioFileURL.flatMap(URL.init(string:)),
                             FileManager.default.fileExists(atPath: audioURL.path)
                         {
                             do {
-                                try FileManager.default.removeItem(at: audioURL)
+                                let stagedURL = try stageAudioFile(at: audioURL)
+                                stagedAudioFiles.append((audioURL, stagedURL))
                             } catch {
                                 audioFileErrorCount += 1
                                 logger.error(
@@ -72,10 +85,18 @@ private actor TranscriptionCleanupWorker {
                         do {
                             try batchContext.save()
                         } catch {
+                            for file in stagedAudioFiles {
+                                restoreAudioFile(from: file.staged, to: file.original)
+                            }
                             throw TranscriptionBatchSaveError(
-                                audioFileErrorCount: audioFileErrorCount
+                                audioFileErrorCount: audioFileErrorCount,
+                                underlyingError: error
                             )
                         }
+                    }
+
+                    for file in stagedAudioFiles {
+                        try? FileManager.default.removeItem(at: file.staged)
                     }
 
                     return (transcriptions.count, deletedIDs, audioFileErrorCount)
@@ -90,7 +111,9 @@ private actor TranscriptionCleanupWorker {
                 }
             } catch let error as TranscriptionBatchSaveError {
                 result.audioFileErrorCount += error.audioFileErrorCount
-                logger.error("Failed to save a transcript cleanup batch: \(error, privacy: .public)")
+                logger.error(
+                    "Failed to save a transcript cleanup batch: \(error.underlyingError, privacy: .public)"
+                )
                 result.errorMessage = String(
                     localized: "VoiceInk couldn't finish deleting transcript history. Try again or export logs from Settings."
                 )
@@ -226,9 +249,10 @@ final class TranscriptionAutoCleanupService {
         let audioURL = transcription.audioFileURL.flatMap(URL.init(string:))
         let transcriptionID = transcription.id
 
+        var stagedAudioURL: URL?
         if let audioURL, FileManager.default.fileExists(atPath: audioURL.path) {
             do {
-                try FileManager.default.removeItem(at: audioURL)
+                stagedAudioURL = try stageAudioFile(at: audioURL)
             } catch {
                 logger.error("Failed to delete audio file: \(error, privacy: .public)")
                 return
@@ -238,9 +262,15 @@ final class TranscriptionAutoCleanupService {
         modelContext.delete(transcription)
         do {
             try modelContext.save()
+            if let stagedAudioURL {
+                try? FileManager.default.removeItem(at: stagedAudioURL)
+            }
             Notification.postTranscriptionDeleted(ids: [transcriptionID])
         } catch {
             modelContext.rollback()
+            if let audioURL, let stagedAudioURL {
+                restoreAudioFile(from: stagedAudioURL, to: audioURL)
+            }
             logger.error("Failed to save after transcription deletion: \(error, privacy: .public)")
         }
     }

--- a/VoiceInk/Views/History/HistorySettingsPanel.swift
+++ b/VoiceInk/Views/History/HistorySettingsPanel.swift
@@ -95,11 +95,11 @@ struct HistorySettingsPanel: View {
             Button("Done", role: .cancel) {}
         } message: {
             if let errorMessage = transcriptCleanupResult.errorMessage {
-                if transcriptCleanupResult.deletedCount > 0 {
-                    Text(successfulTranscriptCleanupMessage + " " + errorMessage)
-                } else {
-                    Text(errorMessage)
-                }
+                let resultMessage = transcriptCleanupResult.audioFileErrorCount > 0
+                    ? partialTranscriptCleanupMessage
+                    : transcriptCleanupResult.deletedCount > 0
+                        ? successfulTranscriptCleanupMessage : ""
+                Text([resultMessage, errorMessage].filter { !$0.isEmpty }.joined(separator: " "))
             } else if transcriptCleanupResult.audioFileErrorCount > 0 {
                 Text(partialTranscriptCleanupMessage)
             } else if transcriptCleanupResult.deletedCount == 0 {

--- a/VoiceInk/Views/History/HistorySettingsPanel.swift
+++ b/VoiceInk/Views/History/HistorySettingsPanel.swift
@@ -17,6 +17,14 @@ struct HistorySettingsPanel: View {
     @State private var showAudioCleanupResult = false
     @State private var audioCleanupResult: (deletedCount: Int, errorCount: Int) = (0, 0)
     @State private var showTranscriptCleanupResult = false
+    @State private var transcriptCleanupResult = TranscriptionCleanupResult(
+        deletedCount: 0,
+        audioFileErrorCount: 0,
+        errorMessage: nil
+    )
+    @State private var isPerformingTranscriptCleanup = false
+    @State private var showEnableTranscriptCleanupConfirmation = false
+    @State private var showManualTranscriptCleanupConfirmation = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,7 +32,8 @@ struct HistorySettingsPanel: View {
 
             Form {
                 Section {
-                    Toggle("Auto-delete Transcript History", isOn: $isTranscriptionCleanupEnabled)
+                    Toggle("Auto-delete Transcript History", isOn: transcriptCleanupEnabledBinding)
+                        .disabled(isPerformingTranscriptCleanup)
 
                     if isTranscriptionCleanupEnabled {
                         Picker("Delete After", selection: $transcriptionRetentionMinutes) {
@@ -34,16 +43,14 @@ struct HistorySettingsPanel: View {
                             Text("3 days").tag(3 * 24 * 60)
                             Text("7 days").tag(7 * 24 * 60)
                         }
+                        .disabled(isPerformingTranscriptCleanup)
 
-                        Button("Run Cleanup Now") {
-                            Task {
-                                await TranscriptionAutoCleanupService.shared.runManualCleanup(
-                                    modelContext: modelContext)
-                                await MainActor.run {
-                                    showTranscriptCleanupResult = true
-                                }
-                            }
+                        Button {
+                            showManualTranscriptCleanupConfirmation = true
+                        } label: {
+                            Text(isPerformingTranscriptCleanup ? "Deleting Transcript History..." : "Run Cleanup Now")
                         }
+                        .disabled(isPerformingTranscriptCleanup)
                     }
                 } header: {
                     sectionHeader(
@@ -85,9 +92,33 @@ struct HistorySettingsPanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .alert("Transcript Cleanup", isPresented: $showTranscriptCleanupResult) {
-            Button("OK", role: .cancel) {}
+            Button("Done", role: .cancel) {}
         } message: {
-            Text("Cleanup complete.")
+            if let errorMessage = transcriptCleanupResult.errorMessage {
+                Text(errorMessage)
+            } else if transcriptCleanupResult.audioFileErrorCount > 0 {
+                Text(partialTranscriptCleanupMessage)
+            } else if transcriptCleanupResult.deletedCount == 0 {
+                Text("No transcripts were old enough to delete.")
+            } else {
+                Text(successfulTranscriptCleanupMessage)
+            }
+        }
+        .alert("Enable Transcript Auto-Delete?", isPresented: $showEnableTranscriptCleanupConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Enable Auto-Delete", role: .destructive) {
+                enableTranscriptCleanup()
+            }
+        } message: {
+            Text("Existing transcripts older than the selected retention period and their saved audio files will be permanently deleted. This action cannot be undone.")
+        }
+        .alert("Delete Old Transcript History?", isPresented: $showManualTranscriptCleanupConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete Old Transcripts", role: .destructive) {
+                runTranscriptCleanup()
+            }
+        } message: {
+            Text("This will permanently delete transcripts older than the selected retention period and their saved audio files. This action cannot be undone.")
         }
         .alert("Audio Cleanup", isPresented: $isShowingAudioConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -120,14 +151,6 @@ struct HistorySettingsPanel: View {
                 Text(String(localized: "Deleted \(audioCleanupResult.deletedCount) audio files."))
             }
         }
-        .onChange(of: isTranscriptionCleanupEnabled) { _, newValue in
-            if newValue {
-                isAudioCleanupEnabled = false
-                AudioCleanupManager.shared.stopAutomaticCleanup()
-            } else if isAudioCleanupEnabled {
-                AudioCleanupManager.shared.startAutomaticCleanup(modelContext: modelContext)
-            }
-        }
         .onChange(of: isAudioCleanupEnabled) { _, newValue in
             guard !isTranscriptionCleanupEnabled else {
                 if newValue {
@@ -142,6 +165,62 @@ struct HistorySettingsPanel: View {
             } else {
                 AudioCleanupManager.shared.stopAutomaticCleanup()
             }
+        }
+    }
+
+    private var transcriptCleanupEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { isTranscriptionCleanupEnabled },
+            set: { newValue in
+                if newValue {
+                    showEnableTranscriptCleanupConfirmation = true
+                } else {
+                    isTranscriptionCleanupEnabled = false
+                    if isAudioCleanupEnabled {
+                        AudioCleanupManager.shared.startAutomaticCleanup(modelContext: modelContext)
+                    }
+                }
+            }
+        )
+    }
+
+    private func enableTranscriptCleanup() {
+        isAudioCleanupEnabled = false
+        AudioCleanupManager.shared.stopAutomaticCleanup()
+        isTranscriptionCleanupEnabled = true
+        runTranscriptCleanup()
+    }
+
+    private var successfulTranscriptCleanupMessage: String {
+        if transcriptCleanupResult.deletedCount == 1 {
+            return String(localized: "Deleted 1 transcript.")
+        }
+        return String(
+            localized: "Deleted \(transcriptCleanupResult.deletedCount) transcripts."
+        )
+    }
+
+    private var partialTranscriptCleanupMessage: String {
+        if transcriptCleanupResult.deletedCount == 1 && transcriptCleanupResult.audioFileErrorCount == 1 {
+            return String(
+                localized:
+                    "Deleted 1 transcript, but couldn't delete its saved audio file. Try again or export logs from Settings."
+            )
+        }
+        return String(
+            localized:
+                "Deleted \(transcriptCleanupResult.deletedCount) transcripts, but couldn't delete \(transcriptCleanupResult.audioFileErrorCount) saved audio files. Try again or export logs from Settings."
+        )
+    }
+
+    private func runTranscriptCleanup() {
+        isPerformingTranscriptCleanup = true
+        Task { @MainActor in
+            transcriptCleanupResult = await TranscriptionAutoCleanupService.shared.runManualCleanup(
+                modelContext: modelContext
+            )
+            isPerformingTranscriptCleanup = false
+            showTranscriptCleanupResult = true
         }
     }
 

--- a/VoiceInk/Views/History/HistorySettingsPanel.swift
+++ b/VoiceInk/Views/History/HistorySettingsPanel.swift
@@ -95,11 +95,13 @@ struct HistorySettingsPanel: View {
             Button("Done", role: .cancel) {}
         } message: {
             if let errorMessage = transcriptCleanupResult.errorMessage {
-                let resultMessage = transcriptCleanupResult.audioFileErrorCount > 0
-                    ? partialTranscriptCleanupMessage
-                    : transcriptCleanupResult.deletedCount > 0
-                        ? successfulTranscriptCleanupMessage : ""
-                Text([resultMessage, errorMessage].filter { !$0.isEmpty }.joined(separator: " "))
+                Text(
+                    transcriptCleanupResult.audioFileErrorCount > 0
+                        ? partialTranscriptCleanupMessage
+                        : transcriptCleanupResult.deletedCount > 0
+                            ? successfulTranscriptCleanupMessage + " " + errorMessage
+                            : errorMessage
+                )
             } else if transcriptCleanupResult.audioFileErrorCount > 0 {
                 Text(partialTranscriptCleanupMessage)
             } else if transcriptCleanupResult.deletedCount == 0 {

--- a/VoiceInk/Views/History/HistorySettingsPanel.swift
+++ b/VoiceInk/Views/History/HistorySettingsPanel.swift
@@ -95,7 +95,11 @@ struct HistorySettingsPanel: View {
             Button("Done", role: .cancel) {}
         } message: {
             if let errorMessage = transcriptCleanupResult.errorMessage {
-                Text(errorMessage)
+                if transcriptCleanupResult.deletedCount > 0 {
+                    Text(successfulTranscriptCleanupMessage + " " + errorMessage)
+                } else {
+                    Text(errorMessage)
+                }
             } else if transcriptCleanupResult.audioFileErrorCount > 0 {
                 Text(partialTranscriptCleanupMessage)
             } else if transcriptCleanupResult.deletedCount == 0 {

--- a/VoiceInk/Views/History/InlineHistoryView.swift
+++ b/VoiceInk/Views/History/InlineHistoryView.swift
@@ -15,6 +15,7 @@ struct InlineHistoryView: View {
     @State private var hasMoreContent = true
     @State private var lastTimestamp: Date?
     @State private var isViewCurrentlyVisible = false
+    @State private var historyReloadTask: Task<Void, Never>?
 
     private let exportService = VoiceInkCSVExportService()
     private let pageSize = 20
@@ -122,25 +123,26 @@ struct InlineHistoryView: View {
         }
         .onAppear {
             isViewCurrentlyVisible = true
-            Task { await loadInitialContent() }
+            scheduleHistoryReload()
         }
         .onDisappear {
             isViewCurrentlyVisible = false
+            historyReloadTask?.cancel()
+            historyReloadTask = nil
         }
         .onChange(of: searchText) { _, _ in
-            Task {
-                await resetPagination()
-                await loadInitialContent()
-            }
+            scheduleHistoryReload()
         }
         .onChange(of: latestTranscriptionIndicator.first?.id) { oldId, newId in
             guard isViewCurrentlyVisible else { return }
             if newId != oldId {
-                Task {
-                    await resetPagination()
-                    await loadInitialContent()
-                }
+                scheduleHistoryReload()
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { _ in
+            guard isViewCurrentlyVisible else { return }
+            clearStateAfterStoreDeletion()
+            scheduleHistoryReload()
         }
     }
 
@@ -380,6 +382,34 @@ struct InlineHistoryView: View {
         isLoading = false
     }
 
+    @MainActor
+    private func reloadHistory() async {
+        resetPagination()
+        await loadInitialContent()
+    }
+
+    private func clearStateAfterStoreDeletion() {
+        selectedTranscriptions.removeAll()
+        expandedId = nil
+
+        switch panelMode {
+        case .info, .analysis:
+            panelTranscriptionId = nil
+            closePanel()
+        case .historySettings:
+            break
+        }
+    }
+
+    private func scheduleHistoryReload() {
+        historyReloadTask?.cancel()
+        historyReloadTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled, isViewCurrentlyVisible else { return }
+            await reloadHistory()
+        }
+    }
+
     // MARK: - Selection & Deletion
 
     private func toggleSelection(_ transcription: Transcription) {
@@ -424,7 +454,6 @@ struct InlineHistoryView: View {
             do {
                 try modelContext.save()
                 NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
-                await loadInitialContent()
             } catch {
                 print("Error saving deletion: \(error.localizedDescription)")
                 await loadInitialContent()

--- a/VoiceInk/Views/History/InlineHistoryView.swift
+++ b/VoiceInk/Views/History/InlineHistoryView.swift
@@ -139,9 +139,11 @@ struct InlineHistoryView: View {
                 scheduleHistoryReload()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { notification in
             guard isViewCurrentlyVisible else { return }
-            clearStateAfterStoreDeletion()
+            if let deletedIDs = notification.deletedTranscriptionIDs {
+                clearStateAfterStoreDeletion(ids: deletedIDs)
+            }
             scheduleHistoryReload()
         }
     }
@@ -388,14 +390,25 @@ struct InlineHistoryView: View {
         await loadInitialContent()
     }
 
-    private func clearStateAfterStoreDeletion() {
-        selectedTranscriptions.removeAll()
-        expandedId = nil
+    private func clearStateAfterStoreDeletion(ids deletedIDs: Set<UUID>) {
+        selectedTranscriptions = Set(
+            selectedTranscriptions.filter { !deletedIDs.contains($0.id) }
+        )
+
+        if let expandedId, deletedIDs.contains(expandedId) {
+            self.expandedId = nil
+        }
 
         switch panelMode {
-        case .info, .analysis:
-            panelTranscriptionId = nil
-            closePanel()
+        case .info:
+            if let panelTranscriptionId, deletedIDs.contains(panelTranscriptionId) {
+                self.panelTranscriptionId = nil
+                closePanel()
+            }
+        case .analysis:
+            if selectedTranscriptions.isEmpty {
+                closePanel()
+            }
         case .historySettings:
             break
         }
@@ -445,6 +458,7 @@ struct InlineHistoryView: View {
     }
 
     private func deleteSelectedTranscriptions() {
+        let deletedIDs = Set(selectedTranscriptions.map(\.id))
         for transcription in selectedTranscriptions {
             performDeletion(for: transcription)
         }
@@ -453,7 +467,7 @@ struct InlineHistoryView: View {
         Task {
             do {
                 try modelContext.save()
-                NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
+                Notification.postTranscriptionDeleted(ids: deletedIDs)
             } catch {
                 print("Error saving deletion: \(error.localizedDescription)")
                 await loadInitialContent()

--- a/VoiceInk/Views/History/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/History/TranscriptionHistoryView.swift
@@ -160,9 +160,11 @@ struct TranscriptionHistoryView: View {
                 scheduleHistoryReload()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { notification in
             guard isViewCurrentlyVisible else { return }
-            clearStateAfterStoreDeletion()
+            if let deletedIDs = notification.deletedTranscriptionIDs {
+                clearStateAfterStoreDeletion(ids: deletedIDs)
+            }
             scheduleHistoryReload()
         }
     }
@@ -444,11 +446,19 @@ struct TranscriptionHistoryView: View {
         await loadInitialContent()
     }
 
-    private func clearStateAfterStoreDeletion() {
-        selectedTranscriptions.removeAll()
-        selectedTranscription = nil
-        closeInfoPanel()
-        closeAnalysisPanel()
+    private func clearStateAfterStoreDeletion(ids deletedIDs: Set<UUID>) {
+        selectedTranscriptions = Set(
+            selectedTranscriptions.filter { !deletedIDs.contains($0.id) }
+        )
+
+        if let selectedTranscription, deletedIDs.contains(selectedTranscription.id) {
+            self.selectedTranscription = nil
+            closeInfoPanel()
+        }
+
+        if isAnalysisPanelPresented && selectedTranscriptions.isEmpty {
+            closeAnalysisPanel()
+        }
     }
 
     private func scheduleHistoryReload() {
@@ -474,16 +484,17 @@ struct TranscriptionHistoryView: View {
 
         if selectedTranscription == transcription {
             selectedTranscription = nil
+            closeInfoPanel()
         }
 
         selectedTranscriptions.remove(transcription)
         modelContext.delete(transcription)
     }
 
-    private func saveAndReload() async {
+    private func saveAndReload(deletedIDs: Set<UUID>) async {
         do {
             try modelContext.save()
-            NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
+            Notification.postTranscriptionDeleted(ids: deletedIDs)
         } catch {
             print("Error saving deletion: \(error.localizedDescription)")
             await loadInitialContent()
@@ -491,13 +502,14 @@ struct TranscriptionHistoryView: View {
     }
 
     private func deleteSelectedTranscriptions() {
+        let deletedIDs = Set(selectedTranscriptions.map(\.id))
         for transcription in selectedTranscriptions {
             performDeletion(for: transcription)
         }
         selectedTranscriptions.removeAll()
 
         Task {
-            await saveAndReload()
+            await saveAndReload(deletedIDs: deletedIDs)
         }
     }
 

--- a/VoiceInk/Views/History/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/History/TranscriptionHistoryView.swift
@@ -16,6 +16,7 @@ struct TranscriptionHistoryView: View {
     @State private var isLoading = false
     @State private var hasMoreContent = true
     @State private var lastTimestamp: Date?
+    @State private var historyReloadTask: Task<Void, Never>?
 
     private let exportService = VoiceInkCSVExportService()
     private let pageSize = 20
@@ -143,27 +144,26 @@ struct TranscriptionHistoryView: View {
         }
         .onAppear {
             isViewCurrentlyVisible = true
-            Task {
-                await loadInitialContent()
-            }
+            scheduleHistoryReload()
         }
         .onDisappear {
             isViewCurrentlyVisible = false
+            historyReloadTask?.cancel()
+            historyReloadTask = nil
         }
         .onChange(of: searchText) { _, _ in
-            Task {
-                await resetPagination()
-                await loadInitialContent()
-            }
+            scheduleHistoryReload()
         }
         .onChange(of: latestTranscriptionIndicator.first?.id) { oldId, newId in
             guard isViewCurrentlyVisible else { return }
             if newId != oldId {
-                Task {
-                    await resetPagination()
-                    await loadInitialContent()
-                }
+                scheduleHistoryReload()
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptionDeleted)) { _ in
+            guard isViewCurrentlyVisible else { return }
+            clearStateAfterStoreDeletion()
+            scheduleHistoryReload()
         }
     }
 
@@ -438,6 +438,28 @@ struct TranscriptionHistoryView: View {
         isLoading = false
     }
 
+    @MainActor
+    private func reloadHistory() async {
+        resetPagination()
+        await loadInitialContent()
+    }
+
+    private func clearStateAfterStoreDeletion() {
+        selectedTranscriptions.removeAll()
+        selectedTranscription = nil
+        closeInfoPanel()
+        closeAnalysisPanel()
+    }
+
+    private func scheduleHistoryReload() {
+        historyReloadTask?.cancel()
+        historyReloadTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled, isViewCurrentlyVisible else { return }
+            await reloadHistory()
+        }
+    }
+
     private func performDeletion(for transcription: Transcription) {
         if let urlString = transcription.audioFileURL,
             let url = URL(string: urlString),
@@ -462,7 +484,6 @@ struct TranscriptionHistoryView: View {
         do {
             try modelContext.save()
             NotificationCenter.default.post(name: .transcriptionDeleted, object: nil)
-            await loadInitialContent()
         } catch {
             print("Error saving deletion: \(error.localizedDescription)")
             await loadInitialContent()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves transcript history cleanup by batching work in a `@ModelActor` and posting deleted IDs. Previously cleanup ran in one shot and removed audio first without IDs; now it deletes records first, removes audio afterward, reports errors, and debounces history reloads while clearing affected UI.

- Adds a `@ModelActor` cleanup worker that fetches in 1k batches; deletes transcription records, saves, then removes associated audio files; counts audio delete failures; returns deleted IDs and an `errorMessage` on fetch/save errors.
- `TranscriptionAutoCleanupService.runManualCleanup(...)` returns `TranscriptionCleanupResult` for success, partial, and error states. Enabling auto-delete prompts confirmation, runs an initial sweep, disables automatic audio cleanup, and disables controls while running.
- Posts `.transcriptionDeleted` with IDs via `Notification.postTranscriptionDeleted(ids:)`; consumers can read `notification.deletedTranscriptionIDs`.
- History views listen for deletion IDs, clear selection/expanded panels, and schedule a debounced reload that cancels when hidden.
- Orphan audio cleanup removes only unreferenced recordings older than 7 days.
- Adds localized strings for confirmations and result messages (en, de, zh‑Hans).

Migration/rollout:
- No schema changes. If you call `runManualCleanup`, await it and handle `TranscriptionCleanupResult`.
- Ensure `TranscriptionAutoCleanupService.startMonitoring(modelContext:)` is called so the worker initializes.
- If you listen for `.transcriptionDeleted`, use `deletedTranscriptionIDs` to clear local UI state.

<sup>Written for commit 6053e0ee674a6148953c388274d01b14fd171c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

