### PR TITLE
fix(screencapture): use display-backed SCContentFilter and start context capture on recording start

### DIFF
--- a/VoiceInk/Services/ScreenCaptureService.swift
+++ b/VoiceInk/Services/ScreenCaptureService.swift
@@ -3,9 +3,11 @@ import ApplicationServices
 import Foundation
 import ScreenCaptureKit
 import Vision
+import os
 
 @MainActor
 class ScreenCaptureService: ObservableObject {
+    private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ScreenCaptureService")
     @Published var isCapturing = false
     @Published var lastCapturedText: String?
 
@@ -109,13 +111,18 @@ class ScreenCaptureService: ObservableObject {
                     currentPID: currentPID
                 )
             else {
+                logger.info("ScreenCaptureService: no suitable active window found among \(content.windows.count) windows")
                 return nil
             }
 
             let title = window.title ?? window.owningApplication?.applicationName ?? "Unknown"
             let appName = window.owningApplication?.applicationName ?? "Unknown"
-
-            let filter = SCContentFilter(desktopIndependentWindow: window)
+            let filter: SCContentFilter
+            if let display = content.displays.first(where: { $0.frame.intersects(window.frame) }) ?? content.displays.first {
+                filter = SCContentFilter(display: display, including: [window])
+            } else {
+                filter = SCContentFilter(desktopIndependentWindow: window)
+            }
 
             let configuration = SCStreamConfiguration()
             let captureScale = captureScale(for: window.frame.size)
@@ -133,14 +140,17 @@ class ScreenCaptureService: ObservableObject {
 
             let extractedText = extractText(from: cgImage)
             if let extractedText, !extractedText.isEmpty {
+                logger.info("ScreenCaptureService: extracted \(extractedText.count) chars of OCR text")
                 contextText += "Window Content:\n\(extractedText)"
             } else {
+                logger.info("ScreenCaptureService: no text detected in OCR")
                 contextText += "Window Content:\nNo text detected via OCR"
             }
 
             return contextText
 
         } catch {
+            logger.error("ScreenCaptureService error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/VoiceInk/Services/ScreenCaptureService.swift
+++ b/VoiceInk/Services/ScreenCaptureService.swift
@@ -123,7 +123,15 @@ class ScreenCaptureService: ObservableObject {
             configuration.height = max(1, Int(window.frame.height * captureScale))
 
             let filter: SCContentFilter
-            if let display = content.displays.first(where: { $0.frame.intersects(window.frame) }) ?? content.displays.first {
+            let bestDisplay = content.displays.max(by: { d1, d2 in
+                let r1 = d1.frame.intersection(window.frame)
+                let area1 = r1.isNull ? 0 : r1.width * r1.height
+                let r2 = d2.frame.intersection(window.frame)
+                let area2 = r2.isNull ? 0 : r2.width * r2.height
+                return area1 < area2
+            }) ?? content.displays.first
+
+            if let display = bestDisplay {
                 filter = SCContentFilter(display: display, including: [window])
                 let relativeX = max(0, window.frame.origin.x - display.frame.origin.x)
                 let relativeY = max(0, window.frame.origin.y - display.frame.origin.y)

--- a/VoiceInk/Services/ScreenCaptureService.swift
+++ b/VoiceInk/Services/ScreenCaptureService.swift
@@ -117,17 +117,25 @@ class ScreenCaptureService: ObservableObject {
 
             let title = window.title ?? window.owningApplication?.applicationName ?? "Unknown"
             let appName = window.owningApplication?.applicationName ?? "Unknown"
-            let filter: SCContentFilter
-            if let display = content.displays.first(where: { $0.frame.intersects(window.frame) }) ?? content.displays.first {
-                filter = SCContentFilter(display: display, including: [window])
-            } else {
-                filter = SCContentFilter(desktopIndependentWindow: window)
-            }
-
             let configuration = SCStreamConfiguration()
             let captureScale = captureScale(for: window.frame.size)
             configuration.width = max(1, Int(window.frame.width * captureScale))
             configuration.height = max(1, Int(window.frame.height * captureScale))
+
+            let filter: SCContentFilter
+            if let display = content.displays.first(where: { $0.frame.intersects(window.frame) }) ?? content.displays.first {
+                filter = SCContentFilter(display: display, including: [window])
+                let relativeX = max(0, window.frame.origin.x - display.frame.origin.x)
+                let relativeY = max(0, window.frame.origin.y - display.frame.origin.y)
+                configuration.sourceRect = CGRect(
+                    x: relativeX,
+                    y: relativeY,
+                    width: window.frame.width,
+                    height: window.frame.height
+                )
+            } else {
+                filter = SCContentFilter(desktopIndependentWindow: window)
+            }
 
             let cgImage = try await SCScreenshotManager.captureImage(
                 contentFilter: filter, configuration: configuration)

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -288,6 +288,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                                 self.activeRecordingStartID == startID,
                                 !self.shouldCancelRecording
                             else {
+                                self.clearActiveRecordingContext()
                                 return
                             }
 

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine.swift
@@ -280,6 +280,7 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             }
 
                             self.recordingState = .recording
+                            self.startRecordingContextCapture()
 
                             await activeModeTask.value
 
@@ -289,8 +290,6 @@ class VoiceInkEngine: NSObject, ObservableObject {
                             else {
                                 return
                             }
-
-                            self.startRecordingContextCapture()
 
                             let modelResolution = ModeRuntimeResolver.transcriptionModelResolution(
                                 transcriptionModelManager: self.transcriptionModelManager


### PR DESCRIPTION
Fixes #882

### Summary

1. **Use display-backed `SCContentFilter`**: `SCContentFilter(desktopIndependentWindow:)` can fail or trigger SkyLight assertion errors on macOS when not associated with a display. Initializing with `SCContentFilter(display:including:)` for the target window's display and setting `configuration.sourceRect` to the relative window coordinates resolves this and ensures crisp 1:1 window capture.
2. **Immediate context capture**: Move `startRecordingContextCapture()` to trigger immediately upon entering `.recording` state so background OCR, clipboard, and selection capture execute concurrently throughout dictation.
3. **Clean context lifecycle**: Symmetrically clean up context tasks on early returns if recording state changes during setup.

### Verification
- Tested window capture and Vision OCR on active macOS application windows.
- Verified extracted window text is attached to `<CURRENT_WINDOW_CONTEXT>` in the enhancement prompt.