### PR TITLE
Fix clamshell microphone routing for external microphones with 3.5mm headset

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -11,11 +11,11 @@
 		E13461ED2FD1CCCD005B6A81 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = E13461EC2FD1CCCD005B6A81 /* MarkdownUI */; };
 		E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E161D4A02F41ECB90086F83D /* CloudKit.framework */; };
 		E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD45E2CC544F100303ECB /* Sparkle */; };
+		E1AF669B3031B7AA006D50FA /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = E1AF669A3031B7AA006D50FA /* FluidAudio */; };
 		E1C0A0022FA8000000000001 /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = E1C0A0012FA8000000000001 /* TranscribeCpp */; };
 		E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; };
 		E1D7EF9A2E35E19B00640029 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD1EE02FA1D7D30020AF3B /* Zip */; };
-		E1DD20DE2FA20AD90020AF3B /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD20DD2FA20AD90020AF3B /* FluidAudio */; };
 		E1DD20E12FA20AEE0020AF3B /* LLMkit in Frameworks */ = {isa = PBXBuildFile; productRef = E1DD20E02FA20AEE0020AF3B /* LLMkit */; };
 		E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; };
 		E1F350122F1D10D600790A2C /* whisper.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -148,8 +148,8 @@
 				E1D7EF992E35E16C00640029 /* MediaRemoteAdapter in Frameworks */,
 				E161D4A12F41ECB90086F83D /* CloudKit.framework in Frameworks */,
 				E1ADD45F2CC544F100303ECB /* Sparkle in Frameworks */,
-				E1DD20DE2FA20AD90020AF3B /* FluidAudio in Frameworks */,
 				E1C0A0022FA8000000000001 /* TranscribeCpp in Frameworks */,
+				E1AF669B3031B7AA006D50FA /* FluidAudio in Frameworks */,
 				E1DD1EE12FA1D7D30020AF3B /* Zip in Frameworks */,
 				E13461ED2FD1CCCD005B6A81 /* MarkdownUI in Frameworks */,
 				E1DD20E12FA20AEE0020AF3B /* LLMkit in Frameworks */,
@@ -256,11 +256,11 @@
 				E1D7EF982E35E16C00640029 /* MediaRemoteAdapter */,
 				E1342C1E2EB4844800CED8A2 /* Atomics */,
 				E1DD1EE02FA1D7D30020AF3B /* Zip */,
-				E1DD20DD2FA20AD90020AF3B /* FluidAudio */,
 				E1C0A0012FA8000000000001 /* TranscribeCpp */,
 				E1DD20E02FA20AEE0020AF3B /* LLMkit */,
 				E1F511032FA3B47000F00001 /* SelectedTextKit */,
 				E13461EC2FD1CCCD005B6A81 /* MarkdownUI */,
+				E1AF669A3031B7AA006D50FA /* FluidAudio */,
 			);
 			productName = VoiceInk;
 			productReference = E11473B02CBE0F0A00318EE4 /* VoiceInk.app */;
@@ -381,7 +381,6 @@
 				E1D7EF972E35E16C00640029 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */,
 				E1ECEC142E44590200DFFBA8 /* XCRemoteSwiftPackageReference "Zip" */,
 				E1342C1D2EB4844800CED8A2 /* XCRemoteSwiftPackageReference "swift-atomics" */,
-				E1DD20DC2FA20AD90020AF3B /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				E1DD20DF2FA20AEE0020AF3B /* XCRemoteSwiftPackageReference "LLMkit" */,
 				E1F511022FA3B47000F00001 /* XCRemoteSwiftPackageReference "SelectedTextKit" */,
 				E13461EB2FD1CCCD005B6A81 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
@@ -389,6 +388,7 @@
 				E1F900022FA6000000000001 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
 				E1F900032FA6000000000001 /* XCRemoteSwiftPackageReference "swift-transformers" */,
 				E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */,
+				E1AF66993031B7AA006D50FA /* XCRemoteSwiftPackageReference "FluidAudio" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E11473B12CBE0F0A00318EE4 /* Products */;
@@ -881,6 +881,14 @@
 				minimumVersion = 2.6.4;
 			};
 		};
+		E1AF66993031B7AA006D50FA /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FluidInference/FluidAudio";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Beingpax/Transcribe-cpp-swift.git";
@@ -894,14 +902,6 @@
 			repositoryURL = "https://github.com/Beingpax/mediaremote-adapter";
 			requirement = {
 				branch = master;
-				kind = branch;
-			};
-		};
-		E1DD20DC2FA20AD90020AF3B /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
-			requirement = {
-				branch = main;
 				kind = branch;
 			};
 		};
@@ -973,6 +973,11 @@
 			package = E1ADD45D2CC544F100303ECB /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
 		};
+		E1AF669A3031B7AA006D50FA /* FluidAudio */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1AF66993031B7AA006D50FA /* XCRemoteSwiftPackageReference "FluidAudio" */;
+			productName = FluidAudio;
+		};
 		E1C0A0012FA8000000000001 /* TranscribeCpp */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E1C0A0002FA8000000000001 /* XCRemoteSwiftPackageReference "Transcribe-cpp-swift" */;
@@ -987,11 +992,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1ECEC142E44590200DFFBA8 /* XCRemoteSwiftPackageReference "Zip" */;
 			productName = Zip;
-		};
-		E1DD20DD2FA20AD90020AF3B /* FluidAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1DD20DC2FA20AD90020AF3B /* XCRemoteSwiftPackageReference "FluidAudio" */;
-			productName = FluidAudio;
 		};
 		E1DD20E02FA20AEE0020AF3B /* LLMkit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a16b09e2c0e3fee7d86fbd260972eb0b946296e1771f315691d250410632fd8c",
+  "originHash" : "ef9eb8e09cc8ad47145fb9d97103e7267e9dd9e5ee5b02f0ceb041eb1eb8f85c",
   "pins" : [
     {
       "identity" : "axswift",
@@ -22,10 +22,10 @@
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
         "branch" : "main",
-        "revision" : "88d6d8166880dee1ac7c32c80f8e10cd782f8ca8"
+        "revision" : "c7b13a3942e79893f3bd76bfe3b1ed8d03e0bfc7"
       }
     },
     {

--- a/VoiceInk/Recorder+RecordingDeviceSetup.swift
+++ b/VoiceInk/Recorder+RecordingDeviceSetup.swift
@@ -40,7 +40,7 @@ extension Recorder {
             return
         }
 
-        if resolution.fellBackFromClosedBuiltInMicrophone {
+        if resolution.fellBackFromClosedInternalMicrophone {
             NotificationManager.shared.showNotification(
                 title: String(format: String(localized: "Using: %@"), deviceName),
                 type: .info
@@ -104,7 +104,7 @@ extension Recorder {
 
     private func showNoFallbackNotification(reason: RecordingDeviceChangeReason) {
         let presentation = AudioInputFailurePresentation.noUsableMicrophone(
-            builtInBlockedByClosedLid: reason == .closedLid
+            internalMicrophoneBlockedByClosedLid: reason == .closedLid
         )
         NotificationManager.shared.showNotification(
             title: presentation.title,

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -30,7 +30,7 @@ class Recorder: NSObject, ObservableObject {
 
     enum RecorderError: Error {
         case couldNotStartRecording
-        case noUsableMicrophone(builtInBlockedByClosedLid: Bool)
+        case noUsableMicrophone(internalMicrophoneBlockedByClosedLid: Bool)
     }
 
     override init() {
@@ -58,7 +58,7 @@ class Recorder: NSObject, ObservableObject {
         guard var deviceID = resolution.deviceID else {
             onAudioChunk = nil
             throw RecorderError.noUsableMicrophone(
-                builtInBlockedByClosedLid: resolution.builtInBlockedByClosedLid
+                internalMicrophoneBlockedByClosedLid: resolution.internalMicrophoneBlockedByClosedLid
             )
         }
 
@@ -79,7 +79,7 @@ class Recorder: NSObject, ObservableObject {
             } catch {
                 let retryResolution = deviceManager.resolveCurrentRecordingDevice(excluding: deviceID)
                 guard deviceManager.isClamshellClosed,
-                    deviceManager.isBuiltInDevice(deviceID),
+                    deviceManager.isInternalMicrophone(deviceID),
                     let fallbackDeviceID = retryResolution.deviceID
                 else {
                     throw error

--- a/VoiceInk/Services/AudioDeviceManager+RecordingRouting.swift
+++ b/VoiceInk/Services/AudioDeviceManager+RecordingRouting.swift
@@ -4,8 +4,8 @@ import os
 
 struct RecordingDeviceResolution {
     let deviceID: AudioDeviceID?
-    let builtInBlockedByClosedLid: Bool
-    let fellBackFromClosedBuiltInMicrophone: Bool
+    let internalMicrophoneBlockedByClosedLid: Bool
+    let fellBackFromClosedInternalMicrophone: Bool
 }
 
 struct RecordingDeviceSession {
@@ -57,8 +57,8 @@ extension AudioDeviceManager {
     ) -> RecordingDeviceResolution {
         let preferredCandidates = preferredRecordingDeviceIDs()
         let preferredAvailableDevice = preferredCandidates.first(where: isOperationalInputDevice)
-        let builtInBlockedByClosedLid = isClamshellClosed
-            && preferredAvailableDevice.map(isBuiltInDevice) == true
+        let internalMicrophoneBlockedByClosedLid = isClamshellClosed
+            && preferredAvailableDevice.map(isInternalMicrophone) == true
 
         var seen = Set<AudioDeviceID>()
         let candidates = (preferredCandidates + fallbackRecordingDeviceIDs()).filter { deviceID in
@@ -69,8 +69,8 @@ extension AudioDeviceManager {
 
         return RecordingDeviceResolution(
             deviceID: resolvedDeviceID,
-            builtInBlockedByClosedLid: builtInBlockedByClosedLid,
-            fellBackFromClosedBuiltInMicrophone: builtInBlockedByClosedLid
+            internalMicrophoneBlockedByClosedLid: internalMicrophoneBlockedByClosedLid,
+            fellBackFromClosedInternalMicrophone: internalMicrophoneBlockedByClosedLid
                 && resolvedDeviceID != preferredAvailableDevice
         )
     }
@@ -83,17 +83,9 @@ extension AudioDeviceManager {
         fallbackRecordingDeviceIDs().first(where: isDeviceUsableForRecording)
     }
 
-    func isBuiltInDevice(_ deviceID: AudioDeviceID) -> Bool {
-        let transportType = getUInt32DeviceProperty(
-            deviceID: deviceID,
-            selector: kAudioDevicePropertyTransportType
-        )
-        return transportType == kAudioDeviceTransportTypeBuiltIn
-    }
-
     func isDeviceUsableForRecording(_ deviceID: AudioDeviceID) -> Bool {
         isOperationalInputDevice(deviceID)
-            && !(isClamshellClosed && isBuiltInDevice(deviceID))
+            && !(isClamshellClosed && isInternalMicrophone(deviceID))
     }
 
     private func preferredRecordingDeviceIDs() -> [AudioDeviceID] {
@@ -116,9 +108,9 @@ extension AudioDeviceManager {
     }
 
     private func fallbackRecordingDeviceIDs() -> [AudioDeviceID] {
-        let builtIn = availableDevices.filter { isBuiltInDevice($0.id) }.map { $0.id }
-        let external = availableDevices.filter { !isBuiltInDevice($0.id) }.map { $0.id }
-        return isClamshellClosed ? external + builtIn : builtIn + external
+        let internalMicrophones = availableDevices.filter { isInternalMicrophone($0.id) }.map { $0.id }
+        let otherInputs = availableDevices.filter { !isInternalMicrophone($0.id) }.map { $0.id }
+        return isClamshellClosed ? otherInputs + internalMicrophones : internalMicrophones + otherInputs
     }
 
     func isOperationalInputDevice(_ deviceID: AudioDeviceID) -> Bool {
@@ -134,7 +126,7 @@ extension AudioDeviceManager {
         }
         guard isClosed,
             let activeRecordingDeviceID,
-            isBuiltInDevice(activeRecordingDeviceID)
+            isInternalMicrophone(activeRecordingDeviceID)
         else {
             return
         }

--- a/VoiceInk/Services/AudioDeviceManager.swift
+++ b/VoiceInk/Services/AudioDeviceManager.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import CoreAudio
 import Foundation
+import IOKit.audio
 import os
 
 struct PrioritizedDevice: Codable, Identifiable {
@@ -562,6 +563,42 @@ class AudioDeviceManager: ObservableObject {
         )
         guard status == noErr else { return nil }
         return property
+    }
+
+    /// The MacBook's internal microphone is physically disconnected when the lid closes.
+    /// A headset-jack microphone also uses the built-in codec, so transport alone cannot identify lid-dependent inputs.
+    func isInternalMicrophone(_ deviceID: AudioDeviceID) -> Bool {
+        guard
+            getUInt32DeviceProperty(
+                deviceID: deviceID,
+                selector: kAudioDevicePropertyTransportType
+            ) == kAudioDeviceTransportTypeBuiltIn
+        else {
+            return false
+        }
+
+        let uid = getDeviceUID(deviceID: deviceID)
+        let dataSource = getUInt32DeviceProperty(
+            deviceID: deviceID,
+            selector: kAudioDevicePropertyDataSource,
+            scope: kAudioDevicePropertyScopeInput
+        )
+        let internalMicrophoneSource = UInt32(kIOAudioSelectorControlSelectionValueInternalMicrophone)
+        let externalMicrophoneSource = UInt32(kIOAudioSelectorControlSelectionValueExternalMicrophone)
+
+        if dataSource == externalMicrophoneSource {
+            return false
+        }
+        if dataSource == internalMicrophoneSource {
+            return true
+        }
+
+        // Older Apple drivers may not implement data-source controls. Keep the known system
+        // device UIDs only as a final compatibility fallback and fail open for unknown inputs.
+        if uid == "BuiltInHeadphoneInputDevice" {
+            return false
+        }
+        return uid == "BuiltInMicrophoneDevice"
     }
 
     func notifyDeviceChange() {

--- a/VoiceInk/Transcription/Engine/VoiceInkEngine+AudioInputFailure.swift
+++ b/VoiceInk/Transcription/Engine/VoiceInkEngine+AudioInputFailure.swift
@@ -7,9 +7,9 @@ struct AudioInputFailurePresentation {
 
     @MainActor
     static func noUsableMicrophone(
-        builtInBlockedByClosedLid: Bool
+        internalMicrophoneBlockedByClosedLid: Bool
     ) -> AudioInputFailurePresentation {
-        let title = builtInBlockedByClosedLid
+        let title = internalMicrophoneBlockedByClosedLid
             ? String(
                 localized:
                     "No usable microphone is available. Open the lid or connect an external microphone."
@@ -30,13 +30,13 @@ extension VoiceInkEngine {
         for error: Error
     ) -> (title: String, actionLabel: String, action: () -> Void)? {
         guard let recorderError = error as? Recorder.RecorderError,
-            case .noUsableMicrophone(let builtInBlockedByClosedLid) = recorderError
+            case .noUsableMicrophone(let internalMicrophoneBlockedByClosedLid) = recorderError
         else {
             return nil
         }
 
         let presentation = AudioInputFailurePresentation.noUsableMicrophone(
-            builtInBlockedByClosedLid: builtInBlockedByClosedLid
+            internalMicrophoneBlockedByClosedLid: internalMicrophoneBlockedByClosedLid
         )
         return (presentation.title, presentation.actionLabel, presentation.action)
     }


### PR DESCRIPTION
Fixes #878 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clamshell routing by distinguishing the Mac’s internal microphone from headset‑jack microphones that share the built‑in codec. Previously, closing the lid disabled all built‑in-transport inputs and blocked 3.5mm headset mics; now only the internal microphone is blocked when the lid is closed.

- Detects internal vs external microphones via `IOKit.audio` data source values, with UID fallbacks; replaces transport-only checks.
- Updates fallback order: when the lid is closed, prefer non-internal inputs; otherwise prefer internal first.
- Renames “built-in” to “internal microphone” across resolution, errors, and notifications to match behavior.
- Recorder retry excludes the internal microphone when clamshell is closed.
- Adjusts SwiftPM setup for `FluidAudio` (repository URL and product dependency) without behavior change.

<sup>Written for commit bcfe2decb8bac0b47a9a59ad09ffbf28d014ae06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

