### PR TITLE
Improve local build handling

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,62 +1,12 @@
 # Building VoiceInk
 
-This guide provides detailed instructions for building VoiceInk from source.
+## Requirements
 
-## Prerequisites
-
-Before you begin, ensure you have:
 - macOS 14.4 or later
-- Xcode (latest version recommended)
-- Swift (latest version recommended)
-- Git (for cloning repositories)
+- Xcode with Command Line Tools
+- Git
 
-## Quick Start with Makefile (Recommended)
-
-The easiest way to build VoiceInk is using the included Makefile, which automates the entire build process including building and linking the whisper framework.
-
-### Simple Build Commands
-
-```bash
-# Clone the repository
-git clone https://github.com/Beingpax/VoiceInk.git
-cd VoiceInk
-
-# Build everything (recommended for first-time setup)
-make all
-
-# Or for development (build and run)
-make dev
-```
-
-### Available Makefile Commands
-
-- `make check` or `make healthcheck` - Verify all required tools are installed
-- `make whisper` - Clone and build whisper.cpp XCFramework automatically
-- `make setup` - Prepare the whisper framework for linking
-- `make build` - Build the VoiceInk Xcode project
-- `make local` - Build for local use (no Apple Developer certificate needed)
-- `make run` - Launch the built VoiceInk app
-- `make dev` - Build and run (ideal for development workflow)
-- `make all` - Complete build process (default)
-- `make clean` - Remove build artifacts and dependencies
-- `make help` - Show all available commands
-
-### How the Makefile Helps
-
-The Makefile automatically:
-1. **Manages Dependencies**: Creates a dedicated `~/VoiceInk-Dependencies` directory for all external frameworks
-2. **Builds Whisper Framework**: Clones whisper.cpp and builds the XCFramework with the correct configuration
-3. **Handles Framework Linking**: Sets up the whisper.xcframework in the proper location for Xcode to find
-4. **Verifies Prerequisites**: Checks that git, xcodebuild, and swift are installed before building
-5. **Streamlines Development**: Provides convenient shortcuts for common development tasks
-
-This approach ensures consistent builds across different machines and eliminates manual framework setup errors.
-
----
-
-## Building for Local Use (No Apple Developer Certificate)
-
-If you don't have an Apple Developer certificate, use `make local`:
+## Local Build
 
 ```bash
 git clone https://github.com/Beingpax/VoiceInk.git
@@ -65,75 +15,48 @@ make local
 open ~/Downloads/VoiceInk.app
 ```
 
-This builds VoiceInk with ad-hoc signing using a separate build configuration (`LocalBuild.xcconfig`) that requires no Apple Developer account.
+`make local` prepares `whisper.xcframework` in `~/VoiceInk-Dependencies`, builds in `.local-build`, and copies `VoiceInk.app` to `~/Downloads`.
 
-### How It Works
+It uses `LocalBuild.xcconfig`, `VoiceInk.local.entitlements`, and the `LOCAL_BUILD` Swift flag. Without an override, it uses the only available Apple Development identity or falls back to ad-hoc signing when none or multiple are found.
 
-The `make local` command uses:
-- `LocalBuild.xcconfig` to override signing and entitlements settings
-- `VoiceInk.local.entitlements` (stripped-down, no CloudKit/keychain groups)
-- `LOCAL_BUILD` Swift compilation flag for conditional code paths
+Choose an identity explicitly:
 
-Your normal `make all` / `make build` commands are completely unaffected.
-
----
-
-## Manual Build Process (Alternative)
-
-If you prefer to build manually or need more control over the build process, follow these steps:
-
-### Building whisper.cpp Framework
-
-1. Clone and build whisper.cpp:
 ```bash
-git clone https://github.com/ggerganov/whisper.cpp.git
-cd whisper.cpp
-./build-xcframework.sh
-```
-This will create the XCFramework at `build-apple/whisper.xcframework`.
-
-### Building VoiceInk
-
-1. Clone the VoiceInk repository:
-```bash
-git clone https://github.com/Beingpax/VoiceInk.git
-cd VoiceInk
+make local LOCAL_CODESIGN_IDENTITY="<SHA or name>"
 ```
 
-2. Add the whisper.xcframework to your project:
-   - Drag and drop `../whisper.cpp/build-apple/whisper.xcframework` into the project navigator, or
-   - Add it manually in the "Frameworks, Libraries, and Embedded Content" section of project settings
+Force ad-hoc signing:
 
-3. Build and Run
-   - Build the project using Cmd+B or Product > Build
-   - Run the project using Cmd+R or Product > Run
+```bash
+make local LOCAL_CODESIGN_IDENTITY=-
+```
 
-## Development Setup
+Local builds do not include iCloud dictionary sync or automatic updates. Ad-hoc builds may require macOS permissions again after rebuilding. Normal project Debug and Release settings are unchanged.
 
-1. **Xcode Configuration**
-   - Ensure you have the latest Xcode version
-   - Install any required Xcode Command Line Tools
+## Other Commands
 
-2. **Dependencies**
-   - The project uses [whisper.cpp](https://github.com/ggerganov/whisper.cpp) for transcription
-   - Ensure the whisper.xcframework is properly linked in your Xcode project
-   - Test the whisper.cpp installation independently before proceeding
+- `make check` — verify required tools
+- `make whisper` — prepare `whisper.xcframework`
+- `make build` — build the standard Debug configuration
+- `make dev` — build and launch the app
+- `make run` — launch the latest app found
+- `make release` — create the signed release package
+- `make release-setup` — configure release notarization credentials
+- `make clean` — remove `~/VoiceInk-Dependencies`
+- `make help` — list all commands
 
-3. **Building for Development**
-   - Use the Debug configuration for development
-   - Enable relevant debugging options in Xcode
+## Build with Xcode
 
-4. **Testing**
-   - Run the test suite before making changes
-   - Ensure all tests pass after your modifications
+```bash
+make setup
+open VoiceInk.xcodeproj
+```
+
+Select the `VoiceInk` scheme and use the Debug configuration. Xcode uses the project’s normal signing settings; `LOCAL_BUILD` applies only through `make local`.
 
 ## Troubleshooting
 
-If you encounter any build issues:
-1. Clean the build folder (Cmd+Shift+K)
-2. Clean the build cache (Cmd+Shift+K twice)
-3. Check Xcode and macOS versions
-4. Verify all dependencies are properly installed
-5. Make sure whisper.xcframework is properly built and linked
-
-For more help, please check the [issues](https://github.com/Beingpax/VoiceInk/issues) section or create a new issue.
+- Run `make check` to verify the required tools.
+- Run `make whisper` if the framework is missing.
+- If several Apple Development identities exist, set `LOCAL_CODESIGN_IDENTITY` explicitly.
+- For additional help, open a [GitHub issue](https://github.com/Beingpax/VoiceInk/issues).

--- a/LocalBuild.xcconfig
+++ b/LocalBuild.xcconfig
@@ -1,8 +1,8 @@
 // LocalBuild.xcconfig
-// Build configuration for local/unsigned builds (no Apple Developer certificate required).
+// Build configuration for local builds with an ad-hoc fallback when no Apple Development identity is available.
 // Used by `make local` — does NOT affect Debug or Release configurations.
 
-// Ad-hoc signing (works without a developer account)
+// Defaults to ad-hoc signing; make local overrides this when an Apple Development identity is available.
 CODE_SIGN_IDENTITY = -
 CODE_SIGN_STYLE = Manual
 DEVELOPMENT_TEAM =

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,13 @@ local: check setup
 	@rm -rf "$(LOCAL_DERIVED_DATA)"
 	@SIGNING_IDENTITY="$(LOCAL_CODESIGN_IDENTITY)"; \
 	if [ -z "$$SIGNING_IDENTITY" ]; then \
-		SIGNING_IDENTITY=$$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Apple Development: / { print $$2; exit }'); \
+		SIGNING_IDENTITIES=$$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Apple Development: / { print $$2 }'); \
+		SIGNING_IDENTITY_COUNT=$$(printf '%s\n' "$$SIGNING_IDENTITIES" | awk 'NF { count++ } END { print count + 0 }'); \
+		if [ "$$SIGNING_IDENTITY_COUNT" -eq 1 ]; then \
+			SIGNING_IDENTITY=$$(printf '%s\n' "$$SIGNING_IDENTITIES" | awk 'NF { print; exit }'); \
+		elif [ "$$SIGNING_IDENTITY_COUNT" -gt 1 ]; then \
+			echo "Multiple Apple Development identities found; set LOCAL_CODESIGN_IDENTITY to choose one; using ad-hoc signing"; \
+		fi; \
 	fi; \
 	if [ -n "$$SIGNING_IDENTITY" ] && [ "$$SIGNING_IDENTITY" != "-" ]; then \
 		SIGNING_REQUIRED=YES; \
@@ -59,7 +65,7 @@ local: check setup
 	else \
 		SIGNING_IDENTITY="-"; \
 		SIGNING_REQUIRED=NO; \
-		echo "No Apple Development identity found; using ad-hoc signing (permissions may need approval after rebuilds)"; \
+		echo "Using ad-hoc signing (permissions may need approval after rebuilds)"; \
 	fi; \
 	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug \
 		-derivedDataPath "$(LOCAL_DERIVED_DATA)" \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DEPS_DIR := $(HOME)/VoiceInk-Dependencies
 WHISPER_CPP_DIR := $(DEPS_DIR)/whisper.cpp
 FRAMEWORK_PATH := $(WHISPER_CPP_DIR)/build-apple/whisper.xcframework
 LOCAL_DERIVED_DATA := $(CURDIR)/.local-build
+LOCAL_CODESIGN_IDENTITY ?=
 
 .PHONY: all clean whisper setup build local check healthcheck help dev run release release-setup
 
@@ -44,15 +45,27 @@ setup: whisper
 build: setup
 	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug CODE_SIGN_IDENTITY="" build
 
-# Build for local use without Apple Developer certificate
+# Build locally with stable Apple Development signing when available.
 local: check setup
 	@echo "Building VoiceInk for local use (no Apple Developer certificate required)..."
 	@rm -rf "$(LOCAL_DERIVED_DATA)"
+	@SIGNING_IDENTITY="$(LOCAL_CODESIGN_IDENTITY)"; \
+	if [ -z "$$SIGNING_IDENTITY" ]; then \
+		SIGNING_IDENTITY=$$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Apple Development: / { print $$2; exit }'); \
+	fi; \
+	if [ -n "$$SIGNING_IDENTITY" ] && [ "$$SIGNING_IDENTITY" != "-" ]; then \
+		SIGNING_REQUIRED=YES; \
+		echo "Using stable local signing identity: $$SIGNING_IDENTITY"; \
+	else \
+		SIGNING_IDENTITY="-"; \
+		SIGNING_REQUIRED=NO; \
+		echo "No Apple Development identity found; using ad-hoc signing (permissions may need approval after rebuilds)"; \
+	fi; \
 	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug \
 		-derivedDataPath "$(LOCAL_DERIVED_DATA)" \
 		-xcconfig LocalBuild.xcconfig \
-		CODE_SIGN_IDENTITY="-" \
-		CODE_SIGNING_REQUIRED=NO \
+		CODE_SIGN_IDENTITY="$$SIGNING_IDENTITY" \
+		CODE_SIGNING_REQUIRED="$$SIGNING_REQUIRED" \
 		CODE_SIGNING_ALLOWED=YES \
 		DEVELOPMENT_TEAM="" \
 		CODE_SIGN_ENTITLEMENTS="$(CURDIR)/VoiceInk/VoiceInk.local.entitlements" \
@@ -118,7 +131,8 @@ help:
 	@echo "  whisper            Clone and build whisper.cpp XCFramework"
 	@echo "  setup              Copy whisper XCFramework to VoiceInk project"
 	@echo "  build              Build the VoiceInk Xcode project"
-	@echo "  local              Build for local use (no Apple Developer certificate needed)"
+	@echo "  local              Build locally with stable signing when available"
+	@echo "    LOCAL_CODESIGN_IDENTITY=<SHA or name> overrides automatic Apple Development detection"
 	@echo "  run                Launch the built VoiceInk app"
 	@echo "  dev                Build and run the app (for development)"
 	@echo "  release            Build DMG and Appcast using release-notes/<version>.html"

--- a/VoiceInk/Models/LicenseViewModel.swift
+++ b/VoiceInk/Models/LicenseViewModel.swift
@@ -73,7 +73,12 @@ final class LicenseViewModel: ObservableObject {
         self.automaticallyRetriesStorage = automaticallyRetriesStorage
         self.automaticallyRefreshesTime = automaticallyRefreshesTime
 
-        loadPersistentState()
+        #if LOCAL_BUILD
+            isPersistentStateAvailable = true
+            licenseState = .licensed
+        #else
+            loadPersistentState()
+        #endif
     }
 
     deinit {
@@ -141,8 +146,11 @@ final class LicenseViewModel: ObservableObject {
     }
 
     var hasVerifiedLicense: Bool {
-        guard isPersistentStateAvailable else { return false }
-        return storedLicenseKey != nil && licenseState == .licensed
+        #if LOCAL_BUILD
+            true
+        #else
+            isPersistentStateAvailable && storedLicenseKey != nil && licenseState == .licensed
+        #endif
     }
 
     var canUseApp: Bool {
@@ -451,6 +459,10 @@ final class LicenseViewModel: ObservableObject {
     }
 
     private func resolvedState(at date: Date) -> LicenseState {
+        #if LOCAL_BUILD
+            return .licensed
+        #endif
+
         if storedLicenseKey != nil,
             activationId != nil || !requiresActivation
         {

--- a/VoiceInk/Services/KeychainService.swift
+++ b/VoiceInk/Services/KeychainService.swift
@@ -2,7 +2,7 @@ import Foundation
 import Security
 import os
 
-/// Stores credentials with caller-selected Keychain synchronization and accessibility.
+/// Stores production credentials in the Data Protection Keychain and local-build credentials in a separate, non-syncing login Keychain namespace.
 final class KeychainService {
     static let shared = KeychainService()
 
@@ -24,7 +24,13 @@ final class KeychainService {
     }
 
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "KeychainService")
-    private let service = "com.prakashjoshipax.VoiceInk"
+    #if LOCAL_BUILD
+        private let service = "com.prakashjoshipax.VoiceInk.Local"
+        private let defaults = UserDefaults.standard
+        private let legacyLocalPrefix = "LocalKeychain_"
+    #else
+        private let service = "com.prakashjoshipax.VoiceInk"
+    #endif
 
     private init() {}
 
@@ -55,13 +61,12 @@ final class KeychainService {
     ) -> Bool {
         let query = baseQuery(forKey: key, syncable: syncable)
         var attributes: [String: Any] = [kSecValueData as String: data]
-        if let accessibility {
-            attributes[kSecAttrAccessible as String] = accessibility.value
-        }
+        applyAccessibility(accessibility, to: &attributes)
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
 
         if updateStatus == errSecSuccess {
             logger.info("Successfully updated keychain item for key: \(key, privacy: .public)")
+            removeLegacyLocalFallback(forKey: key)
             return true
         }
 
@@ -74,13 +79,12 @@ final class KeychainService {
 
         var addQuery = query
         addQuery[kSecValueData as String] = data
-        if let accessibility {
-            addQuery[kSecAttrAccessible as String] = accessibility.value
-        }
+        applyAccessibility(accessibility, to: &addQuery)
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
 
         if addStatus == errSecSuccess {
             logger.info("Successfully saved keychain item for key: \(key, privacy: .public)")
+            removeLegacyLocalFallback(forKey: key)
             return true
         }
 
@@ -88,6 +92,7 @@ final class KeychainService {
             let retryStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
             if retryStatus == errSecSuccess {
                 logger.info("Successfully updated concurrently created keychain item for key: \(key, privacy: .public)")
+                removeLegacyLocalFallback(forKey: key)
                 return true
             }
 
@@ -153,6 +158,13 @@ final class KeychainService {
         }
 
         if status == errSecItemNotFound {
+            #if LOCAL_BUILD
+                if let legacyData = defaults.data(forKey: legacyLocalPrefix + key) {
+                    _ = save(data: legacyData, forKey: key, syncable: false)
+                    return .value(legacyData)
+                }
+            #endif
+
             return .notFound
         }
 
@@ -169,6 +181,7 @@ final class KeychainService {
         let status = SecItemDelete(query as CFDictionary)
 
         if status == errSecSuccess || status == errSecItemNotFound {
+            removeLegacyLocalFallback(forKey: key)
             if status == errSecSuccess {
                 logger.info("Successfully deleted keychain item for key: \(key, privacy: .public)")
             }
@@ -187,6 +200,12 @@ final class KeychainService {
         query[kSecReturnData as String] = kCFBooleanFalse
 
         let status = SecItemCopyMatching(query as CFDictionary, nil)
+        #if LOCAL_BUILD
+            if status == errSecItemNotFound {
+                return defaults.data(forKey: legacyLocalPrefix + key) != nil
+            }
+        #endif
+
         return status == errSecSuccess
     }
 
@@ -198,13 +217,31 @@ final class KeychainService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
-            kSecUseDataProtectionKeychain as String: true,
         ]
 
-        if syncable {
-            query[kSecAttrSynchronizable as String] = kCFBooleanTrue
-        }
+        #if !LOCAL_BUILD
+            query[kSecUseDataProtectionKeychain as String] = true
+
+            if syncable {
+                query[kSecAttrSynchronizable as String] = kCFBooleanTrue
+            }
+        #endif
 
         return query
+    }
+
+    private func applyAccessibility(_ accessibility: Accessibility?, to attributes: inout [String: Any]) {
+        #if !LOCAL_BUILD
+            if let accessibility {
+                attributes[kSecAttrAccessible as String] = accessibility.value
+            }
+        #endif
+    }
+
+    // Removes the old local UserDefaults copy after secure storage succeeds or the credential is deleted.
+    private func removeLegacyLocalFallback(forKey key: String) {
+        #if LOCAL_BUILD
+            defaults.removeObject(forKey: legacyLocalPrefix + key)
+        #endif
     }
 }

--- a/VoiceInk/Views/Onboarding/OnboardingCoordinator.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingCoordinator.swift
@@ -94,6 +94,12 @@ final class OnboardingCoordinator: ObservableObject {
     }
 
     var stage: OnboardingStage {
+        #if LOCAL_BUILD
+            if storedStage == OnboardingStage.license.rawValue {
+                return .trust
+            }
+        #endif
+
         if let stage = OnboardingStage(rawValue: storedStage) {
             return stage
         }
@@ -138,7 +144,11 @@ final class OnboardingCoordinator: ObservableObject {
     }
 
     var totalStepCount: Int {
-        OnboardingStage.baseStepCount + activeExperienceSteps.count + contextAwarenessStepCount + 2
+        #if LOCAL_BUILD
+            OnboardingStage.baseStepCount + activeExperienceSteps.count + contextAwarenessStepCount + 1
+        #else
+            OnboardingStage.baseStepCount + activeExperienceSteps.count + contextAwarenessStepCount + 2
+        #endif
     }
 
     var experienceStep: OnboardingExperienceStep {

--- a/VoiceInk/Views/Onboarding/OnboardingFlowController.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingFlowController.swift
@@ -344,9 +344,14 @@ final class OnboardingFlowController {
         isTranscriptionSetupReady: Bool,
         onComplete: () -> Void
     ) {
+        #if LOCAL_BUILD
+            let isFinalStage = coordinator.stage == .license || coordinator.stage == .trust
+        #else
+            let isFinalStage = coordinator.stage == .license
+        #endif
+
         guard
-            coordinator.stage == .license
-                || coordinator.isCurrentExperienceReady(isTranscriptionSetupReady: isTranscriptionSetupReady)
+            isFinalStage || coordinator.isCurrentExperienceReady(isTranscriptionSetupReady: isTranscriptionSetupReady)
         else {
             return
         }

--- a/VoiceInk/Views/Onboarding/OnboardingView.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingView.swift
@@ -165,9 +165,17 @@ struct OnboardingView: View {
                             )
                         },
                         onContinue: {
-                            coordinator.flow.goToLicenseStep(
-                                isTranscriptionSetupReady: isTranscriptionSetupReady
-                            )
+                            #if LOCAL_BUILD
+                                coordinator.flow.completeOnboarding(
+                                    isTranscriptionSetupReady: isTranscriptionSetupReady
+                                ) {
+                                    hasCompletedOnboardingV2 = true
+                                }
+                            #else
+                                coordinator.flow.goToLicenseStep(
+                                    isTranscriptionSetupReady: isTranscriptionSetupReady
+                                )
+                            #endif
                         }
                     )
                     .transition(.opacity)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves local builds by preferring a single Apple Development signing identity and isolating local credentials; previously `make local` always used ad‑hoc signing and shared production Keychain entries. Local onboarding now treats the app as licensed to speed testing, and docs focus on `make local` behavior and overrides.

**What to review/test**
- `make local` detects a single Apple Development identity and sets `CODE_SIGNING_REQUIRED=YES`; falls back to ad‑hoc with a clear message. Override with `LOCAL_CODESIGN_IDENTITY=<SHA or name>`; use `LOCAL_CODESIGN_IDENTITY=-` to force ad‑hoc. Ad‑hoc builds may prompt for macOS permissions after rebuilds.
- Local Keychain namespace under `LOCAL_BUILD`: service `com.prakashjoshipax.VoiceInk.Local` in the login Keychain (no sync). Automatically migrates from `UserDefaults` keys prefixed `LocalKeychain_` on first read and removes legacy copies after save/delete. Production keychain behavior is unchanged.
- Onboarding under `LOCAL_BUILD`: license is considered verified, license step is skipped, and “Continue” completes onboarding once transcription is ready.
- BUILDING.md is simplified: highlights `make local`, lists command shortcuts, and notes that local builds exclude iCloud dictionary sync and automatic updates.

**Rollout**
- No production migration required; existing local credentials migrate automatically.
- Developer action (optional): set `LOCAL_CODESIGN_IDENTITY` to select a stable identity or `-` to force ad‑hoc.

<sup>Written for commit f26d902885b26d8a5b19b7c95e47ee3b12eef614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

