### PR TITLE
Rebuild the recorder panel instead of reusing it for the app's lifetime

### DIFF
--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 import os
@@ -58,6 +59,8 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
 
     private var notchWindowManager: NotchWindowManager?
     private var miniWindowManager: MiniWindowManager?
+    private var panelInvalidationTask: Task<Void, Never>?
+    private var didSetupNotifications = false
 
     private weak var engine: VoiceInkEngine?
     private var recorder: Recorder?
@@ -65,6 +68,11 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "RecorderUIManager")
 
     init() {}
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
+    }
 
     /// Call after VoiceInkEngine is created to break the circular init dependency.
     func configure(engine: VoiceInkEngine, recorder: Recorder) {
@@ -77,6 +85,8 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
 
     private func showRecorderPanel() {
         guard let engine = engine, let recorder = recorder else { return }
+
+        let shown: Bool
 
         switch recorderPanelStyle {
         case .notch:
@@ -102,7 +112,7 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
                     }
                 )
             }
-            notchWindowManager?.show()
+            shown = notchWindowManager?.show() ?? false
         case .mini:
             if miniWindowManager == nil {
                 miniWindowManager = MiniWindowManager(
@@ -126,17 +136,65 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
                     }
                 )
             }
-            miniWindowManager?.show()
+            shown = miniWindowManager?.show() ?? false
+        }
+
+        if shown {
+            logger.notice("Showed recorder panel style=\(self.recorderPanelStyle.rawValue, privacy: .public)")
+        } else {
+            // Only reachable with no screens at all. Recording still works, so the session is
+            // left running rather than cancelled, but it runs without any UI — say so loudly,
+            // because this is exactly the symptom users report.
+            logger.error("Recorder panel could not be shown style=\(self.recorderPanelStyle.rawValue, privacy: .public) screens=\(NSScreen.screens.count, privacy: .public)")
         }
     }
 
     private func hideRecorderPanel() {
+        // `dismissRecorderPanel()` calls this directly and then clears the flag, which calls it
+        // again, so this deliberately stays at debug level.
+        logger.debug("Hiding recorder panel style=\(self.recorderPanelStyle.rawValue, privacy: .public)")
         switch recorderPanelStyle {
         case .notch:
             notchWindowManager?.hide()
         case .mini:
             miniWindowManager?.hide()
         }
+    }
+
+    // MARK: - Panel Invalidation
+
+    /// Recorder panels must not outlive a sleep/wake cycle or a display reconfiguration.
+    ///
+    /// `NotchWindowManager.show()` already rebuilds a panel that is not on screen, so the work
+    /// here is only about the panel that is currently *hidden but retained*: dropping it frees
+    /// the window early and keeps `destroyWindow()` on a path that actually runs. When a
+    /// dictation is in progress the panel stays put and is only repositioned, so an active
+    /// session never loses its UI.
+    ///
+    /// `didChangeScreenParameters` fires several times per reconfiguration and displays need a
+    /// moment to settle afterwards, so the work is debounced and re-armed on every event
+    /// instead of guessing a single settle delay.
+    private func invalidatePanels(reason: String) {
+        panelInvalidationTask?.cancel()
+        panelInvalidationTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            guard !Task.isCancelled, let self else { return }
+            self.applyPanelInvalidation(reason: reason)
+        }
+    }
+
+    private func applyPanelInvalidation(reason: String) {
+        guard isRecorderPanelVisible else {
+            logger.notice("Discarding idle recorder panels (\(reason, privacy: .public))")
+            notchWindowManager?.destroyWindow()
+            notchWindowManager = nil
+            miniWindowManager?.destroyWindow()
+            miniWindowManager = nil
+            return
+        }
+
+        logger.notice("Repositioning visible recorder panel (\(reason, privacy: .public))")
+        showRecorderPanel()
     }
 
     private func rebuildVisiblePanel(previousStyle: RecorderPanelStyle) {
@@ -153,7 +211,8 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
 
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 50_000_000)
-            showRecorderPanel()
+            guard self.isRecorderPanelVisible else { return }
+            self.showRecorderPanel()
         }
     }
 
@@ -214,6 +273,9 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
     // MARK: - Notification Handling
 
     private func setupNotifications() {
+        guard !didSetupNotifications else { return }
+        didSetupNotifications = true
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleToggleRecorderPanelNotification),
@@ -226,6 +288,44 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
             name: .dismissRecorderPanel,
             object: nil
         )
+        // System sleep and display-only sleep are separate notifications, and a laptop hits
+        // display sleep far more often than system sleep.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleSystemDidWake),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleScreensDidWake),
+            name: NSWorkspace.screensDidWakeNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScreenParametersChange),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleSystemDidWake() {
+        Task { @MainActor in
+            self.invalidatePanels(reason: "system wake")
+        }
+    }
+
+    @objc private func handleScreensDidWake() {
+        Task { @MainActor in
+            self.invalidatePanels(reason: "displays wake")
+        }
+    }
+
+    @objc private func handleScreenParametersChange() {
+        Task { @MainActor in
+            self.invalidatePanels(reason: "screen parameters changed")
+        }
     }
 
     @objc public func handleToggleRecorderPanelNotification() {

--- a/VoiceInk/Views/Recorder/MiniRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/MiniRecorderPanel.swift
@@ -1,9 +1,12 @@
 import AppKit
 import SwiftUI
+import os
 
 class MiniRecorderPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
+
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MiniRecorderPanel")
 
     init(contentRect: NSRect) {
         super.init(
@@ -31,13 +34,13 @@ class MiniRecorderPanel: NSPanel {
         standardWindowButton(.closeButton)?.isHidden = true
     }
 
-    static func calculateWindowMetrics() -> NSRect {
+    /// Returns `nil` when there is no screen at all, so callers can skip showing the panel
+    /// instead of placing it at the global origin.
+    static func calculateWindowMetrics() -> NSRect? {
         let width: CGFloat = 540
         let height: CGFloat = 430
 
-        guard let screen = NSScreen.main else {
-            return NSRect(x: 0, y: 0, width: width, height: height)
-        }
+        guard let screen = RecorderScreenResolver.resolve() else { return nil }
 
         // Host stays large enough for assistant output; SwiftUI controls the visible mini width.
         let padding: CGFloat = 24
@@ -55,10 +58,23 @@ class MiniRecorderPanel: NSPanel {
         )
     }
 
-    func show() {
-        let metrics = MiniRecorderPanel.calculateWindowMetrics()
+    @discardableResult
+    func show() -> Bool {
+        guard let metrics = MiniRecorderPanel.calculateWindowMetrics() else {
+            logger.error("Mini panel show skipped: no screen available")
+            return false
+        }
+
         setFrame(metrics, display: true)
         orderFrontRegardless()
+
+        logger.notice(
+            "Mini panel frame=\(NSStringFromRect(self.frame), privacy: .public) screens=\(NSScreen.screens.count, privacy: .public) onActiveSpace=\(self.isOnActiveSpace, privacy: .public)"
+        )
+        return true
     }
 
+    deinit {
+        logger.debug("Mini panel deallocated")
+    }
 }

--- a/VoiceInk/Views/Recorder/MiniWindowManager.swift
+++ b/VoiceInk/Views/Recorder/MiniWindowManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import os
 
 @MainActor
 class MiniWindowManager {
@@ -7,6 +8,7 @@ class MiniWindowManager {
     private var panel: MiniRecorderPanel?
 
     private let makeView: () -> AnyView
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "MiniWindowManager")
 
     init(
         engine: VoiceInkEngine,
@@ -30,22 +32,43 @@ class MiniWindowManager {
         }
     }
 
-    func show() {
+    /// Builds a fresh panel whenever one is not already on screen.
+    ///
+    /// The panel and its hosting view used to be created once and then reused for the whole
+    /// lifetime of the app, so a window that stopped rendering — after a sleep/wake cycle, a
+    /// display reconfiguration, or any other WindowServer hiccup — kept swallowing every later
+    /// `orderFrontRegardless()`, and only relaunching VoiceInk brought the recorder back.
+    /// A window in that state still reports `isVisible == true` with a sane frame, so there is
+    /// nothing reliable to test for from inside the process. Rebuilding unconditionally removes
+    /// the question: a stale window can never survive into a second dictation. The cost is one
+    /// NSPanel plus one hosting controller per dictation, which is noise next to starting audio
+    /// capture and a transcription session in the same code path.
+    @discardableResult
+    func show() -> Bool {
         if panel == nil { initializeWindow() }
-        panel?.show()
+        guard let panel else { return false }
+        return panel.show()
     }
 
+    /// Tears the window down rather than just ordering it out, so `isVisible` is never used as a
+    /// liveness test and no panel is carried across dictations.
     func hide() {
-        panel?.orderOut(nil)
+        deinitializeWindow()
     }
 
     func destroyWindow() {
         deinitializeWindow()
     }
 
+    // Rebuilding gives the SwiftUI content a new identity, so view-local state inside it is
+    // reset — currently the assistant follow-up draft and its focus. The conversation itself
+    // lives in `AssistantSession`, which is owned by the engine and survives.
     private func initializeWindow() {
         deinitializeWindow()
-        let metrics = MiniRecorderPanel.calculateWindowMetrics()
+        guard let metrics = MiniRecorderPanel.calculateWindowMetrics() else {
+            logger.error("Mini panel not created: no screen available")
+            return
+        }
         let newPanel = MiniRecorderPanel(contentRect: metrics)
         let view = makeView()
         let hostingController = NSHostingController(rootView: view)

--- a/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderPanel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import os
 
 class KeyablePanel: NSPanel {
     override var canBecomeKey: Bool { true }
@@ -10,11 +11,13 @@ class NotchRecorderPanel: KeyablePanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 
-    init(contentRect: NSRect) {
-        let metrics = NotchRecorderPanel.calculateWindowMetrics()
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "NotchRecorderPanel")
 
+    init(contentRect: NSRect) {
+        // Previously this initializer ignored `contentRect` and recomputed the metrics itself.
+        // The only caller passes the metrics it just computed, so behaviour is unchanged.
         super.init(
-            contentRect: metrics.frame,
+            contentRect: contentRect,
             styleMask: [.nonactivatingPanel, .fullSizeContentView, .hudWindow],
             backing: .buffered,
             defer: false
@@ -36,19 +39,12 @@ class NotchRecorderPanel: KeyablePanel {
         self.titleVisibility = .hidden
         self.standardWindowButton(.closeButton)?.isHidden = true
         self.isMovable = false
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleScreenParametersChange),
-            name: NSApplication.didChangeScreenParametersNotification,
-            object: nil
-        )
     }
 
-    static func calculateWindowMetrics() -> (frame: NSRect, notchWidth: CGFloat, notchHeight: CGFloat) {
-        guard let screen = NSScreen.main else {
-            return (NSRect(x: 0, y: 0, width: 280, height: 24), 280, 24)
-        }
+    /// Returns `nil` when there is no screen at all, so callers can skip showing the panel
+    /// instead of placing it at the global origin.
+    static func calculateWindowMetrics() -> (frame: NSRect, notchWidth: CGFloat, notchHeight: CGFloat)? {
+        guard let screen = RecorderScreenResolver.resolve() else { return nil }
 
         let safeAreaInsets = screen.safeAreaInsets
         let notchHeight: CGFloat = safeAreaInsets.top > 0 ? safeAreaInsets.top : NSStatusBar.system.thickness
@@ -74,22 +70,24 @@ class NotchRecorderPanel: KeyablePanel {
         return (frame, notchWidth, notchHeight)
     }
 
-    func show() {
-        let metrics = NotchRecorderPanel.calculateWindowMetrics()
+    @discardableResult
+    func show() -> Bool {
+        guard let metrics = NotchRecorderPanel.calculateWindowMetrics() else {
+            logger.error("Notch panel show skipped: no screen available")
+            return false
+        }
+
         setFrame(metrics.frame, display: true)
         orderFrontRegardless()
-    }
 
-    @objc private func handleScreenParametersChange() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            guard let self else { return }
-            let metrics = NotchRecorderPanel.calculateWindowMetrics()
-            self.setFrame(metrics.frame, display: true)
-        }
+        logger.notice(
+            "Notch panel frame=\(NSStringFromRect(self.frame), privacy: .public) notch=\(metrics.notchWidth, privacy: .public)x\(metrics.notchHeight, privacy: .public) screens=\(NSScreen.screens.count, privacy: .public) onActiveSpace=\(self.isOnActiveSpace, privacy: .public)"
+        )
+        return true
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        logger.debug("Notch panel deallocated")
     }
 }
 

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -8,6 +8,10 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
     let onCloseTapped: () -> Void
     let onAssistantFollowUp: (String) -> Void
     @AppStorage(RecorderDisplaySettingsKeys.showLiveTranscript) private var showLiveTranscript = true
+    /// Bumped on every screen reconfiguration to invalidate the view. The notch metrics below
+    /// come from AppKit, which SwiftUI cannot observe on its own, so without this the view keeps
+    /// whatever sizes it happened to compute the last time it was rendered.
+    @State private var screenGeneration = 0
 
     // MARK: - Display State
 
@@ -36,21 +40,34 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
 
     // MARK: - Screen Geometry
 
-    private var notchWidth: CGFloat {
-        guard let screen = NSScreen.main else { return 180 }
-        if let left = screen.auxiliaryTopLeftArea?.width,
-            let right = screen.auxiliaryTopRightArea?.width
-        {
-            return screen.frame.width - left - right
-        }
-        return 180
+    /// Reads `screenGeneration` so SwiftUI records a dependency on it: the metrics below come
+    /// from AppKit, which it cannot observe, and a view only re-evaluates the parts that depend
+    /// on the state that changed.
+    private var screenMetrics: (width: CGFloat, height: CGFloat) {
+        _ = screenGeneration
+
+        guard let screen = RecorderScreenResolver.resolve() else { return (180, 37) }
+
+        let width: CGFloat = {
+            if let left = screen.auxiliaryTopLeftArea?.width,
+                let right = screen.auxiliaryTopRightArea?.width
+            {
+                return screen.frame.width - left - right
+            }
+            return 180
+        }()
+
+        let height: CGFloat = {
+            if screen.safeAreaInsets.top > 0 { return screen.safeAreaInsets.top }
+            return NSApplication.shared.mainMenu?.menuBarHeight ?? NSStatusBar.system.thickness
+        }()
+
+        return (width, height)
     }
 
-    private var notchHeight: CGFloat {
-        guard let screen = NSScreen.main else { return 37 }
-        if screen.safeAreaInsets.top > 0 { return screen.safeAreaInsets.top }
-        return NSApplication.shared.mainMenu?.menuBarHeight ?? NSStatusBar.system.thickness
-    }
+    private var notchWidth: CGFloat { screenMetrics.width }
+
+    private var notchHeight: CGFloat { screenMetrics.height }
 
     // MARK: - Layout Constants
 
@@ -123,6 +140,11 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
             pill.position(x: geo.size.width / 2, y: pillHeight / 2)
         }
         .animation(pillAnimation, value: displayState)
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+        ) { _ in
+            screenGeneration += 1
+        }
     }
 
     // MARK: - Pill

--- a/VoiceInk/Views/Recorder/NotchWindowManager.swift
+++ b/VoiceInk/Views/Recorder/NotchWindowManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import os
 
 @MainActor
 class NotchWindowManager {
@@ -7,6 +8,7 @@ class NotchWindowManager {
     private var panel: NotchRecorderPanel?
 
     private let makeView: () -> AnyView
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "NotchWindowManager")
 
     init(
         engine: VoiceInkEngine,
@@ -30,22 +32,43 @@ class NotchWindowManager {
         }
     }
 
-    func show() {
+    /// Builds a fresh panel whenever one is not already on screen.
+    ///
+    /// The panel and its hosting view used to be created once and then reused for the whole
+    /// lifetime of the app, so a window that stopped rendering — after a sleep/wake cycle, a
+    /// display reconfiguration, or any other WindowServer hiccup — kept swallowing every later
+    /// `orderFrontRegardless()`, and only relaunching VoiceInk brought the recorder back.
+    /// A window in that state still reports `isVisible == true` with a sane frame, so there is
+    /// nothing reliable to test for from inside the process. Rebuilding unconditionally removes
+    /// the question: a stale window can never survive into a second dictation. The cost is one
+    /// NSPanel plus one hosting controller per dictation, which is noise next to starting audio
+    /// capture and a transcription session in the same code path.
+    @discardableResult
+    func show() -> Bool {
         if panel == nil { initializeWindow() }
-        panel?.show()
+        guard let panel else { return false }
+        return panel.show()
     }
 
+    /// Tears the window down rather than just ordering it out, so `isVisible` is never used as a
+    /// liveness test and no panel is carried across dictations.
     func hide() {
-        panel?.orderOut(nil)
+        deinitializeWindow()
     }
 
     func destroyWindow() {
         deinitializeWindow()
     }
 
+    // Rebuilding gives the SwiftUI content a new identity, so view-local state inside it is
+    // reset — currently the assistant follow-up draft and its focus. The conversation itself
+    // lives in `AssistantSession`, which is owned by the engine and survives.
     private func initializeWindow() {
         deinitializeWindow()
-        let metrics = NotchRecorderPanel.calculateWindowMetrics()
+        guard let metrics = NotchRecorderPanel.calculateWindowMetrics() else {
+            logger.error("Notch panel not created: no screen available")
+            return
+        }
         let newPanel = NotchRecorderPanel(contentRect: metrics.frame)
         let view = makeView()
         let hostingController = NotchRecorderHostingController(rootView: view)

--- a/VoiceInk/Views/Recorder/RecorderScreenResolver.swift
+++ b/VoiceInk/Views/Recorder/RecorderScreenResolver.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+/// Resolves the screen the recorder panel should be placed on.
+///
+/// `NSScreen.main` is the screen containing the window with keyboard focus. VoiceInk is a
+/// menu-bar style app that usually has no key window, so `NSScreen.main` can return `nil` —
+/// most plausibly while displays are asleep or being reconfigured.
+///
+/// The point of this helper is the fallback chain, not the nil case itself: callers must never
+/// fall back to a rect at the global origin, because a transparent, shadowless panel placed at
+/// (0, 0) sits behind the Dock and is indistinguishable from a panel that never appeared.
+enum RecorderScreenResolver {
+    static func resolve() -> NSScreen? {
+        if let main = NSScreen.main { return main }
+
+        let mouseLocation = NSEvent.mouseLocation
+        if let screenUnderMouse = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) }) {
+            return screenUnderMouse
+        }
+
+        return NSScreen.screens.first
+    }
+}


### PR DESCRIPTION
Fixes #898 (and very likely #813, same symptom).

## The bug

After the app has been running for a while, the recorder panel stops appearing entirely. The hotkey works, the start sound plays, audio is recorded, transcription completes and the text is pasted — but no bar is ever drawn. Quitting and relaunching brings it back, and it degrades again after some hours.

## Root cause

The panel and its `NSHostingView` are created once and reused for the entire lifetime of the app. `destroyWindow()` had exactly one caller — `rebuildVisiblePanel(previousStyle:)`, i.e. only when the user switches between `notch` and `mini` in Settings. Nothing recreated the window on sleep/wake or display reconfiguration, so a single `NSPanel` had to survive every sleep/wake cycle for days. Once that window stops rendering, every later `orderFrontRegardless()` is a no-op from the user's point of view, and only a relaunch recovers.

The important part: a window in that state still reports `isVisible == true` with a perfectly sane frame. There is nothing dependable to test for from inside the process — which is also why "add a check and retry" is not a real fix.

## What this changes

**Never reuse a panel across dictations.** `hide()` now tears the window down instead of just ordering it out, and `show()` builds a fresh panel + hosting view. A stale window therefore cannot survive into the next dictation, and `isVisible` is never used as a liveness test. The cost is one `NSPanel` plus one `NSHostingController` per dictation — noise next to starting CoreAudio capture and a transcription session in the same code path.

**Drop idle panels on wake and display changes.** `RecorderUIManager` now observes `NSWorkspace.didWakeNotification`, `NSWorkspace.screensDidWakeNotification` (display-only sleep is a separate notification, and a laptop hits it far more often than system sleep) and `NSApplication.didChangeScreenParametersNotification`. Those arrive in bursts, so the work is debounced through a single cancellable task rather than a fixed delay per event. If a dictation is in progress the panel is repositioned rather than destroyed, so an active session never loses its UI. The notch panel's own reposition observer is gone — screen-change handling now lives in one place.

**Never place the panel at the global origin.** `NSScreen.main` is documented as the screen containing the window with keyboard focus; a menu-bar app usually has no key window, so it can return `nil`. The old fallback was `NSRect(x: 0, y: 0, width: 280, height: 24)` — a transparent, shadowless window at the bottom-left corner behind the Dock, which is indistinguishable from "the bar never appeared". Resolution now falls back to the screen under the pointer and then to the first screen; if there is genuinely no screen, the show is skipped and logged at `error` level instead of drawing off-screen.

**Make the notch geometry react to screen changes.** `notchWidth` / `notchHeight` read AppKit state that SwiftUI cannot observe. They now go through one property that depends on a generation counter bumped on `didChangeScreenParameters`.

**Add logging.** The whole recorder-panel path had no logging at all, which is why the original report could not be confirmed from a user's log — `RecorderUIManager` had a logger but used it only in `resetOnLaunch()`. Show, hide, wake invalidation and failure-to-present are now traceable, with the failure case at `error` level so it survives in an exported log.

Deliberately left alone: `pillHeight == 0` for `.collapsed`. It does contribute to how invisible this failure is, but giving the collapsed pill a minimum height would change idle UX, which does not belong in a bug fix.

## Testing

I have been running this build as my daily driver today: about 7 hours and 43 recorder sessions with no reproduction, where previously it usually came back within an hour. Worth being precise about the limits of that: the last review round landed near the end of that window, so the exact revision in this PR has had less soak time than the branch as a whole, and my Mac did not go through a full system sleep during it — so the wake-invalidation path specifically has had light real-world coverage. The main lever of the fix (rebuild on every show) ran all 43 times. I will keep running it and report back if anything shows up.

## About the review

Full disclosure on how this was produced, since it matters for how carefully you will want to read it: the fix was written by Claude Opus 5 (Claude Code) against my reproduction and log evidence, then reviewed twice by two independent models — first a separate Claude Opus 5 instance, then OpenAI Codex CLI (`gpt-5.6-sol`, `xhigh` reasoning). Both came back "ship with changes" and the changes were applied; the second review overturned one of the first review's conclusions, and the current code follows the second.

**I am not deep enough in this codebase to vouch for it myself, so please review it properly rather than taking the above as a substitute.** In particular I would appreciate your eyes on whether rebuilding the panel on every dictation is acceptable to you, and on whether repositioning-instead-of-rebuilding for an in-progress session is the right trade-off.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the recorder panel on every show and drops idle panels on wake/display changes to prevent the bar from becoming invisible after sleep or screen reconfiguration. Previously one `NSPanel` was reused for the app’s lifetime; once it stopped rendering, `orderFrontRegardless()` drew nothing while `isVisible` remained true.

- Build per-dictation panel: `show()` creates a fresh window and returns a Bool; `hide()` destroys the window. This removes reliance on `isVisible` and prevents stale panels from persisting.
- Centralize screen-change handling: `RecorderUIManager` observes system/display wake and screen-parameter changes, debounces invalidation, destroys idle panels, and repositions the visible panel; the notch panel’s own observer is removed.
- Resolve screen safely via `RecorderScreenResolver`: fall back to the screen under the pointer, then the first screen; skip showing when no screen exists instead of placing at the global origin behind the Dock.
- Make notch geometry reactive: `NotchRecorderView` re-reads AppKit metrics via a generation counter on screen changes.
- Add logging across show/hide/invalidation and failures; failure-to-present logs at error level so sessions without UI are traceable.
- Side effects to note: creating a new panel per dictation resets view-local SwiftUI state inside the panel; engine-owned conversation state persists. If no screens are available, recording continues without UI and logs an error.

<sup>Written for commit 1db3681217d924bc0a822288933b80724f664157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

