### PR TITLE
Improve Escape recording cancellation behavior

### DIFF
--- a/VoiceInk/Shortcuts/RecorderPanelShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecorderPanelShortcutManager.swift
@@ -13,6 +13,7 @@ final class RecorderPanelShortcutManager: ObservableObject {
     private var firstEscapePressTime: Date? = nil
     private let escapeDoublePressThreshold: TimeInterval = 1.5
     private var escapeTimeoutTask: Task<Void, Never>?
+    private var activeEscapePressID: UUID?
     private var isEscapeConfirmationHintVisible = false
 
     private static let escapeConfirmationHintShownKey = "hasShownEscapeCancelConfirmationHint"
@@ -66,6 +67,7 @@ final class RecorderPanelShortcutManager: ObservableObject {
 
     private func resetEscapeState() {
         firstEscapePressTime = nil
+        activeEscapePressID = nil
         escapeTimeoutTask?.cancel()
         escapeTimeoutTask = nil
 
@@ -136,7 +138,9 @@ final class RecorderPanelShortcutManager: ObservableObject {
             return
         }
 
+        let escapePressID = UUID()
         firstEscapePressTime = now
+        activeEscapePressID = escapePressID
         showEscapeConfirmationHintIfNeeded()
         escapeTimeoutTask = Task { [weak self] in
             do {
@@ -148,7 +152,9 @@ final class RecorderPanelShortcutManager: ObservableObject {
             }
 
             await MainActor.run {
+                guard self?.activeEscapePressID == escapePressID else { return }
                 self?.firstEscapePressTime = nil
+                self?.activeEscapePressID = nil
                 self?.escapeTimeoutTask = nil
                 self?.isEscapeConfirmationHintVisible = false
             }

--- a/VoiceInk/Shortcuts/RecorderPanelShortcutManager.swift
+++ b/VoiceInk/Shortcuts/RecorderPanelShortcutManager.swift
@@ -13,6 +13,13 @@ final class RecorderPanelShortcutManager: ObservableObject {
     private var firstEscapePressTime: Date? = nil
     private let escapeDoublePressThreshold: TimeInterval = 1.5
     private var escapeTimeoutTask: Task<Void, Never>?
+    private var isEscapeConfirmationHintVisible = false
+
+    private static let escapeConfirmationHintShownKey = "hasShownEscapeCancelConfirmationHint"
+
+    static func resetEscapeConfirmationHint() {
+        UserDefaults.standard.removeObject(forKey: escapeConfirmationHintShownKey)
+    }
 
     init(recorderUIManager: RecorderUIManager) {
         self.recorderUIManager = recorderUIManager
@@ -34,6 +41,7 @@ final class RecorderPanelShortcutManager: ObservableObject {
             }
 
             Task { @MainActor in
+                self?.resetEscapeState()
                 self?.refreshVisibleShortcuts()
             }
         }
@@ -60,6 +68,11 @@ final class RecorderPanelShortcutManager: ObservableObject {
         firstEscapePressTime = nil
         escapeTimeoutTask?.cancel()
         escapeTimeoutTask = nil
+
+        if isEscapeConfirmationHintVisible {
+            isEscapeConfirmationHintVisible = false
+            NotificationManager.shared.dismissNotification()
+        }
     }
 
     private func refreshVisibleShortcuts() {
@@ -124,17 +137,35 @@ final class RecorderPanelShortcutManager: ObservableObject {
         }
 
         firstEscapePressTime = now
+        showEscapeConfirmationHintIfNeeded()
+        escapeTimeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(
+                    nanoseconds: UInt64((self?.escapeDoublePressThreshold ?? 1.5) * 1_000_000_000)
+                )
+            } catch {
+                return
+            }
+
+            await MainActor.run {
+                self?.firstEscapePressTime = nil
+                self?.escapeTimeoutTask = nil
+                self?.isEscapeConfirmationHintVisible = false
+            }
+        }
+    }
+
+    private func showEscapeConfirmationHintIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.escapeConfirmationHintShownKey) else { return }
+
+        defaults.set(true, forKey: Self.escapeConfirmationHintShownKey)
+        isEscapeConfirmationHintVisible = true
         NotificationManager.shared.showNotification(
             title: String(localized: "Press Esc again to cancel"),
             type: .info,
             duration: escapeDoublePressThreshold
         )
-        escapeTimeoutTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64((self?.escapeDoublePressThreshold ?? 1.5) * 1_000_000_000))
-            await MainActor.run {
-                self?.firstEscapePressTime = nil
-            }
-        }
     }
 
     private func handleModeSelectionShortcut(index: Int) {

--- a/VoiceInk/Shortcuts/ShortcutRecorder.swift
+++ b/VoiceInk/Shortcuts/ShortcutRecorder.swift
@@ -260,7 +260,13 @@ final class ShortcutRecorderModel: ObservableObject {
         let modifiers = Shortcut.normalizedModifierFlags(modifierFlags, forKeyCode: keyCode)
 
         if keyCode == UInt16(kVK_Escape), modifiers.isEmpty {
-            cancel()
+            if activeAction == .cancelRecorder {
+                let shortcut = Shortcut.key(keyCode: keyCode, modifierFlags: modifiers)
+                previewShortcut = shortcut
+                finish(with: shortcut)
+            } else {
+                cancel()
+            }
             return true
         }
 

--- a/VoiceInk/Shortcuts/ShortcutValidator.swift
+++ b/VoiceInk/Shortcuts/ShortcutValidator.swift
@@ -23,7 +23,7 @@ enum ShortcutValidationError: Equatable {
 
 enum ShortcutValidator {
     static func validationError(for shortcut: Shortcut, action: ShortcutAction) -> ShortcutValidationError? {
-        if let error = userRecordingShortcutError(for: shortcut) {
+        if let error = userRecordingShortcutError(for: shortcut, action: action) {
             return error
         }
 
@@ -42,11 +42,21 @@ enum ShortcutValidator {
         return nil
     }
 
-    private static func userRecordingShortcutError(for shortcut: Shortcut) -> ShortcutValidationError? {
+    private static func userRecordingShortcutError(
+        for shortcut: Shortcut,
+        action: ShortcutAction
+    ) -> ShortcutValidationError? {
         switch shortcut.kind {
         case .modifierOnly:
             return shortcut.modifierFlags.isEmpty ? .plainKeyRequiresModifier : nil
         case .key:
+            if action == .cancelRecorder,
+                shortcut.keyCode == UInt16(kVK_Escape),
+                shortcut.modifierFlags.isEmpty
+            {
+                return nil
+            }
+
             if Shortcut.isFunctionKeyCode(shortcut.keyCode) {
                 return nil
             }

--- a/VoiceInk/Views/Settings/SettingsView.swift
+++ b/VoiceInk/Views/Settings/SettingsView.swift
@@ -25,7 +25,6 @@ struct SettingsView: View {
     @AppStorage(RecorderDisplaySettingsKeys.showLiveTranscript) private var showLiveTranscript = true
     @State private var showResetOnboardingAlert = false
     @State private var showLanguageRestartAlert = false
-    @State private var hasCancelRecordingShortcut = ShortcutStore.shortcut(for: .cancelRecorder) != nil
     @State private var cancelRecordingShortcutRecorderResetID = 0
 
     @State private var isMiddleClickExpanded = false
@@ -98,20 +97,18 @@ struct SettingsView: View {
                     .controlSize(.small)
                 }
 
-                LabeledContent("Cancel Recording") {
+                LabeledContent {
                     HStack(spacing: 8) {
                         ShortcutRecorder(
                             action: .cancelRecorder,
                             defaultShortcut: Self.defaultCancelRecordingShortcut
-                        ) {
-                            hasCancelRecordingShortcut = true
-                        }
+                        )
                         .id(cancelRecordingShortcutRecorderResetID)
                         .controlSize(.small)
 
                         Button {
+                            RecorderPanelShortcutManager.resetEscapeConfirmationHint()
                             ShortcutStore.setShortcut(nil, for: .cancelRecorder)
-                            hasCancelRecordingShortcut = false
                             cancelRecordingShortcutRecorderResetID += 1
                         } label: {
                             Image(systemName: "arrow.counterclockwise")
@@ -119,10 +116,13 @@ struct SettingsView: View {
                         .buttonStyle(.plain)
                         .help("Reset to default")
                     }
-                }
-                .onReceive(NotificationCenter.default.publisher(for: ShortcutStore.shortcutDidChange)) { notification in
-                    guard let action = notification.object as? ShortcutAction, action == .cancelRecorder else { return }
-                    hasCancelRecordingShortcut = ShortcutStore.shortcut(for: .cancelRecorder) != nil
+                } label: {
+                    HStack(spacing: 2) {
+                        Text("Cancel Recording")
+                        InfoTip(
+                            "The assigned shortcut cancels the recording. Resetting restores the default double-Escape behavior."
+                        )
+                    }
                 }
 
                 ExpandableSettingsRow(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changes how Escape behaves during shortcut recording so the Cancel Recording action can be assigned to plain Escape instead of always aborting the recording.

- Pressing Escape now records it as the shortcut when the active action is Cancel Recording; for all other actions it still cancels.
- The shortcut validator now allows a plain, unmodified Escape for Cancel Recording.
- The "Press Esc again to cancel" hint now shows only once per install instead of on every Escape press.
- Resetting the Cancel Recording shortcut in Settings restores the double-Escape hint.
- Escape-timer state is cleared on panel refresh, and the timeout is guarded by a press ID so a stale timer can't clear a newer press's state.

**Migration**
- Users who previously assigned an Escape-based shortcut to Cancel Recording may need to re-record it.

<sup>Written for commit 59e62656304ac4d281d35e221d41f6d83b21949f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

