### PR TITLE
Centralize lifecycle events for audio recovery

### DIFF
--- a/VoiceInk/CoreAudioRecorder.swift
+++ b/VoiceInk/CoreAudioRecorder.swift
@@ -167,6 +167,16 @@ final class CoreAudioRecorder: @unchecked Sendable {
         }
     }
 
+    /// Discards an idle prepared AUHAL so the next recording creates a fresh connection.
+    /// Active recordings keep their existing device-switching lifecycle.
+    func invalidatePreparation() {
+        guard !isRecording, audioUnit != nil else { return }
+
+        teardownPreparedAudioUnit()
+        currentDeviceID = 0
+        resetMeters()
+    }
+
     /// Starts recording from the specified device to the given URL (WAV format)
     func startRecording(toOutputFile url: URL, deviceID: AudioDeviceID) throws {
         // Stop any existing recording

--- a/VoiceInk/Recorder.swift
+++ b/VoiceInk/Recorder.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import CoreAudio
 import Foundation
 import os
@@ -8,7 +9,7 @@ class Recorder: NSObject, ObservableObject {
     var recorder: CoreAudioRecorder?
     let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "Recorder")
     let deviceManager = AudioDeviceManager.shared
-    private var audioDeviceChangedObserver: NSObjectProtocol?
+    private var lifecycleCancellable: AnyCancellable?
     var recordingDeviceChangeObserver: NSObjectProtocol?
     private let mediaController = MediaController.shared
     private let playbackController = PlaybackController.shared
@@ -35,22 +36,15 @@ class Recorder: NSObject, ObservableObject {
 
     override init() {
         super.init()
-        setupAudioDeviceChangedObserver()
-        setupRecordingDeviceChangeObserver()
-        schedulePrepareForCurrentDevice(reason: "init")
-    }
-
-    private func setupAudioDeviceChangedObserver() {
-        audioDeviceChangedObserver = NotificationCenter.default.addObserver(
-            forName: Notification.Name("AudioDeviceChanged"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        lifecycleCancellable = LifecycleObserver.shared.publisher(
+            for: [.audioDeviceChanged, .systemWillSleep, .systemDidWake]
+        ).sink { [weak self] _ in
             Task { @MainActor in
-                guard let self, !self.deviceManager.isRecordingActive else { return }
-                self.schedulePrepareForCurrentDevice(reason: "device-changed")
+                self?.invalidatePreparedAudioUnit()
             }
         }
+        setupRecordingDeviceChangeObserver()
+        schedulePrepareForCurrentDevice(reason: "init")
     }
 
     func startRecording(toOutputFile url: URL) async throws {
@@ -174,6 +168,13 @@ class Recorder: NSObject, ObservableObject {
         }
     }
 
+    private func invalidatePreparedAudioUnit() {
+        guard let coreAudioRecorder = recorder else { return }
+        audioSetupQueue.async {
+            coreAudioRecorder.invalidatePreparation()
+        }
+    }
+
     func audioMeterSnapshot() -> AudioMeter {
         guard let recorder else {
             return AudioMeter(averagePower: 0, peakPower: 0)
@@ -231,9 +232,6 @@ class Recorder: NSObject, ObservableObject {
         audioMuteTask?.cancel()
         mediaPauseTask?.cancel()
         audioRestorationTask?.cancel()
-        if let observer = audioDeviceChangedObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
         if let observer = recordingDeviceChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/VoiceInk/Services/AudioDeviceConfiguration.swift
+++ b/VoiceInk/Services/AudioDeviceConfiguration.swift
@@ -30,17 +30,4 @@ class AudioDeviceConfiguration {
         }
         return defaultDeviceID
     }
-
-    /// Creates a device change observer that calls handler on the specified queue
-    static func createDeviceChangeObserver(
-        handler: @escaping () -> Void,
-        queue: OperationQueue = .main
-    ) -> NSObjectProtocol {
-        return NotificationCenter.default.addObserver(
-            forName: NSNotification.Name("AudioDeviceChanged"),
-            object: nil,
-            queue: queue,
-            using: { _ in handler() }
-        )
-    }
 }

--- a/VoiceInk/Services/LifecycleObserver.swift
+++ b/VoiceInk/Services/LifecycleObserver.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Combine
+import Foundation
+
+@MainActor
+final class LifecycleObserver {
+    static let shared = LifecycleObserver()
+
+    enum Event: Hashable {
+        case audioDeviceChanged
+        case systemWillSleep
+        case systemDidWake
+        case displaysDidWake
+        case applicationDidBecomeActive
+        case screenConfigurationChanged
+    }
+
+    private let events = PassthroughSubject<Event, Never>()
+    private var defaultCenterObservers: [NSObjectProtocol] = []
+    private var workspaceObservers: [NSObjectProtocol] = []
+
+    private init() {
+        observeDefaultCenter(
+            Notification.Name("AudioDeviceChanged"),
+            as: .audioDeviceChanged
+        )
+        observeDefaultCenter(
+            NSApplication.didBecomeActiveNotification,
+            as: .applicationDidBecomeActive
+        )
+        observeDefaultCenter(
+            NSApplication.didChangeScreenParametersNotification,
+            as: .screenConfigurationChanged
+        )
+
+        observeWorkspace(
+            NSWorkspace.willSleepNotification,
+            as: .systemWillSleep
+        )
+        observeWorkspace(
+            NSWorkspace.didWakeNotification,
+            as: .systemDidWake
+        )
+        observeWorkspace(
+            NSWorkspace.screensDidWakeNotification,
+            as: .displaysDidWake
+        )
+    }
+
+    func publisher(for event: Event) -> AnyPublisher<Event, Never> {
+        publisher(for: [event])
+    }
+
+    func publisher(for selectedEvents: Set<Event>) -> AnyPublisher<Event, Never> {
+        events
+            .filter { selectedEvents.contains($0) }
+            .eraseToAnyPublisher()
+    }
+
+    private func observeDefaultCenter(_ name: Notification.Name, as event: Event) {
+        let observer = NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.events.send(event)
+            }
+        }
+        defaultCenterObservers.append(observer)
+    }
+
+    private func observeWorkspace(_ name: Notification.Name, as event: Event) {
+        let observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.events.send(event)
+            }
+        }
+        workspaceObservers.append(observer)
+    }
+
+    deinit {
+        for observer in defaultCenterObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+
+        let workspaceNotifications = NSWorkspace.shared.notificationCenter
+        for observer in workspaceObservers {
+            workspaceNotifications.removeObserver(observer)
+        }
+    }
+}

--- a/VoiceInk/Services/ModelPrewarmService.swift
+++ b/VoiceInk/Services/ModelPrewarmService.swift
@@ -1,4 +1,4 @@
-import AppKit
+import Combine
 import Foundation
 import SwiftData
 import os
@@ -16,6 +16,7 @@ final class ModelPrewarmService: ObservableObject {
     )
     private let prewarmAudioURL = Bundle.main.url(forResource: "sound7", withExtension: "wav")
     private let prewarmEnabledKey = "PrewarmModelOnWake"
+    private var lifecycleCancellable: AnyCancellable?
 
     init(
         transcriptionModelManager: TranscriptionModelManager, whisperModelManager: WhisperModelManager,
@@ -24,24 +25,13 @@ final class ModelPrewarmService: ObservableObject {
         self.transcriptionModelManager = transcriptionModelManager
         self.whisperModelManager = whisperModelManager
         self.modelContext = modelContext
-        setupNotifications()
+        lifecycleCancellable = LifecycleObserver.shared.publisher(for: .systemDidWake).sink {
+            [weak self] _ in
+            Task { @MainActor in
+                self?.schedulePrewarm()
+            }
+        }
         schedulePrewarmOnAppLaunch()
-    }
-
-    // MARK: - Notification Setup
-
-    private func setupNotifications() {
-        let center = NSWorkspace.shared.notificationCenter
-
-        // Trigger on wake from sleep
-        center.addObserver(
-            self,
-            selector: #selector(schedulePrewarm),
-            name: NSWorkspace.didWakeNotification,
-            object: nil
-        )
-
-        logger.notice("ModelPrewarmService initialized - listening for wake and app launch")
     }
 
     // MARK: - Trigger Handlers
@@ -56,7 +46,7 @@ final class ModelPrewarmService: ObservableObject {
     }
 
     /// Trigger on wake from sleep or screen unlock
-    @objc private func schedulePrewarm() {
+    private func schedulePrewarm() {
         logger.notice("Mac activity detected (wake/unlock), scheduling prewarm")
         Task {
             try? await Task.sleep(for: .seconds(3))
@@ -130,8 +120,4 @@ final class ModelPrewarmService: ObservableObject {
         }
     }
 
-    deinit {
-        NSWorkspace.shared.notificationCenter.removeObserver(self)
-        logger.notice("ModelPrewarmService deinitialized")
-    }
 }

--- a/VoiceInk/Transcription/Engine/RecorderUIManager.swift
+++ b/VoiceInk/Transcription/Engine/RecorderUIManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 import SwiftUI
 import os
@@ -61,6 +62,7 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
     private var miniWindowManager: MiniWindowManager?
     private var panelInvalidationTask: Task<Void, Never>?
     private var didSetupNotifications = false
+    private var lifecycleCancellable: AnyCancellable?
 
     private weak var engine: VoiceInkEngine?
     private var recorder: Recorder?
@@ -71,7 +73,6 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
 
     /// Call after VoiceInkEngine is created to break the circular init dependency.
@@ -288,43 +289,22 @@ class RecorderUIManager: ObservableObject, RecorderPanelPresenting {
             name: .dismissRecorderPanel,
             object: nil
         )
-        // System sleep and display-only sleep are separate notifications, and a laptop hits
-        // display sleep far more often than system sleep.
-        NSWorkspace.shared.notificationCenter.addObserver(
-            self,
-            selector: #selector(handleSystemDidWake),
-            name: NSWorkspace.didWakeNotification,
-            object: nil
-        )
-        NSWorkspace.shared.notificationCenter.addObserver(
-            self,
-            selector: #selector(handleScreensDidWake),
-            name: NSWorkspace.screensDidWakeNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleScreenParametersChange),
-            name: NSApplication.didChangeScreenParametersNotification,
-            object: nil
-        )
-    }
-
-    @objc private func handleSystemDidWake() {
-        Task { @MainActor in
-            self.invalidatePanels(reason: "system wake")
-        }
-    }
-
-    @objc private func handleScreensDidWake() {
-        Task { @MainActor in
-            self.invalidatePanels(reason: "displays wake")
-        }
-    }
-
-    @objc private func handleScreenParametersChange() {
-        Task { @MainActor in
-            self.invalidatePanels(reason: "screen parameters changed")
+        lifecycleCancellable = LifecycleObserver.shared.publisher(
+            for: [.systemDidWake, .displaysDidWake, .screenConfigurationChanged]
+        ).sink { [weak self] event in
+            Task { @MainActor in
+                guard let self else { return }
+                switch event {
+                case .systemDidWake:
+                    self.invalidatePanels(reason: "system wake")
+                case .displaysDidWake:
+                    self.invalidatePanels(reason: "displays wake")
+                case .screenConfigurationChanged:
+                    self.invalidatePanels(reason: "screen parameters changed")
+                default:
+                    break
+                }
+            }
         }
     }
 

--- a/VoiceInk/Views/Dashboard/DashboardContent.swift
+++ b/VoiceInk/Views/Dashboard/DashboardContent.swift
@@ -97,7 +97,7 @@ struct DashboardContent: View {
             refreshAccessibilityStatus()
             updaterViewModel.checkForUpdatesIfDue()
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+        .onReceive(LifecycleObserver.shared.publisher(for: .applicationDidBecomeActive)) { _ in
             refreshAccessibilityStatus()
         }
         .onReceive(NotificationCenter.default.publisher(for: .sessionMetricsDidChange)) { _ in

--- a/VoiceInk/Views/Onboarding/OnboardingView.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingView.swift
@@ -241,7 +241,7 @@ struct OnboardingView: View {
         .onDisappear {
             coordinator.permissions.cancelRefreshTask()
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+        .onReceive(LifecycleObserver.shared.publisher(for: .applicationDidBecomeActive)) { _ in
             coordinator.permissions.refreshPermissionStatuses()
             coordinator.flow.refreshTranscriptionSetupVerification()
             let refreshedTranscriptionSetupReady = coordinator.isTranscriptionSetupReady(

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -141,7 +141,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
         }
         .animation(pillAnimation, value: displayState)
         .onReceive(
-            NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            LifecycleObserver.shared.publisher(for: .screenConfigurationChanged)
         ) { _ in
             screenGeneration += 1
         }

--- a/VoiceInk/VoiceInk.swift
+++ b/VoiceInk/VoiceInk.swift
@@ -354,10 +354,11 @@ struct VoiceInkApp: App {
                 }
             }
             .confettiCelebrationPresenter()
-            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-                licenseViewModel.refreshLicenseState()
-            }
-            .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)) { _ in
+            .onReceive(
+                LifecycleObserver.shared.publisher(
+                    for: [.applicationDidBecomeActive, .systemDidWake]
+                )
+            ) { _ in
                 licenseViewModel.refreshLicenseState()
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralizes lifecycle event subscriptions into a shared `LifecycleObserver` and uses it to invalidate idle prepared audio units, so recordings after device changes or sleep/wake create a fresh audio connection instead of reusing a stale one.

**Bug Fixes**
- Discards the prepared AUHAL when the audio device changes or when the system sleeps or wakes.
- `Recorder` now invalidates the prepared unit on these events instead of re-preparing on device change only.

**Refactors**
- Moves all system, workspace, and app lifecycle observation in `Recorder`, `ModelPrewarmService`, `RecorderUIManager`, and app views to the shared `LifecycleObserver`.
- Removes the duplicated device-change observer helper from `AudioDeviceConfiguration`.

<sup>Written for commit c7496e62d1b2b067132a361a6a2b2eb1bd82c961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

