### PR TITLE
Add SenseVoice Small transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ If you encounter any issues or have questions, please:
 ### Core Technology
 - [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - High-performance inference of OpenAI's Whisper model
 - [FluidAudio](https://github.com/FluidInference/FluidAudio) - Used for Parakeet model implementation
-- [TranscribeCpp for Swift](https://github.com/Beingpax/Transcribe-cpp-swift) - SwiftPM distribution of [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp), used for Cohere Transcribe
+- [TranscribeCpp for Swift](https://github.com/Beingpax/Transcribe-cpp-swift) - SwiftPM distribution of [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp), used for local GGUF transcription models
+- [SenseVoice Small](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) by FunAudioLLM / Alibaba - Multilingual model available under the [FunASR Model Open Source License Agreement](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE)
 
 ### Essential Dependencies
 - [Sparkle](https://github.com/sparkle-project/Sparkle) - Keeping VoiceInk up to date

--- a/VoiceInk/Models/LanguageDictionary.swift
+++ b/VoiceInk/Models/LanguageDictionary.swift
@@ -134,6 +134,11 @@ enum LanguageDictionary {
         "ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh",
     ])
 
+    static let senseVoiceSmall = forCodes(
+        ["en", "ja", "ko", "yue", "zh"],
+        includesAutoDetect: true
+    )
+
     private static func languages(matching codes: Set<String>) -> [String: String] {
         all.filter { codes.contains($0.key) }
     }

--- a/VoiceInk/Models/TranscriptionModelRegistry.swift
+++ b/VoiceInk/Models/TranscriptionModelRegistry.swift
@@ -85,6 +85,17 @@ enum TranscriptionModelRegistry {
                 publisher: "Cohere",
                 supportedLanguages: LanguageDictionary.cohereTranscribe
             ),
+            TranscribeCppModel(
+                name: "sensevoice-small",
+                displayName: "SenseVoice Small",
+                description: "Fast CJK and English transcription that runs privately on your Mac",
+                size: "241 MB",
+                speed: 0.99,
+                accuracy: 0.92,
+                ramUsage: 0.5,
+                publisher: "FunAudioLLM / Alibaba",
+                supportedLanguages: LanguageDictionary.senseVoiceSmall
+            ),
 
             // Local Models
             WhisperModel(

--- a/VoiceInk/Transcription/TranscribeCpp/OfflineTranscribeCppService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/OfflineTranscribeCppService.swift
@@ -4,7 +4,8 @@ import Foundation
 import TranscribeCpp
 import os
 
-final class CohereTranscriptionService: TranscriptionService, @unchecked Sendable {
+/// Shared offline runtime for catalog-backed transcribe.cpp model families.
+final class OfflineTranscribeCppService: TranscriptionService, @unchecked Sendable {
     private struct LoadedState {
         let modelName: String
         let model: Model
@@ -34,7 +35,7 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     private let audioConverter = AudioConverter()
     private let logger = Logger(
         subsystem: "com.prakashjoshipax.voiceink",
-        category: "CohereTranscriptionService"
+        category: "OfflineTranscribeCppService"
     )
 
     init() {
@@ -94,7 +95,7 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     ) async throws -> String {
         guard let transcribeCppModel = model as? TranscribeCppModel else {
             throw NSError(
-                domain: "CohereTranscriptionService",
+                domain: "OfflineTranscribeCppService",
                 code: -1,
                 userInfo: [NSLocalizedDescriptionKey: "Unsupported transcription model"]
             )
@@ -107,16 +108,25 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
 
         let samples = try audioConverter.resampleAudioFile(audioURL)
         let language = selectedLanguage(context.language, for: transcribeCppModel)
-        let options = RunOptions(timestamps: .none, language: language)
+        let options = RunOptions(
+            timestamps: .none,
+            itn: artifact.enablesInverseTextNormalization ? .on : .default,
+            language: language,
+            keepSpecialTags: false
+        )
+        let maximumChunkSeconds = effectiveMaximumChunkSeconds(
+            configuredMaximum: artifact.maximumChunkSeconds,
+            capabilitiesMaximumMilliseconds: nativeModel.capabilities.maxAudioMs
+        )
         let chunks = samples.energyAwareChunks(
-            maximumCount: artifact.maximumChunkSeconds * 16_000,
+            maximumCount: maximumChunkSeconds * 16_000,
             boundarySearchCount: artifact.boundarySearchSeconds * 16_000,
             energyWindowCount: artifact.boundaryEnergyWindowSamples
         )
 
         let startedAt = ContinuousClock.now
-        var texts: [String] = []
-        texts.reserveCapacity(chunks.count)
+        var chunkTranscripts: [(text: String, language: String?)] = []
+        chunkTranscripts.reserveCapacity(chunks.count)
 
         for chunk in chunks {
             try Task.checkCancellation()
@@ -124,14 +134,14 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
             let transcript = try await session.run(chunk, options: options)
             let text = transcript.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !text.isEmpty {
-                texts.append(text)
+                chunkTranscripts.append((text: text, language: transcript.language ?? language))
             }
         }
 
         logger.notice(
             "\(transcribeCppModel.displayName, privacy: .public) completed in \(startedAt.duration(to: .now).formatted(.units(allowed: [.seconds], width: .narrow)), privacy: .public) for \(samples.count, privacy: .public) samples"
         )
-        return TextNormalizer.shared.normalizeSentence(texts.joined(separator: languageUsesSpaces(language) ? " " : ""))
+        return joinedText(from: chunkTranscripts)
     }
 
     func cleanup() {
@@ -289,25 +299,44 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
     }
 
     private func resolveArtifact(for model: TranscribeCppModel) throws -> TranscribeCppModelArtifact {
-        guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name),
-            artifact.modelName == TranscribeCppModelCatalog.cohereTranscribe.modelName
-        else {
+        guard let artifact = TranscribeCppModelCatalog.artifact(for: model.name) else {
             throw NSError(
-                domain: "CohereTranscriptionService",
+                domain: "OfflineTranscribeCppService",
                 code: -2,
-                userInfo: [NSLocalizedDescriptionKey: "Unsupported Cohere transcription model"]
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported transcribe.cpp model"]
             )
         }
         return artifact
     }
 
-    private func selectedLanguage(_ language: String?, for model: TranscribeCppModel) -> String {
+    private func selectedLanguage(_ language: String?, for model: TranscribeCppModel) -> String? {
         let compatibleLanguage = TranscriptionLanguageSupport.validLanguageOrFallback(language, for: model)
-        return compatibleLanguage.split(separator: "-").first.map(String.init)?.lowercased() ?? "en"
+        guard compatibleLanguage != "auto" else { return nil }
+        return compatibleLanguage.split(separator: "-").first.map(String.init)?.lowercased()
     }
 
-    private func languageUsesSpaces(_ language: String) -> Bool {
-        language != "ja" && language != "zh"
+    private func effectiveMaximumChunkSeconds(
+        configuredMaximum: Int,
+        capabilitiesMaximumMilliseconds: Int64
+    ) -> Int {
+        guard capabilitiesMaximumMilliseconds > 0 else { return configuredMaximum }
+        let capabilitiesMaximum = Swift.max(1, Int(capabilitiesMaximumMilliseconds / 1_000))
+        return Swift.min(configuredMaximum, capabilitiesMaximum)
+    }
+
+    private func joinedText(from chunks: [(text: String, language: String?)]) -> String {
+        chunks.enumerated().reduce(into: "") { result, entry in
+            let (index, chunk) = entry
+            if index > 0, languageUsesSpaces(chunk.language) {
+                result.append(" ")
+            }
+            result.append(chunk.text)
+        }
+    }
+
+    private func languageUsesSpaces(_ language: String?) -> Bool {
+        guard let language else { return true }
+        return language != "ja" && language != "yue" && language != "zh"
     }
 
     private static func initializeBackendsIfNeeded() throws {
@@ -320,7 +349,7 @@ final class CohereTranscriptionService: TranscriptionService, @unchecked Sendabl
 }
 
 private extension Array where Element == Float {
-    /// Matches Cohere's long-form splitter, using the chunk tail for boundary search rather than overlap.
+    /// Splits long-form audio near low-energy boundaries without overlapping samples.
     func energyAwareChunks(
         maximumCount: Int,
         boundarySearchCount: Int,

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppModelCatalog.swift
@@ -8,6 +8,7 @@ struct TranscribeCppModelArtifact: Sendable {
     let expectedFileSize: Int64
     let expectedSHA256: String
     let architectureHint: String?
+    let enablesInverseTextNormalization: Bool
     let maximumChunkSeconds: Int
     let boundarySearchSeconds: Int
     let boundaryEnergyWindowSamples: Int
@@ -73,13 +74,29 @@ enum TranscribeCppModelCatalog {
         expectedFileSize: 1_558_162_944,
         expectedSHA256: "0ea56826d8bd5d74b7143a4a04e022dc1bb75452cfae49d98b6acb0c1d16a1fb",
         architectureHint: "cohere",
+        enablesInverseTextNormalization: false,
         maximumChunkSeconds: 35,
         boundarySearchSeconds: 5,
         boundaryEnergyWindowSamples: 1_600
     )
 
+    static let senseVoiceSmall = TranscribeCppModelArtifact(
+        modelName: "sensevoice-small",
+        fileName: "SenseVoiceSmall-Q8_0.gguf",
+        repository: "handy-computer/SenseVoiceSmall-gguf",
+        repositoryRevision: "4a08b8e900b38a977e32eb08d5d0697d6e72ba04",
+        expectedFileSize: 252_684_608,
+        expectedSHA256: "6c759ee4c9748c9b3f7a5a60ca74f0f7e685fb9d45d1378fce7cfd62f59adf29",
+        architectureHint: "sensevoice",
+        enablesInverseTextNormalization: true,
+        maximumChunkSeconds: 30,
+        boundarySearchSeconds: 3,
+        boundaryEnergyWindowSamples: 1_600
+    )
+
     private static let artifactsByModelName = [
-        cohereTranscribe.modelName: cohereTranscribe
+        cohereTranscribe.modelName: cohereTranscribe,
+        senseVoiceSmall.modelName: senseVoiceSmall,
     ]
 
     static func artifact(for modelName: String) -> TranscribeCppModelArtifact? {

--- a/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
+++ b/VoiceInk/Transcription/TranscribeCpp/TranscribeCppTranscriptionService.swift
@@ -1,16 +1,14 @@
 import Foundation
 
-/// Routes transcribe.cpp-backed models to their model-specific service.
+/// Routes catalog-backed models through the shared transcribe.cpp runtime.
 final class TranscribeCppTranscriptionService: TranscriptionService, @unchecked Sendable {
-    private let cohereService = CohereTranscriptionService()
+    private let offlineService = OfflineTranscribeCppService()
 
     func loadModel(for model: TranscribeCppModel) async throws {
-        switch model.name {
-        case TranscribeCppModelCatalog.cohereTranscribe.modelName:
-            try await cohereService.loadModel(for: model)
-        default:
+        guard TranscribeCppModelCatalog.artifact(for: model.name) != nil else {
             throw unsupportedModelError(model.name)
         }
+        try await offlineService.loadModel(for: model)
     }
 
     func transcribe(
@@ -26,20 +24,18 @@ final class TranscribeCppTranscriptionService: TranscriptionService, @unchecked 
             )
         }
 
-        switch transcribeCppModel.name {
-        case TranscribeCppModelCatalog.cohereTranscribe.modelName:
-            return try await cohereService.transcribe(
-                audioURL: audioURL,
-                model: transcribeCppModel,
-                context: context
-            )
-        default:
+        guard TranscribeCppModelCatalog.artifact(for: transcribeCppModel.name) != nil else {
             throw unsupportedModelError(transcribeCppModel.name)
         }
+        return try await offlineService.transcribe(
+            audioURL: audioURL,
+            model: transcribeCppModel,
+            context: context
+        )
     }
 
     func cleanup() {
-        cohereService.cleanup()
+        offlineService.cleanup()
     }
 
     private func unsupportedModelError(_ modelName: String) -> NSError {

--- a/VoiceInk/Views/AI Models/FluidAudioModelCardView.swift
+++ b/VoiceInk/Views/AI Models/FluidAudioModelCardView.swift
@@ -18,11 +18,6 @@ struct FluidAudioModelCardView: View {
         fluidAudioModelManager.isFluidAudioModelDownloading(model)
     }
 
-    private var showsExperimentalBadge: Bool {
-        FluidAudioModelManager.isParakeetUnifiedModel(named: model.name)
-            || FluidAudioModelManager.isNemotronModel(named: model.name)
-    }
-
     var body: some View {
         HStack(alignment: .top, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
@@ -44,15 +39,6 @@ struct FluidAudioModelCardView: View {
             Text(model.displayName)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(Color(.labelColor))
-
-            if showsExperimentalBadge {
-                Text("Experimental")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.black)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color(red: 0.96, green: 0.79, blue: 0.63)))
-            }
 
             Spacer()
         }

--- a/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
+++ b/VoiceInk/Views/AI Models/TranscribeCppModelCardView.swift
@@ -15,13 +15,6 @@ struct TranscribeCppModelCardView: View {
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(Color(.labelColor))
 
-                    Text("Experimental")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(.black)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Capsule().fill(Color(red: 0.96, green: 0.79, blue: 0.63)))
-
                     Spacer()
                 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds SenseVoice Small as a local transcription model by generalizing the transcribe.cpp runtime to support any catalog-backed model instead of being hardcoded to Cohere.

- Registers SenseVoice Small with language support for English, Japanese, Korean, Cantonese, and Chinese.
- Renames `CohereTranscriptionService` to `OfflineTranscribeCppService` and routes all transcribe.cpp models through it.
- Enables inverse text normalization for SenseVoice, disables special tags, and caps chunk length to the model's maximum audio duration.
- Joins chunk text using per-chunk language spacing rules (no spaces for Japanese, Cantonese, Chinese).
- Removes the Experimental badge from FluidAudio and TranscribeCpp model cards.

<sup>Written for commit fa28f3d755c8b3353ccbf8156d3f0357229ae7f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

