### PR TITLE
Add Gemini 3.8 Flash as the default enhancement model

### DIFF
--- a/VoiceInk/Features/Enhancement/State/AIService.swift
+++ b/VoiceInk/Features/Enhancement/State/AIService.swift
@@ -64,7 +64,7 @@ enum AIProvider: String, CaseIterable {
         case .groq:
             return "openai/gpt-oss-120b"
         case .gemini:
-            return "gemini-3.7-flash"
+            return "gemini-3.8-flash"
         case .anthropic:
             return "claude-sonnet-5"
         case .openAI:
@@ -109,6 +109,7 @@ enum AIProvider: String, CaseIterable {
             ]
         case .gemini:
             return [
+                "gemini-3.8-flash",
                 "gemini-3.7-flash",
                 "gemini-3.6-flash",
                 "gemini-3.5-flash-lite",

--- a/VoiceInk/Infrastructure/Providers/Enhancement/ReasoningConfig.swift
+++ b/VoiceInk/Infrastructure/Providers/Enhancement/ReasoningConfig.swift
@@ -2,8 +2,9 @@ import Foundation
 import LLMkit
 
 struct ReasoningConfig {
-    // Gemini 3.7 Flash and 3.1 Pro Preview do not support "minimal".
+    // Gemini 3.8 Flash, 3.7 Flash, and 3.1 Pro Preview do not support "minimal".
     static let geminiLowThinkingModels: Set<String> = [
+        "gemini-3.8-flash",
         "gemini-3.7-flash",
         "gemini-3.1-pro-preview",
     ]


### PR DESCRIPTION
## Summary
- Adds `gemini-3.8-flash` to the Gemini enhancement model list
- Makes it the default Gemini model (replacing 3.7 Flash)
- Uses the same `low` thinking level as 3.7 Flash, since 3.8 also does not support `minimal`

## Test plan
- [ ] Open enhancement settings and confirm Gemini 3.8 Flash appears in the model picker
- [ ] New Gemini setups default to `gemini-3.8-flash`
- [ ] Existing saved 3.7 selections stay on 3.7
- [ ] Run an enhancement with 3.8 Flash using a Gemini API key


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Gemini enhancement defaults from `gemini-3.7-flash` to `gemini-3.8-flash` for new configurations while preserving existing saved selections.

- Keeps `gemini-3.7-flash` available in the model picker.
- Uses the `low` thinking level because `gemini-3.8-flash` does not support `minimal`.

<sup>Written for commit b890763af4a7267a5e5c033cc3fd90949f057a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

