### PR TITLE
fix: local build failures — CLI plugin/macro validation and launch crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ setup: whisper
 	@echo "Please ensure your Xcode project references the framework from this new location."
 
 build: setup
-	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug CODE_SIGN_IDENTITY="" build
+	xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -configuration Debug CODE_SIGN_IDENTITY="" \
+		-skipPackagePluginValidation \
+		-skipMacroValidation \
+		build
 
 # Build locally with stable Apple Development signing when available.
 local: check setup
@@ -78,6 +81,8 @@ local: check setup
 		DEVELOPMENT_TEAM="" \
 		CODE_SIGN_ENTITLEMENTS="$(CURDIR)/VoiceInk/VoiceInk.local.entitlements" \
 		SWIFT_ACTIVE_COMPILATION_CONDITIONS='$$(inherited) LOCAL_BUILD' \
+		-skipPackagePluginValidation \
+		-skipMacroValidation \
 		build
 	@APP_PATH="$(LOCAL_DERIVED_DATA)/Build/Products/Release/VoiceInk.app" && \
 	if [ -d "$$APP_PATH" ]; then \

--- a/VoiceInk/VoiceInk.local.entitlements
+++ b/VoiceInk/VoiceInk.local.entitlements
@@ -16,5 +16,7 @@
 	<true/>
 	<key>com.apple.security.screen-capture</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
`make build`/`make local` fail to produce a working app on a clean checkout, in two stages:
1. `xcodebuild` from the CLI can't grant the trust approval Xcode's GUI shows for SPM build-tool plugins/macros, so the build fails outright.
2. Once that's fixed, the app builds but crashes on launch because the hardened runtime blocks loading ad-hoc-signed embedded frameworks.

## What changed
- [Makefile](Makefile): added `-skipPackagePluginValidation` and `-skipMacroValidation` to the `build` and `local` targets' `xcodebuild` invocations.
- [VoiceInk/VoiceInk.local.entitlements](VoiceInk/VoiceInk.local.entitlements): added `com.apple.security.cs.disable-library-validation` (local/dev build only, not the signed release entitlements).

## Problem
### 1. Build fails on plugin/macro validation
```
Validate plug-in "CudaBuild" in package "mlx-swift"
** BUILD FAILED **
```
and once bypassed:
```
error: Macro "MLXHuggingFaceMacros" from package "mlx-swift-lm" must be enabled before it can be used
```
Both come from SPM's plugin/macro trust mechanism, which only has an interactive approval UI in Xcode.app. `xcodebuild` on the command line has no way to grant that trust, so any CLI build fails as soon as a dependency (here `mlx-swift` / `mlx-swift-lm`) ships a build-tool plugin or macro target.

### 2. App crashes on launch after a successful build
```
Library not loaded: @rpath/whisper.framework/Versions/Current/whisper
Reason: code signature ... not valid for use in process: mapping
process and mapped file (non-platform) have different Team IDs
```
`make local` ad-hoc-signs the app and each embedded framework separately, so each ends up with a distinct ad-hoc identity. With the hardened runtime enabled, macOS's library validation then refuses to load a framework whose signing identity doesn't match the host binary — even though neither has a real Team ID.

## Fix
- Pass `-skipPackagePluginValidation` and `-skipMacroValidation` to `xcodebuild` — the documented flags for exactly this CLI/CI scenario, for dependencies already pinned by revision/version in the project.
- Add `com.apple.security.cs.disable-library-validation` to the local-build-only entitlements file so the ad-hoc-signed frameworks are allowed to load. This does not touch the real release/notarized build's entitlements.

## Test plan
- [x] Full `make local` on a fresh worktree from `main` — build succeeded
- [x] Reproduced both failures without these changes, and confirmed each fix resolves its corresponding failure in isolation
- [x] Launched the resulting `~/Downloads/VoiceInk.app` — opens and runs without the "cannot be opened because of a problem" crash
- [ ] `make build` (Debug config) — same flags applied, not separately re-verified end-to-end at runtime

## Deployment steps
None — build script and local-build entitlements only; no change to the signed release build.

## Verification
Manually verified via full `make local` producing a working, launchable `VoiceInk.app`.