### PR TITLE
Add speaker diarization and word timestamps to file transcription

### DIFF
--- a/VoiceInk/Core/Transcription/TranscriptionTimingTypes.swift
+++ b/VoiceInk/Core/Transcription/TranscriptionTimingTypes.swift
@@ -58,86 +58,6 @@ struct StereoChannelSamples: Sendable {
     let right: [Float]
 }
 
-/// Deterministic speaker separation for recordings that carry one participant
-/// per stereo channel (standard in telephony/call-center audio): each 100ms
-/// frame is attributed to the channel with more energy, no ML involved.
-enum ChannelDiarizer {
-    static func segments(from channels: StereoChannelSamples, sampleRate: Double = 16000) -> [SpeakerSegment] {
-        let frameSize = Int(sampleRate * 0.1)
-        let frameDuration = Double(frameSize) / sampleRate
-        let frameCount = min(channels.left.count, channels.right.count) / frameSize
-        guard frameCount > 0 else { return [] }
-
-        func rms(_ samples: [Float], frame: Int) -> Float {
-            let start = frame * frameSize
-            var sum: Float = 0
-            for i in start..<(start + frameSize) {
-                sum += samples[i] * samples[i]
-            }
-            return (sum / Float(frameSize)).squareRoot()
-        }
-
-        var leftRMS: [Float] = []
-        var rightRMS: [Float] = []
-        leftRMS.reserveCapacity(frameCount)
-        rightRMS.reserveCapacity(frameCount)
-        for frame in 0..<frameCount {
-            leftRMS.append(rms(channels.left, frame: frame))
-            rightRMS.append(rms(channels.right, frame: frame))
-        }
-
-        // Speech/silence threshold adapted to the recording's level, clamped so
-        // neither silence-only nor loud recordings break it.
-        let sortedRMS = (leftRMS + rightRMS).sorted()
-        let p90 = sortedRMS[Int(Double(sortedRMS.count - 1) * 0.9)]
-        let threshold = max(0.008, min(0.05, p90 * 0.15))
-
-        // 0 = left, 1 = right, nil = silence; each active frame goes to the
-        // louder channel.
-        var frameSpeaker: [Int?] = []
-        frameSpeaker.reserveCapacity(frameCount)
-        for frame in 0..<frameCount {
-            let l = leftRMS[frame]
-            let r = rightRMS[frame]
-            if l < threshold && r < threshold {
-                frameSpeaker.append(nil)
-            } else {
-                frameSpeaker.append(l >= r ? 0 : 1)
-            }
-        }
-
-        // Merge active frames into segments, bridging short pauses (≤1s) by the
-        // same speaker so segments don't fragment on every breath.
-        var segments: [SpeakerSegment] = []
-        var currentSpeaker: Int?
-        var segmentStart: TimeInterval = 0
-        var segmentEnd: TimeInterval = 0
-
-        func flush() {
-            if let speaker = currentSpeaker, segmentEnd - segmentStart >= 0.2 {
-                segments.append(
-                    SpeakerSegment(speakerId: "\(speaker + 1)", start: segmentStart, end: segmentEnd)
-                )
-            }
-        }
-
-        for (frame, speaker) in frameSpeaker.enumerated() {
-            guard let speaker else { continue }
-            let time = Double(frame) * frameDuration
-            if speaker == currentSpeaker, time - segmentEnd <= 1.0 {
-                segmentEnd = time + frameDuration
-            } else {
-                flush()
-                currentSpeaker = speaker
-                segmentStart = time
-                segmentEnd = time + frameDuration
-            }
-        }
-        flush()
-        return segments
-    }
-}
-
 enum SpeakerAlignment {
     /// Assigns a speaker to each word by maximum temporal overlap with the
     /// diarization segments, falling back to the nearest segment for words
@@ -203,16 +123,17 @@ enum SpeakerAlignment {
                 utterances.append(utterance)
             }
         }
-        return utterances.sorted { $0.start < $1.start }
+        return utterances.sorted { ($0.start, $0.speaker) < ($1.start, $1.speaker) }
     }
 
-    /// Groups consecutive words with the same speaker into utterances.
+    /// Groups consecutive words with the same speaker into utterances, splitting
+    /// on pauses longer than `maxGap` so silence stays visible between blocks.
     /// Words without a speaker inherit the previous utterance's speaker.
-    static func utterances(from words: [WordTiming]) -> [SpeakerUtterance] {
+    static func utterances(from words: [WordTiming], maxGap: TimeInterval = 1.5) -> [SpeakerUtterance] {
         var utterances: [SpeakerUtterance] = []
         for word in words {
             let speaker = word.speaker ?? utterances.last?.speaker ?? "Unknown"
-            if var current = utterances.last, current.speaker == speaker {
+            if var current = utterances.last, current.speaker == speaker, word.start - current.end <= maxGap {
                 current.text += " " + word.text
                 current.end = word.end
                 utterances[utterances.count - 1] = current

--- a/VoiceInk/Core/Transcription/TranscriptionTimingTypes.swift
+++ b/VoiceInk/Core/Transcription/TranscriptionTimingTypes.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+/// Timing of a single character within a word, interpolated from the word's timing.
+struct CharTiming: Codable, Sendable, Equatable {
+    let char: String
+    let start: TimeInterval
+    let end: TimeInterval
+}
+
+/// A transcribed word with its position on the audio timeline.
+struct WordTiming: Codable, Sendable, Equatable {
+    var text: String
+    var start: TimeInterval
+    var end: TimeInterval
+    var speaker: String?
+
+    /// Char-level timings are approximated by linear interpolation across the
+    /// word's duration — engines only emit token/word-level timestamps.
+    func interpolatedCharTimings() -> [CharTiming] {
+        let characters = Array(text)
+        guard !characters.isEmpty else { return [] }
+        let step = (end - start) / Double(characters.count)
+        return characters.enumerated().map { index, character in
+            CharTiming(
+                char: String(character),
+                start: start + Double(index) * step,
+                end: start + Double(index + 1) * step
+            )
+        }
+    }
+}
+
+/// A contiguous run of words attributed to a single speaker.
+struct SpeakerUtterance: Codable, Sendable, Equatable {
+    var speaker: String
+    var text: String
+    var start: TimeInterval
+    var end: TimeInterval
+}
+
+/// A span of speech attributed to one speaker by the diarizer.
+struct SpeakerSegment: Sendable, Equatable {
+    let speakerId: String
+    let start: TimeInterval
+    let end: TimeInterval
+}
+
+/// Transcription output that can carry word-level timing alongside the plain text.
+/// Engines without timing support return `words == nil`.
+struct DetailedTranscriptionResult: Sendable {
+    var text: String
+    var words: [WordTiming]?
+}
+
+/// The two channels of a stereo recording as separate 16kHz sample arrays.
+struct StereoChannelSamples: Sendable {
+    let left: [Float]
+    let right: [Float]
+}
+
+/// Deterministic speaker separation for recordings that carry one participant
+/// per stereo channel (standard in telephony/call-center audio): each 100ms
+/// frame is attributed to the channel with more energy, no ML involved.
+enum ChannelDiarizer {
+    static func segments(from channels: StereoChannelSamples, sampleRate: Double = 16000) -> [SpeakerSegment] {
+        let frameSize = Int(sampleRate * 0.1)
+        let frameDuration = Double(frameSize) / sampleRate
+        let frameCount = min(channels.left.count, channels.right.count) / frameSize
+        guard frameCount > 0 else { return [] }
+
+        func rms(_ samples: [Float], frame: Int) -> Float {
+            let start = frame * frameSize
+            var sum: Float = 0
+            for i in start..<(start + frameSize) {
+                sum += samples[i] * samples[i]
+            }
+            return (sum / Float(frameSize)).squareRoot()
+        }
+
+        var leftRMS: [Float] = []
+        var rightRMS: [Float] = []
+        leftRMS.reserveCapacity(frameCount)
+        rightRMS.reserveCapacity(frameCount)
+        for frame in 0..<frameCount {
+            leftRMS.append(rms(channels.left, frame: frame))
+            rightRMS.append(rms(channels.right, frame: frame))
+        }
+
+        // Speech/silence threshold adapted to the recording's level, clamped so
+        // neither silence-only nor loud recordings break it.
+        let sortedRMS = (leftRMS + rightRMS).sorted()
+        let p90 = sortedRMS[Int(Double(sortedRMS.count - 1) * 0.9)]
+        let threshold = max(0.008, min(0.05, p90 * 0.15))
+
+        // 0 = left, 1 = right, nil = silence; each active frame goes to the
+        // louder channel.
+        var frameSpeaker: [Int?] = []
+        frameSpeaker.reserveCapacity(frameCount)
+        for frame in 0..<frameCount {
+            let l = leftRMS[frame]
+            let r = rightRMS[frame]
+            if l < threshold && r < threshold {
+                frameSpeaker.append(nil)
+            } else {
+                frameSpeaker.append(l >= r ? 0 : 1)
+            }
+        }
+
+        // Merge active frames into segments, bridging short pauses (≤1s) by the
+        // same speaker so segments don't fragment on every breath.
+        var segments: [SpeakerSegment] = []
+        var currentSpeaker: Int?
+        var segmentStart: TimeInterval = 0
+        var segmentEnd: TimeInterval = 0
+
+        func flush() {
+            if let speaker = currentSpeaker, segmentEnd - segmentStart >= 0.2 {
+                segments.append(
+                    SpeakerSegment(speakerId: "\(speaker + 1)", start: segmentStart, end: segmentEnd)
+                )
+            }
+        }
+
+        for (frame, speaker) in frameSpeaker.enumerated() {
+            guard let speaker else { continue }
+            let time = Double(frame) * frameDuration
+            if speaker == currentSpeaker, time - segmentEnd <= 1.0 {
+                segmentEnd = time + frameDuration
+            } else {
+                flush()
+                currentSpeaker = speaker
+                segmentStart = time
+                segmentEnd = time + frameDuration
+            }
+        }
+        flush()
+        return segments
+    }
+}
+
+enum SpeakerAlignment {
+    /// Assigns a speaker to each word by maximum temporal overlap with the
+    /// diarization segments, falling back to the nearest segment for words
+    /// that fall inside silence gaps. Same strategy as WhisperX's
+    /// `assign_word_speakers`.
+    static func assignSpeakers(words: [WordTiming], segments: [SpeakerSegment]) -> [WordTiming] {
+        guard !segments.isEmpty else { return words }
+        return words.map { word in
+            var word = word
+            var bestSpeaker: String?
+            var bestOverlap: TimeInterval = 0
+            var nearestSpeaker: String?
+            var nearestDistance: TimeInterval = .greatestFiniteMagnitude
+
+            for segment in segments {
+                let overlap = min(word.end, segment.end) - max(word.start, segment.start)
+                if overlap > bestOverlap {
+                    bestOverlap = overlap
+                    bestSpeaker = segment.speakerId
+                }
+                let distance = overlap > 0 ? 0 : max(segment.start - word.end, word.start - segment.end)
+                if distance < nearestDistance {
+                    nearestDistance = distance
+                    nearestSpeaker = segment.speakerId
+                }
+            }
+
+            // Nearest-segment fallback only within a short gap; distant words keep
+            // speaker == nil and inherit their neighbor's speaker during grouping,
+            // so silence stretches can't drag a far-away speaker across the text.
+            if bestSpeaker == nil, nearestDistance > 2.0 {
+                nearestSpeaker = nil
+            }
+            word.speaker = bestSpeaker ?? nearestSpeaker
+            return word
+        }
+    }
+
+    /// Utterances for dual-channel transcription: each speaker's words are
+    /// grouped into continuous runs (split on pauses longer than `maxGap`)
+    /// independently, then the runs are ordered by start time. Unlike
+    /// `utterances(from:)`, overlapping speech stays as coherent blocks per
+    /// speaker instead of interleaving word by word.
+    static func channelUtterances(from words: [WordTiming], maxGap: TimeInterval = 1.5) -> [SpeakerUtterance] {
+        var utterances: [SpeakerUtterance] = []
+        let bySpeaker = Dictionary(grouping: words) { $0.speaker ?? "Unknown" }
+        for (speaker, speakerWords) in bySpeaker {
+            let sorted = speakerWords.sorted { $0.start < $1.start }
+            var current: SpeakerUtterance?
+            for word in sorted {
+                if var utterance = current, word.start - utterance.end <= maxGap {
+                    utterance.text += " " + word.text
+                    utterance.end = word.end
+                    current = utterance
+                } else {
+                    if let utterance = current {
+                        utterances.append(utterance)
+                    }
+                    current = SpeakerUtterance(speaker: speaker, text: word.text, start: word.start, end: word.end)
+                }
+            }
+            if let utterance = current {
+                utterances.append(utterance)
+            }
+        }
+        return utterances.sorted { $0.start < $1.start }
+    }
+
+    /// Groups consecutive words with the same speaker into utterances.
+    /// Words without a speaker inherit the previous utterance's speaker.
+    static func utterances(from words: [WordTiming]) -> [SpeakerUtterance] {
+        var utterances: [SpeakerUtterance] = []
+        for word in words {
+            let speaker = word.speaker ?? utterances.last?.speaker ?? "Unknown"
+            if var current = utterances.last, current.speaker == speaker {
+                current.text += " " + word.text
+                current.end = word.end
+                utterances[utterances.count - 1] = current
+            } else {
+                utterances.append(
+                    SpeakerUtterance(speaker: speaker, text: word.text, start: word.start, end: word.end)
+                )
+            }
+        }
+        return utterances
+    }
+}

--- a/VoiceInk/Features/AudioImport/State/AudioFileQueueItem.swift
+++ b/VoiceInk/Features/AudioImport/State/AudioFileQueueItem.swift
@@ -11,6 +11,7 @@ enum QueueItemStatus: Equatable {
         case loading = "Loading model..."
         case processingAudio = "Processing audio..."
         case transcribing = "Transcribing..."
+        case diarizing = "Identifying speakers..."
         case enhancing = "Enhancing..."
     }
 

--- a/VoiceInk/Features/AudioImport/State/TranscriptionResultView.swift
+++ b/VoiceInk/Features/AudioImport/State/TranscriptionResultView.swift
@@ -3,4 +3,5 @@ import SwiftUI
 enum TranscriptionTab: String, CaseIterable {
     case original = "Original"
     case enhanced = "Enhanced"
+    case speakers = "Speakers"
 }

--- a/VoiceInk/Features/AudioImport/Views/AudioFileRow.swift
+++ b/VoiceInk/Features/AudioImport/Views/AudioFileRow.swift
@@ -9,8 +9,27 @@ struct AudioFileRow: View {
 
     @State private var selectedTab: TranscriptionTab = .original
 
+    private var hasSpeakers: Bool {
+        item.transcription?.speakerUtterances?.isEmpty == false
+    }
+
+    /// Speaker transcriptions show the Speakers view as their primary text;
+    /// plain transcriptions show the Original. Enhanced appears alongside
+    /// whichever is primary.
+    private var availableTabs: [TranscriptionTab] {
+        var tabs: [TranscriptionTab] = [hasSpeakers ? .speakers : .original]
+        if item.transcription?.enhancedText != nil {
+            tabs.append(.enhanced)
+        }
+        return tabs
+    }
+
+    private var effectiveTab: TranscriptionTab {
+        availableTabs.contains(selectedTab) ? selectedTab : availableTabs[0]
+    }
+
     private var displayText: String {
-        switch selectedTab {
+        switch effectiveTab {
         case .original:
             return item.transcription?.text ?? ""
         case .enhanced:
@@ -136,15 +155,10 @@ struct AudioFileRow: View {
         .onTapGesture { onToggleExpand() }
 
         if isExpanded, let transcription = item.transcription {
-            let hasSpeakers = transcription.speakerUtterances?.isEmpty == false
-            if transcription.enhancedText != nil || hasSpeakers {
+            if availableTabs.count > 1 {
                 HStack(spacing: 4) {
-                    tabButton(tab: .original)
-                    if transcription.enhancedText != nil {
-                        tabButton(tab: .enhanced)
-                    }
-                    if hasSpeakers {
-                        tabButton(tab: .speakers)
+                    ForEach(availableTabs, id: \.self) { tab in
+                        tabButton(tab: tab)
                     }
                     Spacer()
                 }
@@ -180,13 +194,13 @@ struct AudioFileRow: View {
             selectedTab = tab
         } label: {
             Text(LocalizedStringKey(tab.rawValue))
-                .font(.subheadline.weight(selectedTab == tab ? .semibold : .regular))
-                .foregroundColor(selectedTab == tab ? AppTheme.Accent.primary : .secondary)
+                .font(.subheadline.weight(effectiveTab == tab ? .semibold : .regular))
+                .foregroundColor(effectiveTab == tab ? AppTheme.Accent.primary : .secondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)
                 .background(
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(selectedTab == tab ? AppTheme.Accent.fill : Color.clear)
+                        .fill(effectiveTab == tab ? AppTheme.Accent.fill : Color.clear)
                 )
         }
         .buttonStyle(.plain)

--- a/VoiceInk/Features/AudioImport/Views/AudioFileRow.swift
+++ b/VoiceInk/Features/AudioImport/Views/AudioFileRow.swift
@@ -15,6 +15,8 @@ struct AudioFileRow: View {
             return item.transcription?.text ?? ""
         case .enhanced:
             return item.transcription?.enhancedText ?? ""
+        case .speakers:
+            return item.transcription?.speakerTranscriptMarkdown ?? ""
         }
     }
 
@@ -134,10 +136,16 @@ struct AudioFileRow: View {
         .onTapGesture { onToggleExpand() }
 
         if isExpanded, let transcription = item.transcription {
-            if transcription.enhancedText != nil {
+            let hasSpeakers = transcription.speakerUtterances?.isEmpty == false
+            if transcription.enhancedText != nil || hasSpeakers {
                 HStack(spacing: 4) {
                     tabButton(tab: .original)
-                    tabButton(tab: .enhanced)
+                    if transcription.enhancedText != nil {
+                        tabButton(tab: .enhanced)
+                    }
+                    if hasSpeakers {
+                        tabButton(tab: .speakers)
+                    }
                     Spacer()
                 }
             }

--- a/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
@@ -163,7 +163,9 @@ struct AudioTranscribeView: View {
                         .font(.system(size: 12, weight: .medium))
                     Text("Add")
                         .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
                 }
+                .fixedSize(horizontal: true, vertical: false)
                 .foregroundColor(.secondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)
@@ -190,7 +192,9 @@ struct AudioTranscribeView: View {
                             .font(.system(size: 10, weight: .medium))
                         Text("Cancel")
                             .font(.system(size: 12, weight: .medium))
+                            .lineLimit(1)
                     }
+                    .fixedSize(horizontal: true, vertical: false)
                     .foregroundColor(AppTheme.Status.error)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
@@ -210,7 +214,9 @@ struct AudioTranscribeView: View {
                             .font(.system(size: 10, weight: .medium))
                         Text("Start")
                             .font(.system(size: 12, weight: .semibold))
+                            .lineLimit(1)
                     }
+                    .fixedSize(horizontal: true, vertical: false)
                     .foregroundColor(.white)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
@@ -228,8 +234,11 @@ struct AudioTranscribeView: View {
 
             if completedItems.count >= 2 {
                 Menu {
-                    Button("Save All as TXT") { saveAll(fileExtension: "txt") }
-                    Button("Save All as MD") { saveAll(fileExtension: "md") }
+                    Button("Save All Original as TXT") { saveAll(source: .original, fileExtension: "txt") }
+                    Button("Save All Original as MD") { saveAll(source: .original, fileExtension: "md") }
+                    Divider()
+                    Button("Save All Speakers as TXT") { saveAll(source: .speakers, fileExtension: "txt") }
+                    Button("Save All Speakers as MD") { saveAll(source: .speakers, fileExtension: "md") }
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "square.and.arrow.down.on.square")
@@ -289,10 +298,16 @@ struct AudioTranscribeView: View {
         }
     }
 
+    private enum SaveAllSource {
+        case original
+        case speakers
+    }
+
     /// Batch-saves every completed transcription into a chosen folder, one file
-    /// per audio, named after the source file. MD keeps the speaker transcript
-    /// when available; TXT saves the plain (enhanced) text.
-    private func saveAll(fileExtension: String) {
+    /// per audio, named after the source file. Original saves the (enhanced)
+    /// text; Speakers saves the speaker-attributed transcript, falling back to
+    /// the original text for items without speaker data.
+    private func saveAll(source: SaveAllSource, fileExtension: String) {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
@@ -302,26 +317,53 @@ struct AudioTranscribeView: View {
 
         guard panel.runModal() == .OK, let directory = panel.url else { return }
 
+        var usedNames = Set<String>()
         for item in completedItems {
             guard let transcription = item.transcription else { continue }
             let baseName = item.url.deletingPathExtension().lastPathComponent
-            let fileURL = directory.appendingPathComponent("\(baseName).\(fileExtension)")
-            let content: String
-            if fileExtension == "md" {
-                let body =
+            // Two queue items can share a basename (same file name in different
+            // folders); suffix duplicates so no transcript silently overwrites another.
+            var uniqueName = baseName
+            var counter = 2
+            while usedNames.contains(uniqueName.lowercased()) {
+                uniqueName = "\(baseName) \(counter)"
+                counter += 1
+            }
+            usedNames.insert(uniqueName.lowercased())
+            let fileURL = directory.appendingPathComponent("\(uniqueName).\(fileExtension)")
+
+            let body: String
+            switch source {
+            case .original:
+                body = transcription.enhancedText ?? transcription.text
+            case .speakers:
+                body =
                     transcription.speakerTranscriptMarkdown
                     ?? transcription.enhancedText
                     ?? transcription.text
+            }
+
+            let content: String
+            if fileExtension == "md" {
                 content = "# \(item.filename)\n\n\(body)"
             } else {
-                content = transcription.enhancedText ?? transcription.text
+                content = source == .speakers ? Self.plainText(fromMarkdown: body) : body
             }
+
             do {
                 try content.write(to: fileURL, atomically: true, encoding: .utf8)
             } catch {
                 print("Failed to save \(fileURL.lastPathComponent): \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Strips the markdown emphasis used by the speaker transcript for TXT export.
+    private static func plainText(fromMarkdown markdown: String) -> String {
+        let silence = String(localized: "Silence")
+        return markdown
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "*\(silence)*", with: silence)
     }
 
     private var speakersPicker: some View {

--- a/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
@@ -333,21 +333,28 @@ struct AudioTranscribeView: View {
             let fileURL = directory.appendingPathComponent("\(uniqueName).\(fileExtension)")
 
             let body: String
+            let isSpeakerMarkdown: Bool
             switch source {
             case .original:
                 body = transcription.enhancedText ?? transcription.text
+                isSpeakerMarkdown = false
             case .speakers:
-                body =
-                    transcription.speakerTranscriptMarkdown
-                    ?? transcription.enhancedText
-                    ?? transcription.text
+                if let speakerBody = transcription.speakerTranscriptMarkdown {
+                    body = speakerBody
+                    isSpeakerMarkdown = true
+                } else {
+                    body = transcription.enhancedText ?? transcription.text
+                    isSpeakerMarkdown = false
+                }
             }
 
             let content: String
             if fileExtension == "md" {
                 content = "# \(item.filename)\n\n\(body)"
             } else {
-                content = source == .speakers ? Self.plainText(fromMarkdown: body) : body
+                // Only speaker markdown gets its markers stripped; fallback
+                // plain text may legitimately contain asterisks.
+                content = isSpeakerMarkdown ? Self.plainText(fromMarkdown: body) : body
             }
 
             do {

--- a/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
@@ -234,11 +234,8 @@ struct AudioTranscribeView: View {
 
             if completedItems.count >= 2 {
                 Menu {
-                    Button("Save All Original as TXT") { saveAll(source: .original, fileExtension: "txt") }
-                    Button("Save All Original as MD") { saveAll(source: .original, fileExtension: "md") }
-                    Divider()
-                    Button("Save All Speakers as TXT") { saveAll(source: .speakers, fileExtension: "txt") }
-                    Button("Save All Speakers as MD") { saveAll(source: .speakers, fileExtension: "md") }
+                    Button("Save All as TXT") { saveAll(fileExtension: "txt") }
+                    Button("Save All as MD") { saveAll(fileExtension: "md") }
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "square.and.arrow.down.on.square")
@@ -298,16 +295,11 @@ struct AudioTranscribeView: View {
         }
     }
 
-    private enum SaveAllSource {
-        case original
-        case speakers
-    }
-
     /// Batch-saves every completed transcription into a chosen folder, one file
-    /// per audio, named after the source file. Original saves the (enhanced)
-    /// text; Speakers saves the speaker-attributed transcript, falling back to
-    /// the original text for items without speaker data.
-    private func saveAll(source: SaveAllSource, fileExtension: String) {
+    /// per audio, named after the source file. Each item exports its primary
+    /// view — the speaker transcript when the item has speaker data, the
+    /// (enhanced) text otherwise — matching what the result row displays.
+    private func saveAll(fileExtension: String) {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
@@ -334,18 +326,12 @@ struct AudioTranscribeView: View {
 
             let body: String
             let isSpeakerMarkdown: Bool
-            switch source {
-            case .original:
+            if let speakerBody = transcription.speakerTranscriptMarkdown {
+                body = speakerBody
+                isSpeakerMarkdown = true
+            } else {
                 body = transcription.enhancedText ?? transcription.text
                 isSpeakerMarkdown = false
-            case .speakers:
-                if let speakerBody = transcription.speakerTranscriptMarkdown {
-                    body = speakerBody
-                    isSpeakerMarkdown = true
-                } else {
-                    body = transcription.enhancedText ?? transcription.text
-                    isSpeakerMarkdown = false
-                }
             }
 
             let content: String

--- a/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Features/AudioImport/Views/AudioTranscribeView.swift
@@ -9,7 +9,14 @@ struct AudioTranscribeView: View {
     @StateObject private var transcriptionManager = AudioTranscriptionManager.shared
     @State private var isDropTargeted = false
     @State private var showModePopover = false
+    @State private var showSpeakersPopover = false
     @State private var expandedItemId: UUID?
+    @AppStorage("TranscribeDiarizationMode") private var diarizationModeRaw =
+        TranscribeDiarizationMode.current.rawValue
+
+    private var diarizationMode: TranscribeDiarizationMode {
+        TranscribeDiarizationMode(rawValue: diarizationModeRaw) ?? .off
+    }
 
     private var selectedMode: ModeConfig? {
         modeManager.currentEffectiveConfiguration
@@ -170,6 +177,8 @@ struct AudioTranscribeView: View {
 
             Spacer()
 
+            speakersPicker
+
             modePicker
 
             if transcriptionManager.isProcessingQueue {
@@ -217,6 +226,33 @@ struct AudioTranscribeView: View {
                 .help(selectedMode == nil ? "Select an enabled mode to start" : "Start transcription")
             }
 
+            if completedItems.count >= 2 {
+                Menu {
+                    Button("Save All as TXT") { saveAll(fileExtension: "txt") }
+                    Button("Save All as MD") { saveAll(fileExtension: "md") }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "square.and.arrow.down.on.square")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("Save All")
+                            .font(.system(size: 12, weight: .medium))
+                            .lineLimit(1)
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(
+                        Capsule()
+                            .fill(AppTheme.Surface.controlActive)
+                    )
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Save every completed transcription to a folder")
+            }
+
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     transcriptionManager.clearAll()
@@ -228,7 +264,9 @@ struct AudioTranscribeView: View {
                         .font(.system(size: 12, weight: .medium))
                     Text("Clear")
                         .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
                 }
+                .fixedSize(horizontal: true, vertical: false)
                 .foregroundColor(.secondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)
@@ -242,6 +280,136 @@ struct AudioTranscribeView: View {
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 10)
+    }
+
+    private var completedItems: [AudioFileQueueItem] {
+        transcriptionManager.queue.filter {
+            if case .completed = $0.status { return true }
+            return false
+        }
+    }
+
+    /// Batch-saves every completed transcription into a chosen folder, one file
+    /// per audio, named after the source file. MD keeps the speaker transcript
+    /// when available; TXT saves the plain (enhanced) text.
+    private func saveAll(fileExtension: String) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = String(localized: "Save All")
+        panel.message = String(localized: "Choose a folder for the transcriptions")
+
+        guard panel.runModal() == .OK, let directory = panel.url else { return }
+
+        for item in completedItems {
+            guard let transcription = item.transcription else { continue }
+            let baseName = item.url.deletingPathExtension().lastPathComponent
+            let fileURL = directory.appendingPathComponent("\(baseName).\(fileExtension)")
+            let content: String
+            if fileExtension == "md" {
+                let body =
+                    transcription.speakerTranscriptMarkdown
+                    ?? transcription.enhancedText
+                    ?? transcription.text
+                content = "# \(item.filename)\n\n\(body)"
+            } else {
+                content = transcription.enhancedText ?? transcription.text
+            }
+            do {
+                try content.write(to: fileURL, atomically: true, encoding: .utf8)
+            } catch {
+                print("Failed to save \(fileURL.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private var speakersPicker: some View {
+        HStack(spacing: 6) {
+            Text("Speakers")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+
+            Button {
+                showSpeakersPopover.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "person.2.fill")
+                        .font(.system(size: 10, weight: .medium))
+                        .frame(width: 16)
+                    Text(diarizationMode.label)
+                        .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.secondary)
+                }
+                .foregroundColor(.primary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    Capsule()
+                        .fill(AppTheme.Surface.subtle)
+                )
+                .overlay(
+                    Capsule()
+                        .stroke(AppTheme.Accent.fillSubtle, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .help("How speakers are identified (requires a model with word timestamps)")
+            .popover(isPresented: $showSpeakersPopover, arrowEdge: .bottom) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Select Speakers")
+                        .font(.headline)
+                        .foregroundColor(AppTheme.Text.primary)
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+
+                    Divider()
+                        .background(AppTheme.Border.subtle)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(TranscribeDiarizationMode.allCases, id: \.self) { mode in
+                            Button {
+                                diarizationModeRaw = mode.rawValue
+                                showSpeakersPopover = false
+                            } label: {
+                                HStack {
+                                    Text(mode.label)
+                                        .font(.system(size: 13))
+                                        .foregroundColor(AppTheme.Text.primary)
+                                    Spacer()
+                                    if mode == diarizationMode {
+                                        Image(systemName: "checkmark")
+                                            .font(.system(size: 11, weight: .semibold))
+                                            .foregroundColor(AppTheme.Status.positive)
+                                    }
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .contentShape(Rectangle())
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                        .fill(
+                                            mode == diarizationMode
+                                                ? AppTheme.Surface.controlActive : Color.clear)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .help(mode.help)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.bottom, 10)
+                }
+                .frame(width: 230)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private var modePicker: some View {

--- a/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
@@ -486,13 +486,13 @@ class AudioTranscriptionManager: ObservableObject {
 
                 // Keep the persisted word data consistent with the visible
                 // transcript: drop words belonging to utterances that were
-                // filtered out entirely. Matching is by speaker and time, so a
-                // dropped utterance overlapping another speaker's surviving
-                // interval doesn't keep its words alive.
+                // filtered out entirely. Matching is strictly by speaker and
+                // time; words with no speaker sit outside every diarization
+                // segment and are dropped with the rest.
                 if let words = wordTimings {
                     wordTimings = words.filter { word in
                         surviving.contains { utterance in
-                            (word.speaker == nil || word.speaker == utterance.speaker)
+                            word.speaker == utterance.speaker
                                 && word.start >= utterance.start - 0.05
                                 && word.end <= utterance.end + 0.05
                         }

--- a/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
@@ -148,6 +148,20 @@ class AudioTranscriptionManager: ObservableObject {
 
     // MARK: - Private
 
+    /// Whether the model's engine emits word-level timestamps — the requirement
+    /// for any speaker attribution. Engines without them keep the plain
+    /// single-pass transcription path.
+    private static func engineSupportsWordTimings(_ model: any TranscriptionModel) -> Bool {
+        switch model.provider {
+        case .whisper, .nativeApple:
+            return true
+        case .fluidAudio:
+            return !FluidAudioModelManager.isParakeetUnifiedModel(named: model.name)
+        default:
+            return false
+        }
+    }
+
     /// Peak-normalizes one channel so a quiet call participant gets full ASR
     /// signal level regardless of how loud the other channel is.
     private static func normalized(_ samples: [Float]) -> [Float] {
@@ -225,25 +239,31 @@ class AudioTranscriptionManager: ObservableObject {
             let samples = try await audioProcessor.processAudioToSamples(item.url)
             try Task.checkCancellation()
 
-            // Diarization runs concurrently with transcription on the same 16kHz samples.
-            // Stereo files with one participant per channel (telephony recordings)
-            // get exact channel-based separation; everything else uses the neural
-            // diarizer. Channels are extracted here, while the security-scoped
-            // file access is still held.
-            // Speaker identification strategy:
+            // Speaker identification strategy — only for engines that emit word
+            // timestamps (without them there is nothing to attribute, and the
+            // old single-pass behavior is kept untouched):
             //  - stereo file with one participant per channel → one ASR pass per
             //    channel (exact attribution, and a quiet participant isn't
             //    masked by the loud one in the mono downmix)
             //  - otherwise → neural diarization, concurrent with transcription
             let diarizationMode = TranscribeDiarizationMode.current
-            let stereoChannels =
-                (diarizationMode == .auto || diarizationMode == .stereo)
-                ? audioProcessor.extractStereoChannels(item.url) : nil
-            if diarizationMode == .stereo, stereoChannels == nil {
+            let wantsSpeakers = diarizationMode != .off && Self.engineSupportsWordTimings(currentModel)
+            if diarizationMode != .off, !wantsSpeakers {
+                logger.notice(
+                    "Selected engine produces no word timestamps; transcribing without speaker identification")
+            }
+            let sourceURL = item.url
+            let stereoChannels: StereoChannelSamples? =
+                wantsSpeakers && (diarizationMode == .auto || diarizationMode == .stereo)
+                ? await Task.detached(priority: .userInitiated) {
+                    AudioProcessor().extractStereoChannels(sourceURL)
+                }.value
+                : nil
+            if wantsSpeakers, diarizationMode == .stereo, stereoChannels == nil {
                 logger.notice("Stereo diarization selected but file has no distinct channels; skipping")
             }
             let neuralDiarizationTask: Task<[SpeakerSegment], Error>? =
-                (diarizationMode == .voice || (diarizationMode == .auto && stereoChannels == nil))
+                wantsSpeakers && (diarizationMode == .voice || (diarizationMode == .auto && stereoChannels == nil))
                 ? Task.detached(priority: .userInitiated) {
                     try await SpeakerDiarizationService.shared.diarize(samples: samples)
                 }
@@ -311,10 +331,8 @@ class AudioTranscriptionManager: ObservableObject {
                 merged.sort { $0.start < $1.start }
 
                 if merged.isEmpty {
-                    // Engine without word timings: keep both sides, unattributed.
-                    text = [leftResult.text, rightResult.text]
-                        .filter { !$0.isEmpty }
-                        .joined(separator: "\n")
+                    // Both channels filtered down to silence; nothing to attribute.
+                    text = ""
                 } else {
                     wordTimings = merged
                     let utterances = SpeakerAlignment.channelUtterances(from: merged)
@@ -335,7 +353,13 @@ class AudioTranscriptionManager: ObservableObject {
                 if let neuralDiarizationTask {
                     item.status = .processing(phase: .diarizing)
                     do {
-                        let speakerSegments = try await neuralDiarizationTask.value
+                        // Cancel the detached diarization promptly when this task
+                        // is cancelled instead of waiting for it to finish.
+                        let speakerSegments = try await withTaskCancellationHandler {
+                            try await neuralDiarizationTask.value
+                        } onCancel: {
+                            neuralDiarizationTask.cancel()
+                        }
                         if let words = wordTimings, !words.isEmpty, !speakerSegments.isEmpty {
                             let assigned = SpeakerAlignment.assignSpeakers(words: words, segments: speakerSegments)
                             wordTimings = assigned
@@ -435,6 +459,19 @@ class AudioTranscriptionManager: ObservableObject {
                     modeName: modeMetadata.name,
                     modeEmoji: modeMetadata.emoji
                 )
+            }
+
+            // Keep the Speakers view consistent with the cleaned Original text:
+            // utterances go through the same hallucination filter and word
+            // replacements before being persisted.
+            if var utterances = speakerUtterances {
+                for index in utterances.indices {
+                    var utteranceText = TranscriptionOutputFilter.filter(utterances[index].text)
+                    utteranceText = WordReplacementService.shared.applyReplacements(
+                        to: utteranceText, using: modelContext)
+                    utterances[index].text = utteranceText.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                speakerUtterances = utterances.filter { !$0.text.isEmpty }
             }
 
             transcription.wordTimings = wordTimings

--- a/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
@@ -486,10 +486,16 @@ class AudioTranscriptionManager: ObservableObject {
 
                 // Keep the persisted word data consistent with the visible
                 // transcript: drop words belonging to utterances that were
-                // filtered out entirely.
+                // filtered out entirely. Matching is by speaker and time, so a
+                // dropped utterance overlapping another speaker's surviving
+                // interval doesn't keep its words alive.
                 if let words = wordTimings {
                     wordTimings = words.filter { word in
-                        surviving.contains { word.start >= $0.start - 0.05 && word.end <= $0.end + 0.05 }
+                        surviving.contains { utterance in
+                            (word.speaker == nil || word.speaker == utterance.speaker)
+                                && word.start >= utterance.start - 0.05
+                                && word.end <= utterance.end + 0.05
+                        }
                     }
                 }
             }

--- a/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
@@ -253,12 +253,22 @@ class AudioTranscriptionManager: ObservableObject {
                     "Selected engine produces no word timestamps; transcribing without speaker identification")
             }
             let sourceURL = item.url
-            let stereoChannels: StereoChannelSamples? =
-                wantsSpeakers && (diarizationMode == .auto || diarizationMode == .stereo)
-                ? await Task.detached(priority: .userInitiated) {
+            let stereoChannels: StereoChannelSamples?
+            if wantsSpeakers, diarizationMode == .auto || diarizationMode == .stereo {
+                // Off the main actor, and cancelled promptly with the queue —
+                // the extraction loop aborts between chunks on cancellation.
+                let extraction = Task.detached(priority: .userInitiated) {
                     AudioProcessor().extractStereoChannels(sourceURL)
-                }.value
-                : nil
+                }
+                stereoChannels = await withTaskCancellationHandler {
+                    await extraction.value
+                } onCancel: {
+                    extraction.cancel()
+                }
+                try Task.checkCancellation()
+            } else {
+                stereoChannels = nil
+            }
             if wantsSpeakers, diarizationMode == .stereo, stereoChannels == nil {
                 logger.notice("Stereo diarization selected but file has no distinct channels; skipping")
             }
@@ -471,7 +481,17 @@ class AudioTranscriptionManager: ObservableObject {
                         to: utteranceText, using: modelContext)
                     utterances[index].text = utteranceText.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
-                speakerUtterances = utterances.filter { !$0.text.isEmpty }
+                let surviving = utterances.filter { !$0.text.isEmpty }
+                speakerUtterances = surviving
+
+                // Keep the persisted word data consistent with the visible
+                // transcript: drop words belonging to utterances that were
+                // filtered out entirely.
+                if let words = wordTimings {
+                    wordTimings = words.filter { word in
+                        surviving.contains { word.start >= $0.start - 0.05 && word.end <= $0.end + 0.05 }
+                    }
+                }
             }
 
             transcription.wordTimings = wordTimings

--- a/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Features/AudioImport/Workflows/AudioFileTranscriptionManager.swift
@@ -4,6 +4,42 @@ import SwiftData
 import SwiftUI
 import os
 
+/// How the Transcribe tab identifies speakers in imported audio.
+enum TranscribeDiarizationMode: String, CaseIterable {
+    case off
+    case auto
+    case voice
+    case stereo
+
+    /// Resolves the persisted mode, honoring the pre-menu boolean toggle.
+    static var current: TranscribeDiarizationMode {
+        if let raw = UserDefaults.standard.string(forKey: "TranscribeDiarizationMode"),
+            let mode = TranscribeDiarizationMode(rawValue: raw)
+        {
+            return mode
+        }
+        return UserDefaults.standard.bool(forKey: "TranscribeDiarizationEnabled") ? .auto : .off
+    }
+
+    var label: String {
+        switch self {
+        case .off: return "Off"
+        case .auto: return "Auto"
+        case .voice: return "Voice AI"
+        case .stereo: return "Stereo"
+        }
+    }
+
+    var help: String {
+        switch self {
+        case .off: return "No speaker identification"
+        case .auto: return "Stereo channels when each speaker has their own channel, Voice AI otherwise"
+        case .voice: return "Neural voice clustering (works on any audio)"
+        case .stereo: return "One speaker per stereo channel (telephony recordings); off for mono files"
+        }
+    }
+}
+
 @MainActor
 class AudioTranscriptionManager: ObservableObject {
     static let shared = AudioTranscriptionManager()
@@ -112,6 +148,43 @@ class AudioTranscriptionManager: ObservableObject {
 
     // MARK: - Private
 
+    /// Peak-normalizes one channel so a quiet call participant gets full ASR
+    /// signal level regardless of how loud the other channel is.
+    private static func normalized(_ samples: [Float]) -> [Float] {
+        let maxSample = samples.map(abs).max() ?? 0
+        guard maxSample > 0 else { return samples }
+        return samples.map { $0 / maxSample }
+    }
+
+    /// Keeps only words whose time span has audible signal in the (normalized)
+    /// channel they came from — hallucinated words sit on top of silence.
+    /// The span is padded and checked frame by frame so slightly-off word
+    /// timestamps (e.g. from inverse text normalization) don't drop real words.
+    private static func wordsWithSignal(
+        _ words: [WordTiming], samples: [Float], sampleRate: Double = 16000
+    ) -> [WordTiming] {
+        let padding = 0.3
+        let frameSize = Int(sampleRate * 0.05)
+        return words.filter { word in
+            let start = max(0, Int((word.start - padding) * sampleRate))
+            let end = min(samples.count, Int((word.end + padding) * sampleRate))
+            guard end > start else { return false }
+            var frameStart = start
+            while frameStart < end {
+                let frameEnd = min(end, frameStart + frameSize)
+                var sum: Float = 0
+                for i in frameStart..<frameEnd {
+                    sum += samples[i] * samples[i]
+                }
+                if (sum / Float(frameEnd - frameStart)).squareRoot() > 0.012 {
+                    return true
+                }
+                frameStart = frameEnd
+            }
+            return false
+        }
+    }
+
     private func nextPendingItem() -> AudioFileQueueItem? {
         queue.first {
             if case .pending = $0.status { return true }
@@ -152,6 +225,31 @@ class AudioTranscriptionManager: ObservableObject {
             let samples = try await audioProcessor.processAudioToSamples(item.url)
             try Task.checkCancellation()
 
+            // Diarization runs concurrently with transcription on the same 16kHz samples.
+            // Stereo files with one participant per channel (telephony recordings)
+            // get exact channel-based separation; everything else uses the neural
+            // diarizer. Channels are extracted here, while the security-scoped
+            // file access is still held.
+            // Speaker identification strategy:
+            //  - stereo file with one participant per channel → one ASR pass per
+            //    channel (exact attribution, and a quiet participant isn't
+            //    masked by the loud one in the mono downmix)
+            //  - otherwise → neural diarization, concurrent with transcription
+            let diarizationMode = TranscribeDiarizationMode.current
+            let stereoChannels =
+                (diarizationMode == .auto || diarizationMode == .stereo)
+                ? audioProcessor.extractStereoChannels(item.url) : nil
+            if diarizationMode == .stereo, stereoChannels == nil {
+                logger.notice("Stereo diarization selected but file has no distinct channels; skipping")
+            }
+            let neuralDiarizationTask: Task<[SpeakerSegment], Error>? =
+                (diarizationMode == .voice || (diarizationMode == .auto && stereoChannels == nil))
+                ? Task.detached(priority: .userInitiated) {
+                    try await SpeakerDiarizationService.shared.diarize(samples: samples)
+                }
+                : nil
+            defer { neuralDiarizationTask?.cancel() }
+
             let audioAsset = AVURLAsset(url: item.url)
             let duration = CMTimeGetSeconds(try await audioAsset.load(.duration))
 
@@ -171,12 +269,92 @@ class AudioTranscriptionManager: ObservableObject {
             // Phase: Transcribing
             item.status = .processing(phase: .transcribing)
             let transcriptionStart = Date()
-            var text = try await serviceRegistry.transcribe(
-                audioURL: permanentURL,
-                model: currentModel,
-                context: transcriptionConfiguration.requestContext
-            )
+            var text: String
+            var wordTimings: [WordTiming]?
+            var speakerUtterances: [SpeakerUtterance]?
+
+            if let stereoChannels {
+                // Dual-channel transcription: each channel normalized and
+                // transcribed on its own, then merged on the shared timeline.
+                var requestContext = transcriptionConfiguration.requestContext
+                requestContext.preservesTimeline = true
+
+                let tempDirectory = FileManager.default.temporaryDirectory
+                let leftURL = tempDirectory.appendingPathComponent("channel_L_\(UUID().uuidString).wav")
+                let rightURL = tempDirectory.appendingPathComponent("channel_R_\(UUID().uuidString).wav")
+                defer {
+                    try? FileManager.default.removeItem(at: leftURL)
+                    try? FileManager.default.removeItem(at: rightURL)
+                }
+                let leftSamples = Self.normalized(stereoChannels.left)
+                let rightSamples = Self.normalized(stereoChannels.right)
+                try audioProcessor.saveSamplesAsWav(samples: leftSamples, to: leftURL)
+                try audioProcessor.saveSamplesAsWav(samples: rightSamples, to: rightURL)
+
+                let leftResult = try await serviceRegistry.transcribeDetailed(
+                    audioURL: leftURL, model: currentModel, context: requestContext)
+                try Task.checkCancellation()
+                let rightResult = try await serviceRegistry.transcribeDetailed(
+                    audioURL: rightURL, model: currentModel, context: requestContext)
+
+                // With VAD off, engines hallucinate words over silence; drop any
+                // word whose span carries no actual signal in its own channel.
+                var merged: [WordTiming] = []
+                for var word in Self.wordsWithSignal(leftResult.words ?? [], samples: leftSamples) {
+                    word.speaker = "1"
+                    merged.append(word)
+                }
+                for var word in Self.wordsWithSignal(rightResult.words ?? [], samples: rightSamples) {
+                    word.speaker = "2"
+                    merged.append(word)
+                }
+                merged.sort { $0.start < $1.start }
+
+                if merged.isEmpty {
+                    // Engine without word timings: keep both sides, unattributed.
+                    text = [leftResult.text, rightResult.text]
+                        .filter { !$0.isEmpty }
+                        .joined(separator: "\n")
+                } else {
+                    wordTimings = merged
+                    let utterances = SpeakerAlignment.channelUtterances(from: merged)
+                    speakerUtterances = utterances
+                    text = utterances.map(\.text).joined(separator: " ")
+                }
+            } else {
+                var requestContext = transcriptionConfiguration.requestContext
+                requestContext.preservesTimeline = neuralDiarizationTask != nil
+                let detailedResult = try await serviceRegistry.transcribeDetailed(
+                    audioURL: permanentURL,
+                    model: currentModel,
+                    context: requestContext
+                )
+                text = detailedResult.text
+                wordTimings = detailedResult.words
+
+                if let neuralDiarizationTask {
+                    item.status = .processing(phase: .diarizing)
+                    do {
+                        let speakerSegments = try await neuralDiarizationTask.value
+                        if let words = wordTimings, !words.isEmpty, !speakerSegments.isEmpty {
+                            let assigned = SpeakerAlignment.assignSpeakers(words: words, segments: speakerSegments)
+                            wordTimings = assigned
+                            speakerUtterances = SpeakerAlignment.utterances(from: assigned)
+                        } else {
+                            logger.notice(
+                                "Diarization finished but the engine returned no word timings; skipping speaker assignment"
+                            )
+                        }
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        // Diarization failure must not lose the transcription.
+                        logger.error("Diarization failed: \(error, privacy: .public)")
+                    }
+                }
+            }
             let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
+            try Task.checkCancellation()
             text = TranscriptionOutputFilter.filter(text)
             text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -258,6 +436,9 @@ class AudioTranscriptionManager: ObservableObject {
                     modeEmoji: modeMetadata.emoji
                 )
             }
+
+            transcription.wordTimings = wordTimings
+            transcription.speakerUtterances = speakerUtterances
 
             modelContext.insert(transcription)
             try modelContext.save()

--- a/VoiceInk/Features/History/Views/InlineHistoryView.swift
+++ b/VoiceInk/Features/History/Views/InlineHistoryView.swift
@@ -486,7 +486,20 @@ private struct HistoryCardRow: View {
             return transcription.text
         case .enhanced:
             return transcription.enhancedText ?? ""
+        case .speakers:
+            return transcription.speakerTranscriptMarkdown ?? ""
         }
+    }
+
+    private var availableTabs: [TranscriptionTab] {
+        var tabs: [TranscriptionTab] = [.original]
+        if transcription.enhancedText != nil {
+            tabs.append(.enhanced)
+        }
+        if transcription.speakerTranscriptMarkdown != nil {
+            tabs.append(.speakers)
+        }
+        return tabs
     }
 
     private var hasAudioFile: Bool {
@@ -548,9 +561,9 @@ private struct HistoryCardRow: View {
     private var expandedContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             // Tabs
-            if transcription.enhancedText != nil {
+            if availableTabs.count > 1 {
                 HStack(spacing: 4) {
-                    ForEach(TranscriptionTab.allCases, id: \.self) { tab in
+                    ForEach(availableTabs, id: \.self) { tab in
                         Button {
                             withAnimation(.easeInOut(duration: 0.15)) {
                                 selectedTab = tab

--- a/VoiceInk/Features/Recording/Workflows/TranscriptionService.swift
+++ b/VoiceInk/Features/Recording/Workflows/TranscriptionService.swift
@@ -3,6 +3,10 @@ import Foundation
 struct TranscriptionRequestContext {
     let language: String?
     let prompt: String?
+    /// When true, word timestamps must match the original audio timeline —
+    /// engines must not use silence-skipping (VAD) that compresses time.
+    /// Required by diarization, which aligns words against the real timeline.
+    var preservesTimeline: Bool = false
 
     static var currentDefaults: TranscriptionRequestContext {
         let language = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
@@ -14,7 +18,7 @@ struct TranscriptionRequestContext {
 
     func scoped(to model: any TranscriptionModel) -> TranscriptionRequestContext {
         guard model.provider == .whisper else {
-            return TranscriptionRequestContext(language: language, prompt: nil)
+            return TranscriptionRequestContext(language: language, prompt: nil, preservesTimeline: preservesTimeline)
         }
 
         return self
@@ -33,11 +37,24 @@ protocol TranscriptionService {
     /// - Throws: An error if the transcription fails.
     func transcribe(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext) async throws
         -> String
+
+    /// Transcribes and, when the engine supports it, returns word-level timings
+    /// alongside the text. Engines without timing support fall back to the
+    /// default implementation, which wraps `transcribe` with `words == nil`.
+    func transcribeDetailed(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext)
+        async throws -> DetailedTranscriptionResult
 }
 
 extension TranscriptionService {
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
         let context = TranscriptionRequestContext.currentDefaults.scoped(to: model)
         return try await transcribe(audioURL: audioURL, model: model, context: context)
+    }
+
+    func transcribeDetailed(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext)
+        async throws -> DetailedTranscriptionResult
+    {
+        let text = try await transcribe(audioURL: audioURL, model: model, context: context)
+        return DetailedTranscriptionResult(text: text, words: nil)
     }
 }

--- a/VoiceInk/Features/Recording/Workflows/TranscriptionServiceRegistry.swift
+++ b/VoiceInk/Features/Recording/Workflows/TranscriptionServiceRegistry.swift
@@ -59,6 +59,17 @@ class TranscriptionServiceRegistry {
         return try await service.transcribe(audioURL: audioURL, model: model, context: context.scoped(to: model))
     }
 
+    func transcribeDetailed(
+        audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext = .currentDefaults
+    ) async throws -> DetailedTranscriptionResult {
+        let service = service(for: model.provider)
+        logger.debug(
+            "Transcribing (detailed) with \(model.displayName, privacy: .public) using \(String(describing: type(of: service)), privacy: .public)"
+        )
+        return try await service.transcribeDetailed(
+            audioURL: audioURL, model: model, context: context.scoped(to: model))
+    }
+
     /// Creates a streaming or file-based session for the resolved transcription configuration.
     func createSession(
         for configuration: TranscriptionRuntimeConfiguration, onPartialTranscript: ((String) -> Void)? = nil

--- a/VoiceInk/Infrastructure/Audio/AudioFileProcessor.swift
+++ b/VoiceInk/Infrastructure/Audio/AudioFileProcessor.swift
@@ -291,6 +291,7 @@ class AudioProcessor {
         var currentFrame: AVAudioFramePosition = 0
 
         while currentFrame < totalFrames {
+            if Task.isCancelled { return nil }
             let remainingFrames = totalFrames - currentFrame
             let framesToRead = min(chunkSize, AVAudioFrameCount(remainingFrames))
 

--- a/VoiceInk/Infrastructure/Audio/AudioFileProcessor.swift
+++ b/VoiceInk/Infrastructure/Audio/AudioFileProcessor.swift
@@ -273,7 +273,7 @@ class AudioProcessor {
         guard let audioFile = try? AVAudioFile(forReading: url) else { return nil }
 
         let format = audioFile.processingFormat
-        guard format.channelCount >= 2 else { return nil }
+        guard format.channelCount == 2 else { return nil }
 
         guard
             let outputFormat = AVAudioFormat(

--- a/VoiceInk/Infrastructure/Audio/AudioFileProcessor.swift
+++ b/VoiceInk/Infrastructure/Audio/AudioFileProcessor.swift
@@ -264,6 +264,114 @@ class AudioProcessor {
 
         return samples
     }
+    /// Extracts the two channels of a stereo file as separate 16kHz sample
+    /// arrays, for channel-based speaker separation (telephony recordings often
+    /// carry one call participant per channel). Returns nil for mono sources,
+    /// for dual-mono (both channels carrying the same signal), or on decode
+    /// failure — callers should then fall back to voice-based diarization.
+    func extractStereoChannels(_ url: URL) -> StereoChannelSamples? {
+        guard let audioFile = try? AVAudioFile(forReading: url) else { return nil }
+
+        let format = audioFile.processingFormat
+        guard format.channelCount >= 2 else { return nil }
+
+        guard
+            let outputFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: AudioFormat.targetSampleRate,
+                channels: 2,
+                interleaved: false
+            )
+        else { return nil }
+
+        let totalFrames = audioFile.length
+        let chunkSize: AVAudioFrameCount = 50_000_000
+        var left: [Float] = []
+        var right: [Float] = []
+        var currentFrame: AVAudioFramePosition = 0
+
+        while currentFrame < totalFrames {
+            let remainingFrames = totalFrames - currentFrame
+            let framesToRead = min(chunkSize, AVAudioFrameCount(remainingFrames))
+
+            guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: framesToRead) else {
+                return nil
+            }
+
+            audioFile.framePosition = currentFrame
+            guard (try? audioFile.read(into: inputBuffer, frameCount: framesToRead)) != nil else { return nil }
+
+            let buffer: AVAudioPCMBuffer
+            if format.sampleRate == AudioFormat.targetSampleRate && format.channelCount == 2 {
+                buffer = inputBuffer
+            } else {
+                guard let converter = AVAudioConverter(from: format, to: outputFormat) else { return nil }
+                let ratio = AudioFormat.targetSampleRate / format.sampleRate
+                let outputFrameCount = AVAudioFrameCount(Double(inputBuffer.frameLength) * ratio)
+                guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputFrameCount)
+                else { return nil }
+
+                var error: NSError?
+                let status = converter.convert(
+                    to: outputBuffer,
+                    error: &error,
+                    withInputFrom: { _, outStatus in
+                        outStatus.pointee = .haveData
+                        return inputBuffer
+                    }
+                )
+                guard error == nil, status != .error else { return nil }
+                buffer = outputBuffer
+            }
+
+            guard let channelData = buffer.floatChannelData, buffer.format.channelCount >= 2 else { return nil }
+            let frameLength = Int(buffer.frameLength)
+            left.append(contentsOf: UnsafeBufferPointer(start: channelData[0], count: frameLength))
+            right.append(contentsOf: UnsafeBufferPointer(start: channelData[1], count: frameLength))
+
+            currentFrame += AVAudioFramePosition(framesToRead)
+        }
+
+        guard !left.isEmpty, left.count == right.count else { return nil }
+
+        // Normalize both channels by a shared factor so their relative energy
+        // (the speaker-separation signal) is preserved.
+        let maxSample = max(left.map(abs).max() ?? 1, right.map(abs).max() ?? 1)
+        if maxSample > 0 {
+            left = left.map { $0 / maxSample }
+            right = right.map { $0 / maxSample }
+        }
+
+        guard Self.channelsAreDistinct(left, right) else {
+            logger.notice("Stereo file has dual-mono channels; falling back to voice-based diarization")
+            return nil
+        }
+        return StereoChannelSamples(left: left, right: right)
+    }
+
+    /// Dual-mono detection: correlation near ±1 means both channels carry the
+    /// same signal and channel-based speaker separation is meaningless.
+    private static func channelsAreDistinct(_ left: [Float], _ right: [Float]) -> Bool {
+        let stride = max(1, left.count / 200_000)
+        var sumL: Double = 0, sumR: Double = 0, sumLL: Double = 0, sumRR: Double = 0, sumLR: Double = 0
+        var count: Double = 0
+        var i = 0
+        while i < left.count {
+            let l = Double(left[i]), r = Double(right[i])
+            sumL += l; sumR += r
+            sumLL += l * l; sumRR += r * r; sumLR += l * r
+            count += 1
+            i += stride
+        }
+        guard count > 1 else { return false }
+        let covariance = sumLR / count - (sumL / count) * (sumR / count)
+        let varianceL = sumLL / count - (sumL / count) * (sumL / count)
+        let varianceR = sumRR / count - (sumR / count) * (sumR / count)
+        guard varianceL > 0, varianceR > 0 else { return false }
+        let correlation = covariance / (varianceL * varianceR).squareRoot()
+        return abs(correlation) < 0.9
+    }
+
     func saveSamplesAsWav(samples: [Float], to url: URL) throws {
         let outputFormat = AVAudioFormat(
             commonFormat: .pcmFormatInt16,

--- a/VoiceInk/Infrastructure/Persistence/Models/Transcription.swift
+++ b/VoiceInk/Infrastructure/Persistence/Models/Transcription.swift
@@ -30,6 +30,8 @@ final class Transcription {
     @Attribute(originalName: "powerModeEmoji")
     var modeEmoji: String?
     var transcriptionStatus: String?
+    var wordTimingsJSON: Data?
+    var speakerUtterancesJSON: Data?
 
     init(
         text: String,
@@ -63,6 +65,57 @@ final class Transcription {
         self.modeName = modeName
         self.modeEmoji = modeEmoji
         self.transcriptionStatus = transcriptionStatus.rawValue
+    }
+
+    var wordTimings: [WordTiming]? {
+        get { wordTimingsJSON.flatMap { try? JSONDecoder().decode([WordTiming].self, from: $0) } }
+        set { wordTimingsJSON = newValue.flatMap { try? JSONEncoder().encode($0) } }
+    }
+
+    var speakerUtterances: [SpeakerUtterance]? {
+        get { speakerUtterancesJSON.flatMap { try? JSONDecoder().decode([SpeakerUtterance].self, from: $0) } }
+        set { speakerUtterancesJSON = newValue.flatMap { try? JSONEncoder().encode($0) } }
+    }
+
+    /// Markdown rendering of the speaker-attributed transcript, or nil when no
+    /// diarization data exists. Gaps where nobody speaks for at least
+    /// `silenceThreshold` (leading, between utterances, and trailing) are
+    /// rendered as Silence entries — useful for hold-time/dead-air review.
+    var speakerTranscriptMarkdown: String? {
+        guard let utterances = speakerUtterances, !utterances.isEmpty else { return nil }
+        func label(_ id: String) -> String {
+            Int(id) != nil ? "Speaker \(id)" : id.replacingOccurrences(of: "_", with: " ")
+        }
+        func time(_ t: TimeInterval) -> String {
+            String(format: "%d:%02d", Int(t) / 60, Int(t) % 60)
+        }
+
+        let silenceThreshold: TimeInterval = {
+            if let value = UserDefaults.standard.object(forKey: "TranscribeSilenceThreshold") as? Double {
+                return value
+            }
+            return 2.0
+        }()
+
+        func silenceLine(from start: TimeInterval, to end: TimeInterval) -> String {
+            "*Silence* (\(time(start))–\(time(end)), \(Int((end - start).rounded()))s)"
+        }
+
+        var lines: [String] = []
+        var cursor: TimeInterval = 0
+        for utterance in utterances {
+            if silenceThreshold > 0, utterance.start - cursor >= silenceThreshold {
+                lines.append(silenceLine(from: cursor, to: utterance.start))
+            }
+            lines.append(
+                "**\(label(utterance.speaker))** (\(time(utterance.start))–\(time(utterance.end))): \(utterance.text)"
+            )
+            cursor = max(cursor, utterance.end)
+        }
+        if silenceThreshold > 0, duration > 0, duration - cursor >= silenceThreshold {
+            lines.append(silenceLine(from: cursor, to: duration))
+        }
+        return lines.joined(separator: "\n\n")
     }
 
     func markAsCanceledTranscription(

--- a/VoiceInk/Infrastructure/Persistence/Models/Transcription.swift
+++ b/VoiceInk/Infrastructure/Persistence/Models/Transcription.swift
@@ -84,7 +84,9 @@ final class Transcription {
     var speakerTranscriptMarkdown: String? {
         guard let utterances = speakerUtterances, !utterances.isEmpty else { return nil }
         func label(_ id: String) -> String {
-            Int(id) != nil ? "Speaker \(id)" : id.replacingOccurrences(of: "_", with: " ")
+            Int(id) != nil
+                ? "\(String(localized: "Speaker")) \(id)"
+                : id.replacingOccurrences(of: "_", with: " ")
         }
         func time(_ t: TimeInterval) -> String {
             String(format: "%d:%02d", Int(t) / 60, Int(t) % 60)
@@ -98,7 +100,7 @@ final class Transcription {
         }()
 
         func silenceLine(from start: TimeInterval, to end: TimeInterval) -> String {
-            "*Silence* (\(time(start))–\(time(end)), \(Int((end - start).rounded()))s)"
+            "*\(String(localized: "Silence"))* (\(time(start))–\(time(end)), \(Int((end - start).rounded()))s)"
         }
 
         var lines: [String] = []

--- a/VoiceInk/Infrastructure/Providers/Transcription/AppleSpeech/NativeAppleSpeechAssetManager.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/AppleSpeech/NativeAppleSpeechAssetManager.swift
@@ -146,7 +146,7 @@ enum NativeAppleSpeechAssetManager {
                 locale: supportedLocale,
                 transcriptionOptions: [],
                 reportingOptions: [],
-                attributeOptions: []
+                attributeOptions: [.audioTimeRange]
             )
             let resolvedIdentifier = supportedLocale.identifier(.bcp47)
             let installedLocales = await SpeechTranscriber.installedLocales

--- a/VoiceInk/Infrastructure/Providers/Transcription/AppleSpeech/NativeAppleTranscriptionService.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/AppleSpeech/NativeAppleTranscriptionService.swift
@@ -56,6 +56,12 @@ class NativeAppleTranscriptionService: TranscriptionService {
     func transcribe(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext) async throws
         -> String
     {
+        try await transcribeDetailed(audioURL: audioURL, model: model, context: context).text
+    }
+
+    func transcribeDetailed(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext)
+        async throws -> DetailedTranscriptionResult
+    {
         guard model is NativeAppleModel else {
             throw ServiceError.invalidModel
         }
@@ -107,12 +113,25 @@ class NativeAppleTranscriptionService: TranscriptionService {
 
             let modules: [any SpeechModule] = [assetContext.transcriber]
             let analyzer = SpeechAnalyzer(modules: modules)
-            let resultTask = Task<String, Error> {
+            let resultTask = Task<(String, [WordTiming]), Error> {
                 var transcript = ""
+                var words: [WordTiming] = []
                 for try await result in assetContext.transcriber.results {
                     transcript += String(result.text.characters)
+                    for run in result.text.runs {
+                        guard let timeRange = run.audioTimeRange else { continue }
+                        let runText = String(result.text[run.range].characters)
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !runText.isEmpty else { continue }
+                        words.append(
+                            WordTiming(
+                                text: runText,
+                                start: timeRange.start.seconds,
+                                end: timeRange.end.seconds
+                            ))
+                    }
                 }
-                return transcript
+                return (transcript, words)
             }
 
             do {
@@ -136,29 +155,34 @@ class NativeAppleTranscriptionService: TranscriptionService {
 
             let resultTimeout = max(20.0, audioDuration * 4.0 + 10.0)
             let finalTranscription: String
+            let wordTimings: [WordTiming]
             do {
-                finalTranscription = try await waitForResultStream(
+                let (transcript, words) = try await waitForResultStream(
                     resultTask,
                     timeout: resultTimeout
                 )
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+                finalTranscription = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+                wordTimings = words
             } catch {
                 resultTask.cancel()
                 await analyzer.cancelAndFinishNow()
                 throw error
             }
 
-            return finalTranscription
+            return DetailedTranscriptionResult(
+                text: finalTranscription,
+                words: wordTimings.isEmpty ? nil : wordTimings
+            )
         #else
             throw ServiceError.unsupportedOS
         #endif
     }
 
-    private func waitForResultStream(
-        _ resultTask: Task<String, Error>,
+    private func waitForResultStream<T: Sendable>(
+        _ resultTask: Task<T, Error>,
         timeout: TimeInterval
-    ) async throws -> String {
-        try await withThrowingTaskGroup(of: String.self) { group in
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
             group.addTask {
                 try await resultTask.value
             }

--- a/VoiceInk/Infrastructure/Providers/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -138,6 +138,12 @@ class FluidAudioTranscriptionService: TranscriptionService {
     func transcribe(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext) async throws
         -> String
     {
+        try await transcribeDetailed(audioURL: audioURL, model: model, context: context).text
+    }
+
+    func transcribeDetailed(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext)
+        async throws -> DetailedTranscriptionResult
+    {
         if FluidAudioModelManager.isParakeetUnifiedModel(named: model.name) {
             try await ensureUnifiedModelsLoaded()
             guard let unifiedAsrManager else {
@@ -146,7 +152,7 @@ class FluidAudioTranscriptionService: TranscriptionService {
 
             let speechAudio = try loadAudioSamples(from: audioURL)
             let text = try await unifiedAsrManager.transcribe(speechAudio)
-            return text
+            return DetailedTranscriptionResult(text: text, words: nil)
         }
 
         if FluidAudioModelManager.isNemotronModel(named: model.name) {
@@ -171,8 +177,11 @@ class FluidAudioTranscriptionService: TranscriptionService {
             }
 
             _ = try await nemotronAsrManager.process(samples: speechAudio)
-            let text = try await nemotronAsrManager.finish()
-            return text
+            let (text, tokenTimings) = try await nemotronAsrManager.finishWithTokenTimings()
+            let words = buildWordTimings(from: tokenTimings).map {
+                WordTiming(text: $0.word, start: $0.startTime, end: $0.endTime)
+            }
+            return DetailedTranscriptionResult(text: text, words: words.isEmpty ? nil : words)
         }
 
         let targetVersion = version(for: model)
@@ -193,7 +202,16 @@ class FluidAudioTranscriptionService: TranscriptionService {
             language: languageHint
         )
 
-        return result.text
+        let words: [WordTiming]? = result.tokenTimings.flatMap { timings in
+            let grouped = buildWordTimings(from: timings).map {
+                WordTiming(text: $0.word, start: $0.startTime, end: $0.endTime)
+            }
+            return grouped.isEmpty ? nil : grouped
+        }
+        if words == nil {
+            logger.notice("Parakeet returned no token timings; transcription will have no word-level data")
+        }
+        return DetailedTranscriptionResult(text: result.text, words: words)
     }
 
     private func loadAudioSamples(from audioURL: URL) throws -> [Float] {

--- a/VoiceInk/Infrastructure/Providers/Transcription/FluidAudio/SpeakerDiarizationService.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/FluidAudio/SpeakerDiarizationService.swift
@@ -1,0 +1,82 @@
+import FluidAudio
+import Foundation
+import os.log
+
+/// Runs offline speaker diarization on 16kHz mono samples using FluidAudio's
+/// offline pipeline (pyannote-parity AHC clustering — the streaming
+/// DiarizerManager over-splits speakers on telephone audio and ignores
+/// speaker-count hints). Models are downloaded on first use and the
+/// initialized manager is kept for subsequent files.
+actor SpeakerDiarizationService {
+    static let shared = SpeakerDiarizationService()
+
+    private var diarizer: OfflineDiarizerManager?
+    private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "SpeakerDiarizationService")
+
+    func diarize(samples: [Float]) async throws -> [SpeakerSegment] {
+        let manager = try await ensureDiarizer()
+        try Task.checkCancellation()
+
+        let result = try await manager.process(audio: samples)
+        logger.notice(
+            "Diarization completed: \(result.segments.count) segments, \(Set(result.segments.map(\.speakerId)).count) speakers"
+        )
+
+        return result.segments.map { segment in
+            SpeakerSegment(
+                speakerId: segment.speakerId,
+                start: TimeInterval(segment.startTimeSeconds),
+                end: TimeInterval(segment.endTimeSeconds)
+            )
+        }
+    }
+
+    private func ensureDiarizer() async throws -> OfflineDiarizerManager {
+        if let diarizer {
+            return diarizer
+        }
+
+        logger.notice("Loading offline diarization models")
+        do {
+            let models = try await OfflineDiarizerModels.load()
+            // Another caller may have finished loading while we awaited the download.
+            if let diarizer {
+                return diarizer
+            }
+            let manager = OfflineDiarizerManager(config: Self.makeConfig(logger: logger))
+            manager.initialize(models: models)
+            diarizer = manager
+            return manager
+        } catch {
+            logger.error("Failed to load diarization models: \(error, privacy: .public)")
+            throw error
+        }
+    }
+
+    func cleanup() {
+        diarizer = nil
+    }
+
+    /// Tuning knobs, overridable without a rebuild (app restart applies them):
+    ///   defaults write com.prakashjoshipax.VoiceInk TranscribeDiarizationNumSpeakers -int 2
+    ///   defaults write com.prakashjoshipax.VoiceInk TranscribeDiarizationClusteringThreshold -float 0.6
+    /// NumSpeakers pins the speaker count when known upfront. The threshold is the
+    /// AHC cut distance in [0, 2] — LARGER values merge more and yield FEWER speakers.
+    private static func makeConfig(logger: Logger) -> OfflineDiarizerConfig {
+        var config = OfflineDiarizerConfig.default
+        let defaults = UserDefaults.standard
+        if let threshold = defaults.object(forKey: "TranscribeDiarizationClusteringThreshold") as? Double,
+            threshold > 0
+        {
+            config.clustering.threshold = threshold
+        }
+        let numSpeakers = defaults.integer(forKey: "TranscribeDiarizationNumSpeakers")
+        if numSpeakers > 0 {
+            config.clustering.numSpeakers = numSpeakers
+        }
+        logger.notice(
+            "Offline diarizer config: threshold=\(config.clustering.threshold, privacy: .public), numSpeakers=\(String(describing: config.clustering.numSpeakers), privacy: .public)"
+        )
+        return config
+    }
+}

--- a/VoiceInk/Infrastructure/Providers/Transcription/Whisper/LibWhisper.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/Whisper/LibWhisper.swift
@@ -15,6 +15,7 @@ actor WhisperContext {
     private var prompt: String?
     private var promptCString: [CChar]?
     private var vadModelPath: String?
+    private var preserveTimeline = false
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "WhisperContext")
 
     private init() {}
@@ -66,11 +67,15 @@ actor WhisperContext {
         params.no_context = true
         params.single_segment = false
         params.temperature = 0.2
+        params.token_timestamps = true
+        params.max_len = 0
 
         whisper_reset_timings(context)
 
-        // Configure VAD if enabled by user and model is available
-        let isVADEnabled = UserDefaults.standard.bool(forKey: "IsVADEnabled")
+        // Configure VAD if enabled by user and model is available.
+        // VAD strips silence, which compresses token timestamps relative to the
+        // original audio — unusable when the caller needs the real timeline.
+        let isVADEnabled = UserDefaults.standard.bool(forKey: "IsVADEnabled") && !preserveTimeline
         if isVADEnabled, let vadModelPath = self.vadModelPath {
             params.vad = true
             params.vad_model_path = (vadModelPath as NSString).utf8String
@@ -108,6 +113,46 @@ actor WhisperContext {
             transcription += String(cString: whisper_full_get_segment_text(context, i))
         }
         return transcription
+    }
+
+    /// Word-level timings harvested from whisper.cpp token data (t0/t1 are in
+    /// 10ms units). Tokens are grouped into words on their leading space.
+    func getWordTimings() -> [WordTiming] {
+        guard let context = context else { return [] }
+        var words: [WordTiming] = []
+        var current: WordTiming?
+        let endOfTextToken = whisper_token_eot(context)
+
+        for i in 0..<whisper_full_n_segments(context) {
+            for j in 0..<whisper_full_n_tokens(context, i) {
+                let tokenData = whisper_full_get_token_data(context, i, j)
+                guard tokenData.id < endOfTextToken else { continue }
+
+                let tokenText = String(cString: whisper_full_get_token_text(context, i, j))
+                let start = TimeInterval(tokenData.t0) * 0.01
+                let end = TimeInterval(tokenData.t1) * 0.01
+                let startsNewWord = tokenText.hasPrefix(" ") || current == nil
+
+                if startsNewWord {
+                    if let finished = current, !finished.text.isEmpty {
+                        words.append(finished)
+                    }
+                    current = WordTiming(
+                        text: tokenText.trimmingCharacters(in: .whitespaces),
+                        start: start,
+                        end: end
+                    )
+                } else {
+                    current?.text += tokenText
+                    current?.end = end
+                }
+            }
+            if let finished = current, !finished.text.isEmpty {
+                words.append(finished)
+            }
+            current = nil
+        }
+        return words.filter { !$0.text.isEmpty }
     }
 
     static func createContext(path: String) async throws -> WhisperContext {
@@ -161,6 +206,10 @@ actor WhisperContext {
 
     func setLanguage(_ language: String?) {
         self.language = language
+    }
+
+    func setPreserveTimeline(_ preserve: Bool) {
+        self.preserveTimeline = preserve
     }
 }
 

--- a/VoiceInk/Infrastructure/Providers/Transcription/Whisper/LibWhisper.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/Whisper/LibWhisper.swift
@@ -147,10 +147,12 @@ actor WhisperContext {
                     current?.end = end
                 }
             }
-            if let finished = current, !finished.text.isEmpty {
-                words.append(finished)
-            }
-            current = nil
+            // The current word deliberately carries across segment boundaries:
+            // whisper can split a word between two segments, and it only ends
+            // when a token starts a new word (or the stream ends).
+        }
+        if let finished = current, !finished.text.isEmpty {
+            words.append(finished)
         }
         return words.filter { !$0.text.isEmpty }
     }

--- a/VoiceInk/Infrastructure/Providers/Transcription/Whisper/WhisperTranscriptionService.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/Whisper/WhisperTranscriptionService.swift
@@ -77,7 +77,9 @@ class WhisperTranscriptionService: TranscriptionService {
         }
 
         let text = await whisperContext.getTranscription()
-        let words = await whisperContext.getWordTimings()
+        // Word timings are only trustworthy when VAD didn't compress the
+        // timeline; callers that don't preserve it (live dictation) get none.
+        let words = context.preservesTimeline ? await whisperContext.getWordTimings() : []
 
         logger.notice("Whisper transcription completed successfully.")
 

--- a/VoiceInk/Infrastructure/Providers/Transcription/Whisper/WhisperTranscriptionService.swift
+++ b/VoiceInk/Infrastructure/Providers/Transcription/Whisper/WhisperTranscriptionService.swift
@@ -17,6 +17,12 @@ class WhisperTranscriptionService: TranscriptionService {
     func transcribe(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext) async throws
         -> String
     {
+        try await transcribeDetailed(audioURL: audioURL, model: model, context: context).text
+    }
+
+    func transcribeDetailed(audioURL: URL, model: any TranscriptionModel, context: TranscriptionRequestContext)
+        async throws -> DetailedTranscriptionResult
+    {
         guard model.provider == .whisper else {
             throw VoiceInkEngineError.modelLoadFailed
         }
@@ -60,6 +66,7 @@ class WhisperTranscriptionService: TranscriptionService {
         // Set prompt
         await whisperContext.setLanguage(context.language)
         await whisperContext.setPrompt(context.prompt ?? "")
+        await whisperContext.setPreserveTimeline(context.preservesTimeline)
 
         // Transcribe
         let success = await whisperContext.fullTranscribe(samples: data)
@@ -70,6 +77,7 @@ class WhisperTranscriptionService: TranscriptionService {
         }
 
         let text = await whisperContext.getTranscription()
+        let words = await whisperContext.getWordTimings()
 
         logger.notice("Whisper transcription completed successfully.")
 
@@ -79,7 +87,7 @@ class WhisperTranscriptionService: TranscriptionService {
             self.whisperContext = nil
         }
 
-        return text
+        return DetailedTranscriptionResult(text: text, words: words.isEmpty ? nil : words)
     }
 
     private func readAudioSamples(_ url: URL) throws -> [Float] {

--- a/VoiceInk/Localizable.xcstrings
+++ b/VoiceInk/Localizable.xcstrings
@@ -1124,6 +1124,57 @@
         }
       }
     },
+    "Identifying speakers..." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprecher werden erkannt..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在识别说话人..."
+          }
+        }
+      }
+    },
+    "Silence" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stille"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "静默"
+          }
+        }
+      }
+    },
+    "Speaker" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprecher"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "说话人"
+          }
+        }
+      }
+    },
     "••••••••" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
Adds speaker identification and word-level timestamps to the Transcribe tab, so imported recordings of conversations (meetings, interviews, call-center audio) come out attributed per speaker instead of as a single wall of text.

## What this adds

**A Speakers picker in the Transcribe tab** (Off / Auto / Voice AI / Stereo, styled like the Mode picker) controlling how speakers are identified:

- **Stereo**: telephony and call-center recordings usually carry one participant per stereo channel. When the file is stereo and the channels are actually distinct (dual-mono is detected via cross-correlation and rejected), each channel is peak-normalized and transcribed independently, and the words are merged on the shared timeline. Attribution is exact by construction, overlapping speech included — and normalizing each channel separately also fixes a real transcription-quality problem, since a quiet participant is no longer masked by the loud one in the mono downmix.
- **Voice AI**: mono or non-separated audio goes through FluidAudio's offline diarization pipeline (already a dependency, previously unused), and each word is assigned to the speaker segment it overlaps most. Speaker count and clustering threshold can be pinned via `TranscribeDiarizationNumSpeakers` / `TranscribeDiarizationClusteringThreshold` defaults.
- **Auto**: stereo separation when the file supports it, Voice AI otherwise.

**Word-level timestamps across the local engines.** `TranscriptionService` gains a `transcribeDetailed` requirement with a default implementation, so existing engines keep working untouched; engines that can produce timings override it:

- Whisper: `token_timestamps` enabled in whisper.cpp, tokens grouped into words
- Parakeet v2/v3: `ASRResult.tokenTimings` (previously discarded) grouped via `buildWordTimings`
- Nemotron: `finishWithTokenTimings()`
- Apple Speech: `audioTimeRange` attribute on the transcriber results

**A Speakers tab** in the Transcribe results and in History, rendering `Speaker 1 (0:12–0:45): …` blocks with silence gaps (`Silence (1:39–1:54, 15s)`) — silences of 2s or more are derived at render time from the stored utterances, so they also appear on previously saved transcriptions. Word timings and utterances are persisted on `Transcription` as optional JSON fields (lightweight migration).

**Save All** in the Transcribe tab when two or more items are completed: exports every transcription to a chosen folder as TXT (plain/enhanced text) or MD (speaker transcript), one file per audio.

## Notes

- Timestamps must match the real audio timeline for diarization to work, so whisper.cpp's internal VAD is disabled for these transcriptions (`preservesTimeline` on `TranscriptionRequestContext`). Without VAD, engines hallucinate words over silence; an energy check against the word's own channel drops those while keeping real words whose ITN timestamps land slightly off.
- Dual-channel mode runs one ASR pass per channel, so it takes roughly twice as long as a normal file transcription.
- Cloud providers and Parakeet unified fall back to plain text (no words, no attribution) for now.

## Testing

Exercised against real stereo call-center recordings (~12–14 min, PT-BR, one participant per channel with heavy level imbalance between them) with all four engines, plus mono files through the neural path. Attribution on the stereo path matched a manual listen end to end, including overlapping speech and backchannels; live dictation and the existing file-transcription flow are unaffected (default `transcribeDetailed` wraps the current `transcribe`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds speaker diarization and word-level timestamps to file transcription, so conversation recordings come out attributed per speaker instead of a single wall of text.

**New Features**
- A Speakers picker (Off/Auto/Voice AI/Stereo) controls speaker identification; Stereo transcribes each channel separately (also fixing quiet participants masked by the loud one), Auto falls back to `FluidAudio`'s offline diarization.
- A Speakers tab shows speaker-attributed blocks with silence gaps; speaker transcriptions show it as the primary tab in Transcribe results and History.
- Save All exports completed transcriptions to a folder as TXT or MD, one file per audio using its primary view.

**Notes**
- Word timestamps come from Whisper, Parakeet v2/v3, Nemotron, and Apple Speech; unsupported providers keep the plain single-pass path.
- VAD is disabled and an energy check drops hallucinated words to keep timestamps aligned with the real audio timeline.
- Stereo mode runs one ASR pass per channel, roughly doubling transcription time.
- Word timings and utterances persist as optional JSON fields, so previously saved transcriptions also gain the Speakers tab; cleanup drops words strictly by speaker and time, keeping persisted data consistent.

<sup>Written for commit 9faf5c46f2dcae0531365f0f8bfc3586f8f9e73b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

