### PR TITLE
Improve OpenRouter latency and request handling

### DIFF
--- a/VoiceInk.xcodeproj/project.pbxproj
+++ b/VoiceInk.xcodeproj/project.pbxproj
@@ -919,7 +919,7 @@
 			repositoryURL = "https://github.com/Beingpax/LLMkit.git";
 			requirement = {
 				kind = revision;
-				revision = 95b29c2e1ad22754c2f21495aafb483874c8f06c;
+				revision = 1fc213b8e37ea8b8a755dd30eaf50fa090cd4241;
 			};
 		};
 		E1ECEC142E44590200DFFBA8 /* XCRemoteSwiftPackageReference "Zip" */ = {

--- a/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceInk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Beingpax/LLMkit.git",
       "state" : {
-        "revision" : "95b29c2e1ad22754c2f21495aafb483874c8f06c"
+        "revision" : "1fc213b8e37ea8b8a755dd30eaf50fa090cd4241"
       }
     },
     {

--- a/VoiceInk/App/Configuration/AppDefaults.swift
+++ b/VoiceInk/App/Configuration/AppDefaults.swift
@@ -70,8 +70,8 @@ enum AppDefaults {
             // Enhancement
             "SkipShortEnhancement": true,
             "ShortEnhancementWordThreshold": 3,
-            "EnhancementTimeoutSeconds": 7,
-            "EnhancementRetryOnTimeout": true,
+            EnhancementRequestSettings.timeoutKey: EnhancementRequestSettings.defaultTimeoutSeconds,
+            EnhancementRequestSettings.retryOnTimeoutKey: EnhancementRequestSettings.defaultRetryOnTimeout,
 
             // Model
             "PrewarmModelOnWake": true,

--- a/VoiceInk/App/VoiceInk.swift
+++ b/VoiceInk/App/VoiceInk.swift
@@ -96,7 +96,7 @@ struct VoiceInkApp: App {
         _aiService = StateObject(wrappedValue: aiService)
         aiService.refreshOllamaAvailabilityInBackground()
         Task { @MainActor in
-            await aiService.fetchOpenRouterModels()
+            await aiService.fetchOpenRouterModelsIfNeededForMigration()
         }
 
         let updaterViewModel = UpdaterViewModel()

--- a/VoiceInk/App/VoiceInk.swift
+++ b/VoiceInk/App/VoiceInk.swift
@@ -95,6 +95,9 @@ struct VoiceInkApp: App {
         let aiService = AIService()
         _aiService = StateObject(wrappedValue: aiService)
         aiService.refreshOllamaAvailabilityInBackground()
+        Task { @MainActor in
+            await aiService.fetchOpenRouterModels()
+        }
 
         let updaterViewModel = UpdaterViewModel()
         _updaterViewModel = StateObject(wrappedValue: updaterViewModel)

--- a/VoiceInk/Features/Assistant/Workflows/AssistantChatService.swift
+++ b/VoiceInk/Features/Assistant/Workflows/AssistantChatService.swift
@@ -86,13 +86,23 @@ final class AssistantChatService {
     }
 
     private static func isTimeout(_ error: Error) -> Bool {
-        if let llmKitError = error as? LLMKitError, case .timeout = llmKitError {
-            return true
+        if let llmKitError = error as? LLMKitError {
+            switch llmKitError {
+            case .timeout:
+                return true
+            case .httpError(let statusCode, _):
+                return statusCode == 408
+            default:
+                break
+            }
         }
         if let enhancementError = error as? EnhancementError, case .timeout = enhancementError {
             return true
         }
         if let localError = error as? LocalAIError, case .timeout = localError {
+            return true
+        }
+        if let localCLIError = error as? LocalCLIError, case .timeout = localCLIError {
             return true
         }
 

--- a/VoiceInk/Features/Assistant/Workflows/AssistantChatService.swift
+++ b/VoiceInk/Features/Assistant/Workflows/AssistantChatService.swift
@@ -15,8 +15,7 @@ final class AssistantChatService {
     private let aiService: AIService
 
     private var requestTimeout: TimeInterval {
-        let stored = UserDefaults.standard.integer(forKey: "EnhancementTimeoutSeconds")
-        return stored > 0 ? TimeInterval(stored) : 7
+        EnhancementRequestSettings.timeout
     }
 
     init(modelContext: ModelContext, aiService: AIService) {
@@ -40,12 +39,11 @@ final class AssistantChatService {
         }
 
         let startTime = Date()
-        let text = try await aiService.completeChat(
+        let text = try await requestReplyWithTimeoutPolicy(
             provider: provider,
             modelName: modelName,
             messages: chatMessages,
-            systemPrompt: systemPrompt,
-            timeout: requestTimeout
+            systemPrompt: systemPrompt
         )
 
         return Reply(
@@ -54,6 +52,52 @@ final class AssistantChatService {
             systemPrompt: systemPrompt,
             requestLog: Self.requestLog(from: messages)
         )
+    }
+
+    private func requestReplyWithTimeoutPolicy(
+        provider: AIProvider,
+        modelName: String?,
+        messages: [ChatMessage],
+        systemPrompt: String?
+    ) async throws -> String {
+        let maximumAttempts = EnhancementRequestSettings.retryOnTimeout
+            ? EnhancementRequestSettings.maximumAttempts
+            : 1
+
+        var attempt = 0
+        while attempt < maximumAttempts {
+            do {
+                return try await aiService.completeChat(
+                    provider: provider,
+                    modelName: modelName,
+                    messages: messages,
+                    systemPrompt: systemPrompt,
+                    timeout: requestTimeout
+                )
+            } catch {
+                attempt += 1
+                guard Self.isTimeout(error), attempt < maximumAttempts else {
+                    throw error
+                }
+            }
+        }
+
+        throw EnhancementError.timeout
+    }
+
+    private static func isTimeout(_ error: Error) -> Bool {
+        if let llmKitError = error as? LLMKitError, case .timeout = llmKitError {
+            return true
+        }
+        if let enhancementError = error as? EnhancementError, case .timeout = enhancementError {
+            return true
+        }
+        if let localError = error as? LocalAIError, case .timeout = localError {
+            return true
+        }
+
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
     }
 
     func applyAssistantTurn(

--- a/VoiceInk/Features/Enhancement/State/AIService.swift
+++ b/VoiceInk/Features/Enhancement/State/AIService.swift
@@ -241,6 +241,8 @@ class AIService: ObservableObject {
     private var voiceInkRefineObserver: AnyCancellable?
 
     @Published private var openRouterModels: [String] = []
+    @Published private var openRouterModelCatalog: [OpenRouterModel] = []
+    private var isOpenRouterCatalogRefreshing = false
     @Published private(set) var isOllamaRefreshing = false
 
     var connectedProviders: [AIProvider] {
@@ -429,6 +431,14 @@ class AIService: ObservableObject {
     }
 
     private func loadSavedOpenRouterModels() {
+        if let savedCatalog = userDefaults.data(forKey: "openRouterModelCatalog"),
+            let decodedCatalog = try? JSONDecoder().decode([OpenRouterModel].self, from: savedCatalog)
+        {
+            openRouterModelCatalog = decodedCatalog
+            openRouterModels = decodedCatalog.map(\.id)
+            return
+        }
+
         if let savedModels = userDefaults.array(forKey: "openRouterModels") as? [String] {
             openRouterModels = savedModels
         }
@@ -436,6 +446,9 @@ class AIService: ObservableObject {
 
     private func saveOpenRouterModels() {
         userDefaults.set(openRouterModels, forKey: "openRouterModels")
+        if let encodedCatalog = try? JSONEncoder().encode(openRouterModelCatalog) {
+            userDefaults.set(encodedCatalog, forKey: "openRouterModelCatalog")
+        }
     }
 
     func selectModel(_ model: String) {
@@ -700,25 +713,33 @@ class AIService: ObservableObject {
         NotificationCenter.default.post(name: .AppSettingsDidChange, object: nil)
     }
 
+    func openRouterModelMetadata(for modelName: String) -> OpenRouterModel? {
+        openRouterModelCatalog.first(where: { $0.id == modelName })
+    }
+
+    @MainActor
     func fetchOpenRouterModels() async {
+        guard !isOpenRouterCatalogRefreshing else { return }
+        isOpenRouterCatalogRefreshing = true
+        defer { isOpenRouterCatalogRefreshing = false }
+
         do {
-            let models = try await OpenRouterClient.fetchModels()
-            await MainActor.run {
-                self.openRouterModels = models
-                self.saveOpenRouterModels()
-                if self.selectedProvider == .openRouter && self.currentModel == self.selectedProvider.defaultModel
-                    && !models.isEmpty
-                {
-                    self.selectModel(models.first!)
-                }
-                self.objectWillChange.send()
+            let catalog = try await OpenRouterClient.fetchModelCatalog()
+            openRouterModelCatalog = catalog
+            openRouterModels = catalog.map(\.id)
+            saveOpenRouterModels()
+            if selectedProvider == .openRouter,
+                selectedModels[.openRouter] == nil,
+                !openRouterModels.isEmpty
+            {
+                let initialModel = openRouterModels.contains(AIProvider.openRouter.defaultModel)
+                    ? AIProvider.openRouter.defaultModel
+                    : openRouterModels[0]
+                selectModel(initialModel)
             }
+            objectWillChange.send()
         } catch {
-            await MainActor.run {
-                self.openRouterModels = []
-                self.saveOpenRouterModels()
-                self.objectWillChange.send()
-            }
+            // Keep the last successful catalog during transient OpenRouter failures.
         }
     }
 }

--- a/VoiceInk/Features/Enhancement/State/AIService.swift
+++ b/VoiceInk/Features/Enhancement/State/AIService.swift
@@ -718,6 +718,17 @@ class AIService: ObservableObject {
     }
 
     @MainActor
+    func fetchOpenRouterModelsIfNeededForMigration() async {
+        guard openRouterModelCatalog.isEmpty,
+            APIKeyManager.shared.hasAPIKey(forProvider: AIProvider.openRouter.rawValue)
+        else {
+            return
+        }
+
+        await fetchOpenRouterModels()
+    }
+
+    @MainActor
     func fetchOpenRouterModels() async {
         guard !isOpenRouterCatalogRefreshing else { return }
         isOpenRouterCatalogRefreshing = true
@@ -728,7 +739,15 @@ class AIService: ObservableObject {
             openRouterModelCatalog = catalog
             openRouterModels = catalog.map(\.id)
             saveOpenRouterModels()
-            if selectedProvider == .openRouter,
+            if !openRouterModels.isEmpty,
+                let savedModel = selectedModels[.openRouter],
+                !openRouterModels.contains(savedModel)
+            {
+                let replacement = openRouterModels.contains(AIProvider.openRouter.defaultModel)
+                    ? AIProvider.openRouter.defaultModel
+                    : openRouterModels[0]
+                selectModel(replacement, for: .openRouter)
+            } else if selectedProvider == .openRouter,
                 selectedModels[.openRouter] == nil,
                 !openRouterModels.isEmpty
             {

--- a/VoiceInk/Features/Enhancement/Workflows/AIEnhancementService.swift
+++ b/VoiceInk/Features/Enhancement/Workflows/AIEnhancementService.swift
@@ -233,152 +233,31 @@ class AIEnhancementService: ObservableObject {
             contextSnapshot: contextSnapshot
         )
 
-        if provider == .ollama {
-            do {
-                let result = try await aiService.enhanceWithOllama(
-                    text: formattedText,
-                    systemPrompt: systemMessage,
-                    model: modelName,
-                    timeout: requestTimeout
-                )
-                return (
-                    AIEnhancementOutputFilter.filter(result),
-                    systemMessage,
-                    formattedText
-                )
-            } catch {
-                if let localError = error as? LocalAIError {
-                    switch localError {
-                    case .timeout:
-                        throw EnhancementError.timeout
-                    default:
-                        throw EnhancementError.customError(
-                            localError.errorDescription ?? "An unknown Ollama error occurred.")
-                    }
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
-        if provider == .localCLI {
-            do {
-                let result = try await aiService.enhanceWithLocalCLI(
-                    systemPrompt: systemMessage, userPrompt: formattedText)
-                return (
-                    AIEnhancementOutputFilter.filter(result),
-                    systemMessage,
-                    formattedText
-                )
-            } catch {
-                if let localError = error as? LocalCLIError {
-                    throw EnhancementError.customError(
-                        localError.errorDescription ?? "An unknown Local CLI error occurred.")
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
-        if provider != .openRouter {
+        if provider != .openRouter, provider != .ollama, provider != .localCLI {
             try await waitForRateLimit()
         }
 
         do {
-            let result: String
-            switch provider {
-            case .gemini:
-                result = try await GeminiLLMClient.chatCompletion(
-                    apiKey: try apiKey(for: provider, modelName: modelName),
-                    model: modelName,
-                    messages: [.user(formattedText)],
-                    systemPrompt: systemMessage,
-                    thinkingLevel: ReasoningConfig.geminiThinkingLevel(for: modelName),
-                    store: false,
-                    timeout: requestTimeout
-                )
-            case .anthropic:
-                result = try await AnthropicLLMClient.chatCompletion(
-                    apiKey: try apiKey(for: provider, modelName: modelName),
-                    model: modelName,
-                    messages: [.user(formattedText)],
-                    systemPrompt: systemMessage,
-                    timeout: requestTimeout
-                )
-            case .openRouter:
-                let modelMetadata = aiService.openRouterModelMetadata(for: modelName)
-                let policy = OpenRouterRequestPolicy.lowLatency(
-                    modelName: modelName,
-                    modelMetadata: modelMetadata
-                )
-                let completion = try await OpenRouterClient.chatCompletion(
-                    apiKey: try apiKey(for: provider, modelName: modelName),
-                    model: policy.model,
-                    messages: [.user(formattedText)],
-                    systemPrompt: systemMessage,
-                    temperature: policy.temperature,
-                    reasoning: policy.reasoning,
-                    provider: policy.provider,
-                    includeRouterMetadata: true,
-                    appReferer: URL(string: "https://tryvoiceink.com"),
-                    appTitle: "VoiceInk",
-                    timeout: requestTimeout
-                )
-                guard !OpenRouterRequestPolicy.outputWasTruncated(finishReason: completion.finishReason) else {
-                    throw EnhancementError.outputTruncated
-                }
-                let routedProvider = completion.provider ?? "unknown"
-                let routingAttempt = completion.metadata?.attempt ?? 0
-                let reasoningTokens = completion.usage?.reasoningTokens ?? 0
+            let completion = try await aiService.performChatCompletion(
+                provider: provider,
+                modelName: modelName,
+                messages: [.user(formattedText)],
+                systemPrompt: systemMessage,
+                localUserPrompt: formattedText,
+                timeout: requestTimeout
+            )
+            if let openRouterCompletion = completion.openRouterCompletion {
+                let routedProvider = openRouterCompletion.provider ?? "unknown"
+                let routingAttempt = openRouterCompletion.metadata?.attempt ?? 0
+                let reasoningTokens = openRouterCompletion.usage?.reasoningTokens ?? 0
                 logger.debug(
                     "OpenRouter completed requestedModel=\(modelName, privacy: .public) routedProvider=\(routedProvider, privacy: .public) routingAttempt=\(routingAttempt, privacy: .public) reasoningTokens=\(reasoningTokens, privacy: .public)"
                 )
-                result = completion.text
-            case .custom:
-                guard
-                    let customConfiguration = CustomAIProviderManager.shared.requestConfiguration(forModel: modelName),
-                    let baseURL = URL(string: customConfiguration.baseURL)
-                else {
-                    throw EnhancementError.notConfigured
-                }
-                result = try await OpenAILLMClient.chatCompletion(
-                    baseURL: baseURL,
-                    apiKey: customConfiguration.apiKey,
-                    model: customConfiguration.modelName,
-                    messages: [.user(formattedText)],
-                    systemPrompt: systemMessage,
-                    temperature: 0.3,
-                    timeout: requestTimeout
-                )
-            default:
-                guard let baseURL = URL(string: provider.baseURL) else {
-                    throw EnhancementError.customError(
-                        "\(provider.rawValue) has an invalid API endpoint URL. Please update it in AI settings.")
-                }
-                let reasoningEffort = ReasoningConfig.getReasoningParameter(
-                    for: provider,
-                    modelName: modelName
-                )
-                let extraBody = ReasoningConfig.getExtraBodyParameters(
-                    for: provider,
-                    modelName: modelName
-                )
-                result = try await OpenAILLMClient.chatCompletion(
-                    baseURL: baseURL,
-                    apiKey: try apiKey(for: provider, modelName: modelName),
-                    model: modelName,
-                    messages: [.user(formattedText)],
-                    systemPrompt: systemMessage,
-                    temperature: 0.3,
-                    reasoningEffort: reasoningEffort,
-                    extraBody: extraBody,
-                    timeout: requestTimeout
-                )
             }
             let filteredResult = AIEnhancementOutputFilter.filter(
-                result.trimmingCharacters(in: .whitespacesAndNewlines)
+                completion.text.trimmingCharacters(in: .whitespacesAndNewlines)
             )
-            guard !filteredResult.isEmpty else {
+            guard provider == .ollama || provider == .localCLI || !filteredResult.isEmpty else {
                 throw EnhancementError.enhancementFailed
             }
             return (
@@ -388,26 +267,25 @@ class AIEnhancementService: ObservableObject {
             )
         } catch let error as LLMKitError {
             throw mapLLMKitError(error)
+        } catch let error as LocalAIError {
+            if case .timeout = error {
+                throw EnhancementError.timeout
+            }
+            throw EnhancementError.customError(
+                error.errorDescription ?? "An unknown Ollama error occurred."
+            )
+        } catch let error as LocalCLIError {
+            if case .timeout = error {
+                throw EnhancementError.timeout
+            }
+            throw EnhancementError.customError(
+                error.errorDescription ?? "An unknown Local CLI error occurred."
+            )
         } catch let error as EnhancementError {
             throw error
         } catch {
             throw EnhancementError.customError(error.localizedDescription)
         }
-    }
-
-    private func apiKey(for provider: AIProvider, modelName: String) throws -> String {
-        if provider == .custom {
-            guard let customConfiguration = CustomAIProviderManager.shared.requestConfiguration(forModel: modelName)
-            else {
-                throw EnhancementError.notConfigured
-            }
-            return customConfiguration.apiKey
-        }
-
-        guard let key = APIKeyManager.shared.getAPIKey(forProvider: provider.rawValue), !key.isEmpty else {
-            throw EnhancementError.notConfigured
-        }
-        return key
     }
 
     private func mapLLMKitError(_ error: LLMKitError) -> EnhancementError {

--- a/VoiceInk/Features/Enhancement/Workflows/AIEnhancementService.swift
+++ b/VoiceInk/Features/Enhancement/Workflows/AIEnhancementService.swift
@@ -29,9 +29,8 @@ class AIEnhancementService: ObservableObject {
     private let aiService: AIService
     private let screenCaptureService: ScreenCaptureService
     private let customVocabularyService: CustomVocabularyService
-    private var baseTimeout: TimeInterval {
-        let stored = UserDefaults.standard.integer(forKey: "EnhancementTimeoutSeconds")
-        return stored > 0 ? TimeInterval(stored) : 7
+    private var requestTimeout: TimeInterval {
+        EnhancementRequestSettings.timeout
     }
     private let rateLimitInterval: TimeInterval = 1.0
     private var lastRequestTime: Date?
@@ -240,7 +239,7 @@ class AIEnhancementService: ObservableObject {
                     text: formattedText,
                     systemPrompt: systemMessage,
                     model: modelName,
-                    timeout: baseTimeout
+                    timeout: requestTimeout
                 )
                 return (
                     AIEnhancementOutputFilter.filter(result),
@@ -281,7 +280,9 @@ class AIEnhancementService: ObservableObject {
             }
         }
 
-        try await waitForRateLimit()
+        if provider != .openRouter {
+            try await waitForRateLimit()
+        }
 
         do {
             let result: String
@@ -294,7 +295,7 @@ class AIEnhancementService: ObservableObject {
                     systemPrompt: systemMessage,
                     thinkingLevel: ReasoningConfig.geminiThinkingLevel(for: modelName),
                     store: false,
-                    timeout: baseTimeout
+                    timeout: requestTimeout
                 )
             case .anthropic:
                 result = try await AnthropicLLMClient.chatCompletion(
@@ -302,8 +303,37 @@ class AIEnhancementService: ObservableObject {
                     model: modelName,
                     messages: [.user(formattedText)],
                     systemPrompt: systemMessage,
-                    timeout: baseTimeout
+                    timeout: requestTimeout
                 )
+            case .openRouter:
+                let modelMetadata = aiService.openRouterModelMetadata(for: modelName)
+                let policy = OpenRouterRequestPolicy.lowLatency(
+                    modelName: modelName,
+                    modelMetadata: modelMetadata
+                )
+                let completion = try await OpenRouterClient.chatCompletion(
+                    apiKey: try apiKey(for: provider, modelName: modelName),
+                    model: policy.model,
+                    messages: [.user(formattedText)],
+                    systemPrompt: systemMessage,
+                    temperature: policy.temperature,
+                    reasoning: policy.reasoning,
+                    provider: policy.provider,
+                    includeRouterMetadata: true,
+                    appReferer: URL(string: "https://tryvoiceink.com"),
+                    appTitle: "VoiceInk",
+                    timeout: requestTimeout
+                )
+                guard !OpenRouterRequestPolicy.outputWasTruncated(finishReason: completion.finishReason) else {
+                    throw EnhancementError.outputTruncated
+                }
+                let routedProvider = completion.provider ?? "unknown"
+                let routingAttempt = completion.metadata?.attempt ?? 0
+                let reasoningTokens = completion.usage?.reasoningTokens ?? 0
+                logger.debug(
+                    "OpenRouter completed requestedModel=\(modelName, privacy: .public) routedProvider=\(routedProvider, privacy: .public) routingAttempt=\(routingAttempt, privacy: .public) reasoningTokens=\(reasoningTokens, privacy: .public)"
+                )
+                result = completion.text
             case .custom:
                 guard
                     let customConfiguration = CustomAIProviderManager.shared.requestConfiguration(forModel: modelName),
@@ -318,7 +348,7 @@ class AIEnhancementService: ObservableObject {
                     messages: [.user(formattedText)],
                     systemPrompt: systemMessage,
                     temperature: 0.3,
-                    timeout: baseTimeout
+                    timeout: requestTimeout
                 )
             default:
                 guard let baseURL = URL(string: provider.baseURL) else {
@@ -342,13 +372,17 @@ class AIEnhancementService: ObservableObject {
                     temperature: 0.3,
                     reasoningEffort: reasoningEffort,
                     extraBody: extraBody,
-                    timeout: baseTimeout
+                    timeout: requestTimeout
                 )
             }
+            let filteredResult = AIEnhancementOutputFilter.filter(
+                result.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            guard !filteredResult.isEmpty else {
+                throw EnhancementError.enhancementFailed
+            }
             return (
-                AIEnhancementOutputFilter.filter(
-                    result.trimmingCharacters(in: .whitespacesAndNewlines)
-                ),
+                filteredResult,
                 systemMessage,
                 formattedText
             )
@@ -382,6 +416,7 @@ class AIEnhancementService: ObservableObject {
             return .notConfigured
         case .httpError(let statusCode, let message):
             if statusCode == 429 { return .rateLimitExceeded }
+            if statusCode == 408 { return .timeout }
             if (500...599).contains(statusCode) { return .serverError }
             return .customError("HTTP \(statusCode): \(message)")
         case .noResultReturned:
@@ -398,20 +433,20 @@ class AIEnhancementService: ObservableObject {
     }
 
     private var retryOnTimeout: Bool {
-        UserDefaults.standard.bool(forKey: "EnhancementRetryOnTimeout")
+        EnhancementRequestSettings.retryOnTimeout
     }
 
     private func makeRequestWithRetry(
         text: String,
         configuration: EnhancementRuntimeConfiguration,
         contextSnapshot: RecordingContextSnapshot?,
-        maxRetries: Int = 3,
+        maxAttempts: Int = EnhancementRequestSettings.maximumAttempts,
         initialDelay: TimeInterval = 1.0
     ) async throws -> (text: String, systemMessage: String?, userMessage: String?) {
         var retries = 0
         var currentDelay = initialDelay
 
-        while retries < maxRetries {
+        while retries < maxAttempts {
             do {
                 return try await makeRequest(
                     text: text,
@@ -422,25 +457,25 @@ class AIEnhancementService: ObservableObject {
                 switch error {
                 case .networkError, .serverError, .rateLimitExceeded:
                     retries += 1
-                    if retries < maxRetries {
+                    if retries < maxAttempts {
                         logger.warning(
-                            "Request failed, retrying in \(currentDelay, privacy: .public)s... (Attempt \(retries, privacy: .public)/\(maxRetries, privacy: .public))"
+                            "Request failed, retrying in \(currentDelay, privacy: .public)s... (Attempt \(retries, privacy: .public)/\(maxAttempts, privacy: .public))"
                         )
                         try await Task.sleep(nanoseconds: UInt64(currentDelay * 1_000_000_000))
                         currentDelay *= 2
                     } else {
-                        logger.error("Request failed after \(maxRetries, privacy: .public) retries.")
+                        logger.error("Request failed after \(maxAttempts, privacy: .public) attempts.")
                         throw error
                     }
                 case .timeout:
                     if retryOnTimeout {
                         retries += 1
-                        if retries < maxRetries {
+                        if retries < maxAttempts {
                             logger.warning(
-                                "Request timed out, retrying immediately... (Attempt \(retries, privacy: .public)/\(maxRetries, privacy: .public))"
+                                "Request timed out, retrying immediately... (Attempt \(retries, privacy: .public)/\(maxAttempts, privacy: .public))"
                             )
                         } else {
-                            logger.error("Request timed out after \(maxRetries, privacy: .public) retries.")
+                            logger.error("Request timed out after \(maxAttempts, privacy: .public) attempts.")
                             throw error
                         }
                     } else {
@@ -457,14 +492,14 @@ class AIEnhancementService: ObservableObject {
                         nsError.code)
                 {
                     retries += 1
-                    if retries < maxRetries {
+                    if retries < maxAttempts {
                         logger.warning(
-                            "Request failed with network error, retrying in \(currentDelay, privacy: .public)s... (Attempt \(retries, privacy: .public)/\(maxRetries, privacy: .public))"
+                            "Request failed with network error, retrying in \(currentDelay, privacy: .public)s... (Attempt \(retries, privacy: .public)/\(maxAttempts, privacy: .public))"
                         )
                         try await Task.sleep(nanoseconds: UInt64(currentDelay * 1_000_000_000))
                         currentDelay *= 2
                     } else {
-                        logger.error("Request failed after \(maxRetries, privacy: .public) retries with network error.")
+                        logger.error("Request failed after \(maxAttempts, privacy: .public) attempts with network error.")
                         throw EnhancementError.networkError
                     }
                 } else {
@@ -488,7 +523,8 @@ class AIEnhancementService: ObservableObject {
             let requestResult = try await makeRequestWithRetry(
                 text: text,
                 configuration: configuration,
-                contextSnapshot: contextSnapshot
+                contextSnapshot: contextSnapshot,
+                maxAttempts: EnhancementRequestSettings.maximumAttempts
             )
             let endTime = Date()
             let duration = endTime.timeIntervalSince(startTime)
@@ -602,6 +638,7 @@ enum EnhancementError: Error {
     case notConfigured
     case invalidResponse
     case enhancementFailed
+    case outputTruncated
     case networkError
     case serverError
     case rateLimitExceeded
@@ -618,6 +655,8 @@ extension EnhancementError: LocalizedError {
             return String(localized: "Invalid response from AI provider.")
         case .enhancementFailed:
             return String(localized: "AI enhancement failed to process the text.")
+        case .outputTruncated:
+            return String(localized: "The AI provider stopped before completing the enhancement.")
         case .networkError:
             return String(localized: "Network connection failed. Check your internet.")
         case .serverError:

--- a/VoiceInk/Features/ModelLibrary/Views/ModelSettingsPanel.swift
+++ b/VoiceInk/Features/ModelLibrary/Views/ModelSettingsPanel.swift
@@ -199,8 +199,10 @@ private struct WhisperPromptSettingsSection: View {
 private struct EnhancementModelSettingsView: View {
     @AppStorage("SkipShortEnhancement") private var isSkipShortEnhancementEnabled = true
     @AppStorage("ShortEnhancementWordThreshold") private var shortEnhancementWordThreshold = 3
-    @AppStorage("EnhancementTimeoutSeconds") private var enhancementTimeoutSeconds = 7
-    @AppStorage("EnhancementRetryOnTimeout") private var retryOnTimeout = true
+    @AppStorage(EnhancementRequestSettings.timeoutKey) private var enhancementTimeoutSeconds =
+        EnhancementRequestSettings.defaultTimeoutSeconds
+    @AppStorage(EnhancementRequestSettings.retryOnTimeoutKey) private var retryOnTimeout =
+        EnhancementRequestSettings.defaultRetryOnTimeout
     @State private var isShortEnhancementExpanded = false
 
     var body: some View {

--- a/VoiceInk/Infrastructure/Providers/Enhancement/Chat/AIChatCompletionService.swift
+++ b/VoiceInk/Infrastructure/Providers/Enhancement/Chat/AIChatCompletionService.swift
@@ -31,6 +31,28 @@ extension AIService {
                 systemPrompt: systemPrompt,
                 timeout: timeout
             )
+        case .openRouter:
+            let policy = OpenRouterRequestPolicy.lowLatency(
+                modelName: resolvedModel,
+                modelMetadata: openRouterModelMetadata(for: resolvedModel)
+            )
+            let completion = try await OpenRouterClient.chatCompletion(
+                apiKey: try chatAPIKey(for: provider, modelName: resolvedModel),
+                model: policy.model,
+                messages: messages,
+                systemPrompt: systemPrompt,
+                temperature: policy.temperature,
+                reasoning: policy.reasoning,
+                provider: policy.provider,
+                includeRouterMetadata: true,
+                appReferer: URL(string: "https://tryvoiceink.com"),
+                appTitle: "VoiceInk",
+                timeout: timeout
+            )
+            guard !OpenRouterRequestPolicy.outputWasTruncated(finishReason: completion.finishReason) else {
+                throw EnhancementError.outputTruncated
+            }
+            result = completion.text
         case .custom:
             guard
                 let customConfiguration = CustomAIProviderManager.shared.requestConfiguration(forModel: resolvedModel),
@@ -88,7 +110,11 @@ extension AIService {
             )
         }
 
-        return AIEnhancementOutputFilter.filter(result)
+        let filteredResult = AIEnhancementOutputFilter.filter(result)
+        guard !filteredResult.isEmpty else {
+            throw EnhancementError.enhancementFailed
+        }
+        return filteredResult
     }
 
     private func chatAPIKey(for provider: AIProvider, modelName: String) throws -> String {

--- a/VoiceInk/Infrastructure/Providers/Enhancement/Chat/AIChatCompletionService.swift
+++ b/VoiceInk/Infrastructure/Providers/Enhancement/Chat/AIChatCompletionService.swift
@@ -1,17 +1,24 @@
 import Foundation
 import LLMkit
 
+struct AIChatCompletionResult: Sendable {
+    let text: String
+    let openRouterCompletion: OpenRouterCompletion?
+}
+
 extension AIService {
-    func completeChat(
+    func performChatCompletion(
         provider: AIProvider,
         modelName: String?,
         messages: [ChatMessage],
         systemPrompt: String? = nil,
+        localUserPrompt: String? = nil,
         timeout: TimeInterval = 30
-    ) async throws -> String {
+    ) async throws -> AIChatCompletionResult {
         let resolvedModel = modelName?.isEmpty == false ? modelName! : selectedModel(for: provider)
 
         let result: String
+        var openRouterCompletion: OpenRouterCompletion? = nil
         switch provider {
         case .gemini:
             result = try await GeminiLLMClient.chatCompletion(
@@ -53,6 +60,7 @@ extension AIService {
                 throw EnhancementError.outputTruncated
             }
             result = completion.text
+            openRouterCompletion = completion
         case .custom:
             guard
                 let customConfiguration = CustomAIProviderManager.shared.requestConfiguration(forModel: resolvedModel),
@@ -75,7 +83,7 @@ extension AIService {
             )
         case .ollama:
             result = try await enhanceWithOllama(
-                text: chatPrompt(from: messages),
+                text: localUserPrompt ?? chatPrompt(from: messages),
                 systemPrompt: systemPrompt ?? "",
                 model: resolvedModel,
                 timeout: timeout
@@ -83,7 +91,7 @@ extension AIService {
         case .localCLI:
             result = try await enhanceWithLocalCLI(
                 systemPrompt: systemPrompt ?? "",
-                userPrompt: chatPrompt(from: messages)
+                userPrompt: localUserPrompt ?? chatPrompt(from: messages)
             )
         default:
             guard let baseURL = URL(string: provider.baseURL) else {
@@ -110,8 +118,26 @@ extension AIService {
             )
         }
 
+        return AIChatCompletionResult(text: result, openRouterCompletion: openRouterCompletion)
+    }
+
+    func completeChat(
+        provider: AIProvider,
+        modelName: String?,
+        messages: [ChatMessage],
+        systemPrompt: String? = nil,
+        timeout: TimeInterval = 30
+    ) async throws -> String {
+        let completion = try await performChatCompletion(
+            provider: provider,
+            modelName: modelName,
+            messages: messages,
+            systemPrompt: systemPrompt,
+            timeout: timeout
+        )
+        let result = completion.text
         let filteredResult = AIEnhancementOutputFilter.filter(result)
-        guard !filteredResult.isEmpty else {
+        guard provider != .openRouter || !filteredResult.isEmpty else {
             throw EnhancementError.enhancementFailed
         }
         return filteredResult

--- a/VoiceInk/Infrastructure/Providers/Enhancement/EnhancementRequestSettings.swift
+++ b/VoiceInk/Infrastructure/Providers/Enhancement/EnhancementRequestSettings.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum EnhancementRequestSettings {
+    static let timeoutKey = "EnhancementTimeoutSeconds"
+    static let retryOnTimeoutKey = "EnhancementRetryOnTimeout"
+    static let defaultTimeoutSeconds = 7
+    static let defaultRetryOnTimeout = true
+    static let maximumAttempts = 3
+
+    static var timeout: TimeInterval {
+        let configuredTimeout = UserDefaults.standard.integer(forKey: timeoutKey)
+        return TimeInterval(configuredTimeout > 0 ? configuredTimeout : defaultTimeoutSeconds)
+    }
+
+    static var retryOnTimeout: Bool {
+        guard UserDefaults.standard.object(forKey: retryOnTimeoutKey) != nil else {
+            return defaultRetryOnTimeout
+        }
+        return UserDefaults.standard.bool(forKey: retryOnTimeoutKey)
+    }
+}

--- a/VoiceInk/Infrastructure/Providers/Enhancement/OpenRouterRequestPolicy.swift
+++ b/VoiceInk/Infrastructure/Providers/Enhancement/OpenRouterRequestPolicy.swift
@@ -1,0 +1,64 @@
+import Foundation
+import LLMkit
+
+struct OpenRouterRequestPolicy {
+    let model: String
+    let temperature: Double?
+    let reasoning: OpenRouterReasoning?
+    let provider: OpenRouterProviderPreferences
+
+    static func lowLatency(
+        modelName: String,
+        modelMetadata: OpenRouterModel?
+    ) -> OpenRouterRequestPolicy {
+        let supportedParameters = Set(modelMetadata?.supportedParameters ?? [])
+
+        return OpenRouterRequestPolicy(
+            model: nitroVariant(of: modelName),
+            temperature: supportedParameters.contains("temperature") ? 0.3 : nil,
+            reasoning: reasoningConfiguration(
+                capabilities: modelMetadata?.reasoning,
+                supportsReasoningParameter: supportedParameters.contains("reasoning")
+            ),
+            provider: OpenRouterProviderPreferences(
+                sort: .throughput,
+                preferredMaxLatency: OpenRouterPercentileThresholds(p90: 2.5),
+                requireParameters: true,
+                allowFallbacks: true
+            )
+        )
+    }
+
+    private static func nitroVariant(of modelName: String) -> String {
+        guard let finalComponent = modelName.split(separator: "/").last,
+              !finalComponent.contains(":") else {
+            return modelName
+        }
+        return "\(modelName):nitro"
+    }
+
+    private static func reasoningConfiguration(
+        capabilities: OpenRouterReasoningCapabilities?,
+        supportsReasoningParameter: Bool
+    ) -> OpenRouterReasoning? {
+        guard supportsReasoningParameter, let capabilities else {
+            return nil
+        }
+
+        if capabilities.mandatory {
+            let minimumEffort = capabilities.supportedEfforts.last
+            return OpenRouterReasoning(effort: minimumEffort, exclude: true)
+        }
+
+        if capabilities.supportedEfforts.contains("none") {
+            return OpenRouterReasoning(effort: "none", exclude: true)
+        }
+
+        return OpenRouterReasoning(enabled: false, exclude: true)
+    }
+
+    static func outputWasTruncated(finishReason: String?) -> Bool {
+        guard let finishReason else { return false }
+        return ["length", "max_tokens", "max_output_tokens"].contains(finishReason.lowercased())
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves OpenRouter request latency and reliability by routing to the fastest providers, catching truncated or empty responses, and centralizing timeout/retry settings.

**Latency**
- OpenRouter requests sort providers by throughput and enforce a p90 latency cap of 2.5s, preferring `:nitro` model variants.
- The OpenRouter model catalog now caches provider metadata like supported parameters and reasoning capabilities.
- Models are pre-fetched at launch, and the default OpenRouter model is kept when available.

**Request handling**
- Timeout and retry settings are centralized in `EnhancementRequestSettings`, and all provider requests now flow through one shared completion path.
- Assistant chat retries on timeouts; enhancement retries timeouts immediately without backoff.
- Responses truncated by token limits now surface `outputTruncated` instead of returning partial text.
- Empty enhancements throw `enhancementFailed` rather than returning blank text.
- OpenRouter skips the rate limiter, and HTTP 408 now maps to timeout.
- The `LLMkit` dependency was updated.

<sup>Written for commit 15764ee6aa48799fa6f13d0835bc5a4ac492e9df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Beingpax/VoiceInk/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

