### PR TITLE
Support keyed shortcuts during Secure Event Input

### DIFF
--- a/LocalBuild.xcconfig
+++ b/LocalBuild.xcconfig
@@ -2,7 +2,8 @@
 // Build configuration for local builds with an ad-hoc fallback when no Apple Development identity is available.
 // Applied only by `make local` on top of Release; normal Xcode configurations are unchanged.
 
-// make local supplies the identity; an xcconfig assignment would override its command-line choice.
+// Defaults to ad-hoc signing; make local overrides this when an Apple Development identity is available.
+CODE_SIGN_IDENTITY = -
 CODE_SIGN_STYLE = Manual
 DEVELOPMENT_TEAM =
 PROVISIONING_PROFILE_SPECIFIER =

--- a/LocalBuild.xcconfig
+++ b/LocalBuild.xcconfig
@@ -2,8 +2,7 @@
 // Build configuration for local builds with an ad-hoc fallback when no Apple Development identity is available.
 // Applied only by `make local` on top of Release; normal Xcode configurations are unchanged.
 
-// Defaults to ad-hoc signing; make local overrides this when an Apple Development identity is available.
-CODE_SIGN_IDENTITY = -
+// make local supplies the identity; an xcconfig assignment would override its command-line choice.
 CODE_SIGN_STYLE = Manual
 DEVELOPMENT_TEAM =
 PROVISIONING_PROFILE_SPECIFIER =

--- a/Tests/VoiceInkTests/SystemHotKeyTests.swift
+++ b/Tests/VoiceInkTests/SystemHotKeyTests.swift
@@ -70,7 +70,7 @@ struct SystemHotKeyTests {
         withExtendedLifetime((monitor, replacement)) {}
     }
 
-    @Test @MainActor func fullyRegisteredMonitorWorksWithoutAnEventTap() {
+    @Test @MainActor func fullyRegisteredMonitorHoldsItsRegistrationWithoutAnEventTap() {
         let monitor = ShortcutMonitor(createEventTap: { _, _ in nil })
         let keyCode = UInt16(kVK_F18)
         let modifiers = UInt32(controlKey | optionKey | cmdKey)

--- a/Tests/VoiceInkTests/SystemHotKeyTests.swift
+++ b/Tests/VoiceInkTests/SystemHotKeyTests.swift
@@ -1,0 +1,52 @@
+import AppKit
+import Carbon
+import Testing
+@testable import VoiceInk
+
+@Suite(.serialized)
+struct SystemHotKeyTests {
+    @Test func optionSpaceUsesSystemRegistration() {
+        let shortcut = Shortcut.key(keyCode: UInt16(kVK_Space), modifierFlags: [.option])
+
+        #expect(shortcut.systemHotKeyModifiers == UInt32(optionKey))
+    }
+
+    @Test func functionKeyNormalizesItsImplicitFnFlag() {
+        let shortcut = Shortcut.key(keyCode: UInt16(kVK_F5), modifierFlags: [.function, .control])
+
+        #expect(shortcut.systemHotKeyModifiers == UInt32(controlKey))
+    }
+
+    @Test func unsupportedInputsKeepTheirEventTapRoute() {
+        let shortcuts: [Shortcut] = [
+            .key(keyCode: UInt16(kVK_Space), modifierFlags: [.function]),
+            .rightCommand,
+            .mouseButton(buttonNumber: 3, modifierFlags: [.option]),
+        ]
+
+        #expect(shortcuts.allSatisfy { $0.systemHotKeyModifiers == nil })
+    }
+
+    @Test func unmodifiedEscapeCanCancelTheRecorder() {
+        let shortcut = Shortcut.key(keyCode: UInt16(kVK_Escape), modifierFlags: [])
+
+        #expect(shortcut.systemHotKeyModifiers == 0)
+    }
+
+    @Test @MainActor func releasingARegistrationAllowsTheShortcutToBeReused() {
+        let keyCode = UInt16(kVK_F19)
+        let modifiers = UInt32(controlKey | optionKey | cmdKey)
+        var first = SystemHotKey(keyCode: keyCode, modifiers: modifiers) { _, _ in }
+        #expect(first != nil)
+        withExtendedLifetime(first) {
+            let duplicate = SystemHotKey(keyCode: keyCode, modifiers: modifiers) { _, _ in }
+            #expect(duplicate == nil)
+        }
+
+        first = nil
+        let replacement = SystemHotKey(keyCode: keyCode, modifiers: modifiers) { _, _ in }
+
+        #expect(replacement != nil)
+        withExtendedLifetime(replacement) {}
+    }
+}

--- a/Tests/VoiceInkTests/SystemHotKeyTests.swift
+++ b/Tests/VoiceInkTests/SystemHotKeyTests.swift
@@ -49,4 +49,41 @@ struct SystemHotKeyTests {
         #expect(replacement != nil)
         withExtendedLifetime(replacement) {}
     }
+
+    @Test @MainActor func failedMonitorStartReleasesSuccessfulRegistrations() {
+        let monitor = ShortcutMonitor(createEventTap: { _, _ in nil })
+        let keyCode = UInt16(kVK_F18)
+        let modifiers = UInt32(controlKey | optionKey | cmdKey)
+
+        let started = monitor.start(
+            shortcuts: [
+                .primaryRecording: .key(keyCode: keyCode, modifierFlags: [.control, .option, .command]),
+                .secondaryRecording: .rightCommand,
+            ],
+            onShortcutDown: { _, _ in },
+            onShortcutUp: { _, _ in }
+        )
+        let replacement = SystemHotKey(keyCode: keyCode, modifiers: modifiers) { _, _ in }
+
+        #expect(!started)
+        #expect(replacement != nil)
+        withExtendedLifetime((monitor, replacement)) {}
+    }
+
+    @Test @MainActor func fullyRegisteredMonitorWorksWithoutAnEventTap() {
+        let monitor = ShortcutMonitor(createEventTap: { _, _ in nil })
+        let keyCode = UInt16(kVK_F18)
+        let modifiers = UInt32(controlKey | optionKey | cmdKey)
+
+        let started = monitor.start(
+            shortcuts: [.primaryRecording: .key(keyCode: keyCode, modifierFlags: [.control, .option, .command])],
+            onShortcutDown: { _, _ in },
+            onShortcutUp: { _, _ in }
+        )
+        let duplicate = SystemHotKey(keyCode: keyCode, modifiers: modifiers) { _, _ in }
+
+        #expect(started)
+        #expect(duplicate == nil)
+        withExtendedLifetime(monitor) {}
+    }
 }

--- a/VoiceInk/Features/Shortcuts/Coordination/ShortcutMonitor.swift
+++ b/VoiceInk/Features/Shortcuts/Coordination/ShortcutMonitor.swift
@@ -4,6 +4,8 @@ import Foundation
 import os
 
 final class ShortcutMonitor {
+    typealias EventTapFactory = (CGEventTapCallBack, UnsafeMutableRawPointer) -> CFMachPort?
+
     fileprivate enum EventKind {
         case keyDown
         case keyUp
@@ -29,9 +31,23 @@ final class ShortcutMonitor {
     private var onShortcutInterrupted: ((ShortcutAction, TimeInterval) -> Void)?
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
+    private let createEventTap: EventTapFactory
     private let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "ShortcutMonitor")
 
     private static let shortcutInterruptionWindow: TimeInterval = 1.0
+
+    init(createEventTap: @escaping EventTapFactory = { callback, userInfo in
+        CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: ShortcutMonitor.eventMask,
+            callback: callback,
+            userInfo: userInfo
+        )
+    }) {
+        self.createEventTap = createEventTap
+    }
 
     deinit {
         stop()
@@ -69,7 +85,11 @@ final class ShortcutMonitor {
         }
 
         let hasEventTap = installEventTap()
-        return hasEventTap || systemHotKeys.count == shortcuts.count
+        guard hasEventTap || systemHotKeys.count == shortcuts.count else {
+            stop()
+            return false
+        }
+        return true
     }
 
     func stop() {
@@ -113,14 +133,7 @@ final class ShortcutMonitor {
         }
 
         guard
-            let eventTap = CGEvent.tapCreate(
-                tap: .cgSessionEventTap,
-                place: .headInsertEventTap,
-                options: .defaultTap,
-                eventsOfInterest: Self.eventMask,
-                callback: callback,
-                userInfo: Unmanaged.passUnretained(self).toOpaque()
-            )
+            let eventTap = createEventTap(callback, Unmanaged.passUnretained(self).toOpaque())
         else {
             logger.error("Failed to install global shortcut event tap")
             return false

--- a/VoiceInk/Features/Shortcuts/Coordination/ShortcutMonitor.swift
+++ b/VoiceInk/Features/Shortcuts/Coordination/ShortcutMonitor.swift
@@ -21,6 +21,7 @@ final class ShortcutMonitor {
     }
 
     private var shortcuts: [ShortcutAction: ShortcutState] = [:]
+    private var systemHotKeys: [ShortcutAction: SystemHotKey] = [:]
     private var suppressedMouseButtons = Set<UInt16>()
     private var interruptibleActions: Set<ShortcutAction> = []
     private var onShortcutDown: ((ShortcutAction, TimeInterval) -> Void)?
@@ -59,10 +60,20 @@ final class ShortcutMonitor {
         self.onShortcutUp = onShortcutUp
         self.onShortcutInterrupted = onShortcutInterrupted
 
-        return installEventTap()
+        for (action, shortcut) in shortcuts {
+            guard let modifiers = shortcut.systemHotKeyModifiers else { continue }
+            systemHotKeys[action] = SystemHotKey(keyCode: shortcut.keyCode, modifiers: modifiers) {
+                [weak self] isDown, eventTime in
+                self?.handleSystemHotKey(action: action, isDown: isDown, eventTime: eventTime)
+            }
+        }
+
+        let hasEventTap = installEventTap()
+        return hasEventTap || systemHotKeys.count == shortcuts.count
     }
 
     func stop() {
+        systemHotKeys = [:]
         if let eventTapRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), eventTapRunLoopSource, .commonModes)
             self.eventTapRunLoopSource = nil
@@ -153,7 +164,7 @@ final class ShortcutMonitor {
     private func resetPressedShortcutsAfterTapInterruption() {
         let eventTime = ProcessInfo.processInfo.systemUptime
         let pressedActions = shortcuts.compactMap { action, state in
-            state.isDown ? action : nil
+            state.isDown && systemHotKeys[action] == nil ? action : nil
         }
 
         guard !pressedActions.isEmpty else {
@@ -167,6 +178,24 @@ final class ShortcutMonitor {
                 state.isInterrupted = false
                 shortcuts[action] = state
             }
+            dispatchShortcutUp(for: action, eventTime: eventTime)
+        }
+    }
+
+    private func handleSystemHotKey(action: ShortcutAction, isDown: Bool, eventTime: TimeInterval) {
+        guard var state = shortcuts[action], state.isDown != isDown else { return }
+
+        if isDown {
+            handleShortcutInterruptions(keyCode: state.shortcut.keyCode, eventTime: eventTime)
+        }
+        state.isDown = isDown
+        state.pressedAt = isDown ? eventTime : nil
+        state.isInterrupted = false
+        shortcuts[action] = state
+
+        if isDown {
+            dispatchShortcutDown(for: action, eventTime: eventTime)
+        } else {
             dispatchShortcutUp(for: action, eventTime: eventTime)
         }
     }
@@ -192,6 +221,8 @@ final class ShortcutMonitor {
         }
 
         for action in Array(shortcuts.keys) {
+            // Registered hot keys also work during Secure Input; only that route owns their transitions.
+            guard systemHotKeys[action] == nil else { continue }
             guard var state = shortcuts[action] else {
                 continue
             }

--- a/VoiceInk/Features/Shortcuts/Coordination/SystemHotKey.swift
+++ b/VoiceInk/Features/Shortcuts/Coordination/SystemHotKey.swift
@@ -1,0 +1,72 @@
+import Carbon
+import Foundation
+import os
+
+final class SystemHotKey {
+    private static let signature: OSType = 0x56496E6B
+    private static var nextID: UInt32 = 0
+    private static let logger = Logger(subsystem: "com.prakashjoshipax.voiceink", category: "SystemHotKey")
+
+    private let id: EventHotKeyID
+    private let onChange: (Bool, TimeInterval) -> Void
+    private var handler: EventHandlerRef?
+    private var hotKey: EventHotKeyRef?
+
+    init?(keyCode: UInt16, modifiers: UInt32, onChange: @escaping (Bool, TimeInterval) -> Void) {
+        precondition(Thread.isMainThread)
+        Self.nextID += 1
+        id = EventHotKeyID(signature: Self.signature, id: Self.nextID)
+        self.onChange = onChange
+
+        var eventTypes = [
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed)),
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyReleased)),
+        ]
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, event, context in
+                guard let event, let context else { return OSStatus(eventNotHandledErr) }
+                return Unmanaged<SystemHotKey>.fromOpaque(context).takeUnretainedValue().handle(event)
+            },
+            eventTypes.count,
+            &eventTypes,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &handler
+        )
+        guard handlerStatus == noErr else {
+            Self.logger.error("Failed to install system hot key handler: \(handlerStatus)")
+            return nil
+        }
+
+        let status = RegisterEventHotKey(
+            UInt32(keyCode), modifiers, id, GetApplicationEventTarget(), 0, &hotKey
+        )
+        guard status == noErr else {
+            Self.logger.error("Failed to register system hot key: \(status)")
+            return nil
+        }
+    }
+
+    deinit {
+        if let hotKey {
+            UnregisterEventHotKey(hotKey)
+        }
+        if let handler {
+            RemoveEventHandler(handler)
+        }
+    }
+
+    private func handle(_ event: EventRef) -> OSStatus {
+        var eventID = EventHotKeyID()
+        let status = GetEventParameter(
+            event, EventParamName(kEventParamDirectObject), EventParamType(typeEventHotKeyID),
+            nil, MemoryLayout<EventHotKeyID>.size, nil, &eventID
+        )
+        guard status == noErr, eventID.signature == id.signature, eventID.id == id.id else {
+            return OSStatus(eventNotHandledErr)
+        }
+
+        onChange(GetEventKind(event) == UInt32(kEventHotKeyPressed), GetEventTime(event))
+        return noErr
+    }
+}

--- a/VoiceInk/Features/Shortcuts/Models/Shortcut.swift
+++ b/VoiceInk/Features/Shortcuts/Models/Shortcut.swift
@@ -24,6 +24,20 @@ struct Shortcut: Codable, Equatable {
         kind == .modifierOnly
     }
 
+    var systemHotKeyModifiers: UInt32? {
+        guard kind == .key, !modifierFlags.contains(.function) else {
+            return nil
+        }
+
+        var modifiers: UInt32 = 0
+        for (flag, carbonFlag): (NSEvent.ModifierFlags, Int) in [
+            (.command, cmdKey), (.option, optionKey), (.control, controlKey), (.shift, shiftKey),
+        ] where modifierFlags.contains(flag) {
+            modifiers |= UInt32(carbonFlag)
+        }
+        return modifiers
+    }
+
     var displayString: String {
         displayTokens.joined(separator: " + ")
     }

--- a/scripts/check-system-hotkey.swift
+++ b/scripts/check-system-hotkey.swift
@@ -5,17 +5,19 @@ import Carbon
 @main
 struct CheckSystemHotKey {
     static func main() {
+        requireSecureInput()
         let application = NSApplication.shared
         application.setActivationPolicy(.prohibited)
         var pressedAt: TimeInterval?
 
         let hotKey = SystemHotKey(keyCode: UInt16(kVK_Space), modifiers: UInt32(optionKey)) { isDown, time in
-            print("\(isDown ? "DOWN" : "UP") secureInput=\(IsSecureEventInputEnabled())")
+            requireSecureInput()
+            print("\(isDown ? "DOWN" : "UP") secureInput=true")
             fflush(stdout)
             if isDown {
                 pressedAt = time
             } else if let pressedAt {
-                print("PASS: Option-Space delivered both transitions (\(time - pressedAt) seconds).")
+                print("PASS: Option-Space delivered both transitions with Secure Input enabled at every observed sample (\(time - pressedAt) seconds).")
                 exit(0)
             } else {
                 print("FAIL: release arrived without a press.")
@@ -27,14 +29,24 @@ struct CheckSystemHotKey {
             exit(1)
         }
 
-        print("Press and release Option-Space within 60 seconds. Secure Input: \(IsSecureEventInputEnabled()).")
+        print("Press and release Option-Space within 60 seconds. Secure Input must remain enabled.")
         fflush(stdout)
+        Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
+            requireSecureInput()
+        }
         Timer.scheduledTimer(withTimeInterval: 60, repeats: false) { _ in
             print("FAIL: no complete shortcut press received before the timeout.")
             exit(1)
         }
         withExtendedLifetime(hotKey) {
             application.run()
+        }
+    }
+
+    private static func requireSecureInput() {
+        guard IsSecureEventInputEnabled() else {
+            print("INCONCLUSIVE: Secure Input is disabled; this run cannot validate delivery during Secure Input.")
+            exit(2)
         }
     }
 }

--- a/scripts/check-system-hotkey.swift
+++ b/scripts/check-system-hotkey.swift
@@ -1,0 +1,40 @@
+// mkdir -p build && swiftc VoiceInk/Features/Shortcuts/Coordination/SystemHotKey.swift scripts/check-system-hotkey.swift -o build/check-system-hotkey
+import AppKit
+import Carbon
+
+@main
+struct CheckSystemHotKey {
+    static func main() {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.prohibited)
+        var pressedAt: TimeInterval?
+
+        let hotKey = SystemHotKey(keyCode: UInt16(kVK_Space), modifiers: UInt32(optionKey)) { isDown, time in
+            print("\(isDown ? "DOWN" : "UP") secureInput=\(IsSecureEventInputEnabled())")
+            fflush(stdout)
+            if isDown {
+                pressedAt = time
+            } else if let pressedAt {
+                print("PASS: Option-Space delivered both transitions (\(time - pressedAt) seconds).")
+                exit(0)
+            } else {
+                print("FAIL: release arrived without a press.")
+                exit(1)
+            }
+        }
+        guard let hotKey else {
+            print("FAIL: could not register Option-Space.")
+            exit(1)
+        }
+
+        print("Press and release Option-Space within 60 seconds. Secure Input: \(IsSecureEventInputEnabled()).")
+        fflush(stdout)
+        Timer.scheduledTimer(withTimeInterval: 60, repeats: false) { _ in
+            print("FAIL: no complete shortcut press received before the timeout.")
+            exit(1)
+        }
+        withExtendedLifetime(hotKey) {
+            application.run()
+        }
+    }
+}


### PR DESCRIPTION
Option-Space in Hybrid mode did nothing, even with a live, enabled event tap. Supported keyed shortcuts now use public Carbon system hot-key registrations, with press/release events feeding the existing recording-mode handling.

During the original diagnosis, `IsSecureEventInputEnabled()` returned `true`, and `ioreg` reported `kCGSSessionSecureInputPID=40972`. That live PID mapped to Steam's `steam_osx` executable. After Steam exited, `ps` confirmed the PID was gone, but macOS still reported the same owner PID and Secure Event Input remained enabled. VoiceInk still had an enabled event tap, and the shortcut still failed.

These observations establish a Steam-associated Secure Input state and a stale owner/state after exit in that session. They do not establish whether Steam, WindowServer, or macOS caused the persistence, or a repeatable Steam launch recipe. A later check reported Secure Input disabled and no former owner PID; what cleared the state is unknown.

Apple documents that Secure Event Input withholds keyboard events from event taps, including when the process enabling it is in the background. A live tap therefore does not establish that VoiceInk can receive the shortcut. Apple TN2150: https://developer.apple.com/library/archive/technotes/tn2150/_index.html. AltTab's API experiment matrix documents registered hot keys working through Secure Input: https://github.com/lwouis/alt-tab-macos/blob/609872b10605672bd0e9f8b012449f47c0573539/src/experimentations/README.md.

The shared monitor covers recording, mode, global utility, and visible recorder-panel shortcuts:

- Successfully registered keyed combinations use only the system hot-key route for transitions, preventing duplicate dispatch through the tap. Registrations and handlers are released when monitoring stops.
- Modifier-only shortcuts, mouse buttons, explicit Fn combinations, and failed registrations retain the event-tap route. Additional-key interruption detection remains limited to events macOS delivers during Secure Input.
- If the tap cannot start and system registrations cannot cover every configured shortcut, startup releases all registrations before reporting failure. A fully registered set can start without a tap.
- Tests cover modifier conversion, real registration release/reuse, and both startup outcomes when tap creation fails. A standalone physical-keyboard probe reports success only when Secure Input is enabled at startup, both transitions, and every intervening 50 ms sample. An observed disabled state exits as inconclusive.

The patch does not disable Secure Input, capture protected text, clear another process's protection, or require restarting macOS.

Validation on macOS 26.6.2 / Xcode 26.6, arm64:

The behavioral, build, and launch checks below ran before the final test-name-only follow-up. That follow-up changes no test body, production code, or probe code; Swift parsing and diff checks passed afterward.

- Passed: the Release `VoiceInkTests` suite with `ENABLE_TESTABILITY=YES`: seven shortcut test cases plus the pre-existing empty example. The new partial-startup test failed before the rollback fix and passed afterward.
- Passed: Release build with explicit ad-hoc signing (`CODE_SIGN_IDENTITY=-`); `codesign --verify --deep --strict`; a separate launch check confirmed the exact built app finished launching and remained alive for 12 seconds.
- Passed: standalone production probe compilation and seven simulated probe-verdict scenarios. The real probe returned inconclusive (exit 2) with Secure Input disabled. Simulated events validate the verdict logic, not physical hot-key delivery.
- Passed: an AddressSanitizer harness using the unchanged production registration object exercised 100 duplicate-registration failures, subsequent Carbon event dispatch, and release/reuse without a memory error.
- Passed: `make check` and `git diff --check`.
- The earlier `VoiceInkUITests/VoiceInkUITests/testExample` attempt could not start because XCTest timed out while enabling automation mode (exit 65). UI automation remains unverified.

Physical keyboard delivery during Secure Input, short/long Hybrid and push-to-talk holds, and a complete dictation cycle remain unverified. During the original diagnosis, a minimal prototype reported successful handler installation and registration with `secureInput=true`; no physical press/release was captured. Synthetic keystrokes were not treated as proof.

Substantial AI assistance was used for implementation, code review, verification, and PR text. No human code-review or physical-test completion is claimed. This submission acknowledges the repository's current policy against external PRs.
